### PR TITLE
Fixed: Default From Date for Product Config Item Content truncated to seconds rather than milliseconds. (OFBIZ-12246)

### DIFF
--- a/applications/product/groovyScripts/product/config/ProductConfigItemContentServices.groovy
+++ b/applications/product/groovyScripts/product/config/ProductConfigItemContentServices.groovy
@@ -30,7 +30,7 @@ def createProductConfigItemContent() {
     Map result = success()
     GenericValue newEntity = makeValue("ProdConfItemContent", parameters)
     if (!newEntity.fromDate) {
-        newEntity.fromDate = UtilDateTime.nowTimestamp()
+        newEntity.fromDate = UtilDateTime.getTimestamp(System.currentTimeSeconds() * 1000)
     }
     newEntity.create()
 
@@ -47,7 +47,10 @@ def createProductConfigItemContent() {
  * Update Content For ProductConfigItem
  */
 def updateProductConfigItemContent() {
-    GenericValue lookedUpValue = from("ProdConfItemContent").where(parameters).queryOne()
+    GenericValue pkParameters = makeValue("ProdConfItemContent")
+    pkParameters.setPKFields(parameters)
+
+    GenericValue lookedUpValue = from("ProdConfItemContent").where(pkParameters).queryOne()
     lookedUpValue.setNonPKFields(parameters)
     lookedUpValue.store()
 

--- a/applications/product/widget/catalog/ConfigForms.xml
+++ b/applications/product/widget/catalog/ConfigForms.xml
@@ -177,8 +177,9 @@ under the License.
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="contentId==null" target="createSimpleTextContentForProductConfigItem"/>
         <auto-fields-entity entity-name="ProdConfItemContent" map-name="productContentData"/>
-        <field name="fromDate" title="${uiLabelMap.CommonFromDate}" ></field>
-        <field name="thruDate" title="${uiLabelMap.CommonThruDate}"></field>
+        <field use-when="contentId == null" name="fromDate" title="${uiLabelMap.CommonFromDate}"><date-time/></field>
+        <field use-when="contentId != null" name="fromDate" title="${uiLabelMap.CommonFromDate}"><display/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThruDate}"><date-time/></field>
         <field name="description" title="${uiLabelMap.ProductProductDescription}" map-name="content"><text size="40"/></field>
         <field name="localeString" title="${uiLabelMap.ProductLocaleString}" map-name="content"><text size="40"/></field>
         <field use-when="contentId == null" name="contentId"><ignored/></field>


### PR DESCRIPTION
There was a mismatch in timestamp resolution. Updates to Product Config
Item Contents rely on second resolution timestamps for finding records
to update. By default, millisecond resolution timestamps were created
for config item contents' From Date which caused records to not be found
during update operations.

Also made From Date a display-only field when editing a config item
content since it is a primary key and cannot be modified.
