### PR TITLE
OFBIZ-11428: Set checkstyle to use LF line endings

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -30,7 +30,9 @@ under the License.
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <!-- General file conventions -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
     <module name="FileTabCharacter"/>
     <module name="RegexpSingleline">
        <property name="format" value="\s+$"/>


### PR DESCRIPTION
(OFBIZ-11428)

Setting checkstyle to use LF line endings means that a newline at the
end of a source file is correctly detected no matter whether it is
checked out with LF or CRLF line endings.