### PR TITLE
OFBIZ-11330: Flexible form parameter name

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -136,7 +136,7 @@ public class ModelFormField {
     protected final String name;
     private final List<UpdateArea> onChangeUpdateAreas;
     private final List<UpdateArea> onClickUpdateAreas;
-    protected final String parameterName;
+    protected final FlexibleStringExpander parameterName;
     private final Integer position;
     private final String redWhen;
     private final Boolean requiredField;
@@ -536,7 +536,7 @@ public class ModelFormField {
         return onClickUpdateAreas;
     }
 
-    public String getParameterName() {
+    public FlexibleStringExpander getParameterName() {
         return parameterName;
     }
 
@@ -549,7 +549,7 @@ public class ModelFormField {
     public String getParameterName(Map<String, ? extends Object> context) {
         String baseName;
         if (UtilValidate.isNotEmpty(this.parameterName)) {
-            baseName = this.parameterName;
+            baseName = this.parameterName.expandString(context);
         } else {
             baseName = this.name;
         }
@@ -1902,7 +1902,7 @@ public class ModelFormField {
         public String getParameterNameOther(Map<String, Object> context) {
             String baseName;
             if (UtilValidate.isNotEmpty(getModelFormField().parameterName)) {
-                baseName = getModelFormField().parameterName;
+                baseName = getModelFormField().parameterName.expandString(context);
             } else {
                 baseName = getModelFormField().name;
             }

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormFieldBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormFieldBuilder.java
@@ -90,7 +90,7 @@ public class ModelFormFieldBuilder {
     private String name = "";
     private List<UpdateArea> onChangeUpdateAreas = new ArrayList<>();
     private List<UpdateArea> onClickUpdateAreas = new ArrayList<>();
-    private String parameterName = "";
+    private FlexibleStringExpander parameterName = FlexibleStringExpander.getInstance("");
     private Integer position = null;
     private String redWhen = "";
     private Boolean requiredField = null;
@@ -172,7 +172,7 @@ public class ModelFormFieldBuilder {
         this.mapAcsr = FlexibleMapAccessor.getInstance(fieldElement.getAttribute("map-name"));
         this.modelForm = modelForm;
         this.name = name;
-        this.parameterName = UtilXml.checkEmpty(fieldElement.getAttribute("parameter-name"), name);
+        this.parameterName = FlexibleStringExpander.getInstance(UtilXml.checkEmpty(fieldElement.getAttribute("parameter-name"), name));
         String positionAtttr = fieldElement.getAttribute("position");
         Integer position = null;
         if (!positionAtttr.isEmpty()) {
@@ -445,7 +445,7 @@ public class ModelFormFieldBuilder {
         return onClickUpdateAreas;
     }
 
-    public String getParameterName() {
+    public FlexibleStringExpander getParameterName() {
         return parameterName;
     }
 
@@ -905,7 +905,7 @@ public class ModelFormFieldBuilder {
     }
 
     public ModelFormFieldBuilder setParameterName(String parameterName) {
-        this.parameterName = parameterName;
+        this.parameterName = FlexibleStringExpander.getInstance(parameterName);
         return this;
     }
 

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
@@ -20,6 +20,7 @@ package org.apache.ofbiz.widget.model;
 
 import static org.apache.ofbiz.widget.model.ModelFormField.from;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
@@ -27,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +36,7 @@ public class ModelFormFieldTest {
     private HashMap<String, Object> context;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         context = new HashMap<>();
     }
 
@@ -80,5 +82,20 @@ public class ModelFormFieldTest {
         ModelFormField fA1 = from(b -> b.setName("A").setUseWhen("false"));
         ModelFormField fA2 = from(b -> b.setName("A").setUseWhen("true"));
         assertThat(getUsedField(fA0, fA1, fA2), containsInAnyOrder(fA0, fA1));
+    }
+
+    @Test
+    public void fieldUsesFlexibleParameterName() {
+        ModelFormField field = from(b -> b.setParameterName("${prefix}Param"));
+        assertThat(field.getParameterName(ImmutableMap.of("prefix", "P1")), equalTo("P1Param"));
+        assertThat(field.getParameterName(ImmutableMap.of("prefix", "P2")), equalTo("P2Param"));
+    }
+
+    @Test
+    public void dropDownFieldUsesFlexibleParameterNameOther() {
+        ModelFormField field = from(b -> b.setParameterName("${prefix}Param"));
+        ModelFormField.DropDownField dropDownField = new ModelFormField.DropDownField(field);
+        assertThat(dropDownField.getParameterNameOther(ImmutableMap.of("prefix", "P1")), equalTo("P1Param_OTHER"));
+        assertThat(dropDownField.getParameterNameOther(ImmutableMap.of("prefix", "P2")), equalTo("P2Param_OTHER"));
     }
 }


### PR DESCRIPTION
Update ModelFormField to store parameterName using the FlexibleStringExpander type so that parameter names can be generated at render time.

Added test cases to ModelFormFieldTest to exercise generation of parameter names based on values in the context.