### PR TITLE
Fixed: Remove _PREVIOUS_REQUEST_ Session Attribute on non-authentication pages (OFBIZ-12047)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
@@ -383,13 +383,6 @@ public final class RequestHandler {
 
         // Grab data from request object to process
         String defaultRequestUri = RequestHandler.getRequestUri(request.getPathInfo());
-        if (request.getAttribute("targetRequestUri") == null) {
-            if (request.getSession().getAttribute("_PREVIOUS_REQUEST_") != null) {
-                request.setAttribute("targetRequestUri", request.getSession().getAttribute("_PREVIOUS_REQUEST_"));
-            } else {
-                request.setAttribute("targetRequestUri", "/" + defaultRequestUri);
-            }
-        }
 
         String requestMissingErrorMessage = "Unknown request ["
                 + defaultRequestUri
@@ -635,6 +628,17 @@ public final class RequestHandler {
                 } else {
                     requestMap = ccfg.getRequestMapMap().get("ajaxCheckLogin");
                 }
+            }
+        } else {
+            // Remove previous request attribute on navigation to non-authenticated request
+            request.getSession().removeAttribute("_PREVIOUS_REQUEST_");
+        }
+
+        if (request.getAttribute("targetRequestUri") == null) {
+            if (request.getSession().getAttribute("_PREVIOUS_REQUEST_") != null) {
+                request.setAttribute("targetRequestUri", request.getSession().getAttribute("_PREVIOUS_REQUEST_"));
+            } else {
+                request.setAttribute("targetRequestUri", "/" + defaultRequestUri);
             }
         }
 


### PR DESCRIPTION
Fixed: Remove PREVIOUS_REQUEST Session Attribute on non-authentication pages (OFBIZ-12047)

Added removal of the PREVIOUS_REQUEST attribute when requesting non-authenticated sites and moved targetRequestUri handling to a accommodate this change