### PR TITLE
Fixed: Single product tile is displayed on one row in product search (OFBIZ-12045).

### DIFF
--- a/applications/order/template/entry/catalog/KeywordSearch.ftl
+++ b/applications/order/template/entry/catalog/KeywordSearch.ftl
@@ -60,7 +60,7 @@ under the License.
     </#macro>
 
     <@paginationControls/>
-    <div class="productsummary-container">
+    <div class="productsummary-container row">
         <#list productIds as productId> <#-- note that there is no boundary range because that is being done before the list is put in the content -->
             ${setRequestAttribute("optProductId", productId)}
             ${setRequestAttribute("listIndex", productId_index)}


### PR DESCRIPTION
Cause: Wrong use of bootstrap grid classes.
Fixed: Used row class as a parent to col-* class while rendering the products.