### PR TITLE
Fixed: Form to add an employee position doesn't function properly when invoked from Humanres tree  (OFBIZ-11684)

### DIFF
--- a/applications/humanres/template/category/CategoryTree.ftl
+++ b/applications/humanres/template/category/CategoryTree.ftl
@@ -121,19 +121,7 @@ var rawdata = [
         EmpPosition: { 
             label: "Add Employee Position",
             action: function (NODE, TREE_OBJ) {
-                var dataSet = {};
-                dataSet = {"partyId" : NODE.attr("id")};
-                jQuery.ajax({
-                    type: "GET",
-                    url: "EditEmplPosition",
-                    data: dataSet,
-                    error: function(msg) {
-                        alert("An error occurred loading content! : " + msg);
-                    },
-                    success: function(msg) {
-                        jQuery('div.page-container').html(msg);
-                    }
-                });
+                window.location.href = "EditEmplPosition?partyId=" + NODE.attr("id");
             }
         },
         AddIntOrg: { 


### PR DESCRIPTION
Replaced logic to Ajaxify the response from EditEmplPosition with navigating the user to EditEmplPosition page.
When we are getting the entire page and updating it into the DOM, it would be better if we navigate the user to the page.
The issue with the current approach is the current page and the EditEmplPosition page both have GlobalActions decorator all the js files in GlobalActions are loaded twice. Either we should Ajaxify a section of the page or we should navigate the user to the EditEmplPosition page.

Thanks Pierre Smits for reporting the issue and Sebastian Berg, Michael Brohl, & Jacques Le Roux for the discussion and efforts

