### PR TITLE
[Implemented] Introduce the option for specifying Check (Reference) Number on order entry (OFBIZ-7377)

### DIFF
--- a/applications/order/src/main/java/org/apache/ofbiz/order/OrderManagerEvents.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/OrderManagerEvents.java
@@ -245,6 +245,14 @@ public class OrderManagerEvents {
                     }
 
                     try {
+                        if (UtilValidate.isEmpty(paymentReference)) {
+                            // get the old order preference to copy the reference number and set it as paymentRefNumber for the payment
+                            GenericValue currentPref = EntityQuery.use(delegator).from("OrderPaymentPreference").where("orderId", orderId).queryFirst();
+                            if (currentPref != null) {
+                                paymentReference = (String) currentPref.get("manualRefNum");
+                                paymentPreference.set("manualRefNum", paymentReference);
+                            }
+                        }
                         delegator.create(paymentPreference);
                     } catch (GenericEntityException ex) {
                         Debug.logError(ex, "Cannot create a new OrderPaymentPreference", MODULE);

--- a/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/CheckOutEvents.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/CheckOutEvents.java
@@ -317,6 +317,10 @@ public class CheckOutEvents {
                 if (UtilValidate.isNotEmpty(securityCode)) {
                     paymentMethodInfo.put("securityCode", securityCode);
                 }
+                String paymentRefNumber = request.getParameter("paymentRefNumber");
+                if (UtilValidate.isNotEmpty(paymentRefNumber)) {
+                    paymentMethodInfo.put("refNum", paymentRefNumber);
+                }
                 String amountStr = request.getParameter("amount_" + paymentMethod);
                 BigDecimal amount = null;
                 if (UtilValidate.isNotEmpty(amountStr) && !"REMAINING".equals(amountStr)) {

--- a/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/CheckOutHelper.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/CheckOutHelper.java
@@ -334,10 +334,13 @@ public class CheckOutHelper {
                 // get the selected amount to use
                 BigDecimal paymentAmount = null;
                 String securityCode = null;
+                String refNum = null;
+
                 if (selectedPaymentMethods.get(checkOutPaymentId) != null) {
                     Map<String, Object> checkOutPaymentInfo = selectedPaymentMethods.get(checkOutPaymentId);
                     paymentAmount = (BigDecimal) checkOutPaymentInfo.get("amount");
                     securityCode = (String) checkOutPaymentInfo.get("securityCode");
+                    refNum = (String) checkOutPaymentInfo.get("refNum");
                 }
 
                 boolean singleUse = singleUsePayments.contains(checkOutPaymentId);
@@ -347,6 +350,9 @@ public class CheckOutHelper {
                 }
                 if (securityCode != null) {
                     inf.securityCode = securityCode;
+                }
+                if (refNum != null) {
+                    inf.refNum[0] = refNum;
                 }
             }
         } else if (cart.getGrandTotal().compareTo(BigDecimal.ZERO) != 0) {

--- a/applications/order/template/entry/CheckoutOptions.ftl
+++ b/applications/order/template/entry/CheckoutOptions.ftl
@@ -318,6 +318,7 @@ function submitForm(form, mode, value) {
                       <input type="radio" name="checkOutPaymentId" value="EXT_OFFLINE" <#if "EXT_OFFLINE" == checkOutPaymentId>checked="checked"</#if>/>
                       <span>${uiLabelMap.OrderMoneyOrder}</span>
                       </label>
+                      <input type="text" size="15" name="paymentRefNumber" value="${(requestParameters.paymentRefNumber)!}" onFocus="document.checkoutInfoForm.checkOutPaymentId[0].checked=true;"/>
                     </td>
                   </tr>
                   </#if>


### PR DESCRIPTION
Done the following:

- Added a field on the UI to allow the input of the check reference number, focus on the filed will also check the related payment method.
- Added logic to set this reference number on the cartpaymentinfo map for further processing
- Added logic to fetch the reference number from the order preference record and apply it on the payment.

(OFBIZ-7377)
