### PR TITLE
[Improved]: Overload groovy utility method to handle error logging with only throwable object as parameter. (OFBIZ-11762)

### DIFF
--- a/framework/service/src/main/groovy/org/apache/ofbiz/service/engine/GroovyBaseScript.groovy
+++ b/framework/service/src/main/groovy/org/apache/ofbiz/service/engine/GroovyBaseScript.groovy
@@ -136,6 +136,9 @@ abstract class GroovyBaseScript extends Script {
     def logError(Throwable t, String message) {
         Debug.logError(t, message, getModule())
     }
+    def logError(Throwable t) {
+        Debug.logError(t, null, getModule())
+    }
     def logVerbose(String message) {
         Debug.logVerbose(message, getModule())
     }


### PR DESCRIPTION

(OFBIZ-11762)

This will help us log errors even without passing a custom error message.
Please refer  PR https://github.com/apache/ofbiz-plugins/pull/24

Thanks: Jacques
