### PR TITLE
OFBIZ-4035: Unit tests for MacroFormRenderer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:3.8.3'
     testImplementation 'org.hamcrest:hamcrest-library:2.2' // Enable junit4 to not depend on hamcrest-1.3
     testImplementation 'org.mockito:mockito-core:3.2.0'
+    testImplementation 'org.jmockit:jmockit:1.49'
     testImplementation 'com.pholser:junit-quickcheck-generators:0.9'
     runtimeOnly 'javax.xml.soap:javax.xml.soap-api:1.4.0'
     runtimeOnly 'de.odysseus.juel:juel-spi:2.2.7'
@@ -317,6 +318,10 @@ eclipse.classpath.file.whenMerged { classpath ->
     }
 }
 tasks.eclipse.dependsOn(cleanEclipse)
+
+test {
+    jvmArgs "-javaagent:${classpath.find { it.name.contains("jmockit") }.absolutePath}"
+}
 
 /* ========================================================
  * Tasks

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -3395,7 +3395,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
 
     @Override
     public void renderContainerFindField(Appendable writer, Map<String, Object> context, ContainerField containerField) throws IOException {
-        String id = containerField.getModelFormField().getIdName();
+        final String id = containerField.getModelFormField().getCurrentContainerId(context);
         String className = UtilFormatOut.checkNull(containerField.getModelFormField().getWidgetStyle());
         StringWriter sr = new StringWriter();
         sr.append("<@renderContainerField ");

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -1,3 +1,21 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package org.apache.ofbiz.widget.renderer.macro;
 
 import com.google.common.collect.ImmutableMap;

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -1,0 +1,151 @@
+package org.apache.ofbiz.widget.renderer.macro;
+
+import com.google.common.collect.ImmutableMap;
+import freemarker.core.Environment;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.ofbiz.base.util.UtilCodec;
+import org.apache.ofbiz.base.util.UtilCodec.SimpleEncoder;
+import org.apache.ofbiz.base.util.UtilHttp;
+import org.apache.ofbiz.base.util.template.FreeMarkerWorker;
+import org.apache.ofbiz.webapp.control.RequestHandler;
+import org.apache.ofbiz.widget.model.ModelFormField;
+import org.apache.ofbiz.widget.model.ThemeFactory;
+import org.apache.ofbiz.widget.renderer.VisualTheme;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+
+public class MacroFormRendererTest {
+
+    @Mocked
+    private HttpServletRequest request;
+
+    @Mocked
+    private HttpServletResponse response;
+
+    @Mocked
+    private HttpSession httpSession;
+
+    @Mocked
+    private Template template;
+
+    @Mocked
+    private Environment environment;
+
+    @Mocked
+    private VisualTheme visualTheme;
+
+    @Mocked
+    private RequestHandler requestHandler;
+
+    @Mocked
+    private SimpleEncoder simpleEncoder;
+
+    @Mocked
+    private ModelFormField.ContainerField containerField;
+
+    @Mocked
+    private ModelFormField modelFormField;
+
+    @Mocked
+    private Appendable appendable;
+
+    @Mocked
+    private StringReader stringReader;
+
+    @Before
+    public void setupMockups() {
+        new FreeMarkerWorkerMockUp();
+        new ThemeFactoryMockUp();
+        new RequestHandlerMockUp();
+        new UtilHttpMockUp();
+        new UtilCodecMockUp();
+    }
+
+    @Test
+    public void textRendererUsesContainerId(@Mocked ModelFormField.TextField textField) throws IOException, TemplateException {
+        new Expectations() {{
+            httpSession.getAttribute("delegatorName");
+            result = "delegator";
+
+            textField.getModelFormField();
+            result = modelFormField;
+
+            modelFormField.getTooltip(withNotNull());
+            result = "";
+
+            modelFormField.getCurrentContainerId(withNotNull());
+            result = "CurrentTextId";
+
+            new StringReader(withSubstring("id=\"CurrentTextId\""));
+        }};
+
+        final MacroFormRenderer macroFormRenderer = new MacroFormRenderer(null, request, response);
+        macroFormRenderer.renderTextField(appendable, ImmutableMap.of("session", httpSession), textField);
+    }
+
+    @Test
+    public void containerRendererUsesContainerId() throws IOException, TemplateException {
+        new Expectations() {{
+            modelFormField.getCurrentContainerId(withNotNull());
+            result = "CurrentContainerId";
+
+            new StringReader(withSubstring("id=\"CurrentContainerId\""));
+        }};
+
+        final MacroFormRenderer macroFormRenderer = new MacroFormRenderer(null, request, response);
+        macroFormRenderer.renderContainerFindField(appendable, ImmutableMap.of(), containerField);
+    }
+
+    class FreeMarkerWorkerMockUp extends MockUp<FreeMarkerWorker> {
+        @Mock
+        public Template getTemplate(String templateLocation) {
+            return template;
+        }
+
+        @Mock
+        public Environment renderTemplate(Template template, Map<String, Object> context, Appendable outWriter) {
+            return environment;
+        }
+    }
+
+    class ThemeFactoryMockUp extends MockUp<ThemeFactory> {
+        @Mock
+        public VisualTheme resolveVisualTheme(HttpServletRequest request) {
+            return visualTheme;
+        }
+    }
+
+    class RequestHandlerMockUp extends MockUp<RequestHandler> {
+        @Mock
+        public RequestHandler from(HttpServletRequest request) {
+            return requestHandler;
+        }
+    }
+
+    class UtilHttpMockUp extends MockUp<UtilHttp> {
+        @Mock
+        public boolean isJavaScriptEnabled(HttpServletRequest request) {
+            return true;
+        }
+    }
+
+    class UtilCodecMockUp extends MockUp<UtilCodec> {
+        @Mock
+        public SimpleEncoder getEncoder(String type) {
+            return simpleEncoder;
+        }
+    }
+}
+


### PR DESCRIPTION
This PR introduced changes to unit test MacroFormRenderer, but as this class has a lot of dependencies on static methods from various utility and environment classes, it seemed appropriate to make use of JMockit as a means to mock out static methods.

Ideally it wouldn't have been necessary to introduce a new mocking library, but given MacroFormRenderer's design it was a way to create some tests without having to build a very large number of brittle mockito mocks and lots of environmental setup code.