### PR TITLE
Fixed: javax.ws.rs-api dependency download issue by excluding it as a…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,11 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient-cache:4.5.4'
     compile 'org.apache.logging.log4j:log4j-api:2.10.0' // the API of log4j 2
     compile 'org.apache.shiro:shiro-core:1.4.0'
-    compile 'org.apache.tika:tika-core:1.24.1'
-    compile 'org.apache.tika:tika-parsers:1.24.1'
+    compile 'org.apache.tika:tika-core:1.20'
+    compile('org.apache.tika:tika-parsers:1.20') { // Exclude javax.ws.rs because 2.1 version POM has issues
+        exclude group: 'javax.ws.rs'
+    }
+    compile "javax.ws.rs:javax.ws.rs-api:2.1.1@jar" // @jar will make sure packaging 'jar' is used to resolve the URL. 
     compile 'org.apache.poi:poi:3.17'
     compile 'org.apache.tomcat:tomcat-catalina-ha:9.0.36'
     compile 'org.apache.tomcat:tomcat-catalina:9.0.36'


### PR DESCRIPTION
Fixed:(OFBIZ-)

Explanation

The problem stems from an invalid POM for the artifact javax.ws.rs-api with version 2.1.1. javax.ws.rs-api gets somehow included as a transitive dependency by tika-parsers:1.20 and javax.ws.rs-api:2.1.1 has an invalid POM definition for the packaging.
I checked file https://repo1.maven.org/maven2/javax/ws/rs/javax.ws.rs-api/2.1/javax.ws.rs-api-2.1.pom and this is what I see -
<packaging>${packaging.type}</packaging>

So gradle tries to actually go to https://jcenter.bintray.com/javax/ws/rs/javax.ws.rs-api/2.1.1/javax.ws.rs-api-2.1.1.$%7Bpackaging.type%7D instead of 
https://jcenter.bintray.com/javax/ws/rs/javax.ws.rs-api/2.1.1/javax.ws.rs-api-2.1.1.jar which is a valid URL and JAR does exist.

So the first issue is that the POM file is messed up and it is actually an issue with other versions as well of the artifact javax.ws.rs-api. 
There are two fixes as suggested here - https://github.com/gradle/gradle/issues/3065
1. Exclude javax.ws.rs-api from tika-parsers:1.20 and add it's dependency explicitly using @jar to indicate the packaging type. We will go back to tika-parsers:1.20 because the later version is creating dependency hell problems as pointed out by Jacopo.compile 'org.apache.tika:tika-core:1.20'
compile('org.apache.tika:tika-parsers:1.20') {
 exclude group: 'javax.ws.rs'
}compile "javax.ws.rs:javax.ws.rs-api:2.1.1@jar" // @jar will make sure packaging 'jar' is used to resolve the URLI have tested the above fix and it is working properly. No 404 issue while the solr test is running too.
2. Upgrade Gradle version to 4.5 (see the explanation at https://github.com/gradle/gradle/issues/3065).     I have tested upgrading to 4.5 while being on commit 2d15771d56ab1637efa5685799f86a7bb118cee4. I think Gradle upgrade will be a big upgrade for the release and would probably require proper testing. I am personally not for Gradle upgrade.

Thanks:
Girish