### PR TITLE
OFBIZ-4035 change the id Attribute for input fields in the model macro form renderer from String to FlexibleStringExpander

### DIFF
--- a/framework/widget/dtd/widget-form.xsd
+++ b/framework/widget/dtd/widget-form.xsd
@@ -755,7 +755,18 @@ under the License.
                     <xs:documentation>Used to specify a javascript action that should be run based on an existing specified event.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute type="xs:string" name="id-name" />
+            <xs:attribute type="xs:string" name="id-name">
+                <xs:annotation>
+                    <xs:documentation>Define the string to be used as the identifier (like a DOM id attribute) for this
+                        field.
+
+                        Accepts ${} notation to allow use of expressions.
+
+                        If undefined then defaults to [form-name]_[name] where form-name is set using the form-name
+                        attribute or taken from the containing form element's name attribute.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="separate-column" type="xs:boolean" default="false"/>
             <xs:attribute name="required-field" type="xs:boolean"/>
             <xs:attribute type="xs:string" name="required-field-style">

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -3395,7 +3395,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
 
     @Override
     public void renderContainerFindField(Appendable writer, Map<String, Object> context, ContainerField containerField) throws IOException {
-        String id = containerField.getModelFormField().getIdName();
+        final String id = containerField.getModelFormField().getCurrentContainerId(context);
         String className = UtilFormatOut.checkNull(containerField.getModelFormField().getWidgetStyle());
         StringWriter sr = new StringWriter();
         sr.append("<@renderContainerField ");

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
@@ -98,4 +98,11 @@ public class ModelFormFieldTest {
         assertThat(dropDownField.getParameterNameOther(ImmutableMap.of("prefix", "P1")), equalTo("P1Param_OTHER"));
         assertThat(dropDownField.getParameterNameOther(ImmutableMap.of("prefix", "P2")), equalTo("P2Param_OTHER"));
     }
+
+    @Test
+    public void fieldUsesFlexibleContainerId() {
+        ModelFormField field = from(b -> b.setIdName("${prefix}IdValue"));
+        assertThat(field.getCurrentContainerId(ImmutableMap.of("prefix", "P1")), equalTo("P1IdValue"));
+        assertThat(field.getCurrentContainerId(ImmutableMap.of("prefix", "P2")), equalTo("P2IdValue"));
+    }
 }


### PR DESCRIPTION
Functionality to render a DOM element's id attribute using a FlexibleStringExpander expression already existed in Ofbiz via ModelFormField#getCurrentContainerId.

This PR includes changes in widget-form.xsd to document that the id-name attribute can use ${} notation. It also adds a small unit test to ensure that getCurrentContainerId is processing id-name as a FlexibleStringExpander expression.