### PR TITLE
Improved: Make all related Cancel/Done buttons return to backHome ie. party profile page (OFBIZ-11943)

### DIFF
--- a/applications/party/template/party/AddCheckForParty.ftl
+++ b/applications/party/template/party/AddCheckForParty.ftl
@@ -159,7 +159,7 @@ under the License.
           </tr>
       </table>
       <div class="button-bar">
-        <a href="<@ofbizUrl>${donePage}?partyId=${partyId}</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
+        <a href="<@ofbizUrl>backHome</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
         <input type="submit" value="${uiLabelMap.CommonSave}"/>
       </div>
     </form>

--- a/applications/party/template/party/EditCreditCard.ftl
+++ b/applications/party/template/party/EditCreditCard.ftl
@@ -28,7 +28,7 @@ under the License.
   </div>
   <div class="screenlet-body">
         <div class="button-bar">
-          <a href="<@ofbizUrl>${donePage}?partyId=${partyId!}</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
+          <a href="<@ofbizUrl>backHome</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
           <a href="javascript:document.editcreditcardform.submit()" class="smallSubmit">${uiLabelMap.CommonSave}</a>
         </div>
     <#if !creditCard??>
@@ -112,7 +112,7 @@ under the License.
         </tr>
         </table>
         <div class="button-bar">
-          <a href="<@ofbizUrl>${donePage}?partyId=${partyId}</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
+          <a href="<@ofbizUrl>backHome</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
           <input type="submit" value="${uiLabelMap.CommonSave}"/>
         </div>
       </form>

--- a/applications/party/template/party/EditEftAccount.ftl
+++ b/applications/party/template/party/EditEftAccount.ftl
@@ -28,7 +28,7 @@ under the License.
   </div>
   <div class="screenlet-body">
         <div class="button-bar">
-          <a href="<@ofbizUrl>${donePage}?partyId=${partyId!}</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
+          <a href="<@ofbizUrl>backHome</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
           <a href="javascript:document.editeftaccountform.submit()" class="smallSubmit">${uiLabelMap.CommonSave}</a>
         </div>
     <#if !eftAccount??>

--- a/applications/party/template/party/EditGiftCard.ftl
+++ b/applications/party/template/party/EditGiftCard.ftl
@@ -35,7 +35,7 @@ under the License.
     </#if>
         <input type="hidden" name="partyId" value="${partyId}"/>
         <div class="button-bar">
-          <a href="<@ofbizUrl>${donePage}?partyId=${partyId}</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
+          <a href="<@ofbizUrl>backHome</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
           <a href="javascript:document.editgiftcardform.submit()" class="smallSubmit">${uiLabelMap.CommonSave}</a>
         </div>
         <table class="basic-table" cellspacing="0">
@@ -95,7 +95,7 @@ under the License.
         </tr>
         </table>
         <div class="button-bar">
-          <a href="<@ofbizUrl>${donePage}?partyId=${partyId}</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
+          <a href="<@ofbizUrl>backHome</@ofbizUrl>" class="smallSubmit">${uiLabelMap.CommonCancelDone}</a>
           <input type="submit" value="${uiLabelMap.CommonSave}"/>
         </div>
       </form>

--- a/applications/party/template/party/profileblocks/PaymentMethods.ftl
+++ b/applications/party/template/party/profileblocks/PaymentMethods.ftl
@@ -194,6 +194,7 @@ under the License.
               <#if security.hasEntityPermission("PAY_INFO", "_DELETE", session) || security.hasEntityPermission("ACCOUNTING", "_DELETE", session)>
                 <form name="deletePaymentMethod_${paymentMethod.paymentMethodId}" method="post" action="<@ofbizUrl>deletePaymentMethod</@ofbizUrl>">
                   <input type="hidden" name="partyId" value="${partyId}" />
+                  <input type="hidden" name="roleTypeId" value="${parameters.roleTypeId!}" />
                   <input type="hidden" name="paymentMethodId" value="${paymentMethod.paymentMethodId}" />
                   <input type="submit" value="${uiLabelMap.CommonExpire}"/>
                 </form>

--- a/applications/party/webapp/partymgr/WEB-INF/controller.xml
+++ b/applications/party/webapp/partymgr/WEB-INF/controller.xml
@@ -122,9 +122,11 @@ under the License.
         <event type="service" invoke="createServiceCredit"/>
         <response name="success" type="request-redirect" value="viewprofile">
             <redirect-parameter name="partyId"/>
+            <redirect-parameter name="roleTypeId"/>
         </response>
         <response name="error" type="request-redirect" value="viewprofile">
             <redirect-parameter name="partyId"/>
+            <redirect-parameter name="roleTypeId"/>
         </response>
     </request-map>
 
@@ -373,9 +375,11 @@ under the License.
         <event type="simple" path="component://accounting/minilang/payment/PaymentMethodEvents.xml" invoke="deletePaymentMethod"/>
         <response name="success" type="request-redirect" value="viewprofile">
             <redirect-parameter name="partyId"/>
+            <redirect-parameter name="roleTypeId"/>
         </response>
         <response name="error" type="request-redirect" value="viewprofile">
             <redirect-parameter name="partyId"/>
+            <redirect-parameter name="roleTypeId"/>
         </response>
     </request-map>
 

--- a/applications/party/widget/partymgr/PartyForms.xml
+++ b/applications/party/widget/partymgr/PartyForms.xml
@@ -291,9 +291,7 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonSave}"><submit button-type="button"/></field>
         <field name="cancelLink" title=" " widget-style="smallSubmit">
-            <hyperlink description="${uiLabelMap.CommonCancelDone}" target="${donePage}" also-hidden="false">
-                <parameter param-name="partyId"/>
-            </hyperlink>
+            <hyperlink description="${uiLabelMap.CommonCancelDone}" target="backHome" also-hidden="false"/>
         </field>
     </form>
 
@@ -721,8 +719,7 @@ under the License.
         <field use-when="attribute!=null" name="attrName" tooltip="${uiLabelMap.PartyNotModifRecreateAttribute}"><display/></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}"><submit button-type="button"/></field>
         <field name="cancelLink" title=" " widget-style="smallSubmit">
-            <hyperlink description="${uiLabelMap.CommonCancelDone}" target="${cancelPage}" also-hidden="false">
-                <parameter param-name="partyId"/>
+            <hyperlink description="${uiLabelMap.CommonCancelDone}" target="backHome" also-hidden="false">
             </hyperlink>
         </field>
     </form>
@@ -883,6 +880,7 @@ under the License.
             </drop-down>
         </field>
         <field name="partyId"><hidden value="${partyId}"/></field>
+        <field name="roleTypeId"><hidden value="${parameters.roleTypeId}"/></field>
         <field name="finAccountTypeId"><ignored/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}"><submit button-type="button"/></field>
     </form>

--- a/applications/party/widget/partymgr/PaymentMethodForms.xml
+++ b/applications/party/widget/partymgr/PaymentMethodForms.xml
@@ -33,8 +33,7 @@ under the License.
         <field name="submitButton"><hidden/></field>
         <field name="saveButton" title="${uiLabelMap.CommonSave}" widget-style="buttontext"><submit button-type="button"/></field>
         <field name="cancelLink" title=" " widget-style="buttontext">
-            <hyperlink description="${uiLabelMap.CommonCancelDone}" target="viewprofile">
-                <parameter param-name="partyId" from-field="partyId"/>
+            <hyperlink description="${uiLabelMap.CommonCancelDone}" target="backHome">
             </hyperlink>
         </field>
     </form>


### PR DESCRIPTION
Explanation

- Updated the targets to 'backHome' so as to return back to the profile page
- Added roleTypeId on other instances as it is because of this missing parameter that the SFA profile page is not visible.

(OFBIZ-11943)