### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/product/widget/catalog/ConfigForms.xml
+++ b/applications/product/widget/catalog/ConfigForms.xml
@@ -20,9 +20,8 @@ under the License.
 
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
-    <form name="FindProductConfigItems" type="list" list-name="listIt"
-        default-table-style="basic-table" odd-row-style="alternate-row" paginate-target="FindProductConfigItems"
-        target="" header-row-style="header-row-2" paginate="true">
+    <grid name="FindProductConfigItems" list-name="listIt" paginate="true" paginate-target="FindProductConfigItems"
+        default-table-style="basic-table" odd-row-style="alternate-row" target="" header-row-style="header-row-2">
         <actions>
             <service service-name="performFind" result-map-list="listIt" result-map="performFindResult">
                 <field-map field-name="inputFields" from-field="parameters"/>
@@ -44,7 +43,7 @@ under the License.
             <display description="${typeDescription}"/>
         </field>
         <field name="description"><display/></field>
-    </form>
+    </grid>
     <form name="FindProductConfigItemsFrom" type="single" target="FindProductConfigItems"
         default-map-name="productconfigitems"  header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ProductConfigItem" default-field-type="find"/>
@@ -192,9 +191,8 @@ under the License.
         <field use-when="contentId != null" name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
 
-    <form name="ListProductConfigItem" type="list" list-name="productConfigs"
-        default-table-style="basic-table" odd-row-style="alternate-row" paginate-target="FindProductConfigItems"
-        target="" header-row-style="header-row-2" paginate="true">
+    <grid name="ListProductConfigItem" list-name="productConfigs" paginate="true" paginate-target="FindProductConfigItems"
+        default-table-style="basic-table" odd-row-style="alternate-row" header-row-style="header-row-2">
         <actions>
             <entity-condition entity-name="ProductConfigAndProduct" list="productConfigs" distinct="true">
                 <condition-list>
@@ -214,11 +212,10 @@ under the License.
         </field>
         <field name="productName" title="${uiLabelMap.ProductName}"><display description="${productName}"/></field>
         <field name="piecesIncluded" title="${uiLabelMap.ProductPiecesIncluded}"><display description="${piecesIncluded}"/></field>
-    </form>
+    </grid>
 
-    <form name="ProductConfigOptionList" type="list" list-name="configOptionList"
-        default-table-style="basic-table" odd-row-style="alternate-row" paginate-target="FindProductConfigItems"
-        target="" header-row-style="header-row-2" paginate="true">
+    <grid name="ProductConfigOptionList" list-name="configOptionList" paginate="true" paginate-target="FindProductConfigItems"
+        default-table-style="basic-table" odd-row-style="alternate-row" header-row-style="header-row-2">
         <auto-fields-entity entity-name="ProductConfigOption" default-field-type="display"/>
         <field name="configItemId" widget-style="buttontext" title="${uiLabelMap.ProductConfigOption}">
             <hyperlink description="${configOptionId} - ${configOptionName}" target="EditProductConfigOptions">
@@ -234,11 +231,9 @@ under the License.
                 <parameter param-name="configOptionId"/>
             </hyperlink>
         </field>
-    </form>
-
-    <form name="ProductConfigList" type="list" list-name="configProducts"
-        default-table-style="basic-table" odd-row-style="alternate-row" paginate-target="FindProductConfigItems"
-        target="" header-row-style="header-row-2" paginate="true">
+    </grid>
+    <grid name="ProductConfigList" list-name="configProducts" paginate="true" paginate-target="FindProductConfigItems"
+        default-table-style="basic-table" odd-row-style="alternate-row" header-row-style="header-row-2">
         <row-actions>
             <entity-one entity-name="Product" value-field="product">
                 <field-map field-name="productId"/>
@@ -259,6 +254,5 @@ under the License.
                 <parameter param-name="productId" from-field="product.productId"/>
             </hyperlink>
         </field>
-    </form>
-
+    </grid>
 </forms>

--- a/applications/product/widget/catalog/ConfigScreens.xml
+++ b/applications/product/widget/catalog/ConfigScreens.xml
@@ -76,7 +76,7 @@ under the License.
                                 <include-form name="FindProductConfigItemsFrom" location="component://product/widget/catalog/ConfigForms.xml"/>
                             </decorator-section>
                             <decorator-section name="search-results">
-                                <include-form name="FindProductConfigItems" location="component://product/widget/catalog/ConfigForms.xml"/>
+                                <include-grid name="FindProductConfigItems" location="component://product/widget/catalog/ConfigForms.xml"/>
                             </decorator-section>
                         </decorator-screen>
                     </decorator-section>
@@ -178,7 +178,7 @@ under the License.
             </condition>
             <widgets>
                 <screenlet title="${uiLabelMap.ProductComponents} - ${uiLabelMap.CommonId}: ${configOption.configOptionId} - ${configOption.description}">
-                    <include-form name="ProductConfigList" location="component://product/widget/catalog/ConfigForms.xml"/>
+                    <include-grid name="ProductConfigList" location="component://product/widget/catalog/ConfigForms.xml"/>
                 </screenlet>
                 <section>
                     <condition>

--- a/applications/product/widget/catalog/ConfigScreens.xml
+++ b/applications/product/widget/catalog/ConfigScreens.xml
@@ -148,7 +148,7 @@ under the License.
         <section>
             <widgets>
                 <screenlet title="${uiLabelMap.ProductConfigOptionList}">
-                    <include-form name="ProductConfigOptionList" location="component://product/widget/catalog/ConfigForms.xml"/>
+                    <include-grid name="ProductConfigOptionList" location="component://product/widget/catalog/ConfigForms.xml"/>
                 </screenlet>
                 <section>
                     <condition><not><if-empty field="configOptionId"/></not></condition>
@@ -313,7 +313,7 @@ under the License.
                 <decorator-screen name="CommonConfigDecorator">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleEditProductConfigItemContent}">
-                            <include-form name="ListProductConfigItem" location="component://product/widget/catalog/ConfigForms.xml"/>
+                            <include-grid name="ListProductConfigItem" location="component://product/widget/catalog/ConfigForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

modified in product component:
ConfigScreens.xml: from form ref to grid ref , additional cleanup
ConfigForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up