### PR TITLE
Fixed: Incorrect mapping for Lookup Purchase Order

### DIFF
--- a/applications/order/widget/ordermgr/FieldLookupForms.xml
+++ b/applications/order/widget/ordermgr/FieldLookupForms.xml
@@ -118,7 +118,7 @@ under the License.
         <field name="submitButton" title="${uiLabelMap.CommonFind}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
     <form name="ListLookupOrderHeaderAndShipInfo" list-name="listIt" title="" type="list"
-        odd-row-style="alternate-row" default-table-style="basic-table hover-bar" paginate-target="LookupOrderHeaderAndShipInfo">
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar" paginate-target="${paginateTargetUrl}">
         <actions>
             <service service-name="performFind" result-map="result" result-map-list="listIt">
                 <field-map field-name="inputFields" from-field="parameters"/>

--- a/applications/order/widget/ordermgr/LookupScreens.xml
+++ b/applications/order/widget/ordermgr/LookupScreens.xml
@@ -58,6 +58,7 @@ under the License.
             <actions>
                 <property-map resource="OrderUiLabels" map-name="uiLabelMap" global="true"/>
                 <set field="title" from-field="uiLabelMap.PageTitleLookupOrderHeaderAndShipInfo"/>
+                <set field="paginateTargetUrl" value="LookupOrderHeaderAndShipInfo"/>
                 <set field="parameters.roleTypeId" to-scope="screen" default-value="SHIP_TO_CUSTOMER"/>
                 <set field="queryString" from-field="result.queryString"/>
                 <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer"/>
@@ -87,6 +88,7 @@ under the License.
             <actions>
                 <property-map resource="OrderUiLabels" map-name="uiLabelMap" global="true"/>
                 <set field="title" from-field="uiLabelMap.PageTitleLookupPurchaseOrderHeaderAndShipInfo"/>
+                <set field="paginateTargetUrl" value="LookupPurchaseOrderHeaderAndShipInfo"/>
                 <set field="queryString" from-field="result.queryString"/>
                 <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer"/>
                 <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>


### PR DESCRIPTION
Fixed: Incorrect mapping for Lookup Purchase Order

(OFBIZ-12143)

This issue was due to common form is being used for LookupPurchaseOrderHeaderAndShipInfo and LookupOrderHeaderAndShipInfo screen. Passed the paginateTargetUrl from screen to make sure pagination works properly

Thanks Rajesh Kumar for reporting the issue

