### PR TITLE
Fixed: Payment Applications shows wrong label translation (OFBIZ-12425)

### DIFF
--- a/applications/accounting/widget/PaymentScreens.xml
+++ b/applications/accounting/widget/PaymentScreens.xml
@@ -226,7 +226,7 @@ under the License.
                                 <if-empty field="paymentApplications"/>
                             </condition>
                             <widgets>
-                                <container><label style="h1" text="${uiLabelMap.AccountingPayment} ${uiLabelMap.AccountingPaymentsApplications}"/></container>
+                                <container><label style="h1" text="${uiLabelMap.AccountingAppliedPayments}"/></container>
                                 <container><label style="h1" text="${uiLabelMap.CommonAmount} ${uiLabelMap.CommonTotal} ${payment.amount?currency(${payment.currencyUomId})} ${uiLabelMap.AccountingAmountNotApplied} ${notAppliedAmount?currency(${payment.currencyUomId})}"/></container>
                                 <container><label style="h3" text="${uiLabelMap.AccountingNoPaymentsApplicationsfound}"></label></container>
                             </widgets>
@@ -236,7 +236,7 @@ under the License.
                                         <not><if-empty field="paymentApplicationsInv"/></not>
                                     </condition>
                                     <widgets>
-                                        <screenlet title="${uiLabelMap.AccountingPayment} ${uiLabelMap.AccountingPaymentsApplications}">
+                                        <screenlet title="${uiLabelMap.AccountingAppliedPayments}">
                                             <include-grid name="EditPaymentApplicationsInv" location="component://accounting/widget/PaymentForms.xml"/>
                                         </screenlet>
                                     </widgets>


### PR DESCRIPTION
See: https://demo-trunk.ofbiz.apache.org/accounting/control/editPaymentApplications?paymentId=8004 compared to https://demo-stable.ofbiz.apache.org/accounting/control/editPaymentApplications?paymentId=8004
With changes committed under  https://github.com/apache/ofbiz-framework/commit/4aa2d714328447787455abcd5887ca99bcbf1152 the label used changed, see below
-                                <container><label style="h1" text="${uiLabelMap.AccountingPayment} ${uiLabelMap.AccountingApplications}"/></container>
+                                <container><label style="h1" text="${uiLabelMap.AccountingPayment} ${uiLabelMap.AccountingPaymentsApplications}"/></container>

giving the resulting change from 'Payment Applications' for the section/screenlet (as inline with the menu-item with translation 'Applications') to 'Payment Payments'

modified: EditPaymentsApplications screen in PaymentScreens.xml
changed label combination for a more suitable label.