### PR TITLE
Improved: Converted all TimeEntry related CRUD services from simple to entity-auto

### DIFF
--- a/applications/accounting/webapp/accounting/WEB-INF/controller.xml
+++ b/applications/accounting/webapp/accounting/WEB-INF/controller.xml
@@ -209,7 +209,7 @@ under the License.
     </request-map>
     <request-map uri="unlinkInvoiceFromTimeEntry">
         <security https="true" auth="true"/>
-        <event type="service" invoke="unlinkInvoiceFromTimeEntry"/>
+        <event type="service" invoke="updateTimeEntry"/>
         <response name="success" type="view" value="editInvoiceTimeEntries"/>
         <response name="error" type="view" value="editInvoiceTimeEntries"/>
     </request-map>

--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -628,7 +628,8 @@ under the License.
         <field name="deleteLink" title=" " widget-style="buttontext">
             <hyperlink description="${uiLabelMap.CommonDelete}" target="unlinkInvoiceFromTimeEntry" also-hidden="false">
                 <parameter param-name="timeEntryId"/>
-                <parameter param-name="invoiceId"/>
+                <parameter param-name="invoiceId" value="null"/>
+                <parameter param-name="invoiceItemSeqId" value="null"/>
                 <parameter param-name="viewIndex"/>
                 <parameter param-name="viewSize"/>
             </hyperlink>

--- a/applications/workeffort/minilang/test/WorkEffortTests.xml
+++ b/applications/workeffort/minilang/test/WorkEffortTests.xml
@@ -560,21 +560,4 @@ under the License.
         </assert>
         <check-errors/>
     </simple-method>
-    <simple-method method-name="testUnlinkInvoiceFromTimeEntry" short-description="Test the service unlinkInvoiceFromTimeEntry" login-required="false">
-        <set field="serviceCtx.invoiceId" value="TestInvoice"/>
-        <set field="serviceCtx.timeEntryId" value="TestTimeEntry-3"/>
-        <entity-one entity-name="UserLogin" value-field="userLogin">
-            <field-map field-name="userLoginId" value="system"/>
-        </entity-one>
-        <set field="serviceCtx.userLogin" from-field="userLogin"/>
-        <call-service service-name="unlinkInvoiceFromTimeEntry" in-map-name="serviceCtx"/>
-        <entity-one entity-name="TimeEntry" value-field="timeEntry">
-            <field-map field-name="timeEntryId" value="TestTimeEntry-3"/>
-        </entity-one>
-        <assert>
-            <not><if-empty field="timeEntry"/></not>
-            <if-empty field="timeEntry.invoiceId"/>
-        </assert>
-        <check-errors/>
-    </simple-method>
 </simple-methods>

--- a/applications/workeffort/minilang/timesheet/TimesheetServices.xml
+++ b/applications/workeffort/minilang/timesheet/TimesheetServices.xml
@@ -310,22 +310,6 @@ under the License.
     </simple-method>
 
     <!-- TimeEntry Services -->
-    <simple-method method-name="createTimeEntry" short-description="Create TimeEntry">
-        <call-simple-method method-name="checkTimesheetStatus"/>
-        <now-timestamp field="nowTimestamp"/>
-
-        <make-value entity-name="TimeEntry" value-field="newEntity"/>
-        <sequenced-id sequence-name="TimeEntry" field="newEntity.timeEntryId"/>
-        <field-to-result field="newEntity.timeEntryId" result-name="timeEntryId"/>
-
-        <set-nonpk-fields map="parameters" value-field="newEntity"/>
-        <if-empty field="newEntity.fromDate">
-            <call-class-method class-name="org.apache.ofbiz.base.util.UtilDateTime" method-name="getDayStart" ret-field="newEntity.fromDate">
-                <field field="nowTimestamp" type="java.sql.Timestamp"/>
-            </call-class-method>
-        </if-empty>
-        <create-value value-field="newEntity"/>
-    </simple-method>
     <simple-method method-name="updateTimeEntry" short-description="Update TimeEntry">
         <entity-one entity-name="TimeEntry" value-field="lookedUpValue"/>
         <call-simple-method method-name="checkTimesheetStatus"/>
@@ -364,17 +348,6 @@ under the License.
             </if-empty>
         </if-not-empty>
         
-        <store-value value-field="lookedUpValue"/>
-    </simple-method>
-    <simple-method method-name="deleteTimeEntry" short-description="Delete TimeEntry">
-        <entity-one entity-name="TimeEntry" value-field="lookedUpValue"/>
-        <call-simple-method method-name="checkTimesheetStatus"/>
-        <remove-value value-field="lookedUpValue"/>
-    </simple-method>
-    <simple-method method-name="unlinkInvoiceFromTimeEntry" short-description="Delete TimeEntry">
-        <entity-one entity-name="TimeEntry" value-field="lookedUpValue"/>
-        <field-to-result field="lookedUpValue.invoiceId" result-name="invoiceId"/>
-        <clear-field field="lookedUpValue.invoiceId"/>
         <store-value value-field="lookedUpValue"/>
     </simple-method>
     <simple-method method-name="getTimeEntryRate" short-description="Get TimeEntry Rate">

--- a/applications/workeffort/servicedef/secas.xml
+++ b/applications/workeffort/servicedef/secas.xml
@@ -62,4 +62,7 @@ under the License.
         <condition field-name="orderId" operator="is-empty"/>
         <action service="createOrderHeader" mode="sync"/>
     </eca>
+    <eca service="createTimeEntry" event="invoke">
+        <action service="checkTimesheetStatus" mode="sync"/>
+    </eca>
 </service-eca>

--- a/applications/workeffort/servicedef/services_timesheet.xml
+++ b/applications/workeffort/servicedef/services_timesheet.xml
@@ -121,11 +121,11 @@ under the License.
     </service>
 
     <!-- TimeEntry Services -->
-    <service name="createTimeEntry" default-entity-name="TimeEntry" engine="simple" auth="true"
-        location="component://workeffort/minilang/timesheet/TimesheetServices.xml" invoke="createTimeEntry">
+    <service name="createTimeEntry" default-entity-name="TimeEntry" engine="entity-auto" auth="true" invoke="create">
         <description>Creates TimeEntry</description>
         <auto-attributes include="pk" mode="OUT" optional="false"/>
         <auto-attributes include="nonpk" mode="IN" optional="true"/>
+        <override name="fromDate" default-value="${date:nowTimestamp()}"/>
     </service>
     <service name="updateTimeEntry" default-entity-name="TimeEntry" engine="simple" auth="true"
         location="component://workeffort/minilang/timesheet/TimesheetServices.xml" invoke="updateTimeEntry">
@@ -133,16 +133,9 @@ under the License.
         <auto-attributes include="pk" mode="IN" optional="false"/>
         <auto-attributes include="nonpk" mode="IN" optional="true"/>
     </service>
-    <service name="deleteTimeEntry" default-entity-name="TimeEntry" engine="simple" auth="true"
-        location="component://workeffort/minilang/timesheet/TimesheetServices.xml" invoke="deleteTimeEntry">
+    <service name="deleteTimeEntry" default-entity-name="TimeEntry" engine="entity-auto" auth="true" invoke="delete">
         <description>Deletes TimeEntry</description>
         <auto-attributes include="pk" mode="IN" optional="false"/>
-    </service>
-    <service name="unlinkInvoiceFromTimeEntry" default-entity-name="TimeEntry" engine="simple" auth="true"
-        location="component://workeffort/minilang/timesheet/TimesheetServices.xml" invoke="unlinkInvoiceFromTimeEntry">
-        <description>Deletes TimeEntry</description>
-        <auto-attributes include="pk" mode="IN" optional="false"/>
-        <attribute name="invoiceId" type="String" mode="INOUT" optional="false"/>
     </service>
     <service name="getTimeEntryRate" default-entity-name="TimeEntry" engine="simple" auth="true"
         location="component://workeffort/minilang/timesheet/TimesheetServices.xml" invoke="getTimeEntryRate">


### PR DESCRIPTION
Improved: Converted all TimeEntry related CRUD services from simple to entity-auto

(OFBIZ-11624)
Also, removed unused services named unlinkInvoiceFromTimeEntry, which simply clears invoice related fields of TimeEntry entity, so used updateTimeEntry instead.