### PR TITLE
Improved: Use OFBizTestCase's from method utility instead of using EntityQuery in each test case

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgAdminTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgAdminTests.groovy
@@ -19,7 +19,6 @@
 package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -48,7 +47,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('addPaymentMethodTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue paymentMethodTypeGlAccount = EntityQuery.use(delegator).from('PaymentMethodTypeGlAccount')
+        GenericValue paymentMethodTypeGlAccount = from('PaymentMethodTypeGlAccount')
                 .where('paymentMethodTypeId', 'GIFT_CARD',
                         'organizationPartyId', 'DEMO_COMPANY1')
                 .queryOne()
@@ -65,7 +64,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('removePaymentTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue paymentMethodTypeGlAccount = EntityQuery.use(delegator).from('PaymentGlAccountTypeMap')
+        GenericValue paymentMethodTypeGlAccount = from('PaymentGlAccountTypeMap')
                 .where('paymentTypeId', 'COMMISSION_PAYMENT',
                         'organizationPartyId', 'DEMO_COMPANY1')
                 .queryOne()
@@ -81,7 +80,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createPartyAcctgPreference', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyAcctgPreference = EntityQuery.use(delegator).from('PartyAcctgPreference')
+        GenericValue partyAcctgPreference = from('PartyAcctgPreference')
                 .where('partyId', 'DEMO_COMPANY')
                 .queryOne()
         assert partyAcctgPreference
@@ -98,7 +97,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('updatePartyAcctgPreference', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyAcctgPreference = EntityQuery.use(delegator).from('PartyAcctgPreference')
+        GenericValue partyAcctgPreference = from('PartyAcctgPreference')
                 .where('partyId', 'DEMO_COMPANY1')
                 .queryOne()
         assert partyAcctgPreference
@@ -123,7 +122,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('setAcctgCompany', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue userPreference = EntityQuery.use(delegator).from('UserPreference')
+        GenericValue userPreference = from('UserPreference')
                 .where('userPrefValue', 'DEMO_COMPANY1')
                 .queryFirst()
         assert userPreference
@@ -141,7 +140,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('updateFXConversion', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue uomConversionDated = EntityQuery.use(delegator).from('UomConversionDated')
+        GenericValue uomConversionDated = from('UomConversionDated')
                 .where('uomId', 'INR', 'uomIdTo', 'USD')
                 .queryFirst()
         assert uomConversionDated
@@ -158,7 +157,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createGlAccountTypeDefault', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue glAccountTypeDefault = EntityQuery.use(delegator).from('GlAccountTypeDefault')
+        GenericValue glAccountTypeDefault = from('GlAccountTypeDefault')
                 .where('glAccountTypeId', 'BALANCE_ACCOUNT', 'organizationPartyId', 'DEMO_COMPANY1')
                 .queryOne()
         assert glAccountTypeDefault
@@ -175,7 +174,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('removeGlAccountTypeDefault', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue glAccountTypeDefault = EntityQuery.use(delegator).from('GlAccountTypeDefault')
+        GenericValue glAccountTypeDefault = from('GlAccountTypeDefault')
                 .where('glAccountTypeId', 'ACCOUNTS_PAYABLE',
                         'organizationPartyId', 'DEMO_COMPANY1')
                 .queryOne()
@@ -192,7 +191,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('addInvoiceItemTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue invoiceItemTypeGlAccount = EntityQuery.use(delegator).from('InvoiceItemTypeGlAccount')
+        GenericValue invoiceItemTypeGlAccount = from('InvoiceItemTypeGlAccount')
                 .where('invoiceItemTypeId', 'PINV_FPROD_ITEM',
                         'organizationPartyId', 'DEMO_COMPANY1')
                 .queryOne()
@@ -209,7 +208,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('removeInvoiceItemTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue invoiceItemTypeGlAccount = EntityQuery.use(delegator).from('InvoiceItemTypeGlAccount')
+        GenericValue invoiceItemTypeGlAccount = from('InvoiceItemTypeGlAccount')
                 .where('invoiceItemTypeId', 'PINV_SALES_TAX',
                         'organizationPartyId', 'DEMO_COMPANY1')
                 .queryOne()
@@ -226,7 +225,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('addPaymentTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue paymentGlAccountTypeMap = EntityQuery.use(delegator).from('PaymentGlAccountTypeMap')
+        GenericValue paymentGlAccountTypeMap = from('PaymentGlAccountTypeMap')
                 .where('paymentTypeId', 'TAX_PAYMENT',
                         'organizationPartyId', 'DEMO_COMPANY1')
                 .queryOne()
@@ -243,7 +242,7 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('removePaymentMethodTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue paymentMethodTypeGlAccount = EntityQuery.use(delegator).from('PaymentMethodTypeGlAccount')
+        GenericValue paymentMethodTypeGlAccount = from('PaymentMethodTypeGlAccount')
                 .where('paymentMethodTypeId', 'CASH',
                         'organizationPartyId', 'DEMO_COMPANY1')
                 .queryOne()

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgAgreementTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgAgreementTests.groovy
@@ -19,7 +19,6 @@
 package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -36,7 +35,7 @@ class AutoAcctgAgreementTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('expireAgreement', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue agreement = EntityQuery.use(delegator).from('Agreement')
+        GenericValue agreement = from('Agreement')
                 .where('agreementId', '1000')
                 .filterByDate()
                 .queryOne()
@@ -53,7 +52,7 @@ class AutoAcctgAgreementTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('copyAgreement', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue agreement = EntityQuery.use(delegator).from('Agreement')
+        GenericValue agreement = from('Agreement')
                 .where('agreementId', serviceResult.agreementId)
                 .queryOne()
         List<GenericValue> agreementItems = agreement.getRelated("AgreementItem", null, null, false)

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgBudgetTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgBudgetTests.groovy
@@ -19,7 +19,6 @@
 package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -36,7 +35,7 @@ class AutoAcctgBudgetTests extends OFBizTestCase {
         Map result = dispatcher.runSync('createBudget', serviceCtx)
         assert ServiceUtil.isSuccess(result)
 
-        GenericValue budget = EntityQuery.use(delegator).from('Budget').where(result).queryOne()
+        GenericValue budget = from('Budget').where(result).queryOne()
         assert budget
         assert budget.budgetTypeId == 'CAPITAL_BUDGET'
         assert budget.comments == 'Capital Budget'
@@ -49,7 +48,7 @@ class AutoAcctgBudgetTests extends OFBizTestCase {
         serviceCtx.userLogin = userLogin
         Map result = dispatcher.runSync('updateBudgetStatus', serviceCtx)
 
-        List<GenericValue> budgetStatuses = EntityQuery.use(delegator).from('BudgetStatus').where('budgetId', '9999').orderBy('-statusDate').queryList()
+        List<GenericValue> budgetStatuses = from('BudgetStatus').where('budgetId', '9999').orderBy('-statusDate').queryList()
         assert ! budgetStatuses?.isEmpty()
         assert budgetStatuses[0].statusId == 'BG_APPROVED'
     }

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgCostTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgCostTests.groovy
@@ -19,7 +19,6 @@
 package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -38,7 +37,7 @@ class AutoAcctgCostTests extends OFBizTestCase {
         Map result = dispatcher.runSync('updateProductAverageCostOnReceiveInventory', serviceCtx)
         assert ServiceUtil.isSuccess(result)
 
-        GenericValue productAverageCost = EntityQuery.use(delegator).from('ProductAverageCost').filterByDate()
+        GenericValue productAverageCost = from('ProductAverageCost').filterByDate()
                                 .where('productId', 'TestProduct3', 'facilityId', 'DemoFacility1').queryFirst()
         assert productAverageCost
         assert productAverageCost.productAverageCostTypeId == 'SIMPLE_AVG_COST'
@@ -46,7 +45,7 @@ class AutoAcctgCostTests extends OFBizTestCase {
     }
 
     void testGetProductAverageCost() {
-        GenericValue inventoryItem = EntityQuery.use(delegator).from('InventoryItem')
+        GenericValue inventoryItem = from('InventoryItem')
                                             .where('inventoryItemId', '9999').queryOne()
         Map serviceCtx = [
                 inventoryItem: inventoryItem,

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgFinAccountTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgFinAccountTests.groovy
@@ -20,7 +20,6 @@ package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -44,7 +43,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createFinAccount', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccount = EntityQuery.use(delegator).from('FinAccount')
+        GenericValue finAccount = from('FinAccount')
                                     .where('finAccountId', '1000', 'finAccountTypeId', 'BANK_ACCOUNT')
                                     .queryOne()
         assert finAccount
@@ -60,7 +59,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('updateFinAccount', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccount = EntityQuery.use(delegator).from('FinAccount')
+        GenericValue finAccount = from('FinAccount')
                 .where('finAccountId', '1001')
                 .queryOne()
         assert finAccount
@@ -75,7 +74,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('deleteFinAccount', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccount = EntityQuery.use(delegator).from('FinAccount')
+        GenericValue finAccount = from('FinAccount')
                 .where('finAccountId', '1002')
                 .queryOne()
         assert finAccount == null
@@ -93,7 +92,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createFinAccountRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccountRole = EntityQuery.use(delegator).from('FinAccountRole')
+        GenericValue finAccountRole = from('FinAccountRole')
                 .where('finAccountId', '1003', 'partyId', 'DEMO_COMPANY', 'roleTypeId', 'INTERNAL_ORGANIZATIO')
                 .queryFirst()
         assert finAccountRole
@@ -111,7 +110,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('updateFinAccountRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccountRole = EntityQuery.use(delegator).from('FinAccountRole')
+        GenericValue finAccountRole = from('FinAccountRole')
                 .where('finAccountId', '1004', 'partyId', 'DEMO_COMPANY', 'roleTypeId', 'SUPPLIER')
                 .queryFirst()
         assert finAccountRole
@@ -129,7 +128,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('deleteFinAccountRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccountRole = EntityQuery.use(delegator).from('FinAccountRole')
+        GenericValue finAccountRole = from('FinAccountRole')
                 .where('finAccountId', '1004', 'partyId', 'DEMO_COMPANY', 'roleTypeId', 'SUPPLIER')
                 .queryFirst()
         assert finAccountRole == null
@@ -144,7 +143,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createFinAccountTrans', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccountTran = EntityQuery.use(delegator).from('FinAccountTrans')
+        GenericValue finAccountTran = from('FinAccountTrans')
                 .where('finAccountId', '1003', 'finAccountTransTypeId', 'ADJUSTMENT')
                 .queryFirst()
         assert finAccountTran
@@ -160,7 +159,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createFinAccountStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccountStatus = EntityQuery.use(delegator).from('FinAccountStatus')
+        GenericValue finAccountStatus = from('FinAccountStatus')
                 .where('finAccountId', '1003', 'statusId', 'FNACT_ACTIVE')
                 .queryFirst()
         assert finAccountStatus
@@ -189,7 +188,7 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('setFinAccountTransStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue finAccountTrans = EntityQuery.use(delegator).from('FinAccountTrans')
+        GenericValue finAccountTrans = from('FinAccountTrans')
                 .where('finAccountTransId', '1010')
                 .queryOne()
         assert finAccountTrans

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgInvoiceTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgInvoiceTests.groovy
@@ -20,7 +20,6 @@ package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -42,7 +41,7 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createInvoiceContent', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue invoiceContent = EntityQuery.use(delegator).from('InvoiceContent')
+        GenericValue invoiceContent = from('InvoiceContent')
             .where('invoiceId', serviceResult.invoiceId,
                    'contentId', serviceResult.contentId,
                    'invoiceContentTypeId', serviceResult.invoiceContentTypeId)
@@ -63,7 +62,7 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createSimpleTextContentForInvoice', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue invoiceContent = EntityQuery.use(delegator).from('InvoiceContent')
+        GenericValue invoiceContent = from('InvoiceContent')
                 .where('invoiceId', '1009',
                 'contentId', '1001',
                 'invoiceContentTypeId', 'COMMENTS')
@@ -118,7 +117,7 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('setInvoiceStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue invoice = EntityQuery.use(delegator).from('Invoice')
+        GenericValue invoice = from('Invoice')
                 .where('invoiceId', '1002')
                 .queryOne()
 
@@ -161,7 +160,7 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createInvoiceStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue invoiceStatus = EntityQuery.use(delegator).from('InvoiceStatus')
+        GenericValue invoiceStatus = from('InvoiceStatus')
                 .where('invoiceId', '1004',
                         'statusId', 'INVOICE_IN_PROCESS',
                         'statusDate', nowTimestamp)
@@ -180,7 +179,7 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createInvoiceRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue invoiceRole = EntityQuery.use(delegator).from('InvoiceRole')
+        GenericValue invoiceRole = from('InvoiceRole')
                 .where('invoiceId', '1006',
                         'partyId', 'DEMO_COMPANY',
                         'roleTypeId', 'INTERNAL_ORGANIZATIO')
@@ -201,7 +200,7 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createInvoiceTerm', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue invoiceTerm = EntityQuery.use(delegator).from('InvoiceTerm')
+        GenericValue invoiceTerm = from('InvoiceTerm')
                 .where('invoiceTermId', serviceResult.invoiceTermId)
                 .queryOne()
 

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgLedgerTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgLedgerTests.groovy
@@ -20,7 +20,6 @@ package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -38,7 +37,7 @@ class AutoAcctgLedgerTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createAcctgTrans', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue acctgTrans = EntityQuery.use(delegator).from('AcctgTrans').where('acctgTransId', serviceResult.acctgTransId).queryOne()
+        GenericValue acctgTrans = from('AcctgTrans').where('acctgTransId', serviceResult.acctgTransId).queryOne()
         assert acctgTrans.acctgTransId == serviceResult.acctgTransId
         assert acctgTrans.acctgTransTypeId == 'CREDIT_MEMO'
     }
@@ -50,7 +49,7 @@ class AutoAcctgLedgerTests extends OFBizTestCase {
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createAcctgTransEntry', serviceCtx)
-        GenericValue acctgTransEntry = EntityQuery.use(delegator).from('AcctgTransEntry').where('acctgTransId', '1000', 'acctgTransEntrySeqId', serviceResult.acctgTransEntrySeqId).queryOne()
+        GenericValue acctgTransEntry = from('AcctgTransEntry').where('acctgTransId', '1000', 'acctgTransEntrySeqId', serviceResult.acctgTransEntrySeqId).queryOne()
         assert acctgTransEntry != null
     }
 }

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgPaymentGatewayTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgPaymentGatewayTests.groovy
@@ -19,7 +19,6 @@
 package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -36,7 +35,7 @@ class AutoAcctgPaymentGatewayTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('updatePaymentGatewayConfig', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue paymentGatewayConfig = EntityQuery.use(delegator).from('PaymentGatewayConfig').where('paymentGatewayConfigId', 'SAGEPAY_CONFIG').queryOne()
+        GenericValue paymentGatewayConfig = from('PaymentGatewayConfig').where('paymentGatewayConfigId', 'SAGEPAY_CONFIG').queryOne()
         assert paymentGatewayConfig
         assert paymentGatewayConfig.description  == 'Test Payment Gateway Config Id'
     }

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgPaymentTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/AutoAcctgPaymentTests.groovy
@@ -20,7 +20,6 @@ package org.apache.ofbiz.accounting
 
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -41,7 +40,7 @@ class AutoAcctgPaymentTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createPayment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue payment = EntityQuery.use(delegator).from('Payment').where('paymentId', serviceResult.paymentId).queryOne()
+        GenericValue payment = from('Payment').where('paymentId', serviceResult.paymentId).queryOne()
         assert payment.paymentTypeId == 'CUSTOMER_PAYMENT'
         assert payment.paymentMethodTypeId == 'COMPANY_CHECK'
     }
@@ -53,7 +52,7 @@ class AutoAcctgPaymentTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('setPaymentStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue payment = EntityQuery.use(delegator).from('Payment').where('paymentId', '1000').queryOne()
+        GenericValue payment = from('Payment').where('paymentId', '1000').queryOne()
         assert payment
         assert serviceResult.oldStatusId == 'PAYMENT_NOT_AUTH'
     }
@@ -64,7 +63,7 @@ class AutoAcctgPaymentTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('quickSendPayment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue payment = EntityQuery.use(delegator).from('Payment').where('paymentId', '1001').queryOne()
+        GenericValue payment = from('Payment').where('paymentId', '1001').queryOne()
         assert payment
         assert payment.statusId == 'PMNT_SENT'
     }
@@ -87,7 +86,7 @@ class AutoAcctgPaymentTests extends OFBizTestCase {
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPaymentContent', serviceCtx)
-        GenericValue paymentContent = EntityQuery.use(delegator).from('PaymentContent').where(paymentId: '1006', paymentContentTypeId: 'COMMENTS', contentId: '1006').filterByDate().queryFirst()
+        GenericValue paymentContent = from('PaymentContent').where(paymentId: '1006', paymentContentTypeId: 'COMMENTS', contentId: '1006').filterByDate().queryFirst()
         assert paymentContent
     }
 }

--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/FixedAssetTests.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/FixedAssetTests.groovy
@@ -20,7 +20,6 @@ package org.apache.ofbiz.accounting;
 
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 import java.sql.Timestamp
@@ -41,7 +40,7 @@ class FixedAssetTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createFixedAssetRegistration', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue fixedAssetRegistration = EntityQuery.use(delegator).from('FixedAssetRegistration')
+        GenericValue fixedAssetRegistration = from('FixedAssetRegistration')
                 .where('fixedAssetId', 'DEMO_VEHICLE_01')
                 .filterByDate().queryFirst();
         assert fixedAssetRegistration
@@ -60,7 +59,7 @@ class FixedAssetTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('updateFixedAssetRegistration', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue fixedAssetRegistration = EntityQuery.use(delegator).from('FixedAssetRegistration')
+        GenericValue fixedAssetRegistration = from('FixedAssetRegistration')
                 .where('fixedAssetId', 'DEMO_VEHICLE_01', 'fromDate', fromDate)
                 .filterByDate().queryOne();
         assert fixedAssetRegistration == null
@@ -75,7 +74,7 @@ class FixedAssetTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('deleteFixedAssetRegistration', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue fixedAssetRegistration = EntityQuery.use(delegator).from('FixedAssetRegistration')
+        GenericValue fixedAssetRegistration = from('FixedAssetRegistration')
                 .where('fixedAssetId', 'DEMO_VEHICLE_01', 'fromDate', fromDate)
                 .queryOne();
         assert fixedAssetRegistration == null
@@ -91,7 +90,7 @@ class FixedAssetTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createFixedAssetMeter', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue fixedAssetMeter = EntityQuery.use(delegator).from('FixedAssetMeter')
+        GenericValue fixedAssetMeter = from('FixedAssetMeter')
                 .where('fixedAssetId', 'DEMO_VEHICLE_01', 'productMeterTypeId', 'ODOMETER')
                 .queryFirst();
         assert fixedAssetMeter
@@ -108,7 +107,7 @@ class FixedAssetTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('updateFixedAssetMeter', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue fixedAssetMeter = EntityQuery.use(delegator).from('FixedAssetMeter')
+        GenericValue fixedAssetMeter = from('FixedAssetMeter')
                 .where('fixedAssetId', 'DEMO_VEHICLE_01', 'productMeterTypeId', 'ODOMETER', 'readingDate', readingDate)
                 .queryOne();
         assert fixedAssetMeter
@@ -124,7 +123,7 @@ class FixedAssetTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('deleteFixedAssetMeter', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue fixedAssetMeter = EntityQuery.use(delegator).from('FixedAssetMeter')
+        GenericValue fixedAssetMeter = from('FixedAssetMeter')
                 .where('fixedAssetId', 'DEMO_VEHICLE_01', 'productMeterTypeId', 'ODOMETER', 'readingDate', readingDate)
                 .queryOne();
         assert fixedAssetMeter == null
@@ -138,7 +137,7 @@ class FixedAssetTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createFixedAssetGeoPoint', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue fixedAssetGeoPoint = EntityQuery.use(delegator).from('FixedAssetGeoPoint')
+        GenericValue fixedAssetGeoPoint = from('FixedAssetGeoPoint')
                 .where('fixedAssetId', 'DEMO_VEHICLE_01', 'geoPointId', '9000')
                 .filterByDate().queryFirst();
         assert fixedAssetGeoPoint

--- a/applications/accounting/src/main/java/org/apache/ofbiz/accounting/test/FinAccountTests.java
+++ b/applications/accounting/src/main/java/org/apache/ofbiz/accounting/test/FinAccountTests.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.ofbiz.entity.GenericValue;
-import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.service.ServiceUtil;
 import org.apache.ofbiz.service.testtools.OFBizTestCase;
 

--- a/applications/content/src/main/groovy/org/apache/ofbiz/content/ContentTests.groovy
+++ b/applications/content/src/main/groovy/org/apache/ofbiz/content/ContentTests.groovy
@@ -18,9 +18,6 @@
  *******************************************************************************/
 package org.apache.ofbiz.content
 
-import org.apache.ofbiz.base.util.UtilDateTime
-import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 

--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/OrderRequirementTests.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/OrderRequirementTests.groovy
@@ -18,7 +18,6 @@
  */
 package org.apache.ofbiz.order
 
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 

--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/OrderReturnTests.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/OrderReturnTests.groovy
@@ -18,7 +18,6 @@
  */
 package org.apache.ofbiz.order
 
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 

--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/QuoteTests.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/QuoteTests.groovy
@@ -25,7 +25,6 @@ import static org.apache.ofbiz.entity.condition.EntityCondition.makeCondition
 import java.sql.Timestamp
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.order.shoppingcart.ShoppingCart
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
@@ -50,8 +49,8 @@ class QuoteTests extends OFBizTestCase {
         assert serviceResult.workEffortId == input.workEffortId
 
         // Confirm the database changes.
-        GenericValue quoteWorkEffort = EntityQuery.use(delegator)
-                .from('QuoteWorkEffort').where(quoteId: quoteId, workEffortId: workEffortId).queryOne()
+        GenericValue quoteWorkEffort = from('QuoteWorkEffort')
+                .where(quoteId: quoteId, workEffortId: workEffortId).queryOne()
         assert quoteWorkEffort
     }
 
@@ -79,8 +78,7 @@ class QuoteTests extends OFBizTestCase {
         assert ServiceUtil.isError(serviceResult)
 
         // Confirm the database changes, in this case nothing should have changed
-        GenericValue quoteWorkEffort = EntityQuery.use(delegator)
-                .from('QuoteWorkEffort').where(
+        GenericValue quoteWorkEffort = from('QuoteWorkEffort').where(
                     makeCondition(quoteId: quoteId, workEffortId: workEffortId),
                     makeCondition('lastUpdatedStamp', GREATER_THAN_EQUAL_TO, startTime)
                 ).queryOne()
@@ -97,7 +95,7 @@ class QuoteTests extends OFBizTestCase {
 
         Map serviceResult = dispatcher.runSync('checkUpdateQuoteStatus', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quote = EntityQuery.use(delegator).from('Quote').where(quoteId: '9001').queryOne()
+        GenericValue quote = from('Quote').where(quoteId: '9001').queryOne()
         assert quote.statusId == 'QUO_ORDERED'
     }
 
@@ -120,8 +118,7 @@ class QuoteTests extends OFBizTestCase {
         assert serviceResult.workEffortId
 
         // Confirm that a matching WorkEffort was created.
-        GenericValue workEfforts = EntityQuery.use(delegator)
-                .from('WorkEffort').where(
+        GenericValue workEfforts = from('WorkEffort').where(
                     workEffortId: serviceResult.workEffortId,
                     currentStatusId: input.currentStatusId,
                     workEffortName: input.workEffortName,
@@ -129,8 +126,7 @@ class QuoteTests extends OFBizTestCase {
                 ).queryOne()
         assert workEfforts
 
-        GenericValue quoteWorkEffort = EntityQuery.use(delegator)
-                .from('WorkEffort').where(
+        GenericValue quoteWorkEffort = from('WorkEffort').where(
                     quoteId: input.quoteId,
                     workEffortId: serviceResult.workEffortId
                 ).queryOne()
@@ -146,7 +142,7 @@ class QuoteTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createQuote', input)
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.quoteId
-        GenericValue quote = EntityQuery.use(delegator).from('Quote').where(quoteId: serviceResult.quoteId).queryOne()
+        GenericValue quote = from('Quote').where(quoteId: serviceResult.quoteId).queryOne()
         assert quote
     }
 
@@ -159,7 +155,7 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('updateQuote', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quote = EntityQuery.use(delegator).from('Quote').where(quoteId: '9000').queryOne()
+        GenericValue quote = from('Quote').where(quoteId: '9000').queryOne()
         assert quote.statusId == 'QUO_APPROVED'
 
         input.statusId = 'QUO_CREATED'
@@ -188,7 +184,7 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('createQuoteItem', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = EntityQuery.use(delegator).from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00004').queryOne()
+        GenericValue quoteItem = from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00004').queryOne()
         assert quoteItem.quoteUnitPrice
     }
 
@@ -203,7 +199,7 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('updateQuoteItem', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = EntityQuery.use(delegator).from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00002').queryOne()
+        GenericValue quoteItem = from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00002').queryOne()
         assert quoteItem.productId == 'GZ-1001'
     }
 
@@ -217,9 +213,9 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('removeQuoteItem', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = EntityQuery.use(delegator).from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00002').queryOne()
+        GenericValue quoteItem = from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00002').queryOne()
         assert !quoteItem
-        GenericValue quoteTerm = EntityQuery.use(delegator).from('QuoteTerm').where(quoteId: '9000', quoteItemSeqId: '00002', termTypeId: 'FIN_PAYMENT_DISC').queryOne()
+        GenericValue quoteTerm = from('QuoteTerm').where(quoteId: '9000', quoteItemSeqId: '00002', termTypeId: 'FIN_PAYMENT_DISC').queryOne()
         assert !quoteTerm
     }
 
@@ -237,7 +233,7 @@ class QuoteTests extends OFBizTestCase {
         ]
 
         Map serviceResult = dispatcher.runSync('createQuoteTerm', input)
-        List<GenericValue> terms = EntityQuery.use(delegator).from('QuoteTerm')
+        List<GenericValue> terms = from('QuoteTerm')
                 .where(termTypeId: 'FIN_PAYMENT_DISC', quoteId: '9000', quoteItemSeqId: '00001').queryList()
 
         assert ServiceUtil.isSuccess(serviceResult)
@@ -266,8 +262,7 @@ class QuoteTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
 
         // Confirm that a matching Quoteterm was updated
-        GenericValue quoteTerm = EntityQuery.use(delegator)
-                .from('QuoteTerm').where(
+        GenericValue quoteTerm = from('QuoteTerm').where(
                     termTypeId: input.termTypeId,
                     quoteId: input.quoteId,
                     quoteItemSeqId: input.quoteItemSeqId
@@ -293,7 +288,7 @@ class QuoteTests extends OFBizTestCase {
 
         Map serviceResult = dispatcher.runSync('deleteQuoteTerm', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteTerm = EntityQuery.use(delegator).from('QuoteTerm').where(termTypeId: serviceResult.termTypeId, quoteId: serviceResult.quoteId, quoteItemSeqId: serviceResult.quoteItemSeqId).queryOne()
+        GenericValue quoteTerm = from('QuoteTerm').where(termTypeId: serviceResult.termTypeId, quoteId: serviceResult.quoteId, quoteItemSeqId: serviceResult.quoteItemSeqId).queryOne()
         assert !quoteTerm
     }
 
@@ -335,8 +330,7 @@ class QuoteTests extends OFBizTestCase {
 
     // Test Quote Sequence Enforced
     void testQuoteSequenceEnforced() {
-        GenericValue partyAcctgPreference = EntityQuery.use(delegator)
-                .from('PartyAcctgPreference').where('partyId', 'DemoCustomer').queryOne()
+        GenericValue partyAcctgPreference = from('PartyAcctgPreference').where('partyId', 'DemoCustomer').queryOne()
         Long lastQuoteNumber = partyAcctgPreference.lastQuoteNumber
         if (!lastQuoteNumber) {
             lastQuoteNumber = 0
@@ -366,7 +360,7 @@ class QuoteTests extends OFBizTestCase {
 
         Map serviceResult = dispatcher.runSync('copyQuoteItem', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteAdjustment = EntityQuery.use(delegator).from('QuoteAdjustment').where('quoteId', '9001', 'quoteItemSeqId', '00002', 'quoteAdjustmentTypeId', 'SALES_TAX').queryFirst()
+        GenericValue quoteAdjustment = from('QuoteAdjustment').where('quoteId', '9001', 'quoteItemSeqId', '00002', 'quoteAdjustmentTypeId', 'SALES_TAX').queryFirst()
         assert quoteAdjustment
     }
 
@@ -379,7 +373,7 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('createQuoteAndQuoteItemForRequest', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = EntityQuery.use(delegator).from('QuoteItem').where('quoteId', serviceResult.quoteId, 'custRequestItemSeqId', '00001').queryFirst()
+        GenericValue quoteItem = from('QuoteItem').where('quoteId', serviceResult.quoteId, 'custRequestItemSeqId', '00001').queryFirst()
         assert quoteItem
     }
 
@@ -408,9 +402,9 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('createQuoteFromCart', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = EntityQuery.use(delegator).from('QuoteItem').where('quoteId', serviceResult.quoteId, 'productId', productId).queryFirst()
+        GenericValue quoteItem = from('QuoteItem').where('quoteId', serviceResult.quoteId, 'productId', productId).queryFirst()
         assert quoteItem
-        GenericValue quoteAdjustment = EntityQuery.use(delegator).from('QuoteAdjustment').where('quoteId', serviceResult.quoteId).queryFirst()
+        GenericValue quoteAdjustment = from('QuoteAdjustment').where('quoteId', serviceResult.quoteId).queryFirst()
         assert quoteAdjustment
     }
 
@@ -423,9 +417,9 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('createQuoteFromShoppingList', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = EntityQuery.use(delegator).from('QuoteItem').where('quoteId', serviceResult.quoteId, 'productId', 'SV-1001').queryFirst()
+        GenericValue quoteItem = from('QuoteItem').where('quoteId', serviceResult.quoteId, 'productId', 'SV-1001').queryFirst()
         assert quoteItem
-        GenericValue quoteAdjustment = EntityQuery.use(delegator).from('QuoteAdjustment').where('quoteId', serviceResult.quoteId).queryFirst()
+        GenericValue quoteAdjustment = from('QuoteAdjustment').where('quoteId', serviceResult.quoteId).queryFirst()
         assert quoteAdjustment
     }
 
@@ -439,7 +433,7 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('autoUpdateQuotePrice', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = EntityQuery.use(delegator).from('QuoteItem').where('quoteId', '9000', 'quoteItemSeqId', '00001').queryOne()
+        GenericValue quoteItem = from('QuoteItem').where('quoteId', '9000', 'quoteItemSeqId', '00001').queryOne()
         assert quoteItem.quoteUnitPrice == 12
     }
 
@@ -451,17 +445,12 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('createQuoteFromCustRequest', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = EntityQuery.use(delegator).from('QuoteItem').where('quoteId', serviceResult.quoteId, 'custRequestId', '9000').queryFirst()
+        GenericValue quoteItem = from('QuoteItem').where('quoteId', serviceResult.quoteId, 'custRequestId', '9000').queryFirst()
         assert quoteItem
     }
 
     // Test autoCreateQuoteAdjustments
     void testAutoCreateQuoteAdjustments () {
-        GenericValue userLogin = EntityQuery.use(delegator)
-        .from('UserLogin').where(userLoginId: 'system').queryOne()
-        assert userLogin
-        GenericValue quote = EntityQuery.use(delegator)
-        .from('Quote').where(quoteId: '9001').queryOne()
 
         def input = [
             userLogin: userLogin,
@@ -469,7 +458,7 @@ class QuoteTests extends OFBizTestCase {
         ]
         Map serviceResult = dispatcher.runSync('autoCreateQuoteAdjustments', input)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue promoQuoteAdjustment = EntityQuery.use(delegator).from('QuoteAdjustment').where('quoteId', '9001', 'quoteAdjustmentTypeId', 'PROMOTION_ADJUSTMENT').queryFirst()
+        GenericValue promoQuoteAdjustment = from('QuoteAdjustment').where('quoteId', '9001', 'quoteAdjustmentTypeId', 'PROMOTION_ADJUSTMENT').queryFirst()
         assert promoQuoteAdjustment
     }
 

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/ProductFeatureTypeTests.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/ProductFeatureTypeTests.groovy
@@ -19,7 +19,6 @@
 package org.apache.ofbiz.product
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -37,7 +36,7 @@ class ProductFeatureTypeTests extends OFBizTestCase {
         Map result = dispatcher.runSync('createProductFeatureType', serviceCtx)
         assert ServiceUtil.isSuccess(result)
 
-        GenericValue productFeatureType = EntityQuery.use(delegator).from('ProductFeatureType').where('productFeatureTypeId', 'testProdFeat').queryOne()
+        GenericValue productFeatureType = from('ProductFeatureType').where('productFeatureTypeId', 'testProdFeat').queryOne()
         assert productFeatureType.productFeatureTypeId == 'testProdFeat'
     }
 }

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/ProductPromoActionTests.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/ProductPromoActionTests.groovy
@@ -18,22 +18,14 @@
  */
 package org.apache.ofbiz.product
 
-import org.apache.ofbiz.base.util.Debug
 import org.apache.ofbiz.base.util.UtilDateTime
-import org.apache.ofbiz.base.util.UtilMisc
-import org.apache.ofbiz.base.util.UtilValidate
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.order.shoppingcart.CheckOutHelper
 import org.apache.ofbiz.order.shoppingcart.ShoppingCart
 import org.apache.ofbiz.order.shoppingcart.ShoppingCartItem
 import org.apache.ofbiz.service.testtools.OFBizTestCase
-import org.apache.ofbiz.order.shoppingcart.product.ProductPromoWorker
 import org.apache.ofbiz.order.shoppingcart.product.ProductPromoWorker.ActionResultInfo
 import org.apache.ofbiz.service.ServiceUtil
-
-import java.sql.Timestamp
-import java.util.Map
 
 class ProductPromoActionTests extends OFBizTestCase {
     public ProductPromoActionTests(String name) {
@@ -136,7 +128,7 @@ class ProductPromoActionTests extends OFBizTestCase {
         ShoppingCart cart = loadOrder("DEMO10091")
 
         Map<String, Object> serviceContext = prepareConditionMap(cart, 10, false)
-        GenericValue productPromoAction = EntityQuery.use(delegator).from("ProductPromoAction").where("productPromoId", "9013", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
+        GenericValue productPromoAction = from("ProductPromoAction").where("productPromoId", "9013", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
         serviceContext.productPromoAction = productPromoAction
         Map<String, Object> serviceResult = dispatcher.runSync("productPromoActProdSpecialPrice", serviceContext)
 
@@ -168,7 +160,7 @@ class ProductPromoActionTests extends OFBizTestCase {
         ShoppingCart cart = loadOrder("DEMO10090")
 
         Map<String, Object> serviceContext = prepareConditionMap(cart, 10, false)
-        GenericValue productPromoAction = EntityQuery.use(delegator).from("ProductPromoAction").where("productPromoId", "9012", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
+        GenericValue productPromoAction = from("ProductPromoAction").where("productPromoId", "9012", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
         serviceContext.productPromoAction = productPromoAction
         Map<String, Object> serviceResult = dispatcher.runSync("productPromoActOrderAmount", serviceContext)
 
@@ -189,7 +181,7 @@ class ProductPromoActionTests extends OFBizTestCase {
         ShoppingCart cart = loadOrder("DEMO10090")
 
         Map<String, Object> serviceContext = prepareConditionMap(cart, 10, false)
-        GenericValue productPromoAction = EntityQuery.use(delegator).from("ProductPromoAction").where("productPromoId", "9019", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
+        GenericValue productPromoAction = from("ProductPromoAction").where("productPromoId", "9019", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
         serviceContext.productPromoAction = productPromoAction
         Map<String, Object> serviceResult = dispatcher.runSync("productPromoActOrderPercent", serviceContext)
 
@@ -202,7 +194,7 @@ class ProductPromoActionTests extends OFBizTestCase {
         cart.clearAllAdjustments()
         for (ShoppingCartItem item : cart.items()) {
             if (!item.getIsPromo()) {
-                GenericValue product = EntityQuery.use(delegator).from("Product").where("productId", item.getProductId()).queryOne()
+                GenericValue product = from("Product").where("productId", item.getProductId()).queryOne()
                 if (product != null) {
                     product.put("includeInPromotions", "N")
                     item._product = product
@@ -229,7 +221,7 @@ class ProductPromoActionTests extends OFBizTestCase {
         ShoppingCart cart = loadOrder("DEMO10090")
 
         Map<String, Object> serviceContext = prepareConditionMap(cart, 10, false)
-        GenericValue productPromoAction = EntityQuery.use(delegator).from("ProductPromoAction").where("productPromoId", "9015", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
+        GenericValue productPromoAction = from("ProductPromoAction").where("productPromoId", "9015", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
         serviceContext.productPromoAction = productPromoAction
         Map<String, Object> serviceResult = dispatcher.runSync("productPromoActProdPrice", serviceContext)
 
@@ -264,7 +256,7 @@ class ProductPromoActionTests extends OFBizTestCase {
         ShoppingCart cart = loadOrder("DEMO10090")
 
         Map<String, Object> serviceContext = prepareConditionMap(cart, 10, false)
-        GenericValue productPromoAction = EntityQuery.use(delegator).from("ProductPromoAction").where("productPromoId", "9015", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
+        GenericValue productPromoAction = from("ProductPromoAction").where("productPromoId", "9015", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
         serviceContext.productPromoAction = productPromoAction
         Map<String, Object> serviceResult = dispatcher.runSync("productPromoActProdAMDISC", serviceContext)
 
@@ -292,7 +284,7 @@ class ProductPromoActionTests extends OFBizTestCase {
         ShoppingCart cart = loadOrder("DEMO10090")
 
         Map<String, Object> serviceContext = prepareConditionMap(cart, 10, false)
-        GenericValue productPromoAction = EntityQuery.use(delegator).from("ProductPromoAction").where("productPromoId", "9015", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
+        GenericValue productPromoAction = from("ProductPromoAction").where("productPromoId", "9015", "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
         serviceContext.productPromoAction = productPromoAction
         Map<String, Object> serviceResult = dispatcher.runSync("productPromoActProdDISC", serviceContext)
 
@@ -329,7 +321,7 @@ class ProductPromoActionTests extends OFBizTestCase {
 
         serviceContext.shoppingCart = cart
         serviceContext.actionResultInfo = new ActionResultInfo()
-        GenericValue productPromoAction = EntityQuery.use(delegator).from("ProductPromoAction").where("productPromoId", "9017",  "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
+        GenericValue productPromoAction = from("ProductPromoAction").where("productPromoId", "9017",  "productPromoRuleId", "01", "productPromoActionSeqId", "01").queryOne()
         serviceContext.productPromoAction = productPromoAction
         serviceResult = dispatcher.runSync("productPromoActGiftGWP", serviceContext)
 

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/ProductPromoCondTests.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/ProductPromoCondTests.groovy
@@ -20,9 +20,7 @@ package org.apache.ofbiz.product
 
 import java.sql.Timestamp
 import org.apache.ofbiz.base.util.UtilDateTime
-import org.apache.ofbiz.base.util.UtilMisc
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.order.shoppingcart.ShoppingCart
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 import org.apache.ofbiz.service.ServiceUtil
@@ -220,7 +218,7 @@ class ProductPromoCondTests extends OFBizTestCase {
     void testCondGeoIdPromo() {
         ShoppingCart cart = loadOrder("DEMO10090")
         cart.setShippingContactMechId(0, "9200")
-        GenericValue productPromoCond = EntityQuery.use(delegator).from("ProductPromoCond").where("productPromoId", "9022", "productPromoRuleId", "01", "productPromoCondSeqId", "01").queryOne()
+        GenericValue productPromoCond = from("ProductPromoCond").where("productPromoId", "9022", "productPromoRuleId", "01", "productPromoCondSeqId", "01").queryOne()
 
         // call service promo
         Map<String, Object> serviceContext = [shoppingCart: cart, nowTimestamp: UtilDateTime.nowTimestamp(), productPromoCond: productPromoCond]

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/ProductTests.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/ProductTests.groovy
@@ -18,9 +18,7 @@
  *******************************************************************************/
 package org.apache.ofbiz.product
 
-import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.service.testtools.OFBizTestCase
 
@@ -39,7 +37,7 @@ class ProductTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('updateProductCategory', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue prodCategory = EntityQuery.use(delegator).from('ProductCategory').where('productCategoryId', 'CATALOG1_BEST_SELL').queryOne()
+        GenericValue prodCategory = from('ProductCategory').where('productCategoryId', 'CATALOG1_BEST_SELL').queryOne()
         if (prodCategory) { // fails in framework integration tests only, data is in ecommerce
             assert prodCategory.categoryName == 'Updated Test Product Category'
             assert prodCategory.productCategoryTypeId == 'BEST_SELL_CATEGORY'


### PR DESCRIPTION
Improved: Use OFBizTestCase's from method utility instead of using EntityQuery in each test case

(OFBIZ-11666)

Also, removed some unused imports from the test case files.