### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/product/widget/catalog/CategoryForms.xml
+++ b/applications/product/widget/catalog/CategoryForms.xml
@@ -25,7 +25,8 @@ under the License.
         <field name="productCategoryId"><display/></field>
         <field name="submitForm" title="${uiLabelMap.CommonCreate}"><submit/></field>
     </form>
-    <form name="EditProductCategoryAttributes" odd-row-style="alternate-row" default-table-style="basic-table" type="list" target="updateProductCategoryAttribute" title="" list-name="categoryAttributes">
+    <grid name="EditProductCategoryAttributes" list-name="categoryAttributes" target="updateProductCategoryAttribute"
+        odd-row-style="alternate-row" default-table-style="basic-table" >
         <auto-fields-service service-name="updateProductCategoryAttribute" default-field-type="display"/>
         <field name="productCategoryId"><hidden/></field>
         <field name="attrValue"><text size="60"/></field>
@@ -36,7 +37,7 @@ under the License.
                 <parameter param-name="attrName"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
 
     <!-- Product Category Content Forms  -->
     <form name="AddCategoryContentAssoc" type="single" target="addContentToCategory" title="${uiLabelMap.ProductAddProductCategoryContentFromDate}"
@@ -71,7 +72,7 @@ under the License.
         <field name="submitButton" title="${uiLabelMap.ProductPrepareCreate}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
 
-    <form name="UpdateCategoryContentAssoc" type="list" target="updateContentToCategory" title="" list-name="productCategoryContentList"
+    <grid name="UpdateCategoryContentAssoc" list-name="productCategoryContentList" target="updateContentToCategory"
         odd-row-style="alternate-row" default-table-style="basic-table">
         <field name="productCategoryId"><hidden/></field>
         <field name="contentId" title="${uiLabelMap.ProductContent}">
@@ -89,18 +90,6 @@ under the License.
         </field>
         <field name="fromDate"><display/></field>
         <field name="thruDate"><display/></field>
-        <!--
-        jacopoc: I've disabled the ability to update a content record because it was not working
-        <field name="thruDate"><date-time type="timestamp"/></field>
-        <field name="prodCatContentTypeId">
-            <drop-down>
-                <entity-options entity-name="ProductCategoryContentType">
-                    <entity-order-by field-name="description"/>
-                </entity-options>
-            </drop-down>
-        </field>
-        <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
-        -->
         <field name="editLink" title="${uiLabelMap.ProductEditContent}" widget-style="buttontext">
             <hyperlink description="${contentId}" target="/content/control/EditContent" target-type="inter-app">
                 <parameter param-name="contentId"/>
@@ -114,7 +103,7 @@ under the License.
                 <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
 
     <form name="EditCategoryContentSimpleText" type="single" default-map-name="categoryContent" target="updateSimpleTextContentForCategory" title="${uiLabelMap.ProductUpdateSimpleTextContentCategory}"
         header-row-style="header-row" default-table-style="basic-table">
@@ -149,8 +138,8 @@ under the License.
     </form>
 
     <!-- ProductCategoryLink Forms-->
-    <form name="ListProductCategoryLinks" type="list" list-name="productCategoryLinks" target="updateProductCategoryLink" separate-columns="true"
-        title="" odd-row-style="alternate-row" default-table-style="basic-table">
+    <grid name="ListProductCategoryLinks" list-name="productCategoryLinks" target="updateProductCategoryLink" separate-columns="true"
+        odd-row-style="alternate-row" default-table-style="basic-table">
         <actions>
             <entity-condition entity-name="ProductCategoryLink">
                 <condition-expr field-name="productCategoryId" from-field="productCategoryId"/>
@@ -158,7 +147,6 @@ under the License.
             </entity-condition>
         </actions>
         <auto-fields-service service-name="updateProductCategoryLink"/>
-
         <field name="productCategoryId"><hidden/></field>
         <field name="linkSeqId"><display/></field>
         <field name="fromDate" title="${uiLabelMap.CommonFromDate}"><display/></field>
@@ -180,7 +168,7 @@ under the License.
             </hyperlink>
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}"><submit button-type="button"/></field>
-    </form>
+    </grid>
 
     <form name="AddProductCategoryLink" type="single" target="createProductCategoryLink" title="" default-map-name="productCategoryLink"
         header-row-style="header-row" default-table-style="basic-table">
@@ -212,7 +200,7 @@ under the License.
         </field>
     </form>
 
-    <form name="ListTopCategory" type="list" list-name="noParentCategories" odd-row-style="alternate-row" default-table-style="basic-table">
+    <grid name="ListTopCategory" list-name="noParentCategories" odd-row-style="alternate-row" default-table-style="basic-table">
         <field name="productCategoryId"  widget-style="buttontext">
             <hyperlink description="${productCategoryId}" target="EditCategory" also-hidden="false">
                 <parameter param-name="CATALOG_TOP_CATEGORY" value="${productCategoryId}"/>
@@ -220,7 +208,7 @@ under the License.
             </hyperlink>
         </field>
         <field name="description"><display/></field>
-    </form>
+    </grid>
 
     <form name="FindCategory" type="single" target="FindCategory" title="" default-map-name="category"
         header-row-style="header-row" default-table-style="basic-table">
@@ -232,7 +220,7 @@ under the License.
         </field>
     </form>
 
-    <form name="ListCategory" list-name="listIt" target="" title="" type="list" paginate-target="FindCategory"
+    <grid name="ListCategory" list-name="listIt" paginate-target="FindCategory"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" header-row-style="header-row-2">
         <actions>
             <set field="entityName" value="ProductCategory"/>
@@ -249,12 +237,11 @@ under the License.
                 <parameter param-name="productCategoryId"/>
             </hyperlink>
         </field>
-        
         <field name="productCategoryTypeId" sort-field="true"><display-entity entity-name="ProductCategoryType"/></field>
         <field name="primaryParentCategoryId" sort-field="true"><display/></field>
         <field name="categoryName" sort-field="true"><display/></field>
         <field name="description" sort-field="true"><display/></field>
-    </form>
+    </grid>
 
     <form name="EditCategoryContentSEO" type="single" target="updateContentSEOForCategory" title="${uiLabelMap.ProductUpdateSEOContentCategory}"
         header-row-style="header-row" default-table-style="basic-table">

--- a/applications/product/widget/catalog/CategoryScreens.xml
+++ b/applications/product/widget/catalog/CategoryScreens.xml
@@ -96,7 +96,7 @@ under the License.
                                         <include-form name="FindCategory" location="component://product/widget/catalog/CategoryForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListCategory" location="component://product/widget/catalog/CategoryForms.xml"/>
+                                        <include-grid name="ListCategory" location="component://product/widget/catalog/CategoryForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -204,20 +204,18 @@ under the License.
                 <set field="titleProperty" value="PageTitleEditCategoryContent"/>
                 <set field="tabButtonItem" value="EditCategoryContent"/>
                 <set field="labelTitleProperty" value="ProductCategoryContent"/>
-
                 <set field="productCategoryId" from-field="parameters.productCategoryId"/>
                 <entity-one entity-name="ProductCategory" value-field="productCategory"/>
                 <get-related-one value-field="productCategory" relation-name="ProductCategoryType" to-value-field="productCategoryType"/>
                 <set field="categoryContentOrderList[]" value="prodCatContentTypeId"/>
                 <get-related value-field="productCategory" relation-name="ProductCategoryContent" list="productCategoryContentList" order-by-list="categoryContentOrderList"/>
-
                 <entity-condition entity-name="ProductCategoryType" list="productCategoryTypes"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonCategoryDecorator">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.ProductUpdateCategoryContentAssoc}">
-                            <include-form name="UpdateCategoryContentAssoc" location="component://product/widget/catalog/CategoryForms.xml"/>
+                            <include-grid name="UpdateCategoryContentAssoc" location="component://product/widget/catalog/CategoryForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.ProductAddProductCategoryContentFromDate}">
                             <include-form name="PrepareAddCategoryContentAssoc" location="component://product/widget/catalog/CategoryForms.xml"/>
@@ -459,7 +457,7 @@ under the License.
                             <include-form name="CreateProductCategoryAttribute" location="component://product/widget/catalog/CategoryForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.PageTitleEditCategoryAttributes}">
-                            <include-form name="EditProductCategoryAttributes" location="component://product/widget/catalog/CategoryForms.xml"/>
+                            <include-grid name="EditProductCategoryAttributes" location="component://product/widget/catalog/CategoryForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -529,7 +527,7 @@ under the License.
                 <decorator-screen name="CommonCategoryDecorator">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleEditProductCategoryLink}">
-                            <include-form name="ListProductCategoryLinks" location="component://product/widget/catalog/CategoryForms.xml"/>
+                            <include-grid name="ListProductCategoryLinks" location="component://product/widget/catalog/CategoryForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.PageTitleCreateProductCategoryLink}">
                             <label style="h3">&gt;&gt;&gt;&gt;&gt;This function is depreciated and replaced by the function under the tab &quot;Content&quot; with the content type "Related URL"</label>

--- a/applications/product/widget/catalog/CommonScreens.xml
+++ b/applications/product/widget/catalog/CommonScreens.xml
@@ -309,7 +309,7 @@ under the License.
                             <link target="EditCategory" text="${uiLabelMap.ProductNewCategory}" style="buttontext create"/>
                         </container>
                         <screenlet title="${uiLabelMap.ProductCategoryWithNoParent}">
-                            <include-form name="ListTopCategory" location="component://product/widget/catalog/CategoryForms.xml"/>
+                            <include-grid name="ListTopCategory" location="component://product/widget/catalog/CategoryForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

modified:
CategoryScreens.xml and CommonScreens.xml in product: from form ref to grid ref , additional cleanup
CategoryForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up