### PR TITLE
Improved: Grid and List (OFBIZ-11345)

### DIFF
--- a/applications/product/widget/catalog/CatalogScreens.xml
+++ b/applications/product/widget/catalog/CatalogScreens.xml
@@ -39,7 +39,7 @@ under the License.
                                         <include-form name="FindCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                                        <include-grid name="ListCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -110,7 +110,7 @@ under the License.
                 <decorator-screen name="CommonCatalogDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleEditProductCatalogCategories}">
-                            <include-form name="EditProdCatalogCategories" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                            <include-grid name="EditProdCatalogCategories" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.ProductAddCatalogProdCat}">
                             <include-form name="AddProductCategoryToProdCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
@@ -135,7 +135,7 @@ under the License.
                  <decorator-screen name="CommonCatalogDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleEditProductCatalogParties}">
-                            <include-form name="UpdateProdCatalogToParty" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                            <include-grid name="UpdateProdCatalogToParty" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.PageTitleAddProductCatalogParties}">
                             <include-form name="AddProdCatalogToParty" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
@@ -160,7 +160,7 @@ under the License.
                  <decorator-screen name="CommonCatalogDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleEditProductCatalogStores}">
-                            <include-form name="UpdateProductStoreCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                            <include-grid name="UpdateProductStoreCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.PageTitleAddProductCatalogStores}">
                             <include-form name="CreateProductStoreCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
@@ -170,7 +170,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ShortcutApp">
         <section>
             <actions>

--- a/applications/product/widget/catalog/FeatureForms.xml
+++ b/applications/product/widget/catalog/FeatureForms.xml
@@ -85,14 +85,13 @@
         <field name="productFeatureId" ><hidden/></field>
         <field name="submitForm" title="${uiLabelMap.CommonCreate}"><submit/></field>
     </form>
-    <form name="EditSupplierProductFeatures" type="list" target="updateSupplierProductFeature" title="" list-name="supplierProductFeatures"
+    <grid name="EditSupplierProductFeatures" target="updateSupplierProductFeature" list-name="supplierProductFeatures"
         odd-row-style="alternate-row" default-table-style="basic-table">
         <auto-fields-service service-name="updateSupplierProductFeature" default-field-type="display"/>
         <field name="productFeatureId"><hidden/></field>
         <field name="partyId" title="${uiLabelMap.ProductSuppliers}">
             <display-entity entity-name="PartyGroup" description="${groupName}"/>
         </field>
-
         <field name="description" title="${uiLabelMap.ProductProductDescription}"><text size="40"/></field>
         <field name="idCode" title="${uiLabelMap.ProductIdCode}"><text size="5"/></field>
         <field name="uomId" title="${uiLabelMap.ProductCurrency}">
@@ -107,14 +106,14 @@
                 <parameter param-name="partyId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="FindFeatureType" type="single" target="EditFeatureTypes"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="productFeatureTypeId"><text-find size="25"></text-find></field>
         <field name="description"><text-find size="25"></text-find></field>
         <field name="searchButton" title="${uiLabelMap.CommonFind}" widget-style="smallSubmit"><submit/></field>
     </form>
-    <form name="ListFeatureTypes" list-name="listIt" target="" title="" type="list" paginate-target="EditFeatureTypes"
+    <grid name="ListFeatureTypes" list-name="listIt" paginate-target="EditFeatureTypes"
         odd-row-style="alternate-row" default-table-style="basic-table">
         <actions>
             <set field="parameters.noConditionFind" value="Y"/>
@@ -144,7 +143,7 @@
                 <parameter param-name="productFeatureTypeId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="EditFeatureType" type="single" target="updateProductFeatureType" title="" default-map-name="productFeatureType"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="productFeatureType==null" target="createProductFeatureType"/>
@@ -167,7 +166,7 @@
         <field name="productFeatureIdTo"><text-find size="25"></text-find></field>
         <field name="searchButton" title="${uiLabelMap.CommonFind}" widget-style="smallSubmit"><submit/></field>
     </form>
-    <form name="ListFeatureInterActions" list-name="listIt" target="" title="" type="list" paginate-target="EditFeatureInterAction"
+    <grid name="ListFeatureInterActions" list-name="listIt" paginate-target="EditFeatureInterAction"
         odd-row-style="alternate-row" default-table-style="basic-table">
         <actions>
             <set field="parameters.noConditionFind" value="Y"/>
@@ -179,7 +178,6 @@
                 <field-map field-name="viewSize" from-field="viewSize"/>
                 </service>
             </actions>
-
         <field name="productFeatureId">
             <display-entity entity-name="ProductFeature">
                 <sub-hyperlink target="EditFeature" description="[${productFeatureId}]">
@@ -195,14 +193,13 @@
             </display-entity>
         </field>
         <field name="productFeatureIactnTypeId"><display-entity entity-name="ProductFeatureIactnType"/></field>
-
         <field name="removeFeatureInterAction" title="${uiLabelMap.CommonDelete}" widget-style="buttontext">
             <hyperlink description="${uiLabelMap.CommonDelete}" target="removeProductFeatureIactn">
                 <parameter param-name="productFeatureId"/>
                 <parameter param-name="productFeatureIdTo"/>
             </hyperlink>
         </field>
-        </form>
+        </grid>
     <form name="EditFeatureInterAction" type="single" target="createProductFeatureIactn" title="" default-map-name="productFeatureIactn"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="productFeatureId">
@@ -297,7 +294,7 @@
         <field name="searchButton" title="${uiLabelMap.CommonFind}" widget-style="smallSubmit find"><submit/></field>
     </form>
 
-    <form name="ListProductFeature" type="list" list-name="listIt" paginate-target="EditFeatureCategories" target="UpdateFeatureCategory"
+    <grid name="ListProductFeature" list-name="listIt" paginate-target="EditFeatureCategories" target="UpdateFeatureCategory"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true">
         <actions>
             <set field="parameters.noConditionFind" value="Y"/>
@@ -316,8 +313,7 @@
         </field>
         <field name="description" title="${uiLabelMap.CommonDescription}"><text/></field>
         <field name="update" title="${uiLabelMap.CommonUpdate}"><submit/></field>
-    </form>
-
+    </grid>
     <form name="CreateProductFeature" type="single" target="CreateFeatureCategory">
         <field name="description" title="${uiLabelMap.CommonDescription}" required-field="true"><text size="25"></text></field>
         <field name="parentCategory" title="${uiLabelMap.ProductParentCategory}">
@@ -329,7 +325,7 @@
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}" widget-style="smallSubmit"><submit button-type="button"/></field>
 
     </form>
-    <form name="ListFeaturePrice" type="list" target="updateFeaturePrice"  list-name="productFeaturePrice"
+    <grid name="ListFeaturePrice" target="updateFeaturePrice" list-name="productFeaturePrice"
         odd-row-style="alternate-row" default-table-style="basic-table">
         <actions>
             <entity-and entity-name="ProductFeaturePrice" list="productFeaturePrice">
@@ -352,7 +348,7 @@
                 <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="CreateFeaturePrice" type="single" target="createFeaturePrice">
         <actions>
             <property-to-field field="defaultCurrencyUomId" resource="general" property="currency.uom.id.default" default="USD"/>

--- a/applications/product/widget/catalog/FeatureScreens.xml
+++ b/applications/product/widget/catalog/FeatureScreens.xml
@@ -75,7 +75,7 @@
                             <include-form name="CreateFeaturePrice" location="component://product/widget/catalog/FeatureForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.ProductSupplierSpecificFeatureInformation}">
-                            <include-form name="EditSupplierProductFeatures" location="component://product/widget/catalog/FeatureForms.xml"/>
+                            <include-grid name="EditSupplierProductFeatures" location="component://product/widget/catalog/FeatureForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.ProductCreateInformationNewSupplier}">
                             <include-form name="CreateSupplierProductFeature" location="component://product/widget/catalog/FeatureForms.xml"/>
@@ -107,7 +107,7 @@
                                         <include-form name="FindFeatureType" location="component://product/widget/catalog/FeatureForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListFeatureTypes" location="component://product/widget/catalog/FeatureForms.xml"/>
+                                        <include-grid name="ListFeatureTypes" location="component://product/widget/catalog/FeatureForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -159,7 +159,7 @@
                                         <include-form name="FindFeatureInterAction" location="component://product/widget/catalog/FeatureForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListFeatureInterActions" location="component://product/widget/catalog/FeatureForms.xml"/>
+                                        <include-grid name="ListFeatureInterActions" location="component://product/widget/catalog/FeatureForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -233,7 +233,7 @@
                                         <include-form name="FindProductFeature" location="component://product/widget/catalog/FeatureForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListProductFeature" location="component://product/widget/catalog/FeatureForms.xml"/>
+                                        <include-grid name="ListProductFeature" location="component://product/widget/catalog/FeatureForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -358,7 +358,7 @@
                 <decorator-screen name="CommonFeatureDecorator">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleEditFeaturePrice}">
-                            <include-form name="ListFeaturePrice" location="component://product/widget/catalog/FeatureForms.xml"/>
+                            <include-grid name="ListFeaturePrice" location="component://product/widget/catalog/FeatureForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.PageTitleAddFeaturePrice}">
                             <include-form name="CreateFeaturePrice" location="component://product/widget/catalog/FeatureForms.xml"/>

--- a/applications/product/widget/catalog/PriceForms.xml
+++ b/applications/product/widget/catalog/PriceForms.xml
@@ -20,8 +20,8 @@
 
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
-    <form name="FindProductPriceRules" list-name="listIt" title="" type="list"
-        odd-row-style="alternate-row" default-table-style="basic-table hover-bar" paginate-target="FindProductPriceRules">
+    <grid name="FindProductPriceRules" list-name="listIt" paginate-target="FindProductPriceRules"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <set field="noConditionFind" value="Y"/>
             <set field="parameters.productPriceRuleId" value=""/>
@@ -46,13 +46,12 @@
                 <parameter param-name="productPriceRuleId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="AddPriceRules" type="single" target="createProductPriceRule">
         <field name="ruleName" title="${uiLabelMap.ProductName}" required-field="true"><text size="30"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}"><submit button-type="button"/></field>
     </form>
-    <!-- Below, I tried also single forms but lists are better as long as we have not introduced a better way to handle positions -->   
-    <form name="EditProductPriceRule" type="list" target="updateProductPriceRule" title="" list-name="productPriceRules" 
+    <grid name="EditProductPriceRule" target="updateProductPriceRule" list-name="productPriceRules" 
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true">
         <field name="productPriceRuleId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->
         <field name="ruleName" title="${uiLabelMap.CommonName}"><text size="15"/></field>
@@ -71,9 +70,9 @@
             <hyperlink description="${uiLabelMap.CommonRemove}" target="deleteProductPriceRule">
                 <parameter param-name="productPriceRuleId"/>
             </hyperlink>
-        </field>        
-    </form>            
-    <form name="EditProductPriceRulesCond" type="list" target="updateProductPriceCond" title="" list-name="productPriceConds" 
+        </field>
+    </grid>
+    <grid name="EditProductPriceRulesCond" list-name="productPriceCond" target="updateProductPriceCond" 
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true">
         <field name="productPriceRuleId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->
         <field name="productPriceCondSeqId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->
@@ -83,14 +82,14 @@
                     <entity-constraint name="enumTypeId" operator="equals" value="PROD_PRICE_IN_PARAM"/>
                 </entity-options>
             </drop-down>
-        </field>        
+        </field>
         <field name="operatorEnumId" title="${uiLabelMap.ProductOperator}">
             <drop-down allow-empty="false" current="selected">
                 <entity-options entity-name="Enumeration" key-field-name="enumId">
                     <entity-constraint name="enumTypeId" operator="equals" value="PROD_PRICE_COND"/>
                 </entity-options>
             </drop-down>
-        </field>        
+        </field>
         <field name="condValueInput" title="${uiLabelMap.ProductValue}" entry-name="condValue"><text size="10"/></field>
         <field name="condValue" title=" ">
             <drop-down allow-empty="false" current="selected">
@@ -103,9 +102,9 @@
                 <parameter param-name="productPriceRuleId" from-field="productPriceCond.productPriceRuleId"/>
                 <parameter param-name="productPriceCondSeqId" from-field="productPriceCond.productPriceCondSeqId"/>
             </hyperlink>
-        </field>        
-    </form>
-    <form name="AddProductPriceRulesCond" type="list" target="createProductPriceCond" title="" list-name="productPriceCondAdd" 
+        </field>
+    </grid>
+    <grid name="AddProductPriceRulesCond" list-name="productPriceCondAdd" target="createProductPriceCond" 
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true">
         <field name="productPriceRuleId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->
         <field name="new" title="${uiLabelMap.CommonNew}"><display default-value="${uiLabelMap.ProductPriceRulesNewCond}"/></field>
@@ -115,51 +114,50 @@
                     <entity-constraint name="enumTypeId" operator="equals" value="PROD_PRICE_IN_PARAM"/>
                 </entity-options>
             </drop-down>
-        </field>        
+        </field>
         <field name="operatorEnumId" title="${uiLabelMap.ProductOperator}">
             <drop-down allow-empty="false">
                 <entity-options entity-name="Enumeration" key-field-name="enumId">
                     <entity-constraint name="enumTypeId" operator="equals" value="PROD_PRICE_COND"/>
                 </entity-options>
             </drop-down>
-        </field>        
+        </field>
         <field name="condValueInput" title="${uiLabelMap.ProductValue}"><text size="10"/></field>
         <field name="condValue" title=" ">
             <drop-down allow-empty="false">
-                <list-options list-name="productPriceRulesCondValues" key-name="condValue"/>                
+                <list-options list-name="productPriceRulesCondValues" key-name="condValue"/>
             </drop-down>
         </field>
-        <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit/></field>        
-    </form>
-    <form name="EditProductPriceRulesAction" type="list" target="updateProductPriceAction" title="" list-name="productPriceActions" 
+        <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit/></field>
+    </grid>
+    <grid name="EditProductPriceRulesAction" list-name="productPriceActions" target="updateProductPriceAction"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true">
-        <field name="productPriceRuleId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->
-        <field name="productPriceActionSeqId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->
+        <field name="productPriceRuleId"><hidden/></field>
+        <field name="productPriceActionSeqId"><hidden/></field>
         <field name="productPriceActionTypeId" title="${uiLabelMap.ProductActionType}">
             <drop-down allow-empty="false" current="selected">
                 <entity-options entity-name="ProductPriceActionType" key-field-name="productPriceActionTypeId"/>
             </drop-down>
-        </field>        
+        </field>
         <field name="amount" title="${uiLabelMap.ProductValue}"><text/></field>
-        <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit/></field>        
+        <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit/></field>
         <field name="deleteLink" title=" " widget-style="buttontext" widget-area-style="align-text">
             <hyperlink description="${uiLabelMap.CommonRemove}" target="deleteProductPriceAction">
                 <parameter param-name="productPriceRuleId" from-field="productPriceAction.productPriceRuleId"/>
                 <parameter param-name="productPriceActionSeqId" from-field="productPriceAction.productPriceActionSeqId"/>
             </hyperlink>
-        </field>        
-    </form>        
-    <form name="AddProductPriceRulesAction" type="list" target="createProductPriceAction" title="" list-name="productPriceActionAdd" 
-        odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true">            
-        <field name="productPriceRuleId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->
+        </field>
+    </grid>
+    <grid name="AddProductPriceRulesAction" list-name="productPriceActionAdd" target="createProductPriceAction" 
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true">
+        <field name="productPriceRuleId"><hidden/></field>
         <field name="new" title="${uiLabelMap.CommonNew}"><display default-value="${uiLabelMap.ProductPriceRulesNewAction}"/></field>
         <field name="productPriceActionTypeId" title="${uiLabelMap.ProductActionType}">
             <drop-down allow-empty="false">
                 <entity-options entity-name="ProductPriceActionType" key-field-name="productPriceActionTypeId"/>
             </drop-down>
-        </field>        
+        </field>
         <field name="amount" title="${uiLabelMap.ProductValue}"><text/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit/></field>
-    </form>        
-    
+    </grid>
 </forms>

--- a/applications/product/widget/catalog/PriceScreens.xml
+++ b/applications/product/widget/catalog/PriceScreens.xml
@@ -26,7 +26,7 @@ under the License.
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for CATALOG, _VIEW permission -->
@@ -73,7 +73,6 @@ under the License.
             <actions>
                 <set field="titleProperty" value="PageTitleEditProductPriceRules"/>
                 <set field="headerItem" value="pricerules"/>
-
                 <script location="component://product/groovyScripts/catalog/price/EditProductPriceRules.groovy"/>
             </actions>
             <widgets>
@@ -84,22 +83,22 @@ under the License.
                         <screenlet title="${uiLabelMap.ProductPriceRuleId} [${parameters.productPriceRuleId}]">
                             <label style="h6" text="${uiLabelMap.ProductConditionsActionsRemoveBefore}"/>
                             <horizontal-separator/>
-                            <include-form name="EditProductPriceRule" location="component://product/widget/catalog/PriceForms.xml"/>
+                            <include-grid name="EditProductPriceRule" location="component://product/widget/catalog/PriceForms.xml"/>
                             <horizontal-separator/>
                             <label style="h6" text="${uiLabelMap.ProductConditionsThenActions}"/>
                             <horizontal-separator/>
                             <screenlet title="${uiLabelMap.ProductConditions}">
-                                <include-form name="EditProductPriceRulesCond" location="component://product/widget/catalog/PriceForms.xml"/>
+                                <include-grid name="EditProductPriceRulesCond" location="component://product/widget/catalog/PriceForms.xml"/>
                                 <horizontal-separator/>
-                                <include-form name="AddProductPriceRulesCond" location="component://product/widget/catalog/PriceForms.xml"/>
+                                <include-grid name="AddProductPriceRulesCond" location="component://product/widget/catalog/PriceForms.xml"/>
                             </screenlet>
                             <screenlet title="${uiLabelMap.ProductActions}">
-                                <include-form name="EditProductPriceRulesAction" location="component://product/widget/catalog/PriceForms.xml"/>
+                                <include-grid name="EditProductPriceRulesAction" location="component://product/widget/catalog/PriceForms.xml"/>
                                 <horizontal-separator/>
-                                <include-form name="AddProductPriceRulesAction" location="component://product/widget/catalog/PriceForms.xml"/>
+                                <include-grid name="AddProductPriceRulesAction" location="component://product/widget/catalog/PriceForms.xml"/>
                             </screenlet>
                         </screenlet>
-                    </decorator-section>                    
+                    </decorator-section>
                 </decorator-screen>
             </widgets>
         </section>

--- a/applications/product/widget/catalog/ProdCatalogForms.xml
+++ b/applications/product/widget/catalog/ProdCatalogForms.xml
@@ -29,7 +29,7 @@ under the License.
         </field>
     </form>
 
-    <form name="ListCatalog" list-name="listIt" target="" title="" type="list" paginate-target="FindCatalog"
+    <grid name="ListCatalog" list-name="listIt" paginate-target="FindCatalog"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" header-row-style="header-row-2">
         <actions>
             <set field="entityName" value="ProdCatalog"/>
@@ -48,13 +48,12 @@ under the License.
                 <parameter param-name="prodCatalogId"/>
             </hyperlink>
         </field>
-        
         <field name="prodCatalogId" sort-field="true">
             <hyperlink description="${prodCatalogId}" target="EditProdCatalog?prodCatalogId=${prodCatalogId}"></hyperlink>
         </field>
         <field name="catalogName" sort-field="true"><display/></field>
         <field name="useQuickAdd" title="${uiLabelMap.ProductUseQuickAdd}" sort-field="true"><display/></field>
-    </form>
+    </grid>
     <form name="EditProdCatalog" type="single" target="updateProdCatalog" title="" default-map-name="prodCatalog"
         header-row-style="header-row" default-table-style="basic-table" default-entity-name="ProdCatalog">
 
@@ -101,7 +100,7 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <form name="UpdateProdCatalogToParty" type="list" target="updateProdCatalogToParty" title="" list-name="prodCatalogRoleList"
+    <grid name="UpdateProdCatalogToParty" list-name="prodCatalogRoleList" target="updateProdCatalogToParty"
         odd-row-style="alternate-row" default-table-style="basic-table" separate-columns="true">
         <auto-fields-service service-name="updateProdCatalogToParty"/>
         <field name="prodCatalogId"><hidden/></field>
@@ -125,7 +124,7 @@ under the License.
               <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="CreateProductStoreCatalog" type="single" target="createProdCatalogStore" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createProductStoreCatalog"/>
@@ -139,7 +138,7 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <form name="UpdateProductStoreCatalog" type="list" target="updateProdCatalogStore" title="" list-name="productStoreCatalogList"
+    <grid name="UpdateProductStoreCatalog" list-name="productStoreCatalogList" target="updateProdCatalogStore"
         odd-row-style="alternate-row" default-table-style="basic-table" separate-columns="true">
         <auto-fields-service service-name="updateProductStoreCatalog"/>
         <field name="prodCatalogId"><hidden/></field>
@@ -160,8 +159,8 @@ under the License.
               <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
-    <form name="EditProdCatalogCategories" type="list" target="updateProductCategoryToProdCatalog" title="" list-name="prodCatalogCategories"
+    </grid>
+    <grid name="EditProdCatalogCategories" list-name="prodCatalogCategories" target="updateProductCategoryToProdCatalog"
         odd-row-style="alternate-row" default-table-style="basic-table" paginate-target="EditProdCatalogCategories" separate-columns="true">
         <auto-fields-service service-name="updateProductCategoryToProdCatalog"/>
         <field name="prodCatalogId"><hidden/></field>
@@ -192,7 +191,7 @@ under the License.
             </hyperlink>
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
-    </form>
+    </grid>
     <form name="AddProductCategoryToProdCatalog" type="single" target="addProductCategoryToProdCatalog" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="addProductCategoryToProdCatalog"/>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

modified in product component:
FeatureScreens.xml: from form ref to grid ref , additional cleanup
FeatureForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
PriceScreens.xml: from form ref to grid ref , additional cleanup
PriceForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
CatalogScreens.xml: from form ref to grid ref , additional cleanup
ProdCatalogForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up