### PR TITLE
Improved: order component - Have a Main Action Menu (OFBIZ-11772)

### DIFF
--- a/applications/order/widget/ordermgr/AllocationPlanScreens.xml
+++ b/applications/order/widget/ordermgr/AllocationPlanScreens.xml
@@ -24,6 +24,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for ALLOCPLAN, _VIEW permission -->

--- a/applications/order/widget/ordermgr/CommonScreens.xml
+++ b/applications/order/widget/ordermgr/CommonScreens.xml
@@ -63,17 +63,9 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <section>
-                            <condition>
-                                <not><if-empty field="custRequest"/></not>
-                            </condition>
-                            <widgets>
-                                <include-menu name="RequestTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
-                            </widgets>
-                        </section>
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">
-                        <include-menu name="RequestSubTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
                         <container>
                             <section>
                                 <condition>
@@ -81,6 +73,8 @@ under the License.
                                 </condition>
                                 <widgets>
                                     <label style="h1">${custRequest.custRequestName} [${uiLabelMap.CommonId}:${custRequest.custRequestId}] </label>
+                                    <include-menu name="RequestTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                                    <include-menu name="RequestSubTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
                                 </widgets>
                             </section>
                         </container>

--- a/applications/order/widget/ordermgr/CustRequestScreens.xml
+++ b/applications/order/widget/ordermgr/CustRequestScreens.xml
@@ -47,13 +47,11 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                            <decorator-section name="menu-bar">
-                                <container style="button-bar">
-                                    <link target="request" text="${uiLabelMap.OrderNewRequest}" style="buttontext create"/>
-                                </container>
-                            </decorator-section>
                             <decorator-section name="search-options">
                                 <platform-specific><html><html-template multi-block="true" location="component://common-theme/template/includes/SetMultipleSelectJsList.ftl"/></html></platform-specific>
                                 <include-form name="FindRequests" location="component://order/widget/ordermgr/CustRequestForms.xml"/>

--- a/applications/order/widget/ordermgr/OrderEntryCommonScreens.xml
+++ b/applications/order/widget/ordermgr/OrderEntryCommonScreens.xml
@@ -26,6 +26,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar"/>
                     </decorator-section>

--- a/applications/order/widget/ordermgr/OrderMenus.xml
+++ b/applications/order/widget/ordermgr/OrderMenus.xml
@@ -28,7 +28,6 @@ under the License.
             </condition>
             <link target="FindRequest"/>
         </menu-item>
-
         <menu-item name="quote" title="${uiLabelMap.OrderOrderQuotes}">
             <condition>
                 <or>
@@ -38,21 +37,18 @@ under the License.
             </condition>
             <link target="FindQuote"/>
         </menu-item>
-
         <menu-item name="orderlist" title="${uiLabelMap.OrderOrderList}">
             <condition>
                 <if-has-permission permission="ORDERMGR" action="_VIEW"/>
             </condition>
             <link target="orderlist"/>
         </menu-item>
-
         <menu-item name="findorders" title="${uiLabelMap.OrderFindOrder}">
             <condition>
                 <if-has-permission permission="ORDERMGR" action="_VIEW"/>
             </condition>
             <link target="findorders"/>
         </menu-item>
-
         <menu-item name="orderentry" title="${uiLabelMap.OrderOrderEntry}">
             <condition>
                 <or>
@@ -62,14 +58,12 @@ under the License.
             </condition>
             <link target="orderentry" link-type="anchor"/>
         </menu-item>
-
         <menu-item name="return" title="${uiLabelMap.OrderOrderReturns}">
             <condition>
                 <if-has-permission permission="ORDERMGR" action="_RETURN"/>
             </condition>
             <link target="findreturn"/>
         </menu-item>
-
         <menu-item name="requirement" title="${uiLabelMap.OrderRequirements}">
             <condition>
                 <or>
@@ -79,17 +73,66 @@ under the License.
             </condition>
             <link target="FindRequirements"/>
         </menu-item>
-
         <menu-item name="reports" title="${uiLabelMap.CommonReports}">
             <link target="OrderPurchaseReportOptions"/>
         </menu-item>
-
         <menu-item name="stats" title="${uiLabelMap.CommonStats}">
             <link target="orderstats"/>
         </menu-item>
-
         <menu-item name="allocationPlan" title="${uiLabelMap.OrderAllocationPlan}">
             <link target="FindAllocationPlan"/>
+        </menu-item>
+    </menu>
+
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="NewOrder" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonOrder}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                    <if-has-permission permission="ORDERMGR" action="_PURCHASE_CREATE"/>
+                </or>
+            </condition>
+            <link target="orderentry" link-type="anchor"/>
+        </menu-item>
+        <menu-item name="NewQuote" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonQuote}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditQuote"/>
+        </menu-item>
+        <menu-item name="NewRequest" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonRequest}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="request"/>
+        </menu-item>
+        <menu-item name="NewRequirement" title="${uiLabelMap.CommonNew} ${uiLabelMap.OrderRequirement}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditRequirement"/>
+        </menu-item>
+        <menu-item name="NewReturn" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonReturn}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="returnMain"/>
+        </menu-item>
+        <menu-item name="NewAllocationPlan" title="${uiLabelMap.CommonNew} ${uiLabelMap.OrderAllocationPlan}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="CreateAllocationPlan"/>
         </menu-item>
     </menu>
 
@@ -321,9 +364,6 @@ under the License.
 
     <menu name="RequestSubTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml"
         menu-container-style="button-bar button-style-2">
-        <menu-item name="newRequest" title="${uiLabelMap.OrderNewRequest}">
-            <link target="EditRequest"/>
-        </menu-item>
         <menu-item name="createQuoteFromRequest" title="${uiLabelMap.OrderCreateQuoteFromRequest}">
             <condition>
                 <and>

--- a/applications/order/widget/ordermgr/OrderReturnScreens.xml
+++ b/applications/order/widget/ordermgr/OrderReturnScreens.xml
@@ -22,6 +22,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <widgets>
@@ -49,11 +52,11 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleFindReturn}">
-                            <container style="basic-nav">
-                                <link style="buttontext" target="returnMain" text="${uiLabelMap.OrderCreateNewReturn}"/>
-                            </container>
                             <include-form name="FindReturns" location="component://order/widget/ordermgr/ReturnForms.xml"/>
                             <include-form name="ListReturns" location="component://order/widget/ordermgr/ReturnForms.xml"/>
                         </screenlet>

--- a/applications/order/widget/ordermgr/OrderViewScreens.xml
+++ b/applications/order/widget/ordermgr/OrderViewScreens.xml
@@ -22,6 +22,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <widgets>
@@ -43,6 +46,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <include-portal-page id="OrderPortalPage"/>
                     </decorator-section>

--- a/applications/order/widget/ordermgr/QuoteScreens.xml
+++ b/applications/order/widget/ordermgr/QuoteScreens.xml
@@ -27,6 +27,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for ORDERMGR, _VIEW permission -->
@@ -45,9 +48,6 @@ under the License.
                                         </container>
                                     </widgets>
                                 </section>
-                                <container>
-                                  <link target="EditQuote" text="${uiLabelMap.OrderCreateOrderQuote}" style="buttontext"/>
-                                </container>
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>
@@ -72,11 +72,11 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.OrderOrderQuotes}">
-                            <container>
-                                <link target="EditQuote" text="${uiLabelMap.OrderCreateOrderQuote}" style="buttontext"/>
-                            </container>
                             <include-form name="FindQuotes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                             <include-form name="ListQuotes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>

--- a/applications/order/widget/ordermgr/QuoteWorkEffortScreens.xml
+++ b/applications/order/widget/ordermgr/QuoteWorkEffortScreens.xml
@@ -28,6 +28,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for ORDERMGR, _VIEW permission -->

--- a/applications/order/widget/ordermgr/ReportScreens.xml
+++ b/applications/order/widget/ordermgr/ReportScreens.xml
@@ -29,6 +29,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <label style="h3">${uiLabelMap.BirtOrderReportsWarning}</label>
                         <include-portal-page id="OrderReportPage"/>

--- a/applications/order/widget/ordermgr/RequirementScreens.xml
+++ b/applications/order/widget/ordermgr/RequirementScreens.xml
@@ -24,6 +24,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for ORDERMGR, _VIEW permission -->
@@ -40,9 +43,7 @@ under the License.
                                 <container>
                                     <label style="h1">${uiLabelMap.OrderRequirement} [${requirementId}]</label>
                                 </container>
-
                                 <decorator-section-include name="body"/>
-
                             </widgets>
                             <fail-widgets>
                                 <label style="h3">${uiLabelMap.OrderViewPermissionError}</label>
@@ -57,6 +58,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for ORDERMGR, _VIEW permission -->
@@ -64,9 +68,6 @@ under the License.
                                 <if-has-permission permission="ORDERMGR" action="_VIEW"/>
                             </condition>
                             <widgets>
-                                <container style="button-bar">
-                                    <link target="EditRequirement" text="${uiLabelMap.OrderNewRequirement}" style="buttontext"/>
-                                </container>
                                 <include-menu name="RequirementsTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
                                 <decorator-section-include name="body"/>
                             </widgets>


### PR DESCRIPTION
Improved OrderMenus.xml
added: MainActionMenu for the order component, having:
- menu-item to start the order creation
- menu-item to start the quote creation
- menu-item to start the request creation
- menu-item to start the requirement creation
- menu-item to start the return creation
- menu-item to start the allocation plan creation
removed: menu-item to create a request from RequestSubTabBar

AllocationPlanScreens.xml
added: decorator-section for pre-body to include the MainActionMenu

CommonScreens.xml
improved: grouping regarding customer requests

CustRequestScreens.xml
added: decorator-section for pre-body to include the MainActionMenu
removed 'menu-bar' decorator section

OrderEntryCommonScreens.xml
added: decorator-section for pre-body to include the MainActionMenu

OrderReturnScreens.xml
added: decorator-section for pre-body to include the MainActionMenu
removed: 'basic-nav' container

OrderViewScreens.xml
added: decorator-section for pre-body to include the MainActionMenu

QuoteScreens.xml
added: decorator-section for pre-body to include the MainActionMenu
removed: container with create quote link

QuoteWorkEffortScreens.xml
added: decorator-section for pre-body to include the MainActionMenu

ReportScreens.xml
added: decorator-section for pre-body to include the MainActionMenu

RequirementScreens.xml
added: decorator-section for pre-body to include the MainActionMenu
removed: container having create link

Improved:
Implemented:
Documented:
Completed:
Reverted:
Fixed:
(OFBIZ-)

Explanation

Thanks:
