### PR TITLE
Improved: User with only 'VIEW' permissions and invoice roles (OFBIZ-12413)

### DIFF
--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -524,10 +524,25 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonInvoiceDecorator" location="${parameters.invoiceDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet id="PartyInvoiceRolePanel" title="${uiLabelMap.AccountingPartyRoleAdd}" collapsible="true">
-                            <include-form name="EditInvoiceRole" location="component://accounting/widget/InvoiceForms.xml"/>
-                        </screenlet>
-                        <include-form name="ListInvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet id="PartyInvoiceRolePanel" title="${uiLabelMap.AccountingPartyRoleAdd}" collapsible="true">
+                                    <include-form name="EditInvoiceRole" location="component://accounting/widget/InvoiceForms.xml"/>
+                                </screenlet>
+                                <include-form name="ListInvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                            </widgets>
+                            <fail-widgets>
+                                <include-form name="InvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the roles screen on an invoice sees fields editable and triggers to requests reserved for users with 'CREATE' or 'UPDATE' permissions.

Modified: InvoiceScreens.xml
Introduced
restructured screen InvoiceRoles, to show appropriate content based on the permissions of the user