### PR TITLE
Update services_ledger.xml

### DIFF
--- a/applications/accounting/servicedef/services_ledger.xml
+++ b/applications/accounting/servicedef/services_ledger.xml
@@ -137,7 +137,7 @@ under the License.
             location="component://accounting/minilang/ledger/GeneralLedgerServices.xml" invoke="updateGlReconciliation" auth="true">
         <description>Update a GlReconciliation record</description>
         <permission-service service-name="basicGeneralLedgerPermissionCheck" main-action="UPDATE"/>
-        <auto-attributes include="pk" mode="INOUT" optional="false"/>
+        <auto-attributes include="pk" mode="IN" optional="false"/>
         <auto-attributes include="nonpk" mode="IN" optional="true">
             <exclude field-name="createdByUserLogin"/>
             <exclude field-name="lastModifiedByUserLogin"/>


### PR DESCRIPTION
Fixed: GL Reconciliation unable to be edited (OFBIZ-12290)

updateGlReconciliation does not work because the OUT VALIDATION fails for the glReconciliationId parameter. The glReconciliationId goes through the IN validation successfully, and I am not sure of the need to put it through the OUT validation as well. This change allows the updates to Gl Reconciliation

jleroux: There is no need to put the glReconciliationId  as OUT. That's a PK and can only be created to modified/updated.

Thanks: David S Hunter
