### PR TITLE
Improved: User with only 'VIEW' permissions - Accounting Payments (OFBIZ-12397)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -469,17 +469,6 @@ under the License.
                 <parameter param-name="paymentId" from-field="payment.paymentId"/>
             </link>
         </menu-item>
-        <menu-item name="editPayment" title="${uiLabelMap.AccountingPaymentTabHeader}">
-            <condition>
-                <and>
-                    <not><if-empty field="payment.paymentId"/></not>
-                    <if-compare field="payment.statusId" operator="equals" value="PMNT_NOT_PAID"/>
-                </and>
-            </condition>
-            <link target="editPayment">
-                <parameter param-name="paymentId" from-field="payment.paymentId"/>
-            </link>
-        </menu-item>
         <menu-item name="editPaymentApplications" title="${uiLabelMap.AccountingPaymentTabApplications}">
             <condition>
                 <and>
@@ -504,13 +493,37 @@ under the License.
         </actions>
         <menu-item name="createNew" title="${uiLabelMap.CommonCreate}" widget-style="buttontext create" >
             <condition>
-                <not><if-empty field="payment.paymentId"/></not>
+                <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
+                </and>
             </condition>
             <link target="newPayment"/>
+        </menu-item>
+        <menu-item name="editPayment" title="${uiLabelMap.CommonEdit}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
+                    <not><if-empty field="payment.paymentId"/></not>
+                    <if-compare field="payment.statusId" operator="equals" value="PMNT_NOT_PAID"/>
+                </and>
+            </condition>
+            <link target="editPayment">
+                <parameter param-name="paymentId" from-field="payment.paymentId"/>
+            </link>
         </menu-item>
         <menu-item name="statusToSend" title="${uiLabelMap.AccountingPaymentTabStatusToSent}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <not><if-empty field="payment.paymentId"/></not>
                     <if-compare field="isDisbursement" operator="equals" value="true"/>
                     <if-compare field="payment.statusId" operator="equals" value="PMNT_NOT_PAID"/>
@@ -524,6 +537,10 @@ under the License.
         <menu-item name="statusToReceived" title="${uiLabelMap.AccountingPaymentTabStatusToReceived}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <not><if-empty field="payment.paymentId"/></not>
                     <if-compare field="isDisbursement" operator="equals" value="false"/>
                     <if-compare field="payment.statusId" operator="equals" value="PMNT_NOT_PAID"/>
@@ -537,6 +554,10 @@ under the License.
         <menu-item name="statusToCancelled" title="${uiLabelMap.AccountingPaymentTabStatusToCancelled}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <not><if-empty field="payment.paymentId"/></not>
                     <if-compare field="payment.statusId" operator="equals" value="PMNT_NOT_PAID"/>
                 </and>
@@ -549,6 +570,10 @@ under the License.
         <menu-item name="statusToConfirmed" title="${uiLabelMap.AccountingPaymentTabStatusToConfirmed}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <not><if-empty field="payment.paymentId"/></not>
                     <or>
                         <if-compare field="payment.statusId" operator="equals" value="PMNT_RECEIVED"/>
@@ -564,6 +589,10 @@ under the License.
         <menu-item name="printAsCheck" title="${uiLabelMap.AccountingPrintAsCheck}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <not><if-empty field="payment.paymentId"/></not>
                     <if-compare field="payment.statusId" operator="equals" value="PMNT_NOT_PAID"/>
                 </and>
@@ -575,6 +604,10 @@ under the License.
         <menu-item name="statusToVoidPayment" title="${uiLabelMap.AccountingPaymentTabStatusToVoid}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <not><if-empty field="payment.paymentId"/></not>
                     <and>
                         <if-compare field="payment.statusId" operator="not-equals" value="PMNT_CONFIRMED"/>

--- a/applications/accounting/widget/CommonScreens.xml
+++ b/applications/accounting/widget/CommonScreens.xml
@@ -118,6 +118,7 @@ under the License.
                             </condition>
                             <widgets>
                                 <include-menu name="PaymentTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="PaymentSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
                             </widgets>
                         </section>
                     </decorator-section>

--- a/applications/accounting/widget/PaymentScreens.xml
+++ b/applications/accounting/widget/PaymentScreens.xml
@@ -83,7 +83,7 @@ under the License.
                                         <include-form name="FindPayments" location="component://accounting/widget/PaymentForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListPayments"  location="component://accounting/widget/PaymentForms.xml"/>
+                                        <include-form name="ListPayments" location="component://accounting/widget/PaymentForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -372,17 +372,11 @@ under the License.
                             <widgets>
                                 <container style="lefthalf">
                                     <screenlet title="${uiLabelMap.AccountingPaymentHeader}">
-                                        <link target="editPayment" text="${uiLabelMap.CommonUpdate}" style="buttontext">
-                                            <parameter param-name="paymentId"/>
-                                        </link>
                                         <include-form name="PaymentHeader" location="component://accounting/widget/PaymentForms.xml"/>
                                     </screenlet>
                                 </container>
                                 <container style="righthalf">
                                     <screenlet title="${uiLabelMap.AccountingPaymentsApplied} ${appliedAmount?currency(${payment.currencyUomId})} ${uiLabelMap.AccountingOpenPayments} ${notAppliedAmount?currency(${payment.currencyUomId})}">
-                                        <link target="editPaymentApplications" text="${uiLabelMap.CommonUpdate}" style="buttontext">
-                                            <parameter param-name="paymentId"/>
-                                        </link>
                                         <include-form name="PaymentApplications" location="component://accounting/widget/PaymentForms.xml"/>
                                     </screenlet>
                                     <section>

--- a/applications/accounting/widget/PaymentScreens.xml
+++ b/applications/accounting/widget/PaymentScreens.xml
@@ -30,11 +30,9 @@ under the License.
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
                         <section>
-                            <condition>
-                                <if-service-permission service-name="acctgBasePermissionCheck" main-action="VIEW"/>
-                            </condition>
                             <widgets>
                                 <include-menu name="PaymentTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="PaymentSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
                             </widgets>
                         </section>
                     </decorator-section>
@@ -45,7 +43,6 @@ under the License.
                                 <if-service-permission service-name="acctgBasePermissionCheck" main-action="VIEW"/>
                             </condition>
                             <widgets>
-                                <include-menu name="PaymentSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
                                 <container style="leftclear">
                                     <label style="h1" text="${uiLabelMap[labelTitleProperty]} ${uiLabelMap.CommonId}:[${paymentId}]  ${${extraFunctionName}}"/>
                                 </container>
@@ -79,13 +76,6 @@ under the License.
                         <section>
                             <widgets>
                                 <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                                    <decorator-section name="menu-bar">
-                                        <container style="button-bar">
-                                            <link target="newPayment" text="${uiLabelMap.CommonCreate}" style="buttontext create"/>
-                                            <link target="FindSalesInvoicesByDueDate" text="${uiLabelMap.AccountingFindSalesInvoicesByDueDate}" style="buttontext search"/>
-                                            <link target="FindPurchaseInvoicesByDueDate" text="${uiLabelMap.AccountingFindPurchaseInvoicesByDueDate}" style="buttontext search"/>
-                                        </container>
-                                    </decorator-section>
                                     <decorator-section name="search-options">
                                         <platform-specific>
                                             <html><html-template multi-block="true" location="component://common-theme/template/includes/SetMultipleSelectJsList.ftl"/></html>
@@ -129,7 +119,7 @@ under the License.
                 <property-to-field field="defaultCurrencyUomId" resource="general" property="currency.uom.id.default" default="USD"/>
             </actions>
             <widgets>
-                <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                <decorator-screen name="CommonPaymentDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <section>
                             <widgets>


### PR DESCRIPTION

modified:
PaymentTabBar - removed editPayment menu-item
PaymentSubTabBar
- added CREATE/UPDATE permission condition to menu-item createNew
- added editPayment menu-item
- added CREATE/UPDATE permission condition to menu-item statusToSend
- added CREATE/UPDATE permission condition to menu-item setPaymentStatus
- added CREATE/UPDATE permission condition to menu-item statusToCancelled
- added CREATE/UPDATE permission condition to menu-item statusToConfirmed
- added CREATE/UPDATE permission condition to menu-item printAsCheck
- added CREATE/UPDATE permission condition to menu-item statusToVoid


Modified: CommonPaymentDecorator
added PaymentSubTabBar

Modified: PaymentScreens.xml
screen CommonPaymentDecorator
- removed permission (handled at lower level)
- moved PaymentSubTabBar to pre-body section
screen FindPayment
- removed decorator-section menu-bar (handled by menu PaymentSubTabBar in CommonPaymentDecorator)
Screen NewPayment
- changed decorator section from main-decorator to CommonPaymentDecorator
- removed triggers from screen PaymentOverview, handled by menu-items in PaymentSubTabBar.