### PR TITLE
Improved: Remove _PREVIOUS_REQUEST_ Session Attribute on non-authentication pages (OFBIZ-12047)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
@@ -376,13 +376,6 @@ public class RequestHandler {
 
         // Grab data from request object to process
         String defaultRequestUri = RequestHandler.getRequestUri(request.getPathInfo());
-        if (request.getAttribute("targetRequestUri") == null) {
-            if (request.getSession().getAttribute("_PREVIOUS_REQUEST_") != null) {
-                request.setAttribute("targetRequestUri", request.getSession().getAttribute("_PREVIOUS_REQUEST_"));
-            } else {
-                request.setAttribute("targetRequestUri", "/" + defaultRequestUri);
-            }
-        }
 
         String requestMissingErrorMessage = "Unknown request ["
                 + defaultRequestUri
@@ -628,6 +621,17 @@ public class RequestHandler {
                 } else {
                     requestMap = ccfg.getRequestMapMap().get("ajaxCheckLogin");
                 }
+            }
+        } else {
+            // Remove previous request attribute on navigation to non-authenticated request
+            request.getSession().removeAttribute("_PREVIOUS_REQUEST_");
+        }
+
+        if (request.getAttribute("targetRequestUri") == null) {
+            if (request.getSession().getAttribute("_PREVIOUS_REQUEST_") != null) {
+                request.setAttribute("targetRequestUri", request.getSession().getAttribute("_PREVIOUS_REQUEST_"));
+            } else {
+                request.setAttribute("targetRequestUri", "/" + defaultRequestUri);
             }
         }
 


### PR DESCRIPTION
Improved: Remove _PREVIOUS_REQUEST_ Session Attribute on non-authentication pages (OFBIZ-12047)

Added removal of the _PREVIOUS_REQUEST_ attribute when requesting non-authenticated sites and moved targetRequestUri handling to a accommodate this change