### PR TITLE
Improved: WidgetWorker should not write generated html to Appendable (OFBIZ-11907)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/WidgetWorker.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/WidgetWorker.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.ofbiz.base.util.Debug;
+import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.security.CsrfUtil;
 import org.apache.ofbiz.base.util.UtilGenerics;
 import org.apache.ofbiz.base.util.UtilValidate;
@@ -60,6 +61,10 @@ public final class WidgetWorker {
         // Try to reducing a possibly encoded string down to its simplest form: /projectmgr/control/EditTaskContents?workEffortId=10003
         // This step make sure the following appending externalLoginKey operation to work correctly
         String localRequestName = Parser.unescapeEntities(target, true);
+
+        // To handle cases where target contains javascript we need to encode spaces.
+        // Example:  "javascript:set_value('system', 'system', '')" becomes "javascript:set_value('system',%20'system',%20'')
+        localRequestName = UtilHttp.encodeBlanks(localRequestName);
 
         final URIBuilder uriBuilder;
         final Map<String, String> additionalParameters = new HashMap<>();

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelTree.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelTree.java
@@ -874,13 +874,20 @@ public class ModelTree extends ModelWidget {
 
             // FIXME: Using a widget model in this way is an ugly hack.
             public Link(String style, String target, String text) {
+                this(style, target, text, null);
+            }
+
+            // FIXME: Something to be replaced by a builder class, but allows us to quickly
+            // build Links to represent nodes with parameters in a tree, rather that trying
+            // to encode the parameters early in the link's target.
+            public Link(String style, String target, String text, List<Parameter> parameterList) {
                 this.encode = false;
                 this.fullPath = false;
                 this.idExdr = FlexibleStringExpander.getInstance("");
                 this.image = null;
                 this.linkType = "";
                 this.nameExdr = FlexibleStringExpander.getInstance("");
-                this.parameterList = Collections.emptyList();
+                this.parameterList = parameterList != null ? Collections.unmodifiableList(parameterList) : Collections.emptyList();
                 this.prefixExdr = FlexibleStringExpander.getInstance("");
                 this.secure = false;
                 this.styleExdr = FlexibleStringExpander.getInstance(style);

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/html/HtmlMenuRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/html/HtmlMenuRenderer.java
@@ -20,6 +20,7 @@ package org.apache.ofbiz.widget.renderer.html;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -361,8 +362,10 @@ public class HtmlMenuRenderer extends HtmlWidgetRenderer implements MenuStringRe
                 writer.append("<form method=\"post\"");
                 writer.append(" action=\"");
                 // note that this passes null for the parameterList on purpose so they won't be put into the URL
-                WidgetWorker.buildHyperlinkUrl(writer, target, link.getUrlMode(), null, link.getPrefix(context),
-                        link.getFullPath(), link.getSecure(), link.getEncode(), request, response, context);
+                final URI uri = WidgetWorker.buildHyperlinkUri(target, link.getUrlMode(), null,
+                        link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(),
+                        request, response);
+                writer.append(uri.toString());
                 writer.append("\"");
 
                 if (UtilValidate.isNotEmpty(targetWindow)) {
@@ -425,8 +428,10 @@ public class HtmlMenuRenderer extends HtmlWidgetRenderer implements MenuStringRe
                 writer.append(uniqueItemName);
                 writer.append(".submit()");
             } else {
-                WidgetWorker.buildHyperlinkUrl(writer, target, link.getUrlMode(), link.getParameterMap(context), link.getPrefix(context),
-                        link.getFullPath(), link.getSecure(), link.getEncode(), request, response, context);
+                final URI uri = WidgetWorker.buildHyperlinkUri(target, link.getUrlMode(), link.getParameterMap(context),
+                        link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(),
+                        request, response);
+                writer.append(uri.toString());
             }
             writer.append("\">");
         }

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/html/HtmlTreeRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/html/HtmlTreeRenderer.java
@@ -19,6 +19,7 @@
 package org.apache.ofbiz.widget.renderer.html;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -230,8 +231,10 @@ public class HtmlTreeRenderer extends HtmlWidgetRenderer implements TreeStringRe
             HttpServletRequest req = (HttpServletRequest) context.get("request");
             if (urlMode != null && "intra-app".equalsIgnoreCase(urlMode)) {
                 if (req != null && res != null) {
-                    WidgetWorker.buildHyperlinkUrl(writer, target, link.getUrlMode(), link.getParameterMap(context), link.getPrefix(context),
-                        link.getFullPath(), link.getSecure(), link.getEncode(), req, res, context);
+                    final URI uri = WidgetWorker.buildHyperlinkUri(target, link.getUrlMode(),
+                            link.getParameterMap(context), link.getPrefix(context), link.getFullPath(),
+                            link.getSecure(), link.getEncode(), req, res);
+                    writer.append(uri.toString());
                 } else if (prefix != null) {
                     writer.append(prefix).append(target);
                 } else {

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/FtlWriter.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/FtlWriter.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.ofbiz.widget.renderer.macro;
+
+import freemarker.core.Environment;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.apache.ofbiz.base.util.Debug;
+import org.apache.ofbiz.base.util.UtilMisc;
+import org.apache.ofbiz.base.util.template.FreeMarkerWorker;
+import org.apache.ofbiz.widget.renderer.VisualTheme;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.rmi.server.UID;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+public final class FtlWriter {
+    private static final String MODULE = FtlWriter.class.getName();
+
+    private final WeakHashMap<Appendable, Environment> environments = new WeakHashMap<>();
+    private final Template macroLibrary;
+    private final VisualTheme visualTheme;
+
+    public FtlWriter(final String macroLibraryPath, final VisualTheme visualTheme) throws IOException {
+        this.macroLibrary = FreeMarkerWorker.getTemplate(macroLibraryPath);
+        this.visualTheme = visualTheme;
+    }
+
+    public void executeMacro(Appendable writer, String macro) {
+        try {
+            Environment environment = getEnvironment(writer);
+            environment.setVariable("visualTheme", FreeMarkerWorker.autoWrap(visualTheme, environment));
+            environment.setVariable("modelTheme", FreeMarkerWorker.autoWrap(visualTheme.getModelTheme(), environment));
+            Reader templateReader = new StringReader(macro);
+            Template template = new Template(new UID().toString(), templateReader, FreeMarkerWorker.getDefaultOfbizConfig());
+            templateReader.close();
+            environment.include(template);
+        } catch (TemplateException | IOException e) {
+            Debug.logError(e, "Error rendering screen thru ftl, macro: " + macro, MODULE);
+        }
+    }
+
+    private Environment getEnvironment(Appendable writer) throws TemplateException, IOException {
+        Environment environment = environments.get(writer);
+        if (environment == null) {
+            Map<String, Object> input = UtilMisc.toMap("key", null);
+            environment = FreeMarkerWorker.renderTemplate(macroLibrary, input, writer);
+            environments.put(writer, environment);
+        }
+        return environment;
+    }
+}

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroMenuRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroMenuRenderer.java
@@ -23,6 +23,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigDecimal;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -232,9 +233,11 @@ public class MacroMenuRenderer implements MenuStringRenderer {
         String actionUrl = "";
         StringBuilder targetParameters = new StringBuilder();
         if ("hidden-form".equals(linkType) || "layered-modal".equals(linkType)) {
-            StringBuilder sb = new StringBuilder();
-            WidgetWorker.buildHyperlinkUrl(sb, target, link.getUrlMode(), null, link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(), request, response, context);
-            actionUrl = sb.toString();
+            final URI actionUri = WidgetWorker.buildHyperlinkUri(target, link.getUrlMode(), null,
+                    link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(),
+                    request, response);
+            actionUrl = actionUri.toString();
+
             targetParameters.append("[");
             for (Map.Entry<String, String> parameter : link.getParameterMap(context).entrySet()) {
                 if (targetParameters.length() > 1) {
@@ -255,9 +258,11 @@ public class MacroMenuRenderer implements MenuStringRenderer {
         }
         if (UtilValidate.isNotEmpty(target)) {
             if (!"hidden-form".equals(linkType)) {
-                StringBuilder sb = new StringBuilder();
-                WidgetWorker.buildHyperlinkUrl(sb, target, link.getUrlMode(), "layered-modal".equals(linkType)?null:link.getParameterMap(context), link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(), request, response, context);
-                linkUrl = sb.toString();
+                final URI linkUri = WidgetWorker.buildHyperlinkUri(target, link.getUrlMode(),
+                        "layered-modal".equals(linkType) ? null : link.getParameterMap(context),
+                        link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(),
+                        request, response);
+                linkUrl = linkUri.toString();
             }
         }
         parameters.put("linkUrl", linkUrl);

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroScreenRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroScreenRenderer.java
@@ -23,6 +23,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigDecimal;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
@@ -256,10 +257,10 @@ public class MacroScreenRenderer implements ScreenStringRenderer {
             height = String.valueOf(modelTheme.getLinkDefaultLayeredModalHeight());
         }
         if ("hidden-form".equals(linkType) || "layered-modal".equals(linkType)) {
-            StringBuilder sb = new StringBuilder();
-            WidgetWorker.buildHyperlinkUrl(sb, target, link.getUrlMode(), null, link.getPrefix(context),
-                    link.getFullPath(), link.getSecure(), link.getEncode(), request, response, context);
-            actionUrl = sb.toString();
+            final URI actionUri = WidgetWorker.buildHyperlinkUri(target, link.getUrlMode(), null,
+                    link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(),
+                    request, response);
+            actionUrl = actionUri.toString();
             parameters.append("[");
             for (Map.Entry<String, String> parameter: link.getParameterMap(context).entrySet()) {
                 if (parameters.length() >1) {
@@ -280,10 +281,10 @@ public class MacroScreenRenderer implements ScreenStringRenderer {
         String text = link.getText(context);
         if (UtilValidate.isNotEmpty(target)) {
             if (!"hidden-form".equals(linkType)) {
-                StringBuilder sb = new StringBuilder();
-                WidgetWorker.buildHyperlinkUrl(sb, target, link.getUrlMode(), link.getParameterMap(context), link.getPrefix(context),
-                        link.getFullPath(), link.getSecure(), link.getEncode(), request, response, context);
-                linkUrl = sb.toString();
+                final URI uri = WidgetWorker.buildHyperlinkUri(target, link.getUrlMode(), link.getParameterMap(context),
+                        link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(),
+                        request, response);
+                linkUrl = uri.toString();
             }
         }
         String imgStr = "";

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroTreeRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroTreeRenderer.java
@@ -22,12 +22,14 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.collect.ImmutableList;
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.StringUtil;
 import org.apache.ofbiz.base.util.UtilGenerics;
@@ -37,6 +39,7 @@ import org.apache.ofbiz.base.util.template.FreeMarkerWorker;
 import org.apache.ofbiz.webapp.control.RequestHandler;
 import org.apache.ofbiz.webapp.taglib.ContentUrlTag;
 import org.apache.ofbiz.widget.WidgetWorker;
+import org.apache.ofbiz.widget.model.CommonWidgetModels;
 import org.apache.ofbiz.widget.model.ModelTree;
 import org.apache.ofbiz.widget.model.ModelWidget;
 import org.apache.ofbiz.widget.renderer.ScreenRenderer;
@@ -166,13 +169,8 @@ public class MacroTreeRenderer implements TreeStringRenderer {
                     currentNodeTrailPiped = StringUtil.join(currentNodeTrail, "|");
                     StringBuilder target = new StringBuilder(node.getModelTree().getExpandCollapseRequest(context));
                     String trailName = node.getModelTree().getTrailName(context);
-                    if (target.indexOf("?") < 0) {
-                        target.append("?");
-                    } else {
-                        target.append("&");
-                    }
-                    target.append(trailName).append("=").append(currentNodeTrailPiped);
-                    expandCollapseLink = new ModelTree.ModelNode.Link("collapsed", target.toString(), " ");
+                    expandCollapseLink = new ModelTree.ModelNode.Link("collapsed", target.toString(), " ",
+                            ImmutableList.of(new CommonWidgetModels.Parameter(trailName, currentNodeTrailPiped, false)));
                 }
             } else {
                 context.put("processChildren", Boolean.TRUE);
@@ -183,13 +181,8 @@ public class MacroTreeRenderer implements TreeStringRenderer {
                 }
                 StringBuilder target = new StringBuilder(node.getModelTree().getExpandCollapseRequest(context));
                 String trailName = node.getModelTree().getTrailName(context);
-                if (target.indexOf("?") < 0) {
-                    target.append("?");
-                } else {
-                    target.append("&");
-                }
-                target.append(trailName).append("=").append(currentNodeTrailPiped);
-                expandCollapseLink = new ModelTree.ModelNode.Link("expanded", target.toString(), " ");
+                expandCollapseLink = new ModelTree.ModelNode.Link("expanded", target.toString(), " ",
+                        ImmutableList.of(new CommonWidgetModels.Parameter(trailName, currentNodeTrailPiped, false)));
                 // add it so it can be remove in renderNodeEnd
                 currentNodeTrail.add(lastContentId);
             }
@@ -260,8 +253,10 @@ public class MacroTreeRenderer implements TreeStringRenderer {
         HttpServletRequest request = (HttpServletRequest) context.get("request");
 
         if (UtilValidate.isNotEmpty(target)) {
-            WidgetWorker.buildHyperlinkUrl(linkUrl, target, link.getUrlMode(), link.getParameterMap(context), link.getPrefix(context),
-                    link.getFullPath(), link.getSecure(), link.getEncode(), request, response, context);
+            final URI uri = WidgetWorker.buildHyperlinkUri(target, link.getUrlMode(), link.getParameterMap(context),
+                    link.getPrefix(context), link.getFullPath(), link.getSecure(), link.getEncode(),
+                    request, response);
+            linkUrl.append(uri.toString());
         }
 
         String id = link.getId(context);

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/WidgetWorkerTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/WidgetWorkerTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.ofbiz.widget;
+
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.ofbiz.security.CsrfUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.HashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+
+public class WidgetWorkerTest {
+
+    @Before
+    public void setupMockups() {
+        new RequestHandlerMockUp();
+    }
+
+    @Test
+    public void buildsHyperlinkUriWithAlreadyUrlEncodedTarget() {
+        final URI alreadyEncodedTargetUri = WidgetWorker.buildHyperlinkUri(
+                "&#47;projectmgr&#47;control&#47;EditTaskContents&#63;workEffortId&#61;10003",
+                "plain", new HashMap<>(), null, false, true, true, null, null);
+
+        assertThat(alreadyEncodedTargetUri, hasProperty("path", equalTo("/projectmgr/control/EditTaskContents")));
+        assertThat(alreadyEncodedTargetUri, hasProperty("query", equalTo("workEffortId=10003")));
+    }
+
+    @Test
+    public void buildsHyperlinkUriWithSpaces() {
+        final URI withEncodedSpaces = WidgetWorker.buildHyperlinkUri(
+                "javascript:set_value('system', 'system', '')",
+                "plain", new HashMap<>(), null, false, true, true, null, null);
+
+        assertThat(withEncodedSpaces, hasProperty("scheme", equalTo("javascript")));
+        assertThat(withEncodedSpaces, hasProperty("schemeSpecificPart", equalTo("set_value('system', 'system', '')")));
+    }
+
+    class RequestHandlerMockUp extends MockUp<CsrfUtil> {
+        @Mock
+        public String generateTokenForNonAjax(HttpServletRequest request, String pathOrRequestUri) {
+            return null;
+        }
+    }
+}

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -34,6 +34,7 @@ import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.template.FreeMarkerWorker;
 import org.apache.ofbiz.entity.Delegator;
+import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 import org.apache.ofbiz.webapp.control.RequestHandler;
 import org.apache.ofbiz.widget.model.ModelForm;
 import org.apache.ofbiz.widget.model.ModelFormField;
@@ -50,6 +51,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -70,6 +72,9 @@ public class MacroFormRendererTest {
 
     @Injectable
     private HttpServletResponse response;
+
+    @Injectable
+    private FtlWriter ftlWriter;
 
     @Mocked
     private HttpSession httpSession;
@@ -92,11 +97,7 @@ public class MacroFormRendererTest {
     @Mocked
     private ModelFormField modelFormField;
 
-    @Mocked
-    private Appendable appendable;
-
-    @Mocked
-    private StringReader stringReader;
+    private final StringWriter appendable = new StringWriter();
 
     @Injectable
     private String macroLibraryPath = null;
@@ -120,7 +121,7 @@ public class MacroFormRendererTest {
                 label.getText(withNotNull());
                 result = "";
 
-                new StringReader(anyString);
+                ftlWriter.executeMacro(withNotNull(), withNotNull());
                 times = 0;
             }
         };
@@ -160,6 +161,54 @@ public class MacroFormRendererTest {
 
         macroFormRenderer.renderDisplayField(appendable, ImmutableMap.of(), displayField);
 
+        assertAndGetMacroString("renderDisplayField", ImmutableMap.of("type", "TYPE"));
+    }
+
+    @Test
+    public void displayEntityFieldMacroRenderedWithLink(@Mocked ModelFormField.DisplayEntityField displayEntityField,
+                                                        @Mocked ModelFormField.SubHyperlink subHyperlink)
+            throws IOException {
+
+        final Map<String, ConfigXMLReader.RequestMap> requestMapMap = new HashMap<>();
+
+        new Expectations() {
+            {
+                displayEntityField.getType();
+                result = "TYPE";
+
+                displayEntityField.getDescription(withNotNull());
+                result = "DESCRIPTION";
+
+                modelFormField.getTooltip(withNotNull());
+                result = "TOOLTIP";
+
+                displayEntityField.getSubHyperlink();
+                result = subHyperlink;
+
+                subHyperlink.getStyle(withNotNull());
+                result = "TestLinkStyle";
+
+                subHyperlink.getUrlMode();
+                result = "url-mode";
+
+                subHyperlink.shouldUse(withNotNull());
+                result = true;
+
+                subHyperlink.getDescription(withNotNull());
+                result = "LinkDescription";
+
+                subHyperlink.getTarget(withNotNull());
+                result = "/link/target/path";
+
+                request.getAttribute("requestMapMap");
+                result = requestMapMap;
+            }
+        };
+
+        Map<String, Object> context = new HashMap<>();
+        macroFormRenderer.renderDisplayField(appendable, context, displayEntityField);
+
+        System.out.println(appendable.toString());
         assertAndGetMacroString("renderDisplayField", ImmutableMap.of("type", "TYPE"));
     }
 
@@ -987,7 +1036,7 @@ public class MacroFormRendererTest {
         new Verifications() {
             {
                 List<String> macros = new ArrayList<>();
-                new StringReader(withCapture(macros));
+                ftlWriter.executeMacro(withNotNull(), withCapture(macros));
 
                 assertThat(macros, not(empty()));
                 final String macro = macros.get(0);


### PR DESCRIPTION
Refactoring of WidgetWorker so that it generates URI and JSoup Element
objects to represent created URLs, hidden forms and anchor tags. This
replaces the previous approach where WidgetWorker would write string
representations of the URLS, hidden forms and anchor tags directly to an
Appendable object passed to it.

Callers to WidgetWorker have been modified to render the new objects
created by WidgetWorker to their relevant I/O.