### PR TITLE
Fixed: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/accounting/widget/PaymentForms.xml
+++ b/applications/accounting/widget/PaymentForms.xml
@@ -402,7 +402,7 @@ under the License.
         </field>
     </form>
 
-    <grid name="PaymentApplications" type="list" list-name="paymentApplications"
+    <grid name="PaymentApplications" list-name="paymentApplications"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="PaymentApplication">


### PR DESCRIPTION
Grid PaymentApplications caused an xml validation error
2021-11-30 21:19:15,454 |jsse-nio-8443-exec-7 |UtilXml                       |E| XmlFileLoader: File file:/Users/pierre/dev/Apache/ofbiz/applications/accounting/widget/PaymentForms.xml process error. Line: 406. Error message: cvc-complex-type.3.2.2: Attribute 'type' is not allowed to appear in element 'grid'.

Caused by https://github.com/apache/ofbiz-framework/commit/efcf07c79eb975979fc7c68d49f12d04ddab29e7

Modified: PaymentForms.xml
removed type="list" attribute from grid definition
