### PR TITLE
Fixed: New Employment' widget(s) allows party-groups to be selects as the employee. (OFBIZ-11697)

### DIFF
--- a/applications/humanres/webapp/humanres/WEB-INF/controller.xml
+++ b/applications/humanres/webapp/humanres/WEB-INF/controller.xml
@@ -1109,6 +1109,7 @@ under the License.
     
     <!-- ===================Lookup Request===================== -->
     <request-map uri="LookupPartyName"><security auth="true" https="true"/><response name="success" type="view" value="LookupPartyName"/></request-map>
+    <request-map uri="LookupEmployee"><security auth="true" https="true"/><response name="success" type="view" value="LookupEmployee"/></request-map>
     <request-map uri="LookupPayment"><security auth="true" https="true"/><response name="success" type="view" value="LookupPayment"/></request-map>
     <request-map uri="LookupBudget"><security auth="true" https="true"/><response name="success" type="view" value="LookupBudget"/></request-map>
     <request-map uri="LookupBudgetItem"><security auth="true" https="true"/><response name="success" type="view" value="LookupBudgetItem"/></request-map>
@@ -1126,6 +1127,7 @@ under the License.
     <request-map uri="LookupJobRequisition"><security auth="true" https="true"/><response name="success" type="view" value="LookupJobRequisition"/></request-map>
 
     <view-map name="LookupPartyName" type="screen" page="component://party/widget/partymgr/LookupScreens.xml#LookupPartyName"/>
+    <view-map name="LookupEmployee" type="screen" page="component://party/widget/partymgr/LookupScreens.xml#LookupEmployee"/>
     <view-map name="LookupPayment"  type="screen" page="component://accounting/widget/LookupScreens.xml#LookupPayment"/>
     <view-map name="LookupBudget"  type="screen" page="component://humanres/widget/LookupScreens.xml#LookupBudget"/>
     <view-map name="LookupBudgetItem"  type="screen" page="component://humanres/widget/LookupScreens.xml#LookupBudgetItem"/>

--- a/applications/humanres/widget/forms/EmploymentForms.xml
+++ b/applications/humanres/widget/forms/EmploymentForms.xml
@@ -123,7 +123,7 @@
             </drop-down>
         </field>
         <field name="partyIdFrom" use-when="employment!=null" title="${uiLabelMap.HumanResEmploymentPartyIdFrom}"><hidden/></field>
-        <field name="partyIdTo" use-when="employment==null" title="${uiLabelMap.HumanResEmployeePartyIdTo}" required-field="true"><lookup target-form-name="LookupPartyName"/></field>
+        <field name="partyIdTo" use-when="employment==null" title="${uiLabelMap.HumanResEmployeePartyIdTo}" required-field="true"><lookup target-form-name="LookupEmployee"/></field>
         <field name="partyIdTo" use-when="employment!=null" title="${uiLabelMap.HumanResEmployeePartyIdTo}"><hidden/></field>
         <field name="fromDate" use-when="employment==null" title="${uiLabelMap.CommonFromDate}" required-field="true"><date-time default-value="${nowTimestamp}"/></field>
         <field name="fromDate" use-when="employment!=null" title="${uiLabelMap.CommonFromDate}"><display default-value="${nowTimestamp}"/></field>

--- a/applications/party/widget/partymgr/LookupForms.xml
+++ b/applications/party/widget/partymgr/LookupForms.xml
@@ -467,4 +467,30 @@ under the License.
         <field name="lastName"  title="${uiLabelMap.PartyLastName}"><display/></field>
         <field name="groupName" title="${uiLabelMap.PartyGroupName}"><display/></field>
     </form>
+    <form name="LookupEmployee" target="LookupEmployee" type="single"
+        header-row-style="header-row" default-table-style="basic-table">
+        <field name="roleTypeId"><hidden value="EMPLOYEE"/></field>
+        <field name="partyId" title="${uiLabelMap.PartyPartyId}"><text-find/></field>
+        <field name="firstName" title="${uiLabelMap.PartyFirstName}"><text-find/></field>
+        <field name="lastName"  title="${uiLabelMap.PartyLastName}"><text-find/></field>
+        <field name="noConditionFind"><hidden value="Y"/><!-- if this isn't there then with all fields empty no query will be done --></field>
+        <field name="submitButton" title="${uiLabelMap.CommonFind}"><submit button-type="button"/></field>
+    </form>
+    <form name="ListLookupEmployee" type="list" list-name="listIt" paginate-target="LookupEmployee"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <actions>
+            <set field="inputFields" from-field="parameters"/>
+            <set field="orderBy" value="partyId"/>
+            <set field="entityName" value="PartyRoleNameDetail"/>
+            <script location="component://party/groovyScripts/party/FindLookUp.groovy"/>
+        </actions>
+        <field name="partyId" title="${uiLabelMap.PartyPartyId}"  widget-style="smallSubmit">
+            <hyperlink description="${partyId}" target="javascript:set_value('${partyId}')" also-hidden="false" target-type="plain"/>
+        </field>
+        <field name="partyTypeId" title="${uiLabelMap.PartyTypeId}">
+            <display-entity also-hidden="false" entity-name="PartyType"/>
+        </field>
+        <field name="firstName" title="${uiLabelMap.PartyFirstName}"><display/></field>
+        <field name="lastName"  title="${uiLabelMap.PartyLastName}"><display/></field>
+    </form>
 </forms>

--- a/applications/party/widget/partymgr/LookupScreens.xml
+++ b/applications/party/widget/partymgr/LookupScreens.xml
@@ -460,4 +460,32 @@ under the License.
             </widgets>
         </section>
     </screen>
+    <screen name="LookupEmployee">
+        <section>
+            <condition>
+                <if-service-permission service-name="partyBasePermissionCheck" main-action="VIEW"/>
+            </condition>
+            <actions>
+                <property-map resource="PartyUiLabels" map-name="uiLabelMap" global="true"/>
+                <set field="title" from-field="uiLabelMap.PartyLookupPartyByName"/>
+                <set field="queryString" from-field="result.queryString"/>
+                <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer" default-value="0"/>
+                <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
+                <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
+                <set field="entityName" value="PartyRoleNameDetail"/>
+                <set field="searchFields" value="[partyId, firstName, middleName, lastName]"/>
+                <set field="conditionFields.roleTypeId" value="EMPLOYEE" />
+            </actions>
+            <widgets>
+                <decorator-screen name="LookupDecorator" location="component://common/widget/CommonScreens.xml">
+                    <decorator-section name="search-options">
+                        <include-form name="LookupEmployee" location="component://party/widget/partymgr/LookupForms.xml"/>
+                    </decorator-section>
+                    <decorator-section name="search-results">
+                        <include-form name="ListLookupEmployee" location="component://party/widget/partymgr/LookupForms.xml"/>
+                    </decorator-section>
+                </decorator-screen>
+            </widgets>
+        </section>
+    </screen>
 </screens>


### PR DESCRIPTION
Done following-
1. Added employee lookup to search for employees only.
2. Used the newly added employee lookup on the New Employment screen to avoid selection of party group as an employee while create new employment.

Thanks!
