### PR TITLE
Implemented: Cookie Consent In E-Commerce

### DIFF
--- a/themes/common-theme/webapp/common/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common/js/util/OfbizUtil.js
@@ -29,6 +29,15 @@ $(document).ready(function() {
     ajaxAutoCompleteDropDown();
     // bindObservers will add observer on passed html section when DOM is ready.
     bindObservers("body");
+    if (jQuery.fn.bsgdprcookies !== undefined) {
+        jQuery('body').bsgdprcookies({
+            title: 'This website uses cookies',
+            message: 'We use cookies to provide our services. By using this website, you agree to this.',
+            moreLink: '/ecommerce/control/CookiePolicy',
+            moreLinkLabel: ' More',
+            allowAdvancedOptions: true
+        });
+    }
 });
 
 /* bindObservers function contains the code of adding observers and it can be called for specific section as well


### PR DESCRIPTION
(OFBIZ-11333)
The Cookie Law is a piece of privacy legislation that requires websites to get consent from visitors to store or retrieve any information on their computer, smartphone or tablet. It was designed to protect online privacy, by making consumers aware of how information about them is collected and used online, and give them a choice to allow it or not.

The EU Cookie Legislation began as a directive from the European Union. Some variation on the policy has since been adopted by all countries within the EU.

The EU Cookie Legislation requires 4 actions from website owners who use cookies:

    When someone visits your website, you need to let them know that your site uses cookies.
    You need to provide detailed information regarding how that cookie data will be utilized.
    You need to provide visitors with some means of accepting or refusing the use of cookies in your site.
    If they refuse, you need to ensure that cookies will not be placed on their machine.

Used bsgdprcookies plugin to implement the feature. Thanks Deepak Nigam for initiating and providing initial patch. Thanks Deepak Nigam, Pierre Smits, Michael Brohl, Jacques Le Roux and Swapnil M Mane for inputs.