### PR TITLE
Improved: Switch from jCenter to mavenCentral to handle the jCenter shutdown r18.12 (OFBIZ-12171)

### DIFF
--- a/applications/content/src/main/java/org/apache/ofbiz/content/data/DataServices.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/data/DataServices.java
@@ -28,6 +28,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -49,8 +50,6 @@ import org.apache.ofbiz.service.DispatchContext;
 import org.apache.ofbiz.service.GenericServiceException;
 import org.apache.ofbiz.service.ModelService;
 import org.apache.ofbiz.service.ServiceUtil;
-
-import edu.emory.mathcs.backport.java.util.Arrays;
 
 /**
  * DataServices Class

--- a/build.gradle
+++ b/build.gradle
@@ -236,6 +236,7 @@ dependencies {
     runtime 'org.apache.logging.log4j:log4j-core:2.11.1' // the implementation of the log4j 2 API
     runtime 'org.apache.logging.log4j:log4j-jul:2.11.1' // for external jars using the java.util.logging: routes logging to log4j 2
     runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1' // for external jars using slf4j: routes logging to log4j 2
+    runtime 'org.apache.logging.log4j:log4j-jcl:2.14.0' // need to constrain to version to avoid classpath conflict (ReflectionUtil)
     runtime 'org.codeartisans.thirdparties.swing:batik-all:1.8pre-r1084380'
 
     // plugin libs

--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ dependencies {
     runtime 'org.apache.logging.log4j:log4j-core:2.11.1' // the implementation of the log4j 2 API
     runtime 'org.apache.logging.log4j:log4j-jul:2.11.1' // for external jars using the java.util.logging: routes logging to log4j 2
     runtime 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1' // for external jars using slf4j: routes logging to log4j 2
-    runtime 'org.apache.logging.log4j:log4j-jcl:2.14.0' // need to constrain to version to avoid classpath conflict (ReflectionUtil)
+    runtime 'org.apache.logging.log4j:log4j-jcl:2.11.1' // need to constrain to version to avoid classpath conflict (ReflectionUtil)
     runtime 'org.codeartisans.thirdparties.swing:batik-all:1.8pre-r1084380'
 
     // plugin libs

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,10 @@ import org.asciidoctor.gradle.AsciidoctorTask
  * ======================================================== */
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'at.bxm.gradleplugins:gradle-svntools-plugin:2.2.1'
@@ -106,8 +109,34 @@ defaultTasks 'build'
 
 allprojects {
     repositories{
-        jcenter()
-        mavenLocal()
+        mavenCentral()
+        // the switch from jCenter to mavenCentral needs some additional repositories to be configured here
+        // this should be checked frequently to remove obsolete configurations if the artifacts are available
+        // on mavenCentral directly
+        maven {
+            // org.restlet and org.restlet.ext.servlet
+            url "https://maven.restlet.talend.com"
+        }
+        maven {
+            // apache-xerces:xercesImpl:2.9.1
+            url "https://maven.repository.redhat.com/ga/"
+        }
+        maven {
+            // net.fortuna.ical4j:ical4j:1.0-rc4-atlassian-12
+            url "https://packages.atlassian.com/maven-3rdparty"
+        }
+        maven {
+            // org/milyn/flute/1.3/flute-1.3.jar
+            // need artifact only because of wrong pom metadata in maven central
+            url "https://repo1.maven.org/maven2"
+            metadataSources {
+                artifact()
+            }
+        }
+        maven {
+            // com.springsource.com.sun.syndication
+            url "https://repo.spring.io/plugins-release"
+        }
     }
 }
 
@@ -143,7 +172,7 @@ dependencies {
     compile 'com.ibm.icu:icu4j:63.1'
     compile 'com.lowagie:itext:2.1.7' // Don't update due to license change in newer versions, see OFBIZ-10455
     compile 'com.sun.mail:javax.mail:1.6.2'
-    compile 'com.sun.syndication:com.springsource.com.sun.syndication:0.9.0'
+    compile 'com.sun.syndication:com.springsource.com.sun.syndication:1.0.0'
     compile 'com.thoughtworks.xstream:xstream:1.4.11.1'
     compile 'commons-cli:commons-cli:1.4'
     compile 'commons-net:commons-net:3.6'
@@ -154,7 +183,7 @@ dependencies {
     compile 'javax.servlet:javax.servlet-api:4.0.1'
     compile 'javax.servlet.jsp:javax.servlet.jsp-api:2.3.3'
     compile 'junit:junit-dep:4.11'
-    compile 'net.fortuna.ical4j:ical4j:1.0-rc3-atlassian-11'
+    compile 'net.fortuna.ical4j:ical4j:1.0-rc4-atlassian-12'
     compile 'org.apache.ant:ant-junit:1.10.5'
     compile 'org.apache.axis2:axis2-kernel:1.7.8'
     compile 'org.apache.commons:commons-collections4:4.2'

--- a/framework/base/src/main/java/org/apache/ofbiz/base/container/ContainerLoader.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/container/ContainerLoader.java
@@ -20,6 +20,7 @@ package org.apache.ofbiz.base.container;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,8 +32,6 @@ import org.apache.ofbiz.base.start.StartupException;
 import org.apache.ofbiz.base.start.StartupLoader;
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.UtilValidate;
-
-import edu.emory.mathcs.backport.java.util.Collections;
 
 /**
  * An object that loads containers (background processes).


### PR DESCRIPTION
jCenter migration for the 18.12 release branch. Must be applied together with the corresponding changes in plugins.