### PR TITLE
Improved: Added a SourceSet for groovyScript files specifying the classpath that should be used for compilation (OFBIZ-12149)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -281,6 +281,20 @@ sourceSets {
             srcDirs = getDirectoryInActiveComponentsIfExists('src/test/resources')
         }
     }
+
+    groovyScripts {
+        groovy {
+            srcDirs += getDirectoryInActiveComponentsIfExists('groovyScripts')
+            compileClasspath += sourceSets.main.compileClasspath
+            compileClasspath += sourceSets.main.output
+        }
+    }
+}
+
+tasks.named('compileGroovyScriptsGroovy') {
+    // We don't want to build groovyScripts as they should be considered as standalone elements executed in
+    // isolation by ofbiz. Building them will result in numerous error due to duplicated classes.
+    enabled = false
 }
 
 jar.manifest.attributes(


### PR DESCRIPTION
This helps IDEs navigate to the scripts dependencies, making it easier
to spot issues during development.

However we don't want gradle to attempt to compile groovyScripts,
therefore the compileGroovyScriptsGroovy task is disabled.
