### PR TITLE
Improved: User with only 'VIEW' permissions and invoice items (OFBIZ-12415)

### DIFF
--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -454,27 +454,62 @@ under the License.
                     <condition-expr field-name="parentTypeId" value="PAYROL"/>
                 </entity-condition>
                 <entity-condition entity-name="InvoiceItemType" list="PayrolList"/>
+                <entity-condition entity-name="InvItemAndOrdItem" list="invItemAndOrdItems">
+                    <condition-expr field-name="invoiceId"  operator="equals" from-field="invoiceId"/>
+                    <order-by field-name="invoiceItemSeqId"/>
+                </entity-condition>
                 <script location="component://accounting/groovyScripts/invoice/GetAccountOrganizationAndClass.groovy"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonInvoiceDecorator" location="${parameters.invoiceDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.AccountingInvoiceItemAdd}">
-                            <section>
-                                <condition>
-                                    <not><if-compare field="invoice.invoiceTypeId" operator="equals" value="PAYROL_INVOICE"/></not>
-                                </condition>
-                                <widgets>
-                                    <include-form name="EditInvoiceItem" location="component://accounting/widget/InvoiceForms.xml"/>
-                                </widgets>
-                                <fail-widgets>
-                                    <platform-specific><html><html-template location="component://accounting/template/invoice/InvoiceItemsPayrol.ftl"/></html></platform-specific>
-                                </fail-widgets>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet title="${uiLabelMap.AccountingInvoiceItemAdd}">
+                                    <section>
+                                    <condition>
+                                        <not><if-compare field="invoice.invoiceTypeId" operator="equals" value="PAYROL_INVOICE"/></not>
+                                    </condition>
+                                    <widgets>
+                                        <include-form name="EditInvoiceItem" location="component://accounting/widget/InvoiceForms.xml"/>
+                                    </widgets>
+                                    <fail-widgets>
+                                        <platform-specific><html>
+                                            <html-template location="component://accounting/template/invoice/InvoiceItemsPayrol.ftl"/>
+                                        </html></platform-specific>
+                                        </fail-widgets>
+                                    </section>
+                                </screenlet>
+                                <screenlet title="${uiLabelMap.AccountingInvoiceItems}">
+                                    <include-form name="EditInvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <section>
+                                    <condition>
+                                        <not><if-compare field="invoice.invoiceTypeId" operator="equals" value="PAYROL_INVOICE"/></not>
+                                    </condition>
+                                    <widgets>
+                                <include-form name="InvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
+                                    </widgets>
+                                    <fail-widgets>
+                                        <platform-specific>
+                                            <html>
+                                            <html-template location="component://accounting/template/invoice/InvoiceItemsPayrol.ftl"/>
+                                            </html>
+                                        </platform-specific>
+                                    </fail-widgets>
+                                </section>
+                            </fail-widgets>
                             </section>
-                        </screenlet>
-                        <screenlet title="${uiLabelMap.AccountingInvoiceItems}">
-                            <include-form name="EditInvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
-                        </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the items screen on an invoice sees fields editable and triggers to requests reserved for users with 'CREATE' or 'UPDATE' permissions.
See https://demo-trunk.ofbiz.apache.org/accounting/control/listInvoiceItems?invoiceId=demo10001

modified: InvoiceScreens.xml
restructured screen EditInvoiceItems, to show appropriate content based on the permissions of the user