### PR TITLE
Bugfix/pdf export overlap

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -20,6 +20,7 @@
 name: Java CI with Gradle
 
 on:
+  workflow_dispatch:
   push:
     branches: [ trunk ]
   pull_request:

--- a/applications/order/template/order/CompanyHeader.fo.ftl
+++ b/applications/order/template/order/CompanyHeader.fo.ftl
@@ -35,7 +35,7 @@ under the License.
     </#if>
 
     <#if sendingPartyTaxId?? || phone?? || email?? || website?? || eftAccount??>
-    <fo:list-block provisional-distance-between-starts=".5in">
+    <fo:list-block provisional-distance-between-starts="1in">
         <#if sendingPartyTaxId??>
         <fo:list-item>
             <fo:list-item-label>


### PR DESCRIPTION
Improved:
Implemented:
Documented:
Completed:
Reverted:
Fixed: Overlapped labels in Accounting transaction pdf export
(OFBIZ-12110)

Explanation:
PDF for accounting transaction had overlapping labels in company details.

Thanks:
