### PR TITLE
OFBIZ-11418: Use FlexibleStringExpander in form widget lookup field field target parameters

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -2241,7 +2241,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         StringBuilder targetParameterIter = new StringBuilder();
         StringBuilder imgSrc = new StringBuilder();
         // FIXME: refactor using the StringUtils methods
-        List<String> targetParameterList = lookupField.getTargetParameterList();
+        List<String> targetParameterList = lookupField.getTargetParameterList(context);
         targetParameterIter.append("[");
         for (String targetParameter : targetParameterList) {
             if (targetParameterIter.length() > 1) {

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
@@ -22,6 +22,7 @@ import static org.apache.ofbiz.widget.model.ModelFormField.from;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,8 +30,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.w3c.dom.Element;
 
 public class ModelFormFieldTest {
     private HashMap<String, Object> context;
@@ -104,5 +108,51 @@ public class ModelFormFieldTest {
         ModelFormField field = from(b -> b.setIdName("${prefix}IdValue"));
         assertThat(field.getCurrentContainerId(ImmutableMap.of("prefix", "P1")), equalTo("P1IdValue"));
         assertThat(field.getCurrentContainerId(ImmutableMap.of("prefix", "P2")), equalTo("P2IdValue"));
+    }
+
+    /**
+     * Ensures behaviour of deprecated method LookupField#getTargetParameterList is maintained while the underlying
+     * property type is changed from String to FlexibleStringExpander.
+     */
+    @Test
+    public void lookupFieldDeprecatedMethodTreatsTargetParameterAsString() {
+        Element element = Mockito.mock(Element.class);
+        when(element.getTagName()).thenReturn("lookup");
+        when(element.getAttribute("maxlength")).thenReturn("1");
+        when(element.getAttribute("size")).thenReturn("1");
+        when(element.getAttribute("target-parameter")).thenReturn("${prefix}TargetParam, ${key1}");
+
+        ModelFormField field = from(b -> b.setName("lookup-field"));
+        ModelFormField.LookupField lookupField = new ModelFormField.LookupField(element, field);
+
+        assertThat(lookupField.getTargetParameterList(), Matchers.contains("${prefix}TargetParam", "${key1}"));
+    }
+
+    @Test
+    public void lookupFieldUsesFlexibleTargetParameters() {
+        Element element = Mockito.mock(Element.class);
+        when(element.getTagName()).thenReturn("lookup");
+        when(element.getAttribute("maxlength")).thenReturn("1");
+        when(element.getAttribute("size")).thenReturn("1");
+        when(element.getAttribute("target-parameter")).thenReturn("${prefix}TargetParam");
+
+        ModelFormField field = from(b -> b.setName("lookup-field"));
+        ModelFormField.LookupField lookupField = new ModelFormField.LookupField(element, field);
+
+        assertThat(lookupField.getTargetParameterList(ImmutableMap.of("prefix", "P1")), Matchers.contains("P1TargetParam"));
+    }
+
+    @Test
+    public void lookupFieldEvaluatesExpressionBeforeSplitting() {
+        Element element = Mockito.mock(Element.class);
+        when(element.getTagName()).thenReturn("lookup");
+        when(element.getAttribute("maxlength")).thenReturn("1");
+        when(element.getAttribute("size")).thenReturn("1");
+        when(element.getAttribute("target-parameter")).thenReturn("${prefix}TargetParam, ${key1}");
+
+        ModelFormField field = from(b -> b.setName("lookup-field"));
+        ModelFormField.LookupField lookupField = new ModelFormField.LookupField(element, field);
+
+        assertThat(lookupField.getTargetParameterList(ImmutableMap.of("prefix", "P1", "key1", "AA,BB , CC")), Matchers.contains("P1TargetParam", "AA", "BB", "CC"));
     }
 }


### PR DESCRIPTION
Changed target-parameter attribute of the form widget's Lookup field to
use the FlexibleStringExpander type rather than String. This has been
done to allow reference to other form fields which may have had their
parameter-name attribute set to a FlexibleStringExpander expression.