### PR TITLE
Improved: 'VIEW' permissions and invoice time-entries (OFBIZ-12416)

### DIFF
--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -535,7 +535,22 @@ under the License.
                 <decorator-screen name="CommonInvoiceDecorator" location="${parameters.invoiceDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingInvoiceTimeEntries}">
-                            <include-form name="EditTimeEntries" location="component://accounting/widget/InvoiceForms.xml"/>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <include-form name="EditTimeEntries" location="component://accounting/widget/InvoiceForms.xml"/>
+                            </widgets>
+                            <fail-widgets>
+                                <include-form name="ListTimeEntries" location="component://accounting/widget/InvoiceForms.xml"/>
+                            </fail-widgets>
+                        </section>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the time-entries screen on an invoice sees triggers to requests reserved for users with 'CREATE' or 'UPDATE' permissions.

modified: InvoiceScreens.xml
restructured screen EditInvoiceTimeEntries, to show appropriate content based on the permissions of the user
