### PR TITLE
Improved: Have PartyRole widgets work with life-span fields (OFBIZ-5965)

### DIFF
--- a/applications/datamodel/entitydef/party-entitymodel.xml
+++ b/applications/datamodel/entitydef/party-entitymodel.xml
@@ -2876,7 +2876,9 @@ under the License.
             title="Party Role View">
       <member-entity entity-alias="PR" entity-name="PartyRole"/>
       <member-entity entity-alias="RT" entity-name="RoleType"/>
-      <alias entity-alias="PR" name="partyId"/>
+      <alias-all entity-alias="PR">
+        <exclude field="roleTypeId"/>
+      </alias-all>
       <alias entity-alias="RT" name="roleTypeId"/>
       <alias entity-alias="RT" name="parentTypeId"/>
       <alias entity-alias="RT" name="description"/>

--- a/applications/party/servicedef/services.xml
+++ b/applications/party/servicedef/services.xml
@@ -321,12 +321,20 @@ under the License.
             permission to change the role of this partyId</description>
         <permission-service service-name="partyRolePermissionCheck" main-action="CREATE"/>
         <auto-attributes include="pk" mode="IN" optional="false"/>
+        <auto-attributes include="nonpk" mode="IN" optional="true"/>
     </service>
     <service name="deletePartyRole" default-entity-name="PartyRole" engine="entity-auto" invoke="delete" auth="true">
         <description>Delete a Party Role (remove a Role from a Party). The logged in user must have PARTYMGR_DELETE or have
             permission to change the role of this partyId</description>
         <permission-service service-name="partyRolePermissionCheck" main-action="DELETE"/>
         <auto-attributes include="pk" mode="IN" optional="false"/>
+    </service>
+    <service name="updatePartyRole" default-entity-name="PartyRole" engine="entity-auto" invoke="update" auth="true">
+        <description>Update a Party Role. The logged in user must have PARTYMGR_UPDATE or have
+            permission to change the role of partyId</description>
+        <permission-service service-name="partyRolePermissionCheck" main-action="UPDATE"/>
+        <auto-attributes include="pk" mode="IN" optional="false"/>
+        <auto-attributes include="nonpk" mode="IN" optional="false"/>
     </service>
     <service name="ensurePartyRole" engine="simple"
             location="component://party/minilang/party/PartySimpleMethods.xml" invoke="ensureNaPartyRole" auth="false">

--- a/applications/party/webapp/partymgr/WEB-INF/controller.xml
+++ b/applications/party/webapp/partymgr/WEB-INF/controller.xml
@@ -592,11 +592,24 @@ under the License.
         <response name="success" type="view" value="viewroles"/>
         <response name="error" type="view" value="viewroles"/>
     </request-map>
-    <request-map uri="deleterole">
+    <request-map uri="addPartyRole">
         <security https="true" auth="true"/>
-        <event type="service" path="" invoke="deletePartyRole"/>
+        <response name="success" type="view" value="addPartyRole"/>
+    </request-map>
+    <request-map uri="createPartyRole">
+        <security https="true" auth="true"/>
+        <event type="service" path="" invoke="createPartyRole"/>
         <response name="success" type="view" value="viewroles"/>
         <response name="error" type="view" value="viewroles"/>
+    </request-map>
+    <request-map uri="expirePartyRole">
+        <security https="true" auth="true"/>
+        <response name="success" type="view" value="expirePartyRole"/>
+    </request-map>
+    <request-map uri="updatePartyRole">
+        <security https="true" auth="true"/>
+        <event type="service" invoke="updatePartyRole"/>
+        <response name="success" type="view" value="viewroles"/>
     </request-map>
     <request-map uri="createroletype">
         <security https="true" auth="true"/>
@@ -1409,6 +1422,8 @@ under the License.
 
     <view-map name="viewprofile" type="screen" page="component://party/widget/partymgr/PartyScreens.xml#viewprofile"/>
     <view-map name="partyContentList" type="screen" page="component://party/widget/partymgr/ProfileScreens.xml#ContentList"/>
+    <view-map name="addPartyRole" type="screen" page="component://party/widget/partymgr/PartyScreens.xml#AddPartyRole"/>
+    <view-map name="expirePartyRole" type="screen" page="component://party/widget/partymgr/PartyScreens.xml#ExpirePartyRole"/>
     <view-map name="viewroles" type="screen" page="component://party/widget/partymgr/PartyScreens.xml#viewroles"/>
     <view-map name="addsecondaryroles" type="screen" page="component://party/widget/partymgr/PartyScreens.xml#AddPartySecondaryRoles"/>
     <view-map name="viewidentifications" type="screen" page="component://party/widget/partymgr/PartyScreens.xml#ListPartyIdentifications"/>

--- a/applications/party/widget/partymgr/PartyForms.xml
+++ b/applications/party/widget/partymgr/PartyForms.xml
@@ -1183,27 +1183,42 @@ under the License.
     <grid name="ViewPartyRoles" list-name="partyRoles" target="viewroles"
         default-title-style="tableheadtext"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
-        <field name="roleTypeId" title="${uiLabelMap.PartyRoleTypeId}"><display/></field>
-        <field name="description" title="${uiLabelMap.PartyRole}"><display/></field>
-        <field name="parentTypeId"><display-entity entity-name="RoleType" key-field-name="roleTypeId"/></field>
-        <field name="remove">
-            <hyperlink description="${uiLabelMap.CommonRemove}" target="deleterole">
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}"><display/></field>
+        <field name="description" title="${uiLabelMap.CommonDescription}"><display/></field>
+        <field name="parentTypeId" title="${uiLabelMap.CommonParent} roleTypeId">
+            <display-entity entity-name="RoleType" key-field-name="roleTypeId" description="${parentTypeId}"/>
+        </field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><display type="date-time"/></field>
+        <field name="expireLink" title=" ">
+            <hyperlink description="${uiLabelMap.CommonExpire}" target="expirePartyRole">
                 <parameter param-name="partyId"/>
                 <parameter param-name="roleTypeId"/>
+                <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
     </grid>
-    
-    <form name="AddPartyRole" type="single" title="Add a role to party" target="addrole">
+    <form name="AddPartyRole" type="single" title="Add a role to party" target="createPartyRole">
         <field name="partyId"><hidden value="${parameters.partyId}"/></field>
-        <field name="roleTypeId">
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}">
             <drop-down allow-empty="false">
                 <entity-options entity-name="RoleType">
                     <entity-order-by field-name="description"/>
                 </entity-options>
             </drop-down>
         </field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><date-time/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><date-time/></field>
         <field name="add" title="${uiLabelMap.CommonAdd}"><submit/></field>
+    </form>
+    <form name="ExpirePartyRole" type="single" title="Expire a role assignment" target="updatePartyRole">
+        <field name="partyId"><hidden value="${parameters.partyId}"/></field>
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}">
+            <display-entity entity-name="RoleType"/>
+        </field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}" required-field="true"><date-time/></field>
+        <field name="expire" title="${uiLabelMap.CommonSubmit}"><submit/></field>
     </form>
     <form name="AddPartyMainRole" type="single" title="${uiLabelMap.PartyAddToMainRole}" target="addrole">
         <field name="partyId"><hidden value="${parameters.partyId}"/></field>

--- a/applications/party/widget/partymgr/PartyMenus.xml
+++ b/applications/party/widget/partymgr/PartyMenus.xml
@@ -145,6 +145,14 @@
         </menu-item>
     </menu>
     <menu name="ProfileSubTabBar" menu-container-style="button-bar button-style-2">
+        <menu-item name="NewPartyRole" title="${uiLabelMap.CommonAdd} ${uiLabelMap.CommonRole}" >
+            <condition>
+                <if-has-permission permission="PARTYMGR" action="UPDATE"/>
+            </condition>
+            <link target="addPartyRole">
+                <parameter param-name="partyId"/>
+            </link>
+        </menu-item>
         <menu-item name="createNew" title="${uiLabelMap.AccountingBillingAccount}" >
             <condition>
                 <if-service-permission service-name="acctgBasePermissionCheck" main-action="VIEW"/>

--- a/applications/party/widget/partymgr/PartyScreens.xml
+++ b/applications/party/widget/partymgr/PartyScreens.xml
@@ -177,38 +177,54 @@ under the License.
                         <screenlet title="${uiLabelMap.PartyMemberRoles}" navigation-form-name="ViewPartyRoles">
                             <include-grid name="ViewPartyRoles" location="component://party/widget/partymgr/PartyForms.xml"/>
                         </screenlet>
-                        <section>
-                            <condition>
-                                <if-has-permission permission="PARTYMGR" action="_UPDATE"/>
-                            </condition>
-                            <widgets>
-                                <screenlet title="${uiLabelMap.PartyAddToRole}">
-                                    <container>
-                                        <label style="h2">${uiLabelMap.PartyAddToMainRole}</label>
-                                        <include-form name="AddPartyMainRole" location="component://party/widget/partymgr/PartyForms.xml"/>
-                                        <container id="addPartySecondaryRole"/>
-                                    </container>
-                                    <label style="h2">${uiLabelMap.PartyAddToRoleViewAll}</label>
-                                    <include-form name="AddPartyRole" location="component://party/widget/partymgr/PartyForms.xml"/>
-                                </screenlet>
-                            </widgets>
-                        </section>
-                        <section>
-                            <condition>
-                                <if-has-permission permission="PARTYMGR" action="_CREATE"/>
-                            </condition>
-                            <actions>
-                                <entity-condition entity-name="RoleType" list="parentRoleList">
-                                    <condition-expr field-name="parentTypeId" operator="equals" from-field="nullField"/>
-                                    <order-by field-name="description"/>
-                                </entity-condition>
-                            </actions>
-                            <widgets>
-                                <screenlet title="${uiLabelMap.PartyNewRoleType}">
-                                    <include-form name="AddRoleType" location="component://party/widget/partymgr/PartyForms.xml"/>
-                                </screenlet>
-                            </widgets>
-                        </section>
+                    </decorator-section>
+                </decorator-screen>
+            </widgets>
+        </section>
+    </screen>
+    <screen name="AddPartyRole">
+        <section>
+            <actions>
+                <set field="titleProperty" value="PageTitleViewPartyRole"/>
+                <set field="headerItem" value="find"/>
+                <set field="tabButtonItem" value="viewroles"/>
+                <set field="labelTitleProperty" value="PartyMemberRoles"/>
+                <set field="fromDate" value="${nowTimestamp}"/>
+                <entity-condition entity-name="RoleTypeAndParty" list="partyRoles">
+                    <condition-list combine="and">
+                        <condition-expr field-name="partyId" operator="equals" value="${parameters.partyId}"/>
+                        <condition-expr field-name="roleTypeId" operator="not-equals" value="_NA_"/>
+                    </condition-list>
+                </entity-condition>
+            </actions>
+            <widgets>
+                <decorator-screen name="CommonPartyDecorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="body">
+                        <include-form location="component://party/widget/partymgr/PartyForms.xml" name="AddPartyRole"/>
+                    </decorator-section>
+                </decorator-screen>
+            </widgets>
+        </section>
+    </screen>
+    <screen name="ExpirePartyRole">
+        <section>
+            <actions>
+                <set field="titleProperty" value="PageTitleViewPartyRole"/>
+                <set field="headerItem" value="find"/>
+                <set field="tabButtonItem" value="viewroles"/>
+                <set field="labelTitleProperty" value="PartyMemberRoles"/>
+                <set field="thruDate" value="${nowTimestamp}"/>
+                <entity-condition entity-name="RoleTypeAndParty" list="partyRoles">
+                    <condition-list combine="and">
+                        <condition-expr field-name="partyId" operator="equals" value="${parameters.partyId}"/>
+                        <condition-expr field-name="roleTypeId" operator="not-equals" value="_NA_"/>
+                    </condition-list>
+                </entity-condition>
+            </actions>
+            <widgets>
+                <decorator-screen name="CommonPartyDecorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="body">
+                        <include-form location="component://party/widget/partymgr/PartyForms.xml" name="ExpirePartyRole"/>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
(OFBIZ-5965)

added: Screen and form widget to add a PartyRole to a party with life-span fields
added: Screen and form widget to expire a PartyRole record
added: request and view map to add and update PartyRole records
added: menu-item to ProfileSubTab bar for adding a new PartyRole record
added: service to update a PartyRole record
improved: service to create a PartyRole record given addition of life-span fields to entity