### PR TITLE
Improved: VIEW permissions - invoice overview term triggers (OFBIZ-12429)

### DIFF
--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -248,7 +248,7 @@ under the License.
                                         <include-form name="InvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                     <screenlet title="${uiLabelMap.PartyTerms}">
-                                        <include-form name="ListInvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="InvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
                                         <include-form name="ListInvoicePaymentInfo" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                 </container>


### PR DESCRIPTION
Currently, when using a userId with only VIEW permission, the section terms shows triggers to term line items in the invoice overview. This should not be, as those triggers on the line items are reserved for users with CREATE/UPDATE permissions.
See (test with): https://localhost:8443/accounting/control/invoiceOverview?invoiceId=demo10001

Modified:
invoiceScreens.xml.xml
- adjusted form ref to grid ref for invoice term records