### PR TITLE
OFBIZ-12118 Fixes issue with starting ofbiz via jar

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilXml.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilXml.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -379,7 +380,11 @@ public final class UtilXml {
             Debug.logWarning("[UtilXml.readXmlDocument] URL was null, doing nothing", MODULE);
             return null;
         }
-        try (InputStream is = url.openStream()) {
+
+        URLConnection connection = url.openConnection();
+        // https://issues.apache.org/jira/browse/OFBIZ-12118
+        connection.setUseCaches(false);
+        try (InputStream is = connection.getInputStream();){
             return readXmlDocument(is, validate, url.toString());
         }
     }


### PR DESCRIPTION
Fixed: OFBIZ-12118 

* There is a bug in XML parsing within jar files (JarURLConnection)
* Setting setUseCaches(boolean) solves it

Explanation: There is a bug when parsing xml inside a jar via URL.

https://issues.apache.org/jira/browse/OFBIZ-12118?focusedCommentId=17260119&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17260119

Thanks: Girish and Daniel 
