### PR TITLE
Fixed: Error in sendShipmentScheduledNotification service (OFBIZ-11983)

### DIFF
--- a/applications/product/groovyScripts/shipment/ShipmentServices.groovy
+++ b/applications/product/groovyScripts/shipment/ShipmentServices.groovy
@@ -470,7 +470,7 @@ def sendShipmentScheduledNotification() {
         sendTos << from("PartyAndContactMech")
                 .where(partyId: entry.getKey(),
                         contactMechTypeId: "EMAIL_ADDRESS")
-                .getFieldList("sendTo")
+                .getFieldList("infoString")
     }
     sendEmailMap.sendTo = sendTos.join(',')
 


### PR DESCRIPTION
Fixed: Error in sendShipmentScheduledNotification service
(OFBIZ-11983)

sendTo field was wrongly being fetched from PartyAndContactMech view to get emailAddress, replaced it with the correct entity field infoString.

Thanks: Jacques for the input.