### PR TITLE
Make latitude and longitude numeric fields for correct comparisons

### DIFF
--- a/framework/common/entitydef/entitymodel.xml
+++ b/framework/common/entitydef/entitymodel.xml
@@ -286,8 +286,8 @@ under the License.
         <field name="geoPointTypeEnumId" type="id"/>
         <field name="description" type="description"></field>
         <field name="dataSourceId" type="id"></field>
-        <field name="latitude" type="short-varchar" not-null="true"></field>
-        <field name="longitude" type="short-varchar" not-null="true"></field>
+        <field name="latitude" type="fixed-point" not-null="true"></field>
+        <field name="longitude" type="fixed-point" not-null="true"></field>
         <field name="elevation" type="fixed-point"></field>
         <field name="elevationUomId" type="id"><description>UOM for elevation (feet, meters, etc.)</description></field>
         <field name="information" type="comment"><description>To enter any related information</description></field>

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/jdbc/SqlJdbcUtil.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/jdbc/SqlJdbcUtil.java
@@ -985,6 +985,8 @@ public final class SqlJdbcUtil {
     public static void addValueSingle(StringBuilder buffer, ModelField field, Object value, List<EntityConditionParam> params) {
         if (field != null) {
             buffer.append('?');
+        } else if (value instanceof Number) {
+            buffer.append(value);
         } else {
             buffer.append('\'');
             if (value instanceof String) {


### PR DESCRIPTION
Improved: Make the latitude and longitude fields of `GeoPoint` numeric

Explanation:
Before this commit both are stored as strings in the database and at least PostgreSQL does not correctly compare numeric strings. They will be sorted lexicaly which was not correct with floats.

Thanks to Daniel for checking with his own Google API key