### PR TITLE
Fixed: Updated the tika-parsers dependency version, also remove redundant entry for tika-core. This should fix the build failure (OFBIZ-12100)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,8 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient-cache:4.5.4'
     compile 'org.apache.logging.log4j:log4j-api:2.10.0' // the API of log4j 2
     compile 'org.apache.shiro:shiro-core:1.4.0'
-    compile 'org.apache.tika:tika-core:1.20'
-    compile 'org.apache.tika:tika-parsers:1.20'
+    compile 'org.apache.tika:tika-core:1.24.1'
+    compile 'org.apache.tika:tika-parsers:1.24.1'
     compile 'org.apache.poi:poi:3.17'
     compile 'org.apache.tomcat:tomcat-catalina-ha:9.0.36'
     compile 'org.apache.tomcat:tomcat-catalina:9.0.36'
@@ -160,7 +160,6 @@ dependencies {
     compile 'org.jsoup:jsoup:1.11.2'
     compile 'net.lingala.zip4j:zip4j:2.6.4'
     compile 'org.apache.commons:commons-imaging:1.0-alpha2' // Alpha but OK, "Imaging was working and was used by a number of projects in production even before reaching its initial release as an Apache Commons component."
-    compile 'org.apache.tika:tika-core:1.24.1'
     compile 'batik:batik-svg-dom:1.6-1'
 
     // ofbiz unit-test compile libs


### PR DESCRIPTION
Fixed: Gradle build of 17.12.04 crashes on Centos 8
(OFBIZ- 12100)

Explanation
Updated the tika-parsers dependency version, also remove redundant entry for tika-core. This should fix the build failure related to javax.ws.rs-api

Thanks:  Alexander Tzvetanov for reporting the issue
