### PR TITLE
Fixed: VIEW permissions - error when accessing IncomeStatement (OFBIZ-12421)

### DIFF
--- a/applications/datamodel/data/demo/AccountingDemoData.xml
+++ b/applications/datamodel/data/demo/AccountingDemoData.xml
@@ -62,6 +62,7 @@ under the License.
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="BIZADMIN" permissionId="ACCTG_PREF_UPDATE"/>
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="BIZADMIN" permissionId="ACCTG_PREF_DELETE"/>
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="BIZADMIN" permissionId="ACCTG_PREF_VIEW"/>
+    <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="VIEWADMIN" permissionId="ACCTG_PREF_VIEW"/>
 
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="FULLADMIN" permissionId="ACCTG_FX_UPDATE"/>
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="BIZADMIN" permissionId="ACCTG_FX_UPDATE"/>


### PR DESCRIPTION
When a user with VIEW permissions (e.g. auditor) access the IncomeStatement via following uri, an error is shown.
https://demo-trunk.ofbiz.apache.org/accounting/control/IncomeStatement?organizationPartyId=Company

`java.lang.IllegalArgumentException: Error calling service with name getPartyAccountingPreferences: org.apache.ofbiz.service.ServiceAuthException: You haven't the permission for the service getPartyAccountingPreferences, reason : Access refused`

Modified AccountingDemoData.xml
added SecurityGroupPermission record
