### PR TITLE
Fixed: Display rather than edit the From Date field of a Product Config Item Content when updating the content. (OFBZ-12246)

### DIFF
--- a/applications/product/widget/catalog/ConfigForms.xml
+++ b/applications/product/widget/catalog/ConfigForms.xml
@@ -177,8 +177,9 @@ under the License.
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="contentId==null" target="createSimpleTextContentForProductConfigItem"/>
         <auto-fields-entity entity-name="ProdConfItemContent" map-name="productContentData"/>
-        <field name="fromDate" title="${uiLabelMap.CommonFromDate}" ></field>
-        <field name="thruDate" title="${uiLabelMap.CommonThruDate}"></field>
+        <field use-when="contentId == null" name="fromDate" title="${uiLabelMap.CommonFromDate}"><date-time/></field>
+        <field use-when="contentId != null" name="fromDate" title="${uiLabelMap.CommonFromDate}"><display/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThruDate}"><date-time/></field>
         <field name="description" title="${uiLabelMap.ProductProductDescription}" map-name="content"><text size="40"/></field>
         <field name="localeString" title="${uiLabelMap.ProductLocaleString}" map-name="content"><text size="40"/></field>
         <field use-when="contentId == null" name="contentId"><ignored/></field>


### PR DESCRIPTION
When editing date-time fields, they are truncated to the second. However
the default From Date field value of a Product Config Item Content is
stored in milliseconds. The From Date is a primary key of the config
item content and is used when finding the relevant record to update.

When the From Date field was editable on the Edit Product Config Item
Content content form, it would be truncated to the second and included
in the update request POST to the server. Since the From Date was
altered, the relevant record to be updated could no longer be found by
its primary key.

By making the From Date field display only, we prevent truncation of its
value meaning the record to be updated can be found.
