### PR TITLE
Improved: Upgrade Shiro to 1.7.1 (OFBIZ-12275)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.14.0' // Somehow needed by Buildbot to compile OFBizDynamicThresholdFilter.java
     implementation 'org.apache.poi:poi:4.1.2'
     implementation 'org.apache.pdfbox:pdfbox:2.0.24'
-    implementation 'org.apache.shiro:shiro-core:1.4.1' // So far we did not update from 1.4.1 because of a compile issue or w/ 1.7.0 an EntityCrypto exception when loading data. You may try w/ a newer version than  1.7.0
+    implementation 'org.apache.shiro:shiro-core:1.7.1'
     implementation 'org.apache.sshd:sshd-core:1.7.0' // So far we did not update from 1.7.0 because of a compile issue. You may try w/ a newer version than  2.4.0
     implementation 'org.apache.tika:tika-core:1.26'
     implementation 'org.apache.tika:tika-parsers:1.25'

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/util/EntityCrypto.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/util/EntityCrypto.java
@@ -43,6 +43,7 @@ import org.apache.ofbiz.entity.model.ModelField.EncryptMethod;
 import org.apache.ofbiz.entity.transaction.TransactionUtil;
 import org.apache.shiro.crypto.AesCipherService;
 import org.apache.shiro.crypto.OperationMode;
+import org.apache.shiro.crypto.PaddingScheme;
 import org.apache.shiro.crypto.hash.DefaultHashService;
 import org.apache.shiro.crypto.hash.HashRequest;
 import org.apache.shiro.crypto.hash.HashService;
@@ -236,6 +237,7 @@ public final class EntityCrypto {
             hashService = new DefaultHashService();
             cipherService = new AesCipherService();
             cipherService.setMode(OperationMode.ECB);
+            cipherService.setPaddingScheme(PaddingScheme.PKCS5);
             saltedCipherService = new AesCipherService();
             this.kek = kek;
         }


### PR DESCRIPTION
The default padding scheme of ECB mode for org.apache.shiro.crypto.AesCipherService is different between v1.4.1 and v1.7.1, i.e.:

v1.4.1 getPaddingSchemeName() result is "PKCS5Padding"

v1.7.1 getPaddingSchemeName() result is "NoPadding"

This patch specify padding scheme explicitly, after that exception mentioned in build.gradle does not raise anymore, and initial data can load successfully.