### PR TITLE
(OFBIZ-5980) Improvement: PartyRole record(s) expiration/revocation

### DIFF
--- a/applications/accounting/testdef/data/AccountingTestsData.xml
+++ b/applications/accounting/testdef/data/AccountingTestsData.xml
@@ -28,11 +28,11 @@ under the License.
 
     <!-- For Testing service createPartyAcctgPreference -->
     <Party partyId="DEMO_COMPANY" partyTypeId="PARTY_GROUP"/>
-    <PartyRole partyId="DEMO_COMPANY" roleTypeId="INTERNAL_ORGANIZATIO"/>
+    <PartyRole partyId="DEMO_COMPANY" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
     <PaymentMethod fromDate="2001-05-13 00:00:00.0" partyId="DEMO_COMPANY" paymentMethodId="9020" paymentMethodTypeId="CREDIT_CARD"/>
     <!-- For Testing service updatePartyAcctgPreference / getPartyAccountingPreferences-->
     <Party partyId="DEMO_COMPANY1" partyTypeId="PARTY_GROUP"/>
-    <PartyRole partyId="DEMO_COMPANY1" roleTypeId="INTERNAL_ORGANIZATIO"/>
+    <PartyRole partyId="DEMO_COMPANY1" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
     <PartyAcctgPreference partyId="DEMO_COMPANY1"/>
     <!-- For Testing service updateFXConversion-->
     <UomConversionDated uomId="EUR" uomIdTo="USD" fromDate="2001-01-01 00:00:00.0" conversionFactor="1.5"/>
@@ -49,8 +49,8 @@ under the License.
     <PaymentMethodTypeGlAccount paymentMethodTypeId="CASH" glAccountId="999999" organizationPartyId="DEMO_COMPANY1"/>
 
     <!-- For Testing service cancelAgreement -->
-    <PartyRole partyId="DEMO_COMPANY" roleTypeId="SUPPLIER"/>
-    <PartyRole partyId="DEMO_COMPANY1" roleTypeId="DISTRIBUTOR"/>
+    <PartyRole partyId="DEMO_COMPANY" roleTypeId="SUPPLIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DEMO_COMPANY1" roleTypeId="DISTRIBUTOR" fromDate="2000-01-01 00:00:00.000"/>
     <Agreement agreementId="1000" agreementTypeId="COMMISSION_AGREEMENT" description="Commission Agreement" partyIdFrom="DEMO_COMPANY" partyIdTo="DEMO_COMPANY1" roleTypeIdFrom="SUPPLIER" roleTypeIdTo="DISTRIBUTOR" fromDate="2016-09-29 00:00:00"/>
     <!-- For Testing service copyAgreement -->
     <Product productId="TestProduct2" productName="Test Product 2" internalName="Test Product 2" description="Test Product For Testing getCommissionForProduct services"/>
@@ -65,7 +65,7 @@ under the License.
     <Product productId="TestProduct3" productName="Test Product 3" internalName="Test Product 3" description="Test Product For Testing updateProductAverageCostOnReceiveInventory services"/>
     <Facility facilityId="DemoFacility1" facilityTypeId="WAREHOUSE" facilityName="Demo Facility" />
     <Party partyId="DEMO_COMPANY2" partyTypeId="PARTY_GROUP"/>
-    <PartyRole partyId="DEMO_COMPANY2" roleTypeId="INTERNAL_ORGANIZATIO"/>
+    <PartyRole partyId="DEMO_COMPANY2" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
     <InventoryItem facilityId="DemoFacility1" inventoryItemId="9999" inventoryItemTypeId="NON_SERIAL_INV_ITEM" productId="TestProduct3" ownerPartyId="DEMO_COMPANY2" currencyUomId="USD" unitCost="9"/>
     <PartyAcctgPreference partyId="DEMO_COMPANY2" cogsMethodId="COGS_LIFO"/>
     <!-- For Testing service updateFinAccount -->

--- a/applications/commonext/data/OfbizSetupShippingData.xml
+++ b/applications/commonext/data/OfbizSetupShippingData.xml
@@ -31,11 +31,11 @@
     <PartyGroup partyId="DHL" groupName="DHL"/>
     <PartyGroup partyId="FEDEX" groupName="Federal Express"/>
 
-    <PartyRole partyId="USPS" roleTypeId="CARRIER"/>
-    <PartyRole partyId="UPS" roleTypeId="CARRIER"/>
-    <PartyRole partyId="DHL" roleTypeId="CARRIER"/>
-    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
-    <PartyRole partyId="FEDEX" roleTypeId="CARRIER"/>
+    <PartyRole partyId="USPS" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="UPS" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DHL" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="_NA_" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="FEDEX" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
 
     <PartyStatus partyId="USPS" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyStatus partyId="UPS" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>

--- a/applications/datamodel/data/demo/AccountingDemoData.xml
+++ b/applications/datamodel/data/demo/AccountingDemoData.xml
@@ -134,10 +134,10 @@ under the License.
     <!-- The main Company Internal Organization -->
     <Party partyId="Company" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="Company" groupName="Your Company Name Here" logoImageUrl="/images/ofbiz_logo.png"/>
-    <PartyRole partyId="Company" roleTypeId="BILL_FROM_VENDOR"/>
-    <PartyRole partyId="Company" roleTypeId="BILL_TO_CUSTOMER"/>
-    <PartyRole partyId="Company" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="Company" roleTypeId="_NA_"/>
+    <PartyRole partyId="Company" roleTypeId="BILL_FROM_VENDOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Company" roleTypeId="BILL_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Company" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Company" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="Company" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContactMech contactMechId="9000" contactMechTypeId="POSTAL_ADDRESS"/>
     <PartyContactMech partyId="Company" contactMechId="9000" fromDate="2000-01-01 00:00:00.000" allowSolicitation="Y"/>
@@ -156,90 +156,90 @@ under the License.
     <!-- Sub-Organizations -->
     <Party partyId="MARKETING" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="MARKETING" groupName="Marketing department"/>
-    <PartyRole partyId="MARKETING" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="MARKETING" roleTypeId="_NA_"/>
+    <PartyRole partyId="MARKETING" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="MARKETING" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="MARKETING" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="MARKETING" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="ACCOUNTING" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="ACCOUNTING" groupName="Accounting department"/>
-    <PartyRole partyId="ACCOUNTING" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="ACCOUNTING" roleTypeId="_NA_"/>
-    <PartyRole partyId="ACCOUNTING" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="ACCOUNTING" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="ACCOUNTING" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="ACCOUNTING" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="ACCOUNTING" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="ACCOUNTING" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="SALES" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="SALES" groupName="Sales department"/>
-    <PartyRole partyId="SALES" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="SALES" roleTypeId="_NA_"/>
+    <PartyRole partyId="SALES" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="SALES" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="SALES" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="SALES" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="DEV" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
-    <PartyGroup partyId="DEV" groupName="Development department"/>
-    <PartyRole partyId="DEV" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="DEV" roleTypeId="_NA_"/>
+    <PartyGroup partyId="DEV" groupName="Development department" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DEV" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DEV" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DEV" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="DEV" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="TESTING" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="TESTING" groupName="Testing department"/>
-    <PartyRole partyId="TESTING" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="TESTING" roleTypeId="_NA_"/>
+    <PartyRole partyId="TESTING" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TESTING" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TESTING" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="TESTING" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <!-- Development Teams -->
     <Party partyId="DevTeam1" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2009-05-06 11:16:40.989" createdByUserLogin="admin" lastModifiedDate="2009-05-06 11:16:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="DevTeam1" groupName="Development Team1"/>
-    <PartyRole partyId="DevTeam1" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="DevTeam1" roleTypeId="_NA_"/>
+    <PartyRole partyId="DevTeam1" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DevTeam1" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DevTeam1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="DEV" partyIdTo="DevTeam1" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="DevTeam2" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2009-05-06 11:16:40.989" createdByUserLogin="admin" lastModifiedDate="2009-05-06 11:16:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="DevTeam2" groupName="Development Team2"/>
-    <PartyRole partyId="DevTeam2" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="DevTeam2" roleTypeId="_NA_"/>
+    <PartyRole partyId="DevTeam2" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DevTeam2" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DevTeam2" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="DEV" partyIdTo="DevTeam2" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="DevTeam3" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2009-05-06 11:16:40.989" createdByUserLogin="admin" lastModifiedDate="2009-05-06 11:16:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="DevTeam3" groupName="Development Team3"/>
-    <PartyRole partyId="DevTeam3" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="DevTeam3" roleTypeId="_NA_"/>
+    <PartyRole partyId="DevTeam3" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DevTeam3" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DevTeam3" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="DEV" partyIdTo="DevTeam3" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="DevTeam4" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2009-05-06 11:16:40.989" createdByUserLogin="admin" lastModifiedDate="2009-05-06 11:16:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="DevTeam4" groupName="Development Team4"/>
-    <PartyRole partyId="DevTeam4" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="DevTeam4" roleTypeId="_NA_"/>
+    <PartyRole partyId="DevTeam4" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DevTeam4" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DevTeam4" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="DEV" partyIdTo="DevTeam4" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <!-- Testing Teams-->
     <Party partyId="TestingTeam1" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2009-05-06 11:16:40.989" createdByUserLogin="admin" lastModifiedDate="2009-05-06 11:16:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="TestingTeam1" groupName="Testing Team1"/>
-    <PartyRole partyId="TestingTeam1" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="TestingTeam1" roleTypeId="_NA_"/>
+    <PartyRole partyId="TestingTeam1" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestingTeam1" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestingTeam1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="TESTING" partyIdTo="TestingTeam1" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="TestingTeam2" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2009-05-06 11:16:40.989" createdByUserLogin="admin" lastModifiedDate="2009-05-06 11:16:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="TestingTeam2" groupName="Testing Team2"/>
-    <PartyRole partyId="TestingTeam2" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="TestingTeam2" roleTypeId="_NA_"/>
+    <PartyRole partyId="TestingTeam2" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestingTeam2" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestingTeam2" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="TESTING" partyIdTo="TestingTeam2" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 
     <!--Team Members -->
     <Party partyId="Developer1" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="Developer1" firstName="Developer1"/>
-    <PartyRole partyId="Developer1" roleTypeId="_NA_"/>
-    <PartyRole partyId="Developer1" roleTypeId="EMPLOYEE"/>
-    <PartyRole partyId="Developer1" roleTypeId="MANAGER"/>
+    <PartyRole partyId="Developer1" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Developer1" roleTypeId="EMPLOYEE" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Developer1" roleTypeId="MANAGER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="Developer1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="Developer1" partyRelationshipTypeId="EMPLOYMENT" roleTypeIdFrom="INTERNAL_ORGANIZATIO" roleTypeIdTo="EMPLOYEE"
                        fromDate="2001-05-02 00:00:00.000"/>
@@ -250,8 +250,8 @@ under the License.
 
     <Party partyId="Developer2" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="Developer2" firstName="Developer2"/>
-    <PartyRole partyId="Developer2" roleTypeId="_NA_"/>
-    <PartyRole partyId="Developer2" roleTypeId="EMPLOYEE"/>
+    <PartyRole partyId="Developer2" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Developer2" roleTypeId="EMPLOYEE" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="Developer2" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="Developer2" partyRelationshipTypeId="EMPLOYMENT" roleTypeIdFrom="INTERNAL_ORGANIZATIO" roleTypeIdTo="EMPLOYEE"
                        fromDate="2001-05-02 00:00:00.000"/>
@@ -260,8 +260,8 @@ under the License.
 
     <Party partyId="Developer3" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="Developer3" firstName="Developer3"/>
-    <PartyRole partyId="Developer3" roleTypeId="_NA_"/>
-    <PartyRole partyId="Developer3" roleTypeId="EMPLOYEE"/>
+    <PartyRole partyId="Developer3" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Developer3" roleTypeId="EMPLOYEE" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="Developer3" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="Developer3" partyRelationshipTypeId="EMPLOYMENT" roleTypeIdFrom="INTERNAL_ORGANIZATIO" roleTypeIdTo="EMPLOYEE"
                        fromDate="2001-05-02 00:00:00.000"/>
@@ -270,9 +270,9 @@ under the License.
 
     <Party partyId="TestingTeamMember1" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="TestingTeamMember1" firstName="TestingTeamMember1"/>
-    <PartyRole partyId="TestingTeamMember1" roleTypeId="_NA_"/>
-    <PartyRole partyId="TestingTeamMember1" roleTypeId="EMPLOYEE"/>
-    <PartyRole partyId="TestingTeamMember1" roleTypeId="MANAGER"/>
+    <PartyRole partyId="TestingTeamMember1" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestingTeamMember1" roleTypeId="EMPLOYEE" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestingTeamMember1" roleTypeId="MANAGER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestingTeamMember1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="TestingTeamMember1" partyRelationshipTypeId="EMPLOYMENT" roleTypeIdFrom="INTERNAL_ORGANIZATIO" roleTypeIdTo="EMPLOYEE"
                        fromDate="2001-05-02 00:00:00.000"/>
@@ -283,8 +283,8 @@ under the License.
 
     <Party partyId="TestingTeamMember2" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="TestingTeamMember2" firstName="TestingTeamMember2"/>
-    <PartyRole partyId="TestingTeamMember2" roleTypeId="_NA_"/>
-    <PartyRole partyId="TestingTeamMember2" roleTypeId="EMPLOYEE"/>
+    <PartyRole partyId="TestingTeamMember2" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestingTeamMember2" roleTypeId="EMPLOYEE" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestingTeamMember2" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="TestingTeamMember2" partyRelationshipTypeId="EMPLOYMENT" roleTypeIdFrom="INTERNAL_ORGANIZATIO" roleTypeIdTo="EMPLOYEE"
                        fromDate="2001-05-02 00:00:00.000"/>
@@ -293,8 +293,8 @@ under the License.
 
     <Party partyId="TestingTeamMember3" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="TestingTeamMember3" firstName="TestingTeamMember3"/>
-    <PartyRole partyId="TestingTeamMember3" roleTypeId="_NA_"/>
-    <PartyRole partyId="TestingTeamMember3" roleTypeId="EMPLOYEE"/>
+    <PartyRole partyId="TestingTeamMember3" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestingTeamMember3" roleTypeId="EMPLOYEE" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestingTeamMember3" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="TestingTeamMember3" partyRelationshipTypeId="EMPLOYMENT" roleTypeIdFrom="INTERNAL_ORGANIZATIO" roleTypeIdTo="EMPLOYEE"
                        fromDate="2001-05-02 00:00:00.000"/>
@@ -310,30 +310,30 @@ under the License.
 
     <Party partyId="Enterprise" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="Enterprise" groupName="Large Enterprise, Inc." logoImageUrl="/images/ofbiz_logo.png"/>
-    <PartyRole partyId="Enterprise" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="Enterprise" roleTypeId="PARENT_ORGANIZATION"/>
+    <PartyRole partyId="Enterprise" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Enterprise" roleTypeId="PARENT_ORGANIZATION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="Enterprise" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <!-- Top tier divisions -->
 
     <Party partyId="bu_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="bu_div" groupName="Business Unit Division"/>
-    <PartyRole partyId="bu_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="bu_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="bu_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="bu_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="bu_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Enterprise" partyIdTo="bu_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="PARENT_ORGANIZATION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="md_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="md_div" groupName="Market Development Division"/>
-    <PartyRole partyId="md_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="md_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="md_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="md_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="md_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Enterprise" partyIdTo="md_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="PARENT_ORGANIZATION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="cf_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="cf_div" groupName="Corporate Functions Division"/>
-    <PartyRole partyId="cf_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="cf_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="cf_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="cf_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="cf_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Enterprise" partyIdTo="cf_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="PARENT_ORGANIZATION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
@@ -341,15 +341,15 @@ under the License.
 
     <Party partyId="gizmo_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="gizmo_div" groupName="Gizmo Business Unit"/>
-    <PartyRole partyId="gizmo_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="gizmo_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="gizmo_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="gizmo_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="gizmo_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="bu_div" partyIdTo="gizmo_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="widget_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="widget_div" groupName="Widget Business Unit"/>
-    <PartyRole partyId="widget_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="widget_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="widget_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="widget_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="widget_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="bu_div" partyIdTo="widget_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
@@ -357,43 +357,43 @@ under the License.
 
     <Party partyId="na_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="na_div" groupName="North America"/>
-    <PartyRole partyId="na_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="na_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="na_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="na_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="na_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="md_div" partyIdTo="na_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="sa_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="sa_div" groupName="Central and South America"/>
-    <PartyRole partyId="sa_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="sa_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="sa_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="sa_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="sa_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="md_div" partyIdTo="sa_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="we_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="we_div" groupName="Western Europe"/>
-    <PartyRole partyId="we_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="we_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="we_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="we_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="we_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="md_div" partyIdTo="we_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="asia_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="asia_div" groupName="Asia"/>
-    <PartyRole partyId="asia_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="asia_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="asia_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="asia_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="asia_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="md_div" partyIdTo="asia_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="anz_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="anz_div" groupName="Australia and New Zealand"/>
-    <PartyRole partyId="anz_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="anz_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="anz_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="anz_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="anz_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="md_div" partyIdTo="anz_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="india_div" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="india_div" groupName="India"/>
-    <PartyRole partyId="india_div" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="india_div" roleTypeId="DIVISION"/>
+    <PartyRole partyId="india_div" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="india_div" roleTypeId="DIVISION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="india_div" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="md_div" partyIdTo="india_div" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DIVISION" fromDate="2001-05-13 00:00:00.000"/>
 
@@ -401,32 +401,32 @@ under the License.
 
     <Party partyId="RECEIVING" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="RECEIVING" groupName="Receiving Department"/>
-    <PartyRole partyId="RECEIVING" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="RECEIVING" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="RECEIVING" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="RECEIVING" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="RECEIVING" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="gizmo_div" partyIdTo="RECEIVING" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
     <PartyRelationship partyIdFrom="widget_div" partyIdTo="RECEIVING" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="PRODUCTION" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="PRODUCTION" groupName="Production Department"/>
-    <PartyRole partyId="PRODUCTION" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="PRODUCTION" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="PRODUCTION" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="PRODUCTION" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="PRODUCTION" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="gizmo_div" partyIdTo="PRODUCTION" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
     <PartyRelationship partyIdFrom="widget_div" partyIdTo="PRODUCTION" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="SHIPPING" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="SHIPPING" groupName="Shipping Department"/>
-    <PartyRole partyId="SHIPPING" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="SHIPPING" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="SHIPPING" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="SHIPPING" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="SHIPPING" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="gizmo_div" partyIdTo="SHIPPING" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
     <PartyRelationship partyIdFrom="widget_div" partyIdTo="SHIPPING" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="MAINTENANCE" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="MAINTENANCE" groupName="Maintenance Department"/>
-    <PartyRole partyId="MAINTENANCE" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="MAINTENANCE" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="MAINTENANCE" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="MAINTENANCE" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="MAINTENANCE" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="gizmo_div" partyIdTo="MAINTENANCE" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
     <PartyRelationship partyIdFrom="widget_div" partyIdTo="MAINTENANCE" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
@@ -435,43 +435,43 @@ under the License.
 
     <Party partyId="LEGAL" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="LEGAL" groupName="Legal Department"/>
-    <PartyRole partyId="LEGAL" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="LEGAL" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="LEGAL" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="LEGAL" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="LEGAL" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="cf_div" partyIdTo="LEGAL" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="PUBLIC_REL" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="PUBLIC_REL" groupName="Public Relations"/>
-    <PartyRole partyId="PUBLIC_REL" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="PUBLIC_REL" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="PUBLIC_REL" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="PUBLIC_REL" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="PUBLIC_REL" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="cf_div" partyIdTo="PUBLIC_REL" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="HUMAN_RES" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="HUMAN_RES" groupName="Human Resources"/>
-    <PartyRole partyId="HUMAN_RES" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="HUMAN_RES" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="HUMAN_RES" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="HUMAN_RES" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="HUMAN_RES" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="cf_div" partyIdTo="HUMAN_RES" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="INFO_TECH" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="INFO_TECH" groupName="Information Technology"/>
-    <PartyRole partyId="INFO_TECH" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="INFO_TECH" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="INFO_TECH" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="INFO_TECH" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="INFO_TECH" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="cf_div" partyIdTo="INFO_TECH" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="R_AND_D" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="R_AND_D" groupName="Research and Development"/>
-    <PartyRole partyId="R_AND_D" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="R_AND_D" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="R_AND_D" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="R_AND_D" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="R_AND_D" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="cf_div" partyIdTo="R_AND_D" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
     <Party partyId="LOGISTICS" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <PartyGroup partyId="LOGISTICS" groupName="Logistics"/>
-    <PartyRole partyId="LOGISTICS" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="LOGISTICS" roleTypeId="DEPARTMENT"/>
+    <PartyRole partyId="LOGISTICS" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="LOGISTICS" roleTypeId="DEPARTMENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="LOGISTICS" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="cf_div" partyIdTo="LOGISTICS" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="DIVISION" roleTypeIdTo="DEPARTMENT" fromDate="2001-05-13 00:00:00.000"/>
 
@@ -898,7 +898,7 @@ under the License.
     <!-- Tax Authority Demo Data -->
     <Party partyId="USA_IRS" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="USA_IRS" groupName="United States of America - Internal Revenue Service"/>
-    <PartyRole partyId="USA_IRS" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="USA_IRS" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
 
     <Party partyId="CA_BOE" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="CA_BOE" groupName="State of California Board of Equalization"/>
@@ -907,7 +907,7 @@ under the License.
     <PartyContactMech partyId="CA_BOE" contactMechId="CA_BOE_0" fromDate="2000-01-01 00:00:00.000" allowSolicitation="N"/>
     <PartyContactMechPurpose partyId="CA_BOE" contactMechId="CA_BOE_0" contactMechPurposeTypeId="PAYMENT_LOCATION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyContactMechPurpose partyId="CA_BOE" contactMechId="CA_BOE_0" contactMechPurposeTypeId="BILLING_LOCATION" fromDate="2000-01-01 00:00:00.000"/>
-    <PartyRole partyId="CA_BOE" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="CA_BOE" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
 
     <Party partyId="NY_DTF" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="NY_DTF" groupName="New York Department of Taxation and Finance"/>
@@ -916,25 +916,25 @@ under the License.
     <PartyContactMech partyId="NY_DTF" contactMechId="NY_DTF_0" fromDate="2000-01-01 00:00:00.000" allowSolicitation="N"/>
     <PartyContactMechPurpose partyId="NY_DTF" contactMechId="NY_DTF_0" contactMechPurposeTypeId="PAYMENT_LOCATION" fromDate="2000-01-01 00:00:00.000"/>
     <PartyContactMechPurpose partyId="NY_DTF" contactMechId="NY_DTF_0" contactMechPurposeTypeId="BILLING_LOCATION" fromDate="2000-01-01 00:00:00.000"/>
-    <PartyRole partyId="NY_DTF" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="NY_DTF" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
 
     <Party partyId="TX_TAXMAN" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="TX_TAXMAN" groupName="Texas Sales Tax Authority"/>
-    <PartyRole partyId="TX_TAXMAN" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="TX_TAXMAN" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
 
     <Party partyId="UT_TAXMAN" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="UT_TAXMAN" groupName="Utah Sales Tax Authority"/>
-    <PartyRole partyId="UT_TAXMAN" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="UT_TAXMAN" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <Party partyId="UT_UTAH_TAXMAN" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="UT_UTAH_TAXMAN" groupName="Utah County, Utah Sales Tax Authority"/>
-    <PartyRole partyId="UT_UTAH_TAXMAN" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="UT_UTAH_TAXMAN" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
 
     <Party partyId="CAN_TAXMAN" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="CAN_TAXMAN" groupName="Canada Tax Authority"/>
-    <PartyRole partyId="CAN_TAXMAN" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="CAN_TAXMAN" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <Party partyId="ON_TAXMAN" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="ON_TAXMAN" groupName="Ontario Sales Tax (VAT) Authority"/>
-    <PartyRole partyId="ON_TAXMAN" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="ON_TAXMAN" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
 
     <!-- _NA_ TaxAuthority defs -->
     <ProductCategory productCategoryId="20111"/>
@@ -995,7 +995,7 @@ under the License.
     <!-- China TaxAuthority defs -->
     <Party partyId="CHN_STA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="CNY" statusId="PARTY_ENABLED" createdDate="2009-01-01 00:00:00.000"/>
     <PartyGroup partyId="CHN_STA" groupName="State Taxation Administration"/>
-    <PartyRole partyId="CHN_STA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="CHN_STA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthGeoId="CHN" taxAuthPartyId="CHN_STA" includeTaxInPrice="N" requireTaxIdForExemption="Y"
         taxIdFormatPattern=""/>
     <TaxAuthorityGlAccount taxAuthGeoId="CHN" taxAuthPartyId="CHN_STA" organizationPartyId="Company" glAccountId="224209"/>
@@ -1015,142 +1015,142 @@ under the License.
     <!-- EU tax authorities -->
     <Party partyId="AUT_BMF" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2009-01-01 00:00:00.000"/>
     <PartyGroup partyId="AUT_BMF" groupName="Bundesministerium für Finanzen"/>
-    <PartyRole partyId="AUT_BMF" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="AUT_BMF" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="AUT_BMF" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="AUT" taxIdFormatPattern="^(AT-?)[U]\d{9}$"/>
 
     <Party partyId="BEL_FOD" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2009-01-01 00:00:00.000"/>
     <PartyGroup partyId="BEL_FOD" groupName="Federale OverheidsDienst FINANCIËN"/>
-    <PartyRole partyId="BEL_FOD" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="BEL_FOD" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="BEL_FOD" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="BEL" taxIdFormatPattern="^(BE-?)\d{10}$"/>
 
     <Party partyId="BGR_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="BGN" statusId="PARTY_ENABLED" createdDate="2009-01-01 00:00:00.000"/>
     <PartyGroup partyId="BGR_TA" groupName="Tax Authority of Bulgaria"/>
-    <PartyRole partyId="BGR_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="BGR_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="BGR_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="BGR" taxIdFormatPattern="^(BG-?)\d{10}$"/>
 
     <Party partyId="DEU_BZSt" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2009-01-01 00:00:00.000"/>
     <PartyGroup partyId="DEU_BZSt" groupName="Bundeszentralamt für Steuern"/>
-    <PartyRole partyId="DEU_BZSt" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="DEU_BZSt" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="DEU_BZSt" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="DEU" taxIdFormatPattern="^(DE-?)?{0,1}[0-9]{9}$"/>
 
     <Party partyId="DNK_SKAT" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="DKK" statusId="PARTY_ENABLED" createdDate="2009-01-01 00:00:00.000"/>
     <PartyGroup partyId="DNK_SKAT" groupName="SKAT"/>
-    <PartyRole partyId="DNK_SKAT" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="DNK_SKAT" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="DNK_SKAT" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="DNK" taxIdFormatPattern="^(DK-?)?([0-9]{2}\ ?){3}[0-9]{2}$"/>
 
     <Party partyId="CYP_ΤΕΠ" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="CYP_ΤΕΠ" groupName="Τμήματος Εσωτερικών Προσόδων"/>
-    <PartyRole partyId="CYP_ΤΕΠ" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="CYP_ΤΕΠ" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="CYP_ΤΕΠ" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="CYP" taxIdFormatPattern="^(CY-?)?[0-9]{8}[A-Z]$"/>
 
     <Party partyId="CZE_CDS" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="CZK" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="CZE_CDS" groupName="Česká daňová správa - Ministerstvo financí ČR"/>
-    <PartyRole partyId="CZE_CDS" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="CZE_CDS" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="CZE_CDS" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="CZE" taxIdFormatPattern="^(CZ-?)?[0-9]{8,10}$"/>
 
     <Party partyId="ESP_AT" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="ESP_AT" groupName="Agenzia Tributaria"/>
-    <PartyRole partyId="ESP_AT" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="ESP_AT" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="ESP_AT" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="ESP" taxIdFormatPattern="^(ES-?)?([0-9A-Z][0-9]{7}[A-Z])|([A-Z][0-9]{7}[0-9A-Z])$"/>
 
     <Party partyId="EST_EMTA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="EST_EMTA" groupName="Maksu- ja Tolliamet"/>
-    <PartyRole partyId="EST_EMTA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="EST_EMTA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="EST_EMTA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="EST" taxIdFormatPattern="^(EE-?)?{0,1}[0-9]{9}$"/>
 
     <Party partyId="FIN_VERO" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="FIN_VERO" groupName="Verohallinto"/>
-    <PartyRole partyId="FIN_VERO" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="FIN_VERO" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="FIN_VERO" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="FIN" taxIdFormatPattern="^(FI-?)?{0,1}[0-9]{8}$"/>
 
     <Party partyId="FRA_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="FRA_TA" groupName="Ministère de l'économie et des finances"/>
-    <PartyRole partyId="FRA_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="FRA_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="FRA_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="FRA" taxIdFormatPattern="^(FR-?)?[0-9A-Z]{2}\ ?[0-9]{9}$"/>
 
     <Party partyId="GBR_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="GBP" statusId="PARTY_ENABLED" createdDate="2009-01-01 00:00:00.000"/>
     <PartyGroup partyId="GBR_TA" groupName="HM Revenue and Customs"/>
-    <PartyRole partyId="GBR_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="GBR_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="GBR_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="GBR" taxIdFormatPattern="^(GB)?([0-9]{9}|[0-9]{12}|(GD|HA)[0-9]{3})$"/>
 
     <Party partyId="GRC_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="GRC_TA" groupName="Tax Authority of Greece"/>
-    <PartyRole partyId="GRC_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="GRC_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="GRC_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="GRC" taxIdFormatPattern="^(EL-?)?{0,1}[0-9]{9}$"/>
 
     <Party partyId="HRV_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="HRV_TA" groupName="Porezna Uprava"/>
-    <PartyRole partyId="HRV_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="HRV_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="HRV_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="HRV" taxIdFormatPattern="^(HR-?)?{0,1}[0-9]{11}$"/>
 
     <Party partyId="HUN_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="HUF" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="HUN_TA" groupName="Tax Authority of Hungary"/>
-    <PartyRole partyId="HUN_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="HUN_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="HUN_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="HUN" taxIdFormatPattern="^(HU-?)?{0,1}[0-9]{8}$"/>
 
     <Party partyId="IRL_ITC" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="IRL_ITC" groupName="Irish Tax and Customs"/>
-    <PartyRole partyId="IRL_ITC" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="IRL_ITC" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="IRL_ITC" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="IRL" taxIdFormatPattern="^(IE-?)?[0-9][0-9A-Z\+\*][0-9]{5}[A-Z]$"/>
 
     <Party partyId="ITA_ADE" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="ITA_ADE" groupName="Agenzia delle Entrata"/>
-    <PartyRole partyId="ITA_ADE" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="ITA_ADE" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="ITA_ADE" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="ITA" taxIdFormatPattern="^(IT-?)?{0,1}[0-9]{11}$"/>
 
     <Party partyId="LVA_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="LVA_TA" groupName="Tax Authority of Lativa"/>
-    <PartyRole partyId="LVA_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="LVA_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="LVA_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="LVA" taxIdFormatPattern="^(LV-?)?{0,1}[0-9]{11}$"/>
 
     <Party partyId="LTU_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="LTU_TA" groupName="Tax Authority of Lithuania"/>
-    <PartyRole partyId="LTU_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="LTU_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="LTU_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="LTU" taxIdFormatPattern="^(LT-?)?([0-9]{9}|[0-9]{12})$"/>
 
     <Party partyId="LUX_ACD" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="LUX_ACD" groupName="Administration des Contributions Directe"/>
-    <PartyRole partyId="LUX_ACD" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="LUX_ACD" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="LUX_ACD" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="LUX" taxIdFormatPattern="^(LU-?)?{0,1}[0-9]{8}$"/>
 
     <Party partyId="MLT_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="MLT_TA" groupName="Tax Authority of MT (Malta)"/>
-    <PartyRole partyId="MLT_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="MLT_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="MLT_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="MLT" taxIdFormatPattern="^(MT-?)?{0,1}[0-9]{8}$"/>
 
     <Party partyId="NLD_NBD" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2009-01-01 00:00:00.000"/>
     <PartyGroup partyId="NLD_NBD" groupName="Ned. Belastingdienst"/>
-    <PartyRole partyId="NLD_NBD" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="NLD_NBD" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="NLD_NBD" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="NLD" taxIdFormatPattern="^(NL-?)?[0-9]{9}B[0-9]{2}$"/>
 
     <Party partyId="POL_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="PLN" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="POL_TA" groupName="Tax Authority of PL"/>
-    <PartyRole partyId="POL_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="POL_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="POL_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="POL" taxIdFormatPattern="^(PL-?)?{0,1}[0-9]{10}$"/>
 
     <Party partyId="PRT_AT" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="PRT_AT" groupName="Autoritade Tributária e Aduaneira"/>
-    <PartyRole partyId="PRT_AT" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="PRT_AT" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="PRT_AT" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="PRT" taxIdFormatPattern="^(PT-?)?{0,1}[0-9]{9}$"/>
 
     <Party partyId="ROM_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="RON" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="ROM_TA" groupName="Tax Authority of Romania"/>
-    <PartyRole partyId="ROM_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="ROM_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="ROM_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="ROU"/>
 
     <Party partyId="SVK_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="SVK_TA" groupName="Tax Authority of Slovakia"/>
-    <PartyRole partyId="SVK_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="SVK_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="SVK_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="SVK" taxIdFormatPattern="^(SK-?)?{0,1}[0-9]{10}$"/>
 
     <Party partyId="SVN_TA" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="EUR" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="SVN_TA" groupName="Tax Authority of Slovenia"/>
-    <PartyRole partyId="SVN_TA" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="SVN_TA" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="SVN_TA" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="SVN" taxIdFormatPattern="^(SI-?)?{0,1}[0-9]{8}$"/>
 
     <Party partyId="SWE_SV" partyTypeId="PARTY_GROUP" preferredCurrencyUomId="SEK" statusId="PARTY_ENABLED" createdDate="2013-07-12 00:00:00.000"/>
     <PartyGroup partyId="SWE_SV" groupName="Skatteverket"/>
-    <PartyRole partyId="SWE_SV" roleTypeId="TAX_AUTHORITY"/>
+    <PartyRole partyId="SWE_SV" roleTypeId="TAX_AUTHORITY" fromDate="2000-01-01 00:00:00.000"/>
     <TaxAuthority taxAuthPartyId="SWE_SV" includeTaxInPrice="N" requireTaxIdForExemption="Y" taxAuthGeoId="SWE" taxIdFormatPattern="^(SE-?)?{0,1}[0-9]{12}$"/>
 
     <!-- Accounting Transaction Demo Data -->
@@ -1279,14 +1279,14 @@ under the License.
     <!-- Invoice Payment Demo Data -->
     <Party partyId="AcctBuyer" partyTypeId="PERSON"/>
     <Person partyId="AcctBuyer" firstName="Acct" lastName="Buyer"/>
-    <PartyRole partyId="AcctBuyer" roleTypeId="BUYER"/>
+    <PartyRole partyId="AcctBuyer" roleTypeId="BUYER" fromDate="2000-01-01 00:00:00.000"/>
     <UserLogin partyId="AcctBuyer" userLoginId="AcctBuyer"/>
     <SecurityGroup groupId="ORDERPURCH"/><!-- is needed because accounting is before order -->
     <UserLoginSecurityGroup userLoginId="AcctBuyer" groupId="ORDERPURCH" fromDate="2001-05-13 00:00:00"/>
 
     <Party partyId="AcctBigSupplier" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="AcctBigSupplier" groupName="Acct Big Supplier"/>
-    <PartyRole partyId="AcctBigSupplier" roleTypeId="SUPPLIER"/>
+    <PartyRole partyId="AcctBigSupplier" roleTypeId="SUPPLIER" fromDate="2000-01-01 00:00:00.000"/>
 
     <Payment paymentId="demo10000" paymentTypeId="CUSTOMER_PAYMENT" paymentMethodTypeId="EFT_ACCOUNT" partyIdFrom="AcctBuyer" partyIdTo="Company" statusId="PMNT_NOT_PAID" effectiveDate="2006-04-25 12:56:54.292" amount="190.97" currencyUomId="USD"/>
     <Payment paymentId="demo10010" paymentTypeId="CUSTOMER_REFUND" paymentMethodTypeId="EXT_BILLACT" partyIdFrom="Company" partyIdTo="AcctBuyer" statusId="PMNT_SENT" effectiveDate="2006-04-25 13:11:05.94" amount="20.0" currencyUomId="USD" />
@@ -1410,7 +1410,7 @@ under the License.
 
     <!-- Demo invoice data for sales invoice with INVOICE_PAID status -->
     <Party partyId="DemoCustAgent"/>
-    <PartyRole partyId="DemoCustAgent" roleTypeId="SALES_REP"/>
+    <PartyRole partyId="DemoCustAgent" roleTypeId="SALES_REP" fromDate="2000-01-01 00:00:00.000"/>
     <Product productId="WG-9943" productTypeId="FINISHED_GOOD"/>
     <Product productId="WG-9943-B3" productTypeId="FINISHED_GOOD"/>
 
@@ -1484,16 +1484,16 @@ under the License.
     <!-- Accounting User Demo Data -->
     <Party partyId="accountant_group" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="accountant_group" groupName="Accountant Group"/>
-    <PartyRole partyId="accountant_group" roleTypeId="ORGANIZATION_ROLE"/>
-    <PartyRole partyId="accountant_group" roleTypeId="_NA_"/>
+    <PartyRole partyId="accountant_group" roleTypeId="ORGANIZATION_ROLE" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="accountant_group" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="accountant_group" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="accountant_group" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="accountingadmin" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="accountingadmin" firstName="Accounting" lastName="Administrator"/>
-    <PartyRole partyId="accountingadmin" roleTypeId="ACCOUNTANT"/>
-    <PartyRole partyId="accountingadmin" roleTypeId="EMPLOYEE"/>
-    <PartyRole partyId="accountingadmin" roleTypeId="_NA_"/>
+    <PartyRole partyId="accountingadmin" roleTypeId="ACCOUNTANT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="accountingadmin" roleTypeId="EMPLOYEE" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="accountingadmin" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="accountant_group" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <UserLogin userLoginId="accountingadmin" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a" partyId="accountingadmin"/>
     <UserLoginSecurityGroup groupId="ACCTG_FUNCTNL_ADMIN" userLoginId="accountingadmin" fromDate="2001-01-01 12:00:00.0"/>
@@ -1608,5 +1608,4 @@ under the License.
     <InventoryItem facilityId="WebStoreWarehouse" locationSeqId="TLTLTLUL01" datetimeReceived="2008-08-01 08:00:00.000"
                    inventoryItemId="9030" inventoryItemTypeId="NON_SERIAL_INV_ITEM" productId="MAT_B_COST" ownerPartyId="Company" currencyUomId="USD" unitCost="7.0"/>
     <InventoryItemDetail inventoryItemId="9030" inventoryItemDetailSeqId="0001" effectiveDate="2001-05-13 12:00:00.0" availableToPromiseDiff="20" quantityOnHandDiff="20" accountingQuantityDiff="20"/>
-
 </entity-engine-xml>

--- a/applications/datamodel/data/demo/ContentDemoData.xml
+++ b/applications/datamodel/data/demo/ContentDemoData.xml
@@ -40,34 +40,34 @@ under the License.
     <Party partyId="BLOG_GUEST" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="BLOG_GUEST" lastName="Guest" firstName="Blog"/>
     <UserLogin userLoginId="blog_guest" partyId="BLOG_GUEST"/>
-    <PartyRole partyId="BLOG_GUEST" roleTypeId="_NA_"/>
+    <PartyRole partyId="BLOG_GUEST" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="BLOG_GUEST" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="BLOG_ADMIN" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="BLOG_ADMIN" lastName="Admin" firstName="Blog"/>
     <UserLogin userLoginId="blog_admin" partyId="BLOG_ADMIN"/>
-    <PartyRole partyId="BLOG_ADMIN" roleTypeId="CONTENT_ADMIN"/>
-    <PartyRole partyId="BLOG_ADMIN" roleTypeId="CONTENT_AUTHOR"/>
-    <PartyRole partyId="BLOG_ADMIN" roleTypeId="CONTENT_EDITOR"/>
-    <PartyRole partyId="BLOG_ADMIN" roleTypeId="CONTENT_PUBLISHER"/>
-    <PartyRole partyId="BLOG_ADMIN" roleTypeId="_NA_"/>
+    <PartyRole partyId="BLOG_ADMIN" roleTypeId="CONTENT_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_ADMIN" roleTypeId="CONTENT_AUTHOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_ADMIN" roleTypeId="CONTENT_EDITOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_ADMIN" roleTypeId="CONTENT_PUBLISHER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_ADMIN" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="BLOG_ADMIN" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="BLOG_AUTHOR" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="BLOG_AUTHOR" lastName="Author" firstName="Blog"/>
     <UserLogin userLoginId="blog_author" partyId="BLOG_AUTHOR"/>
-    <PartyRole partyId="BLOG_AUTHOR" roleTypeId="CONTENT_AUTHOR"/>
-    <PartyRole partyId="BLOG_AUTHOR" roleTypeId="CONTENT_PUBLISHER"/>
-    <PartyRole partyId="BLOG_AUTHOR" roleTypeId="_NA_"/>
+    <PartyRole partyId="BLOG_AUTHOR" roleTypeId="CONTENT_AUTHOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_AUTHOR" roleTypeId="CONTENT_PUBLISHER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_AUTHOR" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="BLOG_AUTHOR" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="BLOG_EDITOR" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="BLOG_EDITOR" lastName="Editor" firstName="Blog"/>
     <UserLogin userLoginId="blog_editor" partyId="BLOG_EDITOR"/>
-    <PartyRole partyId="BLOG_EDITOR" roleTypeId="CONTENT_EDITOR"/>
-    <PartyRole partyId="BLOG_EDITOR" roleTypeId="CONTENT_EDITOR"/>
-    <PartyRole partyId="BLOG_EDITOR" roleTypeId="CONTENT_PUBLISHER"/>
-    <PartyRole partyId="BLOG_EDITOR" roleTypeId="_NA_"/>
+    <PartyRole partyId="BLOG_EDITOR" roleTypeId="CONTENT_EDITOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_EDITOR" roleTypeId="CONTENT_EDITOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_EDITOR" roleTypeId="CONTENT_PUBLISHER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_EDITOR" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="BLOG_EDITOR" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <ContactMech contactMechId="ADMIN_CONTACT" contactMechTypeId="EMAIL_ADDRESS" infoString="ofbiztest@example.com"/>
@@ -133,7 +133,7 @@ under the License.
     <Party partyId="BLOGUSER_ADMIN" partyTypeId="PERSON" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <Person partyId="BLOGUSER_ADMIN" lastName="Blog" firstName="Admin"/>
     <UserLogin userLoginId="blog_admin" partyId="BLOGUSER_ADMIN" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a"/>
-    <PartyRole partyId="BLOGUSER_ADMIN" roleTypeId="CONTENT_ADMIN"/>
+    <PartyRole partyId="BLOGUSER_ADMIN" roleTypeId="CONTENT_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="BLOGUSER_ADMIN" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContentRole partyId="BLOGUSER_ADMIN" roleTypeId="CONTENT_ADMIN" contentId="BLOGROOT" fromDate="2004-03-27 09:37:40.989"/>
     <UserLoginSecurityGroup userLoginId="blog_admin" groupId="FULLADMIN" fromDate="2004-09-15 00:00:00.000"/>
@@ -141,7 +141,7 @@ under the License.
     <Party partyId="BLOGUSER_EDITOR" partyTypeId="PERSON" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <Person partyId="BLOGUSER_EDITOR" lastName="Blog" firstName="Editor"/>
     <UserLogin userLoginId="blog_editor" partyId="BLOGUSER_EDITOR" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a"/>
-    <PartyRole partyId="BLOGUSER_EDITOR" roleTypeId="CONTENT_ADMIN"/>
+    <PartyRole partyId="BLOGUSER_EDITOR" roleTypeId="CONTENT_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="BLOGUSER_EDITOR" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContentRole partyId="BLOGUSER_EDITOR" roleTypeId="CONTENT_ADMIN" contentId="BLOGROOT" fromDate="2004-03-27 09:37:40.989"/>
     <UserLoginSecurityGroup userLoginId="blog_editor" groupId="FULLADMIN"  fromDate="2004-09-15 00:00:00.000"/>
@@ -149,8 +149,8 @@ under the License.
     <Party partyId="BLOGUSER_USER" partyTypeId="PERSON" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <Person partyId="BLOGUSER_USER" lastName="Blog" firstName="User"/>
     <UserLogin userLoginId="blog_user" partyId="BLOGUSER_USER" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a"/>
-    <PartyRole partyId="BLOGUSER_USER" roleTypeId="CONTENT_ADMIN"/>
-    <PartyRole partyId="BLOGUSER_USER" roleTypeId="CONTENT_AUTHOR"/>
+    <PartyRole partyId="BLOGUSER_USER" roleTypeId="CONTENT_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOGUSER_USER" roleTypeId="CONTENT_AUTHOR" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="BLOGUSER_USER" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="BLOGUSER_GUEST" partyTypeId="PERSON" statusId="PARTY_ENABLED" createdDate="2004-10-20 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-10-20 09:37:40.989" lastModifiedByUserLogin="admin"/>
@@ -161,7 +161,7 @@ under the License.
     <Party partyId="AUTHOR_BIGAL" partyTypeId="PERSON" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <Person partyId="AUTHOR_BIGAL" lastName="Al" firstName="Big"/>
     <UserLogin userLoginId="bigal" partyId="AUTHOR_BIGAL" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a"/>
-    <PartyRole partyId="AUTHOR_BIGAL" roleTypeId="CONTENT_AUTHOR"/>
+    <PartyRole partyId="AUTHOR_BIGAL" roleTypeId="CONTENT_AUTHOR" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="AUTHOR_BIGAL" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContentRole partyId="AUTHOR_BIGAL" roleTypeId="CONTENT_AUTHOR" contentId="BLOGROOTBIGAL" fromDate="2004-03-27 09:37:40.989"/>
     <ContentPurpose contentId="BLOGROOTBIGAL" contentPurposeTypeId="ARTICLE"/>
@@ -177,11 +177,11 @@ under the License.
 
     <DataSource dataSourceId="BLOG_SITE" dataSourceTypeId="WEBSITE_ENTRY" description="Blog Site"/>
 
-    <PartyRole partyId="BLOG_USERS" roleTypeId="CONTENT_USER"/>
-    <PartyRole partyId="BLOG_EDITORS" roleTypeId="CONTENT_EDITOR"/>
-    <PartyRole partyId="BLOG_AUTHORS" roleTypeId="CONTENT_AUTHOR"/>
-    <PartyRole partyId="BLOG_ADMINS" roleTypeId="CONTENT_ADMIN"/>
-    <PartyRole partyId="BLOG_PUBLISHERS" roleTypeId="CONTENT_ADMIN"/>
+    <PartyRole partyId="BLOG_USERS" roleTypeId="CONTENT_USER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_EDITORS" roleTypeId="CONTENT_EDITOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_AUTHORS" roleTypeId="CONTENT_AUTHOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_ADMINS" roleTypeId="CONTENT_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="BLOG_PUBLISHERS" roleTypeId="CONTENT_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
 
     <PartyStatus partyId="BLOG_USERS" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyStatus partyId="BLOG_EDITORS" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
@@ -203,7 +203,7 @@ under the License.
     <Party partyId="AUTHOR_MADMAX" partyTypeId="PERSON" statusId="PARTY_ENABLED" createdDate="2004-03-27 09:37:40.989" createdByUserLogin="admin" lastModifiedDate="2004-03-27 09:37:40.989" lastModifiedByUserLogin="admin"/>
     <Person partyId="AUTHOR_MADMAX" lastName="Max" firstName="Mad"/>
     <UserLogin userLoginId="madmax" partyId="AUTHOR_MADMAX" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a"/>
-    <PartyRole partyId="AUTHOR_MADMAX" roleTypeId="CONTENT_AUTHOR"/>
+    <PartyRole partyId="AUTHOR_MADMAX" roleTypeId="CONTENT_AUTHOR" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="AUTHOR_MADMAX" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContentRole partyId="AUTHOR_MADMAX" roleTypeId="CONTENT_AUTHOR" contentId="BLOGROOTMADMAX" fromDate="2004-03-27 09:37:40.989"/>
     <ContentPurpose contentId="BLOGROOTMADMAX" contentPurposeTypeId="ARTICLE"/>
@@ -350,9 +350,9 @@ David won't like it. He will probably delete this seed data from the DB, but it 
     <RoleType roleTypeId="REVIEWER" description="Reviewer"/>
     <Party partyId="approver" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person firstName="Robert" lastName="Smith" partyId="approver" personalTitle="Captain"/>
-    <PartyRole partyId="approver" roleTypeId="APPROVER"/>
-    <PartyRole partyId="approver" roleTypeId="REVIEWER"/>
-    <PartyRole partyId="admin" roleTypeId="APPROVER"/>
+    <PartyRole partyId="approver" roleTypeId="APPROVER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="approver" roleTypeId="REVIEWER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="admin" roleTypeId="APPROVER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="approver" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <UserLogin userLoginId="approver" partyId="approver"/>
 

--- a/applications/datamodel/data/demo/HumanresDemoData.xml
+++ b/applications/datamodel/data/demo/HumanresDemoData.xml
@@ -46,7 +46,7 @@ under the License.
 
     <!-- Humanres Demo Data -->
     <Party partyId="DemoEmployee" statusId="PARTY_ENABLED"/>
-    <PartyRole partyId="DemoEmployee" roleTypeId="EMPLOYEE"/><!-- data completed by components loaded later -->
+    <PartyRole partyId="DemoEmployee" roleTypeId="EMPLOYEE" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoEmployee" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <RateAmount rateTypeId="AVERAGE_PAY_RATE" rateCurrencyUomId="USD" periodTypeId="RATE_MONTH" workEffortId="_NA_" partyId="DemoEmployee" emplPositionTypeId="_NA_" fromDate="2000-01-30 17:58:56.038" rateAmount="2300"/>

--- a/applications/datamodel/data/demo/MarketingDemoData.xml
+++ b/applications/datamodel/data/demo/MarketingDemoData.xml
@@ -44,8 +44,8 @@ under the License.
     <!-- demo accounts -->
     <Party partyId="sfa100" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="sfa100" groupName="A profitable Account"/>
-    <PartyRole partyId="sfa100" roleTypeId="_NA_"/>
-    <PartyRole partyId="sfa100" roleTypeId="ACCOUNT"/>
+    <PartyRole partyId="sfa100" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="sfa100" roleTypeId="ACCOUNT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="sfa100" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContactMech contactMechId="sfa100" contactMechTypeId="POSTAL_ADDRESS"/>
     <ContactMech contactMechId="sfa101" contactMechTypeId="TELECOM_NUMBER"/>
@@ -61,23 +61,23 @@ under the License.
 
     <!-- demo contacts -->
     <Party partyId="DemoCustomer1" statusId="PARTY_ENABLED"/>
-    <PartyRole partyId="DemoCustomer1" roleTypeId="CONTACT"/>
+    <PartyRole partyId="DemoCustomer1" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoCustomer1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="sfa100" roleTypeIdFrom="ACCOUNT" partyIdTo="DemoCustomer1" roleTypeIdTo="CONTACT" fromDate="2000-01-01 00:00:00.000" partyRelationshipTypeId="EMPLOYMENT"/>
     <Party partyId="DemoCustomer2" statusId="PARTY_ENABLED"/>
-    <PartyRole partyId="DemoCustomer2" roleTypeId="CONTACT"/>
+    <PartyRole partyId="DemoCustomer2" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoCustomer2" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="DemoCustCompany" roleTypeIdFrom="ACCOUNT" partyIdTo="DemoCustomer2" roleTypeIdTo="CONTACT" fromDate="2000-01-01 00:00:00.000" partyRelationshipTypeId="EMPLOYMENT"/>
     <Party partyId="DemoCustomer3" statusId="PARTY_ENABLED"/>
-    <PartyRole partyId="DemoCustomer3" roleTypeId="CONTACT"/>
+    <PartyRole partyId="DemoCustomer3" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoCustomer3" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="DemoCustCompany" roleTypeIdFrom="ACCOUNT" partyIdTo="DemoCustomer3" roleTypeIdTo="CONTACT" fromDate="2000-01-01 00:00:00.000" partyRelationshipTypeId="EMPLOYMENT"/>
 
     <!-- Demo Lead Owners -->
     <Party partyId="DemoLeadOwner" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoLeadOwner" firstName="Demo" lastName="LeadOwner"/>
-    <PartyRole partyId="DemoLeadOwner" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoLeadOwner" roleTypeId="OWNER"/>
+    <PartyRole partyId="DemoLeadOwner" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoLeadOwner" roleTypeId="OWNER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoLeadOwner" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" roleTypeIdFrom="_NA_" partyIdTo="DemoLeadOwner" roleTypeIdTo="_NA_" partyRelationshipTypeId="EMPLOYMENT" fromDate="2000-01-01 00:00:00"/>
     <UserLogin userLoginId="DemoLeadOwner" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a" partyId="DemoLeadOwner" enabled="Y"/>
@@ -85,8 +85,8 @@ under the License.
 
     <Party partyId="DemoLeadOwner1" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoLeadOwner1" firstName="Demo" lastName="LeadOwner1"/>
-    <PartyRole partyId="DemoLeadOwner1" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoLeadOwner1" roleTypeId="OWNER"/>
+    <PartyRole partyId="DemoLeadOwner1" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoLeadOwner1" roleTypeId="OWNER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoLeadOwner1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" roleTypeIdFrom="_NA_" partyIdTo="DemoLeadOwner1" roleTypeIdTo="_NA_" partyRelationshipTypeId="EMPLOYMENT" fromDate="2000-01-01 00:00:00"/>
     <UserLogin userLoginId="DemoLeadOwner1" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a" partyId="DemoLeadOwner1" enabled="Y"/>
@@ -95,13 +95,13 @@ under the License.
     <!-- Demo Leads -->
     <Party partyId="sfa102" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="sfa102" groupName="A promising Lead Company"/>
-    <PartyRole partyId="sfa102" roleTypeId="ACCOUNT_LEAD"/>
-    <PartyRole partyId="sfa102" roleTypeId="_NA_"/>
+    <PartyRole partyId="sfa102" roleTypeId="ACCOUNT_LEAD" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="sfa102" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="sfa102" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <Party partyId="sfa101" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="sfa101" firstName="John" lastName="Lead"/>
-    <PartyRole partyId="sfa101" roleTypeId="_NA_"/>
-    <PartyRole partyId="sfa101" roleTypeId="LEAD"/>
+    <PartyRole partyId="sfa101" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="sfa101" roleTypeId="LEAD" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="sfa101" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <!-- company to lead relationship -->
     <PartyRelationship partyIdFrom="sfa102" roleTypeIdFrom="ACCOUNT_LEAD" partyIdTo="sfa101" roleTypeIdTo="LEAD" fromDate="2000-01-01 00:00:00.000" partyRelationshipTypeId="EMPLOYMENT"/>
@@ -116,39 +116,39 @@ under the License.
 
     <Party partyId="DemoLead" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoLead" firstName="Demo" lastName="Lead"/>
-    <PartyRole partyId="DemoLead" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoLead" roleTypeId="LEAD"/>
+    <PartyRole partyId="DemoLead" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoLead" roleTypeId="LEAD" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoLead" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="DemoLead1" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoLead1" firstName="Demo" lastName="Lead1"/>
-    <PartyRole partyId="DemoLead1" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoLead1" roleTypeId="LEAD"/>
+    <PartyRole partyId="DemoLead1" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoLead1" roleTypeId="LEAD" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoLead1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="DemoLead2" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoLead2" firstName="Demo" lastName="Lead2"/>
-    <PartyRole partyId="DemoLead2" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoLead2" roleTypeId="LEAD"/>
+    <PartyRole partyId="DemoLead2" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoLead2" roleTypeId="LEAD" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoLead2" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="DemoLead3" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoLead3" firstName="Demo" lastName="Lead3"/>
-    <PartyRole partyId="DemoLead3" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoLead3" roleTypeId="LEAD"/>
+    <PartyRole partyId="DemoLead3" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoLead3" roleTypeId="LEAD" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoLead3" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="DemoLead4" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoLead4" firstName="Demo" lastName="Lead4"/>
-    <PartyRole partyId="DemoLead4" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoLead4" roleTypeId="LEAD"/>
+    <PartyRole partyId="DemoLead4" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoLead4" roleTypeId="LEAD" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoLead4" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <!-- Lead Owners Team -->
     <Party partyId="DemoLeadOwnersGroup" partyTypeId="TEAM" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="DemoLeadOwnersGroup" groupName="A Group of Lead Owners"/>
-    <PartyRole partyId="DemoLeadOwnersGroup" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoLeadOwnersGroup" roleTypeId="OTHER_ORGANIZATION_U"/>
+    <PartyRole partyId="DemoLeadOwnersGroup" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoLeadOwnersGroup" roleTypeId="OTHER_ORGANIZATION_U" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoLeadOwnersGroup" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyRelationship partyIdFrom="Company" partyIdTo="DemoLeadOwnersGroup" partyRelationshipTypeId="GROUP_ROLLUP" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" fromDate="2001-05-13 00:00:00.000"/>
 

--- a/applications/datamodel/data/demo/OrderDemoData.xml
+++ b/applications/datamodel/data/demo/OrderDemoData.xml
@@ -149,9 +149,9 @@ under the License.
     <CustRequest custRequestId="9002" custRequestDate="2008-07-19 18:45:31.928" custRequestTypeId="RF_SUPPORT" statusId="CRQ_SUBMITTED" fromPartyId="DemoCustomer2" priority="9" custRequestName="Customer Same company" description="This will contain a request from the same company?" productStoreId="9000" createdDate="2008-07-28 11:45:31.928" createdByUserLogin="admin" lastModifiedDate="2008-07-28 11:45:31.928" lastModifiedByUserLogin="admin"/>
     <!-- Employees assigned to handle these incoming customer requests-->
     <CustRequestType custRequestTypeId="RF_SUPPORT" partyId="Company"/>
-    <PartyRole partyId="admin" roleTypeId="REQ_TAKER"/>
+    <PartyRole partyId="admin" roleTypeId="REQ_TAKER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyRelationship partyIdFrom="Company" roleTypeIdFrom="_NA_" partyIdTo="admin" roleTypeIdTo="REQ_TAKER" fromDate="2000-01-01 00:00:00"/><!-- so admin can hadle incoming cust request 'support' types -->
-    <PartyRole partyId="DemoEmployee" roleTypeId="REQ_TAKER"/>
+    <PartyRole partyId="DemoEmployee" roleTypeId="REQ_TAKER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyRelationship partyIdFrom="Company" roleTypeIdFrom="_NA_" partyIdTo="DemoEmployee" roleTypeIdTo="REQ_TAKER" fromDate="2000-01-01 00:00:00"/><!-- so DemoEmployee can hadle incoming cust request 'support' types -->
 
     <!-- Order Quote Demo Data -->
@@ -898,7 +898,7 @@ under the License.
     <SupplierProduct partyId="DemoSupplier" minimumOrderQuantity="0" currencyUomId="USD" productId="DS-1000" lastPrice="9.0" supplierProductId="DS-1000_A" supplierProductName="Drop SP" availableFromDate="2005-01-01 00:00:00.000" canDropShip="Y"/>
     <ProductCategoryMember productCategoryId="200" productId="DS-1000" fromDate="2011-08-02 12:00:00.0"/>
     <ProductCategoryMember productCategoryId="CATALOG1_SEARCH" productId="SV-1001" fromDate="2011-08-02 12:00:00.0"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="CUSTOMER"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
     <Agreement agreementId="DS-1000-SALES" agreementTypeId="SALES_AGREEMENT" description="Agreement with DemoCustomer for drop ship" partyIdFrom="DemoCustomer" partyIdTo="Company" roleTypeIdFrom="CUSTOMER" roleTypeIdTo="INTERNAL_ORGANIZATIO" fromDate="2011-08-02 12:00:00.0"/>
     <AgreementItem agreementId="DS-1000-SALES" agreementItemSeqId="00001" agreementItemTypeId="AGREEMENT_PRICING_PR" currencyUomId="USD"/>
     <AgreementProductAppl agreementId="DS-1000-SALES" agreementItemSeqId="00001" price="12" productId="DS-1000"/>
@@ -1904,10 +1904,10 @@ under the License.
     <PartyGroup partyId="USPS" groupName="USPS"/>
     <PartyGroup partyId="UPS" groupName="UPS"/>
 
-    <PartyRole partyId="USPS" roleTypeId="CARRIER"/>
-    <PartyRole partyId="UPS" roleTypeId="CARRIER"/>
-    <PartyRole partyId="Company" roleTypeId="CARRIER"/>
-    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
+    <PartyRole partyId="USPS" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="UPS" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Company" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="_NA_" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
 
     <ShipmentMethodType description="Standard" shipmentMethodTypeId="STANDARD"/>
     <ShipmentMethodType description="Express" shipmentMethodTypeId="EXPRESS"/>
@@ -1955,13 +1955,13 @@ under the License.
     <PartyGroup partyId="DHL" groupName="DHL"/>
     <PartyGroup partyId="FEDEX" groupName="Federal Express"/>
 
-    <PartyRole partyId="USPS" roleTypeId="CARRIER"/>
-    <PartyRole partyId="UPS" roleTypeId="CARRIER"/>
-    <PartyRole partyId="DHL" roleTypeId="CARRIER"/>
-    <PartyRole partyId="FEDEX" roleTypeId="CARRIER"/>
+    <PartyRole partyId="USPS" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="UPS" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DHL" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="FEDEX" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
 
-    <PartyRole partyId="Company" roleTypeId="CARRIER"/>
-    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
+    <PartyRole partyId="Company" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="_NA_" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
 
     <ShipmentMethodType description="No Shipping" shipmentMethodTypeId="NO_SHIPPING"/>
     <ShipmentMethodType description="Local Delivery" shipmentMethodTypeId="LOCAL_DELIVERY"/>
@@ -2175,7 +2175,7 @@ under the License.
     <!-- this person can view any order but only place purchase orders -->
     <Party partyId="DemoBuyer" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoBuyer" firstName="Demo" lastName="Buyer"/>
-    <PartyRole partyId="DemoBuyer" roleTypeId="BUYER"/>
+    <PartyRole partyId="DemoBuyer" roleTypeId="BUYER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoBuyer" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <UserLogin partyId="DemoBuyer" userLoginId="DemoBuyer"/>
     <UserLoginSecurityGroup userLoginId="DemoBuyer" groupId="ORDERPURCH" fromDate="2001-05-13 00:00:00"/>
@@ -2183,7 +2183,7 @@ under the License.
     <!-- this person can create sales orders for any store -->
     <Party partyId="DemoRepAll" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoRepAll" firstName="Demo" lastName="Sales Rep for All Stores"/>
-    <PartyRole partyId="DemoRepAll" roleTypeId="SALES_REP"/>
+    <PartyRole partyId="DemoRepAll" roleTypeId="SALES_REP" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoRepAll" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <UserLogin partyId="DemoRepAll" userLoginId="DemoRepAll"/>
     <UserLoginSecurityGroup userLoginId="DemoRepAll" groupId="ORDERENTRY_ALL" fromDate="2001-05-13 00:00:00"/>
@@ -2191,7 +2191,7 @@ under the License.
     <!-- this person can only create sales orders for stores for which he is a sales rep -->
     <Party partyId="DemoRepStore" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoRepStore" firstName="Demo" lastName="Sales Rep for Specified Stores Only"/>
-    <PartyRole partyId="DemoRepStore" roleTypeId="SALES_REP"/>
+    <PartyRole partyId="DemoRepStore" roleTypeId="SALES_REP" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoRepStore" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <UserLogin partyId="DemoRepStore" userLoginId="DemoRepStore"/>
     <UserLoginSecurityGroup userLoginId="DemoRepStore" groupId="ORDERENTRY" fromDate="2001-05-13 00:00:00"/>
@@ -2210,13 +2210,13 @@ under the License.
 
     <!-- DemoCustCompany -->
     <Party partyId="DemoCustCompany" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
-    <PartyRole partyId="DemoCustCompany" roleTypeId="ACCOUNT"/>
+    <PartyRole partyId="DemoCustCompany" roleTypeId="ACCOUNT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoCustCompany" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyGroup partyId="DemoCustCompany" groupName="Demo Customer Company"/>
     <UserLogin partyId="DemoCustCompany" userLoginId="DemoCustCompany"/>
-    <PartyRole partyId="DemoCustCompany" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="DemoCustCompany" roleTypeId="BILL_TO_CUSTOMER"/>
-    <PartyRole partyId="DemoCustCompany" roleTypeId="_NA_"/>
+    <PartyRole partyId="DemoCustCompany" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustCompany" roleTypeId="BILL_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustCompany" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
 
     <ContactMech contactMechId="9010" contactMechTypeId="POSTAL_ADDRESS"/>
     <PostalAddress contactMechId="9010" toName="Demo Customer Company" address1="2004 Factory Blvd" city="Orem" stateProvinceGeoId="UT" postalCode="84057" countryGeoId="USA" geoPointId="9000"/>
@@ -2250,9 +2250,9 @@ under the License.
     <Party partyId="DemoCustAgent" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoCustAgent" firstName="Demo" lastName="Agent"/>
     <UserLogin partyId="DemoCustAgent" userLoginId="DemoCustAgent"/>
-    <PartyRole partyId="DemoCustAgent" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="DemoCustAgent" roleTypeId="AGENT"/>
-    <PartyRole partyId="DemoCustAgent" roleTypeId="_NA_"/>
+    <PartyRole partyId="DemoCustAgent" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustAgent" roleTypeId="AGENT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustAgent" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoCustAgent" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContactMech contactMechId="9011" contactMechTypeId="POSTAL_ADDRESS"/>
     <PostalAddress contactMechId="9011" toName="Demo Customer Agent" address1="2004 Factory Blvd" city="Orem" stateProvinceGeoId="UT" postalCode="84057" countryGeoId="USA" geoPointId="9000"/>
@@ -2276,9 +2276,9 @@ under the License.
     <Party partyId="DemoCustomer" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="DemoCustomer" firstName="Demo" lastName="Customer"/>
     <UserLogin partyId="DemoCustomer" userLoginId="DemoCustomer"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="CONTACT"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="BILL_TO_CUSTOMER"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="BILL_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoCustomer" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyGeoPoint partyId="DemoCustomer" geoPointId="9000" fromDate="2009-01-09 00:00:00.000"/>
     <PartyRelationship partyIdFrom="DemoCustCompany" roleTypeIdFrom="ACCOUNT" partyIdTo="DemoCustomer" roleTypeIdTo="CONTACT" fromDate="2000-01-01 00:00:00.000" partyRelationshipTypeId="EMPLOYMENT"/>
@@ -2309,8 +2309,8 @@ under the License.
     <Party partyId="EuroCustomer" partyTypeId="PERSON" statusId="PARTY_ENABLED" preferredCurrencyUomId="EUR"/>
     <Person partyId="EuroCustomer" firstName="Euro" lastName="Customer"/>
     <UserLogin partyId="EuroCustomer" userLoginId="EuroCustomer"/>
-    <PartyRole partyId="EuroCustomer" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="EuroCustomer" roleTypeId="BILL_TO_CUSTOMER"/>
+    <PartyRole partyId="EuroCustomer" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="EuroCustomer" roleTypeId="BILL_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="EuroCustomer" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyGeoPoint partyId="EuroCustomer" geoPointId="9001" fromDate="2009-01-09 00:00:00.000"/>
 
@@ -2335,8 +2335,8 @@ under the License.
     <Party partyId="FrenchCustomer" partyTypeId="PERSON" statusId="PARTY_ENABLED" preferredCurrencyUomId="EUR"/>
     <Person partyId="FrenchCustomer" firstName="French" lastName="Customer"/>
     <UserLogin partyId="FrenchCustomer" userLoginId="FrenchCustomer"/>
-    <PartyRole partyId="FrenchCustomer" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="FrenchCustomer" roleTypeId="BILL_TO_CUSTOMER"/>
+    <PartyRole partyId="FrenchCustomer" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="FrenchCustomer" roleTypeId="BILL_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="FrenchCustomer" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyGeoPoint partyId="FrenchCustomer" geoPointId="9002" fromDate="2009-01-09 00:00:00.000"/>
 
@@ -2365,9 +2365,9 @@ under the License.
     <OrderItem orderId="DEMO10090" orderItemSeqId="00001" orderItemTypeId="PRODUCT_ORDER_ITEM" productId="GZ-2644" prodCatalogId="DemoCatalog" isPromo="N" quantity="2.0" selectedAmount="0.0" unitPrice="38.4" unitListPrice="48.0" isModifiedPrice="N" itemDescription="Round Gizmo" statusId="ITEM_APPROVED"/>
     <OrderItemPriceInfo orderItemPriceInfoId="9000" orderId="DEMO10090" orderItemSeqId="00001" productPriceRuleId="9000" productPriceActionSeqId="01" modifyAmount="-9.600" description="[PRODUCT_CATEGORY_IDIsPROMOTIONS] [list:48.0;avgCost:48.0;margin:0.0] [type:PRICE_POL]"/>
 
-    <PartyRole partyId="DemoCustomer" roleTypeId="END_USER_CUSTOMER"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="SHIP_TO_CUSTOMER"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="PLACING_CUSTOMER"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="END_USER_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="SHIP_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="PLACING_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
 
     <OrderRole orderId="DEMO10090" partyId="Company" roleTypeId="BILL_FROM_VENDOR"/>
     <OrderRole orderId="DEMO10090" partyId="DemoCustomer" roleTypeId="BILL_TO_CUSTOMER"/>
@@ -2470,9 +2470,9 @@ under the License.
     <OrderHeader orderId="Demo1002" orderTypeId="SALES_ORDER" orderName="Demo Sales Order" salesChannelEnumId="WEB_SALES_CHANNEL" orderDate="2009-08-17 14:23:49.475" priority="2" entryDate="2009-08-17 14:23:49.475" visitId="10000" statusId="ORDER_COMPLETED" createdBy="admin" currencyUom="USD" productStoreId="9000" remainingSubTotal="107.98" grandTotal="127.09" webSiteId="WebStore"/>
     <OrderItem orderId="Demo1002" orderItemSeqId="00001" orderItemTypeId="PRODUCT_ORDER_ITEM" productId="WG-1111" prodCatalogId="DemoCatalog" isPromo="N" quantity="2.000000" selectedAmount="0.000000" unitPrice="59.99" unitListPrice="60.00" isModifiedPrice="N" itemDescription="Micro Chrome Widget" statusId="ITEM_COMPLETED"/>
     <OrderItem orderId="Demo1002" orderItemSeqId="00004" orderItemTypeId="PRODUCT_ORDER_ITEM" productId="WG-1111" isPromo="Y" quantity="1.000000" selectedAmount="0.000000" unitPrice="59.99" unitListPrice="60.00" isModifiedPrice="N" itemDescription="Micro Chrome Widget" statusId="ITEM_COMPLETED"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="END_USER_CUSTOMER"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="SHIP_TO_CUSTOMER"/>
-    <PartyRole partyId="DemoCustomer" roleTypeId="PLACING_CUSTOMER"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="END_USER_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="SHIP_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoCustomer" roleTypeId="PLACING_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
 
     <OrderRole orderId="Demo1002" partyId="Company" roleTypeId="BILL_FROM_VENDOR"/>
     <OrderRole orderId="Demo1002" partyId="DemoCustomer" roleTypeId="BILL_TO_CUSTOMER"/>

--- a/applications/datamodel/data/demo/PartyDemoData.xml
+++ b/applications/datamodel/data/demo/PartyDemoData.xml
@@ -63,9 +63,9 @@ under the License.
     <Party partyId="admin" statusId="PARTY_ENABLED"/>
     <Party partyId="Company" statusId="PARTY_ENABLED"/>
     <Party partyId="DemoEmployee" statusId="PARTY_ENABLED"/>
-    <PartyRole partyId="admin" roleTypeId="EMAIL_ADMIN"/>
-    <PartyRole partyId="Company" roleTypeId="_NA_"/>
-    <PartyRole partyId="DemoEmployee" roleTypeId="EMAIL_ADMIN"/>
+    <PartyRole partyId="admin" roleTypeId="EMAIL_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Company" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoEmployee" roleTypeId="EMAIL_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="admin" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyStatus partyId="Company" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyStatus partyId="DemoEmployee" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
@@ -79,11 +79,11 @@ under the License.
     <!-- Party Identification numbers-->
     <Party partyId="DemoSupplier" statusId="PARTY_ENABLED" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="DemoSupplier" groupName="Demo Supplier"/>
-    <PartyRole partyId="DemoSupplier" roleTypeId="ACCOUNT"/>
-    <PartyRole partyId="DemoSupplier" roleTypeId="SUPPLIER"/>
-    <PartyRole partyId="DemoSupplier" roleTypeId="BILL_FROM_VENDOR"/>
-    <PartyRole partyId="DemoSupplier" roleTypeId="SHIP_FROM_VENDOR"/>
-    <PartyRole partyId="DemoSupplier" roleTypeId="SUPPLIER_AGENT"/>
+    <PartyRole partyId="DemoSupplier" roleTypeId="ACCOUNT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoSupplier" roleTypeId="SUPPLIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoSupplier" roleTypeId="BILL_FROM_VENDOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoSupplier" roleTypeId="SHIP_FROM_VENDOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoSupplier" roleTypeId="SUPPLIER_AGENT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="DemoSupplier" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContactMech contactMechId="9001" contactMechTypeId="POSTAL_ADDRESS"/>
     <PartyContactMech partyId="DemoSupplier" contactMechId="9001" fromDate="2001-05-13 00:00:00.000" allowSolicitation="Y"/>
@@ -100,15 +100,15 @@ under the License.
 
     <!-- email from an unknown party -->
     <CommunicationEvent communicationEventId="9000" communicationEventTypeId="EMAIL_COMMUNICATION" statusId="COM_UNKNOWN_PARTY" contactMechTypeId="EMAIL_ADDRESS" contactMechIdTo="admin" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" partyIdTo="admin" entryDate="2008-07-28 13:55:55.827" datetimeStarted="2008-07-28 13:55:19.0" subject="Why i would use the OFBiz system" contentMimeTypeId="text/plain" content="Every time i think of you, only you...you are always on my mind......." note="Sent from: my@email.com; Sent Name from: Jo Easy User; Sent to: ofbiztest@example.com; Delivered-To: ofbiztest@example.com; " fromString="mailinglist@example.com" toString="ofbiztest@example.com"/>
-    <PartyRole partyId="admin" roleTypeId="ADDRESSEE"/>
+    <PartyRole partyId="admin" roleTypeId="ADDRESSEE" fromDate="2000-01-01 00:00:00.000"/>
     <CommunicationEventRole communicationEventId="9000" partyId="admin" roleTypeId="ADDRESSEE" contactMechId="admin" statusId="COM_ROLE_CREATED"/>
 
     <!-- new registration notification -->
     <EmailTemplateSetting emailTemplateSettingId="PARTY_REGISTER" bodyScreenLocation="component://party/widget/partymgr/PartyScreens.xml#CreateUserNotification" subject="New Account Created" bccAddress="ofbiztest@example.com" fromAddress="ofbiztest@example.com"/>
 
     <!-- make admin an employee of Company -->
-    <PartyRole partyId="admin" roleTypeId="CONTACT"/>
-    <PartyRole partyId="Company" roleTypeId="ACCOUNT"/>
+    <PartyRole partyId="admin" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="Company" roleTypeId="ACCOUNT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyRelationship partyIdFrom="Company" roleTypeIdFrom="ACCOUNT" partyIdTo="admin" roleTypeIdTo="CONTACT" fromDate="2000-01-01 00:00:00.000" partyRelationshipTypeId="EMPLOYMENT"/>
     
     <!-- Auditor demo data -->
@@ -121,6 +121,5 @@ under the License.
     <!-- Government Agency Demo Data -->
     <Party partyId="DemoGovAgency" statusId="PARTY_ENABLED" partyTypeId="PARTY_GROUP"/>
     <PartyGroup partyId="DemoGovAgency" groupName="Demo Government Agency"/>
-    <PartyRole partyId="DemoGovAgency" roleTypeId="GOV_AGENCY"/>
-
+    <PartyRole partyId="DemoGovAgency" roleTypeId="GOV_AGENCY" fromDate="2000-01-01 00:00:00.000"/>
 </entity-engine-xml>

--- a/applications/datamodel/data/demo/ProductDemoData.xml
+++ b/applications/datamodel/data/demo/ProductDemoData.xml
@@ -111,7 +111,7 @@ under the License.
     <UserLoginSecurityGroup userLoginId="imageUpload" groupId="CATALOGADMIN" fromDate="2010-01-01 12:00:00.0"/>
     <UserLoginSecurityGroup userLoginId="imageUpload" groupId="IMAGEUPLOAD" fromDate="2010-01-01 12:00:00.0"/>
 
-    <PartyRole partyId="admin" roleTypeId="IMAGEAPPROVER"/>
+    <PartyRole partyId="admin" roleTypeId="IMAGEAPPROVER" fromDate="2000-01-01 00:00:00.000"/>
     <!-- Product store group management demo -->
     <ProductStoreGroupType productStoreGroupTypeId="PSGT_AREA" description="Area cover"/>
 

--- a/applications/datamodel/data/demo/SecurityExtDemoData.xml
+++ b/applications/datamodel/data/demo/SecurityExtDemoData.xml
@@ -22,24 +22,24 @@ under the License.
     <!-- OFBiz Core security -->
     <Party partyId="_NA_" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="_NA_"/>
-    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
-    <PartyRole partyId="_NA_" roleTypeId="_NA_"/>
+    <PartyRole partyId="_NA_" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="_NA_" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
 
     <Party partyId="admin" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person firstName="THE" lastName="ADMINISTRATOR" middleName="PRIVILEGED" partyId="admin" personalTitle="Mr."/>
-    <PartyRole partyId="admin" roleTypeId="BUYER"/>
-    <PartyRole partyId="admin" roleTypeId="MANAGER"/>
-    <PartyRole partyId="admin" roleTypeId="ORDER_CLERK"/>
-    <PartyRole partyId="admin" roleTypeId="SHIPMENT_CLERK"/>
-    <PartyRole partyId="admin" roleTypeId="SALES_REP"/>
-    <PartyRole partyId="admin" roleTypeId="_NA_"/>
+    <PartyRole partyId="admin" roleTypeId="BUYER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="admin" roleTypeId="MANAGER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="admin" roleTypeId="ORDER_CLERK" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="admin" roleTypeId="SHIPMENT_CLERK" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="admin" roleTypeId="SALES_REP" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="admin" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="admin" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="ltdadmin" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person firstName="Limited" lastName="Administrator" partyId="ltdadmin" personalTitle="Mr."/>
-    <PartyRole partyId="ltdadmin" roleTypeId="ORDER_CLERK"/>
-    <PartyRole partyId="ltdadmin" roleTypeId="LTD_ADMIN"/>
-    <PartyRole partyId="ltdadmin" roleTypeId="_NA_"/>
+    <PartyRole partyId="ltdadmin" roleTypeId="ORDER_CLERK" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="ltdadmin" roleTypeId="LTD_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="ltdadmin" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="ltdadmin" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyContactMech partyId="ltdadmin" contactMechId="admin" fromDate="2003-01-01 00:00:00.0" allowSolicitation="Y"/>
 
@@ -47,26 +47,26 @@ under the License.
 
     <Party partyId="ltdadmin1" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person firstName="Limited" lastName="Administrator1" partyId="ltdadmin1" personalTitle="Mr."/>
-    <PartyRole partyId="ltdadmin1" roleTypeId="ORDER_CLERK"/>
-    <PartyRole partyId="ltdadmin1" roleTypeId="LTD_ADMIN"/>
-    <PartyRole partyId="ltdadmin1" roleTypeId="_NA_"/>
+    <PartyRole partyId="ltdadmin1" roleTypeId="ORDER_CLERK" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="ltdadmin1" roleTypeId="LTD_ADMIN" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="ltdadmin1" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="ltdadmin1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyContactMech partyId="ltdadmin1" contactMechId="admin" fromDate="2003-01-01 00:00:00.0" allowSolicitation="Y"/>
 
     <Party partyId="externaluser" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person firstName="External" lastName="User" partyId="externaluser" personalTitle="Mr."/>
-    <PartyRole partyId="externaluser" roleTypeId="SUPPLIER"/>
+    <PartyRole partyId="externaluser" roleTypeId="SUPPLIER" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="externaluser" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyContactMech partyId="externaluser" contactMechId="admin" fromDate="2003-01-01 00:00:00.0" allowSolicitation="Y"/>
 
     <Party partyId="bizadmin" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="bizadmin" firstName="Business" lastName="Administrator"/>
-    <PartyRole partyId="bizadmin" roleTypeId="BUYER"/>
-    <PartyRole partyId="bizadmin" roleTypeId="MANAGER"/>
-    <PartyRole partyId="bizadmin" roleTypeId="ORDER_CLERK"/>
-    <PartyRole partyId="bizadmin" roleTypeId="SHIPMENT_CLERK"/>
-    <PartyRole partyId="bizadmin" roleTypeId="SALES_REP"/>
-    <PartyRole partyId="bizadmin" roleTypeId="_NA_"/>
+    <PartyRole partyId="bizadmin" roleTypeId="BUYER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="bizadmin" roleTypeId="MANAGER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="bizadmin" roleTypeId="ORDER_CLERK" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="bizadmin" roleTypeId="SHIPMENT_CLERK" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="bizadmin" roleTypeId="SALES_REP" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="bizadmin" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="bizadmin" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <PartyContactMech partyId="bizadmin" contactMechId="admin" fromDate="2003-01-01 00:00:00.0" allowSolicitation="Y"/>
 

--- a/applications/datamodel/data/demo/WorkEffortDemoData.xml
+++ b/applications/datamodel/data/demo/WorkEffortDemoData.xml
@@ -57,8 +57,8 @@ under the License.
     <UserLogin userLoginId="WorkEffortUser" partyId="WorkEffortUser" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a" />
     <UserLoginSecurityGroup groupId="WORKEFFORT_USER" userLoginId="WorkEffortUser" fromDate="2011-01-01 00:00:00.0" />
 
-    <PartyRole partyId="admin" roleTypeId="CAL_OWNER"/>
-    <PartyRole partyId="admin" roleTypeId="CAL_ATTENDEE"/>
+    <PartyRole partyId="admin" roleTypeId="CAL_OWNER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="admin" roleTypeId="CAL_ATTENDEE" fromDate="2000-01-01 00:00:00.000"/>
 
     <!-- Publish the staff meeting calendar event in iCalendar format -->
     <WorkEffort workEffortId="CALENDAR_PUB_DEMO" workEffortTypeId="PUBLISH_PROPS" currentStatusId="CAL_CANCELLED" scopeEnumId="WES_PUBLIC" description="Demo Project 1 Customer 1" workEffortName="iCalendar Publish Demonstration"/>
@@ -70,9 +70,9 @@ under the License.
     <Party partyId="DemoEmployee2" statusId="PARTY_ENABLED"/>
     <Party partyId="DemoEmployee3" statusId="PARTY_ENABLED"/>
 
-    <PartyRole partyId="DemoEmployee1" roleTypeId="CAL_OWNER"/>
-    <PartyRole partyId="DemoEmployee2" roleTypeId="CAL_ATTENDEE"/>
-    <PartyRole partyId="DemoEmployee3" roleTypeId="CAL_ATTENDEE"/>
+    <PartyRole partyId="DemoEmployee1" roleTypeId="CAL_OWNER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoEmployee2" roleTypeId="CAL_ATTENDEE" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="DemoEmployee3" roleTypeId="CAL_ATTENDEE" fromDate="2000-01-01 00:00:00.000"/>
 
     <WorkEffort workEffortId="PROJECT_PUB_DEMO" workEffortTypeId="PUBLISH_PROPS" currentStatusId="CAL_CANCELLED" scopeEnumId="WES_PRIVATE" description="Demo Project 1 Customer 1" workEffortName="Project iCalendar Publish Demonstration"/>
     <WorkEffortPartyAssignment workEffortId="PROJECT_PUB_DEMO" partyId="DemoEmployee1" statusId="PRTYASGN_ASSIGNED" roleTypeId="CAL_OWNER" fromDate="2008-01-01 00:00:00.0"/>

--- a/applications/datamodel/data/seed/SecurityExtSeedData.xml
+++ b/applications/datamodel/data/seed/SecurityExtSeedData.xml
@@ -24,7 +24,7 @@ under the License.
     <Person partyId="system" firstName="System" lastName="Account"/>
     <PartyStatus partyId="system" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <!-- various automated processes will cause it to be put in this role anyway -->
-    <PartyRole partyId="system" roleTypeId="PACKER"/>
+    <PartyRole partyId="system" roleTypeId="PACKER" fromDate="2000-01-01 00:00:00.000"/>
 
     <UserLogin userLoginId="system" partyId="system"/>
 </entity-engine-xml>

--- a/applications/datamodel/entitydef/party-entitymodel.xml
+++ b/applications/datamodel/entitydef/party-entitymodel.xml
@@ -2559,11 +2559,15 @@ under the License.
     
     <entity entity-name="PartyRole"
             package-name="org.apache.ofbiz.party.party"
-            title="Party Role">
-      <field name="partyId" type="id"></field>
-      <field name="roleTypeId" type="id"></field>
+            title="Party Role"
+            description="RoleTypes associated to a Party">
+      <field name="partyId" type="id"/>
+      <field name="roleTypeId" type="id"/>
+      <field name="fromDate" type="date-time"/>
+      <field name="thruDate" type="date-time"/>
       <prim-key field="partyId"/>
       <prim-key field="roleTypeId"/>
+      <prim-key field="fromDate"/>
       <relation type="one" fk-name="PARTY_RLE_PARTY" rel-entity-name="Party">
         <key-map field-name="partyId"/>
       </relation>
@@ -2898,8 +2902,7 @@ under the License.
             title="Party Role View">
       <member-entity entity-alias="PR" entity-name="PartyRole"/>
       <member-entity entity-alias="RT" entity-name="RoleType"/>
-      <alias entity-alias="PR" name="partyId"/>
-      <alias entity-alias="RT" name="roleTypeId"/>
+      <alias-all entity-alias="PR"/>
       <alias entity-alias="RT" name="parentTypeId"/>
       <alias entity-alias="RT" name="description"/>
       <view-link entity-alias="RT" rel-entity-alias="PR">

--- a/applications/order/testdef/data/OrderTestData.xml
+++ b/applications/order/testdef/data/OrderTestData.xml
@@ -35,18 +35,18 @@ under the License.
 
     <Party partyId="TestDemoCustomer" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="TestDemoCustomer" firstName="Test" lastName="Customer"/>
-    <PartyRole partyId="TestDemoCustomer" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="TestDemoCustomer" roleTypeId="CONTACT"/>
-    <PartyRole partyId="TestDemoCustomer" roleTypeId="ACCOUNTANT"/>
+    <PartyRole partyId="TestDemoCustomer" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestDemoCustomer" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestDemoCustomer" roleTypeId="ACCOUNTANT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestDemoCustomer" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <ContactMech contactMechId="TestContactMech" contactMechTypeId="EMAIL_ADDRESS" infoString="newtest_email@example.com"/>
     <PartyContactMech partyId="TestDemoCustomer" contactMechId="TestContactMech" fromDate="2001-05-13 00:00:00.000"/>
     <PartyContactMechPurpose partyId="TestDemoCustomer" contactMechId="TestContactMech" contactMechPurposeTypeId="PRIMARY_EMAIL" fromDate="2000-01-01 00:00:00"/>
 
-    <PartyRole partyId="TestDemoCustomer" roleTypeId="END_USER_CUSTOMER"/>
-    <PartyRole partyId="TestDemoCustomer" roleTypeId="SHIP_TO_CUSTOMER"/>
-    <PartyRole partyId="TestDemoCustomer" roleTypeId="PLACING_CUSTOMER"/>
-    <PartyRole partyId="TestDemoCustomer" roleTypeId="BILL_TO_CUSTOMER"/>
+    <PartyRole partyId="TestDemoCustomer" roleTypeId="END_USER_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestDemoCustomer" roleTypeId="SHIP_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestDemoCustomer" roleTypeId="PLACING_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestDemoCustomer" roleTypeId="BILL_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
 
     <OrderRole orderId="TEST_DEMO10090" partyId="TestDemoCustomer" roleTypeId="BILL_TO_CUSTOMER"/>
     <OrderRole orderId="TEST_DEMO10090" partyId="TestDemoCustomer" roleTypeId="END_USER_CUSTOMER"/>

--- a/applications/party/groovyScripts/party/PartyServices.groovy
+++ b/applications/party/groovyScripts/party/PartyServices.groovy
@@ -925,3 +925,25 @@ def getChildRoleTypesInline (List roleTypeIdListName) {
     resultMap.childRoleTypeIdList = newRoleTypeIdList
     return resultMap
 }
+
+
+/**
+ * Service to create a PartyRole record. If an existing record is present, expire it before creating the new one.
+ */
+def updatePartyRole() {
+    GenericValue newEntityRecord = delegator.makeValidValue('PartyRole', parameters)
+    if (!newEntityRecord.fromDate) newEntityRecord.fromDate = UtilDateTime.nowTimestamp()
+
+    //Check if the entry already exist with a different fromDate (and without an thruDate), else expire the older to create the new one
+    boolean updating = false
+    GenericValue partyRoleLookedUpValue = from('PartyRole').where('partyId', newEntityRecord.partyId,
+            'roleTypeId', newEntityRecord.roleTypeId).filterByDate().queryFirst()
+    if (partyRoleLookedUpValue) {
+        updating = (partyRoleLookedUpValue.fromDate.compareTo(newEntityRecord.fromDate) == 0)
+        result = run service: 'expirePartyRole', with: partyRoleLookedUpValue.getAllFields()
+        if (ServiceUtil.isError(result)) return result
+    }
+    if (updating) newEntityRecord.store()
+    else newEntityRecord.create()
+    return success()
+}

--- a/applications/party/servicedef/services.xml
+++ b/applications/party/servicedef/services.xml
@@ -369,6 +369,16 @@ under the License.
         </attribute>
         <attribute name="roleTypeIdTo" type="String" mode="IN" optional="true"/>
     </service>
+    <service name="updatePartyRole" default-entity-name="PartyRole" engine="groovy" auth="true"
+        location="component://party/groovyScripts/party/PartyServices.groovy" invoke="updatePartyRole">
+        <description>Create/update PartyRole record</description>
+        <permission-service service-name="acctgBasePermissionCheck" main-action="CREATE"/>
+        <auto-attributes include="all" mode="IN" optional="true"/>
+        <override name="partyId" optional="false"/>
+        <override name="roleTypeId" optional="false"/>
+        <override name="partyId" default-value="_NA_"/>
+        <override name="roleTypeId" default-value="_NA_"/>
+    </service>
 
     <!-- Party Relationship services -->
     <service name="createPartyRelationship" default-entity-name="PartyRelationship" engine="groovy"

--- a/applications/party/servicedef/services_party.xml
+++ b/applications/party/servicedef/services_party.xml
@@ -151,5 +151,10 @@ under the License.
         <description>Delete a PriorityType Record</description>
         <auto-attributes mode="IN" include="pk"/>
     </service>
-
+    <!-- PartyRole services -->
+    <service name="expirePartyRole" default-entity-name="PartyRole" engine="entity-auto" invoke="expire" auth="true">
+        <description>Expires a PartyRole record</description>
+        <auto-attributes include="pk" mode="IN" optional="false"/>
+        <auto-attributes include="nonpk" mode="IN" optional="true"/>
+    </service>
 </services>

--- a/applications/party/testdef/data/PartyTestsData.xml
+++ b/applications/party/testdef/data/PartyTestsData.xml
@@ -21,10 +21,10 @@ under the License.
 <entity-engine-xml>
     <Party partyId="TestCompany" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="TestCompany" groupName="Your Company Name Here"/>
-    <PartyRole partyId="TestCompany" roleTypeId="BILL_FROM_VENDOR"/>
-    <PartyRole partyId="TestCompany" roleTypeId="BILL_TO_CUSTOMER"/>
-    <PartyRole partyId="TestCompany" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="TestCompany" roleTypeId="_NA_"/>
+    <PartyRole partyId="TestCompany" roleTypeId="BILL_FROM_VENDOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCompany" roleTypeId="BILL_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCompany" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCompany" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestCompany" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="TestGroup-1" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
@@ -33,14 +33,14 @@ under the License.
 
     <Party partyId="TestCustomer" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="TestCustomer" firstName="Test" lastName="Customer"/>
-    <PartyRole partyId="TestCustomer" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="TestCustomer" roleTypeId="CONTACT"/>
-    <PartyRole partyId="TestCustomer" roleTypeId="ACCOUNTANT"/>
+    <PartyRole partyId="TestCustomer" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCustomer" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCustomer" roleTypeId="ACCOUNTANT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestCustomer" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="TestParty" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="TestParty" firstName="Test" lastName="Party"/>
-    <PartyRole partyId="TestParty" roleTypeId="CONTACT"/>
+    <PartyRole partyId="TestParty" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestParty" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
     <UserLogin userLoginId="TestParty" partyId="TestParty"/>
 
@@ -69,7 +69,7 @@ under the License.
 
     <CommunicationEvent communicationEventId="TestEvent-1" communicationEventTypeId="EMAIL_COMMUNICATION" statusId="COM_IN_PROGRESS" roleTypeIdFrom="BILL_TO_CUSTOMER" roleTypeIdTo="CUSTOMER" partyIdFrom="TestCompany" partyIdTo="TestCustomer" entryDate="2010-10-27 15:04:17.895" subject="Test Subject 1" contentMimeTypeId="text/plain" />
     <CommunicationEvent communicationEventId="TestEvent-2" communicationEventTypeId="EMAIL_COMMUNICATION" statusId="COM_UNKNOWN_PARTY" contactMechTypeId="EMAIL_ADDRESS" roleTypeIdFrom="_NA_" roleTypeIdTo="_NA_" partyIdTo="TestCompany" entryDate="2010-10-27 15:04:17.895" subject="Why i would use the OFBiz system" contentMimeTypeId="text/plain" content="Every time i think of you, only you...you are always on my mind......." note="Sent from: my@example.com"/>
-    <PartyRole partyId="TestCompany" roleTypeId="ADDRESSEE"/>
+    <PartyRole partyId="TestCompany" roleTypeId="ADDRESSEE" fromDate="2000-01-01 00:00:00.000"/>
     <CommunicationEventRole communicationEventId="TestEvent-2" partyId="TestCompany" roleTypeId="ADDRESSEE" statusId="COM_ROLE_CREATED"/>
 
     <CommunicationEvent communicationEventId="TestEvent-5" communicationEventTypeId="EMAIL_COMMUNICATION" statusId="COM_IN_PROGRESS" contactMechIdFrom="TestContactMech" contactMechIdTo="TestContactMech2" roleTypeIdFrom="BILL_TO_CUSTOMER" roleTypeIdTo="CUSTOMER" partyIdFrom="TestCompany" partyIdTo="TestCustomer" entryDate="2010-10-27 15:04:17.895" subject="Test Subject 1" contentMimeTypeId="text/plain" />

--- a/applications/party/webapp/partymgr/WEB-INF/controller.xml
+++ b/applications/party/webapp/partymgr/WEB-INF/controller.xml
@@ -589,10 +589,13 @@ under the License.
         <response name="error" type="view" value="ViewSegmentRoles"/>
     </request-map>
 
-    <request-map uri="addsecondaryroles"><security https="true" auth="true"/><response name="success" type="view" value="addsecondaryroles"/></request-map>
+    <request-map uri="addsecondaryroles">
+        <security https="true" auth="true"/>
+        <response name="success" type="view" value="addsecondaryroles"/>
+    </request-map>
     <request-map uri="addrole">
         <security https="true" auth="true"/>
-        <event type="service" path="" invoke="createPartyRole"/>
+        <event type="service" path="" invoke="updatePartyRole"/>
         <response name="success" type="view" value="viewroles"/>
         <response name="error" type="view" value="viewroles"/>
     </request-map>
@@ -605,6 +608,12 @@ under the License.
     <request-map uri="createroletype">
         <security https="true" auth="true"/>
         <event type="service" invoke="createRoleType"/>
+        <response name="success" type="view" value="viewroles"/>
+        <response name="error" type="view" value="viewroles"/>
+    </request-map>
+    <request-map uri="expirePartyRole">
+        <security https="true" auth="true"/>
+        <event type="service" invoke="expirePartyRole"/>
         <response name="success" type="view" value="viewroles"/>
         <response name="error" type="view" value="viewroles"/>
     </request-map>

--- a/applications/party/widget/partymgr/PartyForms.xml
+++ b/applications/party/widget/partymgr/PartyForms.xml
@@ -1189,18 +1189,16 @@ under the License.
         <field position="1" name="totalToBeReceived" use-when="finanSummary.get(&quot;totalToBeReceived&quot;)!=null" title="${uiLabelMap.PartyToBePaidTo} ${parameters.partyId}"><display type="currency" currency="${actualCurrencyUomId}"/></field>
     </form>
     
-    <grid name="ViewPartyRoles" list-name="partyRoles" target="viewroles"
+    <grid name="ViewPartyRoles" list-name="partyRoles" paginate-target="viewroles" target="expirePartyRole"
         default-title-style="tableheadtext"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
-        <field name="roleTypeId" title="${uiLabelMap.PartyRoleTypeId}"><display/></field>
-        <field name="description" title="${uiLabelMap.PartyRole}"><display/></field>
+        <field name="partyId"><hidden/></field>
+        <field name="roleTypeId" title="${uiLabelMap.CommonId}"><display/></field>
+        <field name="description" title="${uiLabelMap.CommonRole}"><display/></field>
         <field name="parentTypeId"><display-entity entity-name="RoleType" key-field-name="roleTypeId"/></field>
-        <field name="remove">
-            <hyperlink description="${uiLabelMap.CommonRemove}" target="deleterole">
-                <parameter param-name="partyId"/>
-                <parameter param-name="roleTypeId"/>
-            </hyperlink>
-        </field>
+        <field name="fromDate" title ="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title ="${uiLabelMap.CommonThru}"><display type="date-time"/></field>
+        <field name="expire" title="${uiLabelMap.CommonExpire}"><submit/></field>
     </grid>
     
     <form name="AddPartyRole" type="single" title="Add a role to party" target="addrole">
@@ -1212,6 +1210,7 @@ under the License.
                 </entity-options>
             </drop-down>
         </field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}" required-field="true"><date-time default-value="${nowTimestamp}"/></field>
         <field name="add" title="${uiLabelMap.CommonAdd}"><submit/></field>
     </form>
     <form name="AddPartyMainRole" type="single" title="${uiLabelMap.PartyAddToMainRole}" target="addrole">
@@ -1224,6 +1223,7 @@ under the License.
                 </entity-options>
             </drop-down>
         </field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}" required-field="true"><date-time default-value="${nowTimestamp}"/></field>
         <field name="add" title="${uiLabelMap.CommonAdd}"><submit/></field>
     </form>
     <form name="AddPartySecondaryRoles" type="single" title="${uiLabelMap.PartyAddToSecondRole}" target="addrole">
@@ -1236,6 +1236,7 @@ under the License.
                 </entity-options>
             </drop-down>
         </field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}" required-field="true"><date-time default-value="${nowTimestamp}"/></field>
         <field name="add" title="${uiLabelMap.CommonAdd}"><submit/></field>
     </form>
     <form name="AddRoleType" type="single" title="Add a new roletype" target="createroletype"  list-name="parentRoleList">

--- a/applications/party/widget/partymgr/PartyScreens.xml
+++ b/applications/party/widget/partymgr/PartyScreens.xml
@@ -171,12 +171,14 @@ under the License.
                         <condition-expr field-name="partyId" operator="equals" value="${parameters.partyId}"/>
                         <condition-expr field-name="roleTypeId" operator="not-equals" value="_NA_"/>
                     </condition-list>
+                    <order-by field-name="roleTypeId"/>
+                    <order-by field-name="fromDate"/>
                 </entity-condition>
             </actions>
             <widgets>
                 <decorator-screen name="CommonPartyDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.PartyMemberRoles}" navigation-form-name="ViewPartyRoles">
+                        <screenlet title="${uiLabelMap.CommonRoles}" navigation-form-name="ViewPartyRoles">
                             <include-grid name="ViewPartyRoles" location="component://party/widget/partymgr/PartyForms.xml"/>
                         </screenlet>
                         <section>

--- a/applications/product/testdef/data/ShipmentCostTestData.xml
+++ b/applications/product/testdef/data/ShipmentCostTestData.xml
@@ -33,7 +33,7 @@ under the License.
         <!--simple case-->
         <Party partyId="UPS_SIMPLE" partyTypeId="PARTY_GROUP"/>
         <PartyGroup partyId="UPS_SIMPLE" groupName="UPS_SIMPLE"/>
-        <PartyRole partyId="UPS_SIMPLE" roleTypeId="CARRIER"/>
+        <PartyRole partyId="UPS_SIMPLE" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
 
         <CarrierShipmentMethod partyId="UPS_SIMPLE" roleTypeId="CARRIER" shipmentMethodTypeId="AIR" sequenceNumber="1" carrierServiceCode="01"/>
         <CarrierShipmentMethod partyId="UPS_SIMPLE" roleTypeId="CARRIER" shipmentMethodTypeId="ROAD" sequenceNumber="2" carrierServiceCode="02"/>
@@ -61,7 +61,7 @@ under the License.
 
         <Party partyId="UPS_BREAK" partyTypeId="PARTY_GROUP"/>
         <PartyGroup partyId="UPS_BREAK" groupName="UPS_BREAK"/>
-        <PartyRole partyId="UPS_BREAK" roleTypeId="CARRIER"/>
+        <PartyRole partyId="UPS_BREAK" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
 
         <CarrierShipmentMethod partyId="UPS_BREAK" roleTypeId="CARRIER" shipmentMethodTypeId="AIR" sequenceNumber="1" carrierServiceCode="01"/>
         <CarrierShipmentMethod partyId="UPS_BREAK" roleTypeId="CARRIER" shipmentMethodTypeId="ROAD" sequenceNumber="2" carrierServiceCode="02"/>
@@ -96,7 +96,7 @@ under the License.
         <Party partyId="UPS_MULTI" partyTypeId="PARTY_GROUP"/>
         <Party partyId="RECEIVER" partyTypeId="PARTY_GROUP"/>
         <PartyGroup partyId="UPS_MULTI" groupName="UPS_MULTI"/>
-        <PartyRole partyId="UPS_MULTI" roleTypeId="CARRIER"/>
+        <PartyRole partyId="UPS_MULTI" roleTypeId="CARRIER" fromDate="2000-01-01 00:00:00.000"/>
 
         <CarrierShipmentMethod partyId="UPS_MULTI" roleTypeId="CARRIER" shipmentMethodTypeId="ROAD" sequenceNumber="2" carrierServiceCode="02"/>
         <ProductStoreShipmentMeth productStoreShipMethId="M9002" productStoreId="ShipCost" partyId="UPS_MULTI" includeNoChargeItems="N" allowUspsAddr="N" requireUspsAddr="N" roleTypeId="CARRIER" shipmentMethodTypeId="ROAD" sequenceNumber="2"/>

--- a/applications/workeffort/testdef/data/WorkEffortTestData.xml
+++ b/applications/workeffort/testdef/data/WorkEffortTestData.xml
@@ -21,26 +21,26 @@ under the License.
 <entity-engine-xml>
     <Party partyId="TestCompany" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <PartyGroup partyId="TestCompany" groupName="Your Company Name Here"/>
-    <PartyRole partyId="TestCompany" roleTypeId="BILL_FROM_VENDOR"/>
-    <PartyRole partyId="TestCompany" roleTypeId="BILL_TO_CUSTOMER"/>
-    <PartyRole partyId="TestCompany" roleTypeId="INTERNAL_ORGANIZATIO"/>
-    <PartyRole partyId="TestCompany" roleTypeId="ACCOUNTANT"/>
-    <PartyRole partyId="TestCompany" roleTypeId="_NA_"/>
+    <PartyRole partyId="TestCompany" roleTypeId="BILL_FROM_VENDOR" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCompany" roleTypeId="BILL_TO_CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCompany" roleTypeId="INTERNAL_ORGANIZATIO" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCompany" roleTypeId="ACCOUNTANT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestCompany" roleTypeId="_NA_" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestCompany" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="TestParty" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="TestParty" firstName="Test" lastName="Party"/>
-    <PartyRole partyId="TestParty" roleTypeId="CONTACT"/>
-    <PartyRole partyId="TestParty" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="TestParty" roleTypeId="ACCOUNTANT"/>
-    <PartyRole partyId="TestParty" roleTypeId="CONTENT_AUTHOR"/>
+    <PartyRole partyId="TestParty" roleTypeId="CONTACT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestParty" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestParty" roleTypeId="ACCOUNTANT" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestParty" roleTypeId="CONTENT_AUTHOR" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestParty" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <Party partyId="TestParty-1" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
     <Person partyId="TestParty-1" firstName="Test" lastName="Party"/>
-    <PartyRole partyId="TestParty-1" roleTypeId="CAL_OWNER"/>
-    <PartyRole partyId="TestParty-1" roleTypeId="CUSTOMER"/>
-    <PartyRole partyId="TestParty-1" roleTypeId="ACCOUNTANT"/>
+    <PartyRole partyId="TestParty-1" roleTypeId="CAL_OWNER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestParty-1" roleTypeId="CUSTOMER" fromDate="2000-01-01 00:00:00.000"/>
+    <PartyRole partyId="TestParty-1" roleTypeId="ACCOUNTANT" fromDate="2000-01-01 00:00:00.000"/>
     <PartyStatus partyId="TestParty-1" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
 
     <ContactMech contactMechId="TestContactMech" contactMechTypeId="EMAIL_ADDRESS" infoString="newtest_email@example.com"/>


### PR DESCRIPTION
Currently it only possible to delete a role. That can lead to potential error
messages, when a particular role is associated with records where the roleTypeId
is used as a foreign key in the entity-model/database and the user tries to
delete that role from the list.

In order to avoid such, it is better to revoke the PartyRole record by setting
an expiration date (end date) on the record.

added/changed/updated:
- added field definition for from and through date to the entity
- added service for expiration
- request-map for expiration
- appropriate forms to work with  added entity fields
- added groovy code to check existing when adding PartyRole record and call 
  expiration service if needed
- adding fromDate value to seed, test and demo data
