### PR TITLE
Improved: User with only 'VIEW' permissions and invoice terms ( OFBIZ-12414)

### DIFF
--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -478,6 +478,27 @@ under the License.
         </field>
     </form>
     
+    <grid name="InvoiceTerms" list-name="invoiceTerms" 
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <field name="invoiceId"><hidden/></field>
+        <field name="invoiceItemSeqId" title="${uiLabelMap.CommonItem}"><display/></field>
+        <field name="invoiceTermId"><display/></field>
+        <field name="termTypeId" title="${uiLabelMap.CommonType}">
+            <display-entity entity-name="TermType"/>
+        </field>
+        <field name="description" title="${uiLabelMap.CommonDescription}"><display/></field>
+        <field name="termDays" title="${uiLabelMap.CommonDays}" widget-area-style="align-right" title-area-style="align-right">
+            <display/>
+        </field>
+        <field name="termValue" title="${uiLabelMap.CommonValue}" widget-area-style="align-right" title-area-style="align-right">
+            <display type="currency" currency="${uomId}"/>
+        </field>
+        <field name="uomId" title="${uiLabelMap.CommonCurrency}">
+            <display-entity entity-name="Uom"/>
+        </field>
+        <field name="textValue" title="${uiLabelMap.CommonText}"><display/></field>
+    </grid>
+    
     <form name="EditInvoiceTerm" type="single" target="createInvoiceTerm" title="" 
         header-row-style="header-row" default-table-style="basic-table" default-map-name="invoiceTerm" default-entity-name="InvoiceTerm" >
         <alt-target use-when="invoiceTerm!=null" target="updateInvoiceTerm"/>

--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -569,17 +569,32 @@ under the License.
                     <decorator-section name="body">
                         <section>
                             <condition>
-                                <not>
-                                    <if-compare field="invoice.statusId" operator="equals" value="INVOICE_APPROVED"/>
-                                </not>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                    </or>
+                                </and>
                             </condition>
                             <widgets>
-                                <screenlet id="PartyInvoiceTermPanel" collapsible="true">
-                                    <include-form name="EditInvoiceTerm" location="component://accounting/widget/InvoiceForms.xml"/>
-                                </screenlet>
+                                <section>
+                                    <condition>
+                                        <not>
+                                            <if-compare field="invoice.statusId" operator="equals" value="INVOICE_APPROVED"/>
+                                        </not>
+                                    </condition>
+                                    <widgets>
+                                        <screenlet id="PartyInvoiceTermPanel" collapsible="true">
+                                            <include-form name="EditInvoiceTerm" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        </screenlet>
+                                    </widgets>
+                                </section>
+                                <include-form name="ListInvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
                             </widgets>
+                            <fail-widgets>
+                                <include-grid name="InvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
+                            </fail-widgets>
                         </section>
-                        <include-form name="ListInvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the terms screen on an invoice sees fields editable and triggers to requests reserved for users with 'CREATE' or 'UPDATE' permissions.

Modified: InvoiceForms.xml
added grid 'InvoiceTerms' for displaying records of the list invoiceTerms for users with 'VIEW" missions

Modified: InvoiceScreens.xml
restructured screen InvoiceTerms, to show appropriate content based on the permissions of the user