### PR TITLE
Fixed: VIEW permissions - error when accessing PartyAccountsSummary (OFBIZ-12419)

### DIFF
--- a/applications/accounting/servicedef/services_admin.xml
+++ b/applications/accounting/servicedef/services_admin.xml
@@ -84,7 +84,7 @@ under the License.
     <service name="setAcctgCompany" engine="groovy"
         location="component://accounting/groovyScripts/admin/AcctgAdminServices.groovy" invoke="setAcctgCompany" auth="true">
         <description>Set Accounting Company when select</description>
-        <permission-service service-name="acctgPrefPermissionCheck" main-action="CREATE"/>
+        <permission-service service-name="acctgPrefPermissionCheck" main-action="VIEW"/>
         <attribute type="String" mode="INOUT" name="organizationPartyId" optional="true"/>
     </service>
 


### PR DESCRIPTION
When a user with VIEW permissions (e.g. auditor) access the PartyAccountSummary via following uri, an error is shown.
https://demo-trunk.ofbiz.apache.org/accounting/control/PartyAccountsSummary
The Following Errors Occurred:
You haven't the permission for the service setAcctgCompany, reason : Access refused

Modified: services_admin.xml
changed permission service check from "CREATE" to "VIEW".