### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/accounting/widget/PaymentForms.xml
+++ b/applications/accounting/widget/PaymentForms.xml
@@ -48,7 +48,7 @@ under the License.
         <field name="paymentGatewayResponseId"><text/></field>
         <field name="searchButton" title="${uiLabelMap.CommonFind}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <form name="ListPayments" type="list" separate-columns="true" default-entity-name="Payment" list-name="listIt" paginate-target="findPayments" paginate="true"
+    <grid name="ListPayments" separate-columns="true" default-entity-name="Payment" list-name="listIt" paginate-target="findPayments" paginate="true"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <service service-name="performFind" result-map="result" result-map-list="listIt">
@@ -88,7 +88,7 @@ under the License.
         <field name="currencyUomId"><hidden/></field>
         <field name="amount"><display also-hidden="false" type="currency" currency="${currencyUomId}"/></field>
         <field name="amountToApply"><display also-hidden="false" type="currency" currency="${currencyUomId}"/></field>
-    </form>
+    </grid>
 
     <form name="EditPaymentAttributes" extends="CommonPortletEdit" extends-resource="component://common/widget/PortletEditForms.xml">
         <field name="partyIdFrom"><lookup target-form-name="LookupPartyName"/></field>
@@ -263,7 +263,7 @@ under the License.
         <field position="1" name="updateButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
 
-    <form name="EditPaymentApplicationsInv" default-entity-name="PaymentApplication" list-name="paymentApplicationsInv" target="removePaymentApplication" type="list" separate-columns="false"
+    <grid name="EditPaymentApplicationsInv" default-entity-name="PaymentApplication" list-name="paymentApplicationsInv" target="removePaymentApplication" separate-columns="false"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="paymentApplicationId"><hidden/></field>
         <field name="paymentId"><hidden/></field>
@@ -277,16 +277,16 @@ under the License.
         <field name="invoiceItemSeqId"><display/></field>
         <field name="amountApplied"><display/></field>
         <field name="removeButton"><submit/></field>
-    </form>
-    <form name="EditPaymentApplicationsPay" default-entity-name="PaymentApplication" list-name="paymentApplicationsPay" target="removePaymentApplication" type="list" separate-columns="false"
+    </grid>
+    <grid name="EditPaymentApplicationsPay" default-entity-name="PaymentApplication" list-name="paymentApplicationsPay" target="removePaymentApplication" separate-columns="false"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="paymentApplicationId"><hidden/></field>
         <field name="paymentId"><hidden/></field>
         <field name="toPaymentId"><display/></field>
         <field name="amountApplied"><display/></field>
         <field name="removeButton"><submit/></field>
-    </form>
-    <form name="EditPaymentApplicationsBil" default-entity-name="PaymentApplication" list-name="paymentApplicationsBil" target="removePaymentApplication"  type="list" separate-columns="false"
+    </grid>
+    <grid name="EditPaymentApplicationsBil" default-entity-name="PaymentApplication" list-name="paymentApplicationsBil" target="removePaymentApplication" separate-columns="false"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="paymentApplicationId"><hidden/></field>
         <field name="paymentId"><hidden/></field>
@@ -294,17 +294,17 @@ under the License.
         <field name="invoiceId"><hidden/></field>
         <field name="amountApplied"><display/></field>
         <field name="removeButton" title="${uiLabelMap.CommonRemove}"><submit/></field>
-    </form>
-    <form name="EditPaymentApplicationsTax" default-entity-name="PaymentApplication" list-name="paymentApplicationsTax" target="removePaymentApplication"  type="list" separate-columns="false"
+    </grid>
+    <grid name="EditPaymentApplicationsTax" default-entity-name="PaymentApplication" list-name="paymentApplicationsTax" target="removePaymentApplication" separate-columns="false"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="paymentApplicationId"><hidden/></field>
         <field name="paymentId"><hidden/></field>
         <field name="taxAuthGeoId"><display/></field>
         <field name="amountApplied"><display/></field>
         <field name="removeButton" title="${uiLabelMap.CommonRemove}"><submit/></field>
-    </form>
+    </grid>
 
-    <form name="ListInvoicesNotApplied" type="list" list-name="invoices" target="createPaymentApplication" title=""
+    <grid name="ListInvoicesNotApplied" list-name="invoices" target="createPaymentApplication" title=""
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="paymentId"><hidden/></field>
         <field name="invoiceId" widget-style="buttontext">
@@ -322,11 +322,11 @@ under the License.
         <field name="applyButton" widget-style="smallSubmit">
             <submit button-type="button"/>
         </field>
-    </form>
+    </grid>
 
     <form name="ListInvoicesNotAppliedOtherCurrency" extends="ListInvoicesNotApplied" list-name="invoicesOtherCurrency"/>
 
-    <form name="ListPaymentsNotApplied" type="list" list-name="payments" target="createPaymentApplication" title=""
+    <grid name="ListPaymentsNotApplied" list-name="payments" target="createPaymentApplication" title=""
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="paymentId"><hidden/></field>
         <field name="toPaymentId" widget-style="buttontext">
@@ -341,7 +341,7 @@ under the License.
         <field name="applyButton" widget-style="smallSubmit">
             <submit button-type="button"/>
         </field>
-    </form>
+    </grid>
 
     <form name="AddPaymentApplication" type="single" target="createPaymentApplication" title=""
         header-row-style="header-row" default-table-style="basic-table">
@@ -402,7 +402,7 @@ under the License.
         </field>
     </form>
 
-    <form name="PaymentApplications" type="list" list-name="paymentApplications"
+    <grid name="PaymentApplications" type="list" list-name="paymentApplications"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="PaymentApplication">
@@ -443,7 +443,7 @@ under the License.
         </field>
         <field name="taxAuthGeoId"><display-entity entity-name="Geo" key-field-name="geoId" description="${geoName}"></display-entity></field>
         <field name="amountApplied"><display type="currency" currency="${payment.currencyUomId}"/></field>
-    </form>
+    </grid>
 
     <form name="AcctgTransAndEntries" type="list" list-name="AcctgTransAndEntries" extends="AcctgTransAndEntries" extends-resource="component://accounting/widget/InvoiceForms.xml">
         <field name="paymentId"><hidden/></field>
@@ -519,7 +519,7 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-    <form name="ListInvoicesByDueDate" type="list" list-name="invoicePaymentInfoList"
+    <grid name="ListInvoicesByDueDate" list-name="invoicePaymentInfoList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="invoiceId" widget-style="buttontext">
             <hyperlink description="${invoiceId}" target="invoiceOverview">
@@ -533,7 +533,7 @@ under the License.
         <field name="amount" position="1"><display type="currency" currency="${payment.currencyUomId}"/></field>
         <field name="paidAmount"><display type="currency" currency="${payment.currencyUomId}"/></field>
         <field name="outstandingAmount"><display type="currency" currency="${payment.currencyUomId}"/></field>
-    </form>
+    </grid>
     <form name="FinAccountTransAssociatedWithPayment" type="single" default-map-name="finAccountTrans" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="finAccountTransId" position="1"><display/></field>
         <field name="finAccountTransTypeId" title="${uiLabelMap.FormFieldTitle_finAccountTransType}" position="2"><display-entity entity-name="FinAccountTransType"/></field>

--- a/applications/accounting/widget/PaymentScreens.xml
+++ b/applications/accounting/widget/PaymentScreens.xml
@@ -83,7 +83,7 @@ under the License.
                                         <include-form name="FindPayments" location="component://accounting/widget/PaymentForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListPayments" location="component://accounting/widget/PaymentForms.xml"/>
+                                        <include-grid name="ListPayments" location="component://accounting/widget/PaymentForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -102,7 +102,7 @@ under the License.
             </actions>
             <widgets>
                 <screenlet title="${uiLabelMap.AccountingInvoicePayments}">
-                    <include-form name="ListPayments"  location="component://accounting/widget/PaymentForms.xml"/>
+                    <include-grid name="ListPayments"  location="component://accounting/widget/PaymentForms.xml"/>
                 </screenlet>
             </widgets>
         </section>
@@ -237,7 +237,7 @@ under the License.
                                     </condition>
                                     <widgets>
                                         <screenlet title="${uiLabelMap.AccountingPayment} ${uiLabelMap.AccountingApplications}">
-                                            <include-form name="EditPaymentApplicationsInv" location="component://accounting/widget/PaymentForms.xml"/>
+                                            <include-grid name="EditPaymentApplicationsInv" location="component://accounting/widget/PaymentForms.xml"/>
                                         </screenlet>
                                     </widgets>
                                 </section>
@@ -256,7 +256,7 @@ under the License.
                                                     <not><if-empty field="paymentApplicationsPay"/></not>
                                                 </condition>
                                                 <widgets>
-                                                    <include-form name="EditPaymentApplicationsPay" location="component://accounting/widget/PaymentForms.xml"/>
+                                                    <include-grid name="EditPaymentApplicationsPay" location="component://accounting/widget/PaymentForms.xml"/>
                                                 </widgets>
                                             </section>
                                             <section>
@@ -264,7 +264,7 @@ under the License.
                                                     <not><if-empty field="paymentApplicationsBil"/></not>
                                                 </condition>
                                                 <widgets>
-                                                    <include-form name="EditPaymentApplicationsBil" location="component://accounting/widget/PaymentForms.xml"/>
+                                                    <include-grid name="EditPaymentApplicationsBil" location="component://accounting/widget/PaymentForms.xml"/>
                                                 </widgets>
                                             </section>
                                             <section>
@@ -272,7 +272,7 @@ under the License.
                                                     <not><if-empty field="paymentApplicationsTax"/></not>
                                                 </condition>
                                                 <widgets>
-                                                    <include-form name="EditPaymentApplicationsTax" location="component://accounting/widget/PaymentForms.xml"/>
+                                                    <include-grid name="EditPaymentApplicationsTax" location="component://accounting/widget/PaymentForms.xml"/>
                                                 </widgets>
                                             </section>
                                         </screenlet>
@@ -303,7 +303,7 @@ under the License.
                                                     <not><if-empty field="invoices"/></not>
                                                 </condition>
                                                 <widgets>
-                                                    <include-form name="ListInvoicesNotApplied" location="component://accounting/widget/PaymentForms.xml"/>
+                                                    <include-grid name="ListInvoicesNotApplied" location="component://accounting/widget/PaymentForms.xml"/>
                                                 </widgets>
                                             </section>
                                             <section>
@@ -377,7 +377,7 @@ under the License.
                                 </container>
                                 <container style="righthalf">
                                     <screenlet title="${uiLabelMap.AccountingPaymentsApplied} ${appliedAmount?currency(${payment.currencyUomId})} ${uiLabelMap.AccountingOpenPayments} ${notAppliedAmount?currency(${payment.currencyUomId})}">
-                                        <include-form name="PaymentApplications" location="component://accounting/widget/PaymentForms.xml"/>
+                                        <include-grid name="PaymentApplications" location="component://accounting/widget/PaymentForms.xml"/>
                                     </screenlet>
                                     <section>
                                         <condition>
@@ -403,7 +403,7 @@ under the License.
                                 </container>
                                 <container style="righthalf">
                                     <screenlet title="${uiLabelMap.AccountingPaymentsApplied} ${appliedAmount?currency(${payment.currencyUomId})} ${uiLabelMap.AccountingOpenPayments} ${notAppliedAmount?currency(${payment.currencyUomId})}">
-                                        <include-form name="PaymentApplications" location="component://accounting/widget/PaymentForms.xml"/>
+                                        <include-grid name="PaymentApplications" location="component://accounting/widget/PaymentForms.xml"/>
                                     </screenlet>
                                         <section>
                                             <condition>
@@ -529,7 +529,7 @@ under the License.
                             </condition>
                             <widgets>
                                 <screenlet title="${uiLabelMap.AccountingFindSalesInvoicesByDueDate}">
-                                    <include-form name="ListInvoicesByDueDate"  location="component://accounting/widget/PaymentForms.xml"/>
+                                    <include-grid name="ListInvoicesByDueDate"  location="component://accounting/widget/PaymentForms.xml"/>
                                 </screenlet>
                             </widgets>
                         </section>
@@ -561,7 +561,7 @@ under the License.
                             </condition>
                             <widgets>
                                 <screenlet title="${uiLabelMap.AccountingFindPurchaseInvoicesByDueDate}">
-                                    <include-form name="ListInvoicesByDueDate" location="component://accounting/widget/PaymentForms.xml"/>
+                                    <include-grid name="ListInvoicesByDueDate" location="component://accounting/widget/PaymentForms.xml"/>
                                 </screenlet>
                             </widgets>
                         </section>

--- a/applications/accounting/widget/ap/ApScreens.xml
+++ b/applications/accounting/widget/ap/ApScreens.xml
@@ -40,7 +40,7 @@ under the License.
                                         <include-form name="FindApPayments" location="component://accounting/widget/ap/forms/VendorForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListPayments" location="component://accounting/widget/PaymentForms.xml"/>
+                                        <include-grid name="ListPayments" location="component://accounting/widget/PaymentForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>

--- a/applications/accounting/widget/ar/ArPaymentScreens.xml
+++ b/applications/accounting/widget/ar/ArPaymentScreens.xml
@@ -42,7 +42,7 @@ under the License.
                                         <include-form name="FindArPayments" location="component://accounting/widget/ar/forms/ArPaymentForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListPayments"  location="component://accounting/widget/PaymentForms.xml"/>
+                                        <include-grid name="ListPayments"  location="component://accounting/widget/PaymentForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Associating lists in screens with grids in forms.
modified:
ApScreens.xml: from form ref to grid ref
ArScreens.xml: from form ref to grid ref
PaymentScreens.xml: from form ref to grid ref
PaymentForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
