### PR TITLE
Improved: MacroFormRenderer refactoring of field group open and close elements (OFBIZ-12124)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -2640,71 +2640,15 @@ public final class MacroFormRenderer implements FormStringRenderer {
     }
 
     @Override
-    public void renderFieldGroupOpen(Appendable writer, Map<String, Object> context, ModelForm.FieldGroup fieldGroup) throws IOException {
-        String style = fieldGroup.getStyle();
-        String id = fieldGroup.getId();
-        FlexibleStringExpander titleNotExpanded = FlexibleStringExpander.getInstance(fieldGroup.getTitle());
-        String title = titleNotExpanded.expandString(context);
-        Boolean collapsed = fieldGroup.initiallyCollapsed();
-        String collapsibleAreaId = fieldGroup.getId() + "_body";
-        Boolean collapsible = fieldGroup.collapsible();
-        String expandToolTip = "";
-        String collapseToolTip = "";
-        if (UtilValidate.isNotEmpty(style) || UtilValidate.isNotEmpty(id) || UtilValidate.isNotEmpty(title)) {
-            if (fieldGroup.collapsible()) {
-                Map<String, Object> uiLabelMap = UtilGenerics.cast(context.get("uiLabelMap"));
-                if (uiLabelMap != null) {
-                    expandToolTip = (String) uiLabelMap.get("CommonExpand");
-                    collapseToolTip = (String) uiLabelMap.get("CommonCollapse");
-                }
-            }
-        }
-        StringWriter sr = new StringWriter();
-        sr.append("<@renderFieldGroupOpen ");
-        sr.append(" style=\"");
-        if (style != null) {
-            sr.append(style);
-        }
-        sr.append("\" id=\"");
-        sr.append(id);
-        sr.append("\" title=\"");
-        sr.append(title);
-        sr.append("\" collapsed=");
-        sr.append(Boolean.toString(collapsed));
-        sr.append(" collapsibleAreaId=\"");
-        sr.append(collapsibleAreaId);
-        sr.append("\" collapsible=");
-        sr.append(Boolean.toString(collapsible));
-        sr.append(" expandToolTip=\"");
-        sr.append(expandToolTip);
-        sr.append("\" collapseToolTip=\"");
-        sr.append(collapseToolTip);
-        sr.append("\" />");
-        executeMacro(writer, sr.toString());
+    public void renderFieldGroupOpen(Appendable writer, Map<String, Object> context, ModelForm.FieldGroup fieldGroup) {
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.fieldGroupOpen(context, fieldGroup);
+        ftlWriter.processFtl(writer, renderableFtl);
     }
 
     @Override
-    public void renderFieldGroupClose(Appendable writer, Map<String, Object> context, ModelForm.FieldGroup fieldGroup) throws IOException {
-        String style = fieldGroup.getStyle();
-        String id = fieldGroup.getId();
-        FlexibleStringExpander titleNotExpanded = FlexibleStringExpander.getInstance(fieldGroup.getTitle());
-        String title = titleNotExpanded.expandString(context);
-        StringWriter sr = new StringWriter();
-        sr.append("<@renderFieldGroupClose ");
-        sr.append(" style=\"");
-        if (style != null) {
-            sr.append(style);
-        }
-        sr.append("\" id=\"");
-        if (id != null) {
-            sr.append(id);
-        }
-        sr.append("\" title=\"");
-        if (title != null) {
-            sr.append(title);
-        }
-        sr.append("\" />");
-        executeMacro(writer, sr.toString());
+    public void renderFieldGroupClose(Appendable writer, Map<String, Object> context, ModelForm.FieldGroup fieldGroup) {
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.fieldGroupClose(context, fieldGroup);
+        ftlWriter.processFtl(writer, renderableFtl);
     }
 
     @Override

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
@@ -496,6 +496,49 @@ public final class RenderableFtlFormElementsBuilder {
                 .build();
     }
 
+    public RenderableFtlMacroCall fieldGroupOpen(final Map<String, Object> context, final ModelForm.FieldGroup fieldGroup) {
+        final String style = fieldGroup.getStyle();
+        final String id = fieldGroup.getId();
+        final FlexibleStringExpander titleNotExpanded = FlexibleStringExpander.getInstance(fieldGroup.getTitle());
+        final String title = titleNotExpanded.expandString(context);
+
+        String expandToolTip = "";
+        String collapseToolTip = "";
+        if (UtilValidate.isNotEmpty(style) || UtilValidate.isNotEmpty(id) || UtilValidate.isNotEmpty(title)) {
+            if (fieldGroup.collapsible()) {
+                Map<String, Object> uiLabelMap = UtilGenerics.cast(context.get("uiLabelMap"));
+                if (uiLabelMap != null) {
+                    expandToolTip = (String) uiLabelMap.get("CommonExpand");
+                    collapseToolTip = (String) uiLabelMap.get("CommonCollapse");
+                }
+            }
+        }
+
+        final RenderableFtlMacroCallBuilder macroCallBuilder = RenderableFtlMacroCall.builder().name("renderFieldGroupOpen")
+                .stringParameter("id", id)
+                .stringParameter("title", title)
+                .stringParameter("style", style)
+                .stringParameter("collapsibleAreaId", fieldGroup.getId() + "_body")
+                .booleanParameter("collapsible", fieldGroup.collapsible())
+                .booleanParameter("collapsed", fieldGroup.initiallyCollapsed())
+                .stringParameter("expandToolTip", expandToolTip)
+                .stringParameter("collapseToolTip", collapseToolTip);
+
+        return macroCallBuilder.build();
+    }
+
+    public RenderableFtlMacroCall fieldGroupClose(final Map<String, Object> context, final ModelForm.FieldGroup fieldGroup) {
+        FlexibleStringExpander titleNotExpanded = FlexibleStringExpander.getInstance(fieldGroup.getTitle());
+        final String title = titleNotExpanded.expandString(context);
+
+        final RenderableFtlMacroCallBuilder macroCallBuilder = RenderableFtlMacroCall.builder().name("renderFieldGroupClose")
+                .stringParameter("id", fieldGroup.getId())
+                .stringParameter("title", title)
+                .stringParameter("style", fieldGroup.getStyle());
+
+        return macroCallBuilder.build();
+    }
+
     private String encode(String value, ModelFormField modelFormField, Map<String, Object> context) {
         if (UtilValidate.isEmpty(value)) {
             return value;

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterMatcher.java
@@ -83,6 +83,10 @@ public final class MacroCallParameterMatcher extends TypeSafeMatcher<Map.Entry<S
         return new MacroCallParameterMatcher(name, new MacroCallParameterStringValueMatcher(value));
     }
 
+    public static MacroCallParameterMatcher hasNameAndBooleanValue(final String name, final boolean value) {
+        return new MacroCallParameterMatcher(name, new MacroCallParameterBooleanValueMatcher(value));
+    }
+
     public static MacroCallParameterMatcher hasNameAndMapValue(final String name,
                                                                final Matcher<Map<String, String>> matcher) {
         return new MacroCallParameterMatcher(name, new MacroCallParameterMapValueMatcher(matcher));

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -745,49 +745,28 @@ public class MacroFormRendererTest {
 
     @Test
     public void fieldGroupOpenMacroRendered(@Mocked ModelForm.FieldGroup fieldGroup) throws IOException {
-
         new Expectations() {
             {
-                fieldGroup.getStyle();
-                result = "GROUPSTYLE";
-
-                fieldGroup.getTitle();
-                result = "TITLE${title}";
-
-                fieldGroup.initiallyCollapsed();
-                result = true;
+                renderableFtlFormElementsBuilder.fieldGroupOpen(withNotNull(), withNotNull());
+                result = genericMacroCall;
             }
         };
 
-        final Map<String, Object> context = new HashMap<>();
-        context.put("title", "ABC");
-
-        macroFormRenderer.renderFieldGroupOpen(appendable, context, fieldGroup);
-
-        assertAndGetMacroString("renderFieldGroupOpen", ImmutableMap.of(
-                "title", "TITLEABC",
-                "collapsed", true));
+        macroFormRenderer.renderFieldGroupOpen(appendable, ImmutableMap.of(), fieldGroup);
+        genericSingleMacroRenderedVerification();
     }
 
     @Test
     public void fieldGroupCloseMacroRendered(@Mocked ModelForm.FieldGroup fieldGroup) throws IOException {
-
         new Expectations() {
             {
-                fieldGroup.getStyle();
-                result = "GROUPSTYLE";
-
-                fieldGroup.getTitle();
-                result = "TITLE${title}";
+                renderableFtlFormElementsBuilder.fieldGroupClose(withNotNull(), withNotNull());
+                result = genericMacroCall;
             }
         };
 
-        final Map<String, Object> context = new HashMap<>();
-        context.put("title", "ABC");
-
-        macroFormRenderer.renderFieldGroupClose(appendable, context, fieldGroup);
-
-        assertAndGetMacroString("renderFieldGroupClose", ImmutableMap.of("title", "TITLEABC"));
+        macroFormRenderer.renderFieldGroupClose(appendable, ImmutableMap.of(), fieldGroup);
+        genericSingleMacroRenderedVerification();
     }
 
     @Test

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
@@ -235,4 +235,51 @@ public class RenderableFtlFormElementsBuilderTest {
                         "areaId1,http://host.domain/target1,param1=ThisIsParam1&param2=ThisIsParam2,"
                                 + "areaId2,http://host.domain/target2,")));
     }
+
+    @Test
+    public void fieldGroupOpenRendersCollapsibleAreaId(@Mocked final ModelForm.FieldGroup fieldGroup) {
+        new Expectations() {
+            {
+                fieldGroup.getStyle();
+                result = "GROUPSTYLE";
+
+                fieldGroup.getTitle();
+                result = "TITLE${title}";
+
+                fieldGroup.getId();
+                result = "FIELDGROUPID";
+
+                fieldGroup.initiallyCollapsed();
+                result = true;
+            }
+        };
+
+        final Map<String, Object> context = new HashMap<>();
+        context.put("title", "ABC");
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.fieldGroupOpen(context, fieldGroup);
+        assertThat(renderableFtl, MacroCallMatcher.hasName("renderFieldGroupOpen"));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("title", "TITLEABC")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("style", "GROUPSTYLE")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue(
+                "collapsibleAreaId", "FIELDGROUPID_body")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndBooleanValue("collapsed", true)));
+    }
+
+    @Test
+    public void fieldGroupCloseRendersStyle(@Mocked final ModelForm.FieldGroup fieldGroup) {
+        new Expectations() {
+            {
+                fieldGroup.getStyle();
+                result = "GROUPSTYLE";
+            }
+        };
+
+        final Map<String, Object> context = new HashMap<>();
+        context.put("title", "ABC");
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.fieldGroupClose(context, fieldGroup);
+        assertThat(renderableFtl, MacroCallMatcher.hasName("renderFieldGroupClose"));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("style", "GROUPSTYLE")));
+    }
 }


### PR DESCRIPTION
Part of the OFBIZ-11456 MacroFormRenderer refactoring effort.

Rather than MacroFormRenderer producing and evaulating FTL strings, it now
uses RenderableFtlElementsBuilder to create RenderableFtlMacroCall objects
which are then passed to an FtlWriter for evaluation.

