### PR TITLE
Improved: VIEW permissions FinAccount roles (OFBIZ-12435)

### DIFF
--- a/applications/accounting/widget/FinAccountForms.xml
+++ b/applications/accounting/widget/FinAccountForms.xml
@@ -176,8 +176,18 @@ under the License.
         <field name="availableBalance"><display type="accounting-number"/></field>
     </form>
 
-    <grid name="ListFinAccountRoles" list-name="finAccountRoles"  target="updateFinAccountRole" separate-columns="true"
-        odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar" paginate-target="EditFinAccountRoles">
+    <grid name="FinAccountRoles" list-name="finAccountRoles" paginate-target="EditFinAccountRoles" separate-columns="true"
+        odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
+        <actions>
+        </actions>
+        <field name="finAccountId"><hidden/></field>
+        <field name="partyId" title="${uiLabelMap.CommonParty}"><display/></field>
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}"><display/></field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><display type="date-time"/></field>
+    </grid>
+    <grid name="ListFinAccountRoles" list-name="finAccountRoles" target="updateFinAccountRole" paginate-target="EditFinAccountRoles" separate-columns="true"
+        odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="FinAccountRole">
                 <condition-expr field-name="finAccountId" from-field="finAccountId"/>
@@ -185,13 +195,13 @@ under the License.
             </entity-condition>
         </actions>
         <field name="finAccountId"><hidden/></field>
-        <field name="roleTypeId"><display/></field>
-        <field name="partyId"> <display/></field>
-        <field name="fromDate"><display/></field>
-        <field name="thruDate"><date-time/></field>
+        <field name="partyId" title="${uiLabelMap.CommonParty}"><display/></field>
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}"><display/></field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><date-time/></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
-        <field name="deleteLink" title=" " widget-style="buttontext">
-            <hyperlink description="${uiLabelMap.CommonDelete}" target="deleteFinAccountRole" also-hidden="false">
+        <field name="expireLink" title=" " widget-style="buttontext">
+            <hyperlink description="${uiLabelMap.CommonExpire}" target="deleteFinAccountRole" also-hidden="false">
                 <parameter param-name="finAccountId"/>
                 <parameter param-name="partyId"/>
                 <parameter param-name="roleTypeId"/>

--- a/applications/accounting/widget/FinAccountScreens.xml
+++ b/applications/accounting/widget/FinAccountScreens.xml
@@ -177,18 +177,40 @@ under the License.
                 <set field="helpAnchor" value="_help_for_edit_financial_account_roles"/>
                 <set field="finAccountId" from-field="parameters.finAccountId"/>
                 <entity-one entity-name="FinAccount" value-field="finAccount"/>
-                <set field="partyId" from-field="parameters.partyId"/>
-                <set field="roleTypeId" from-field="parameters.roleTypeId"/>
-                <set field="fromDate" from-field="parameters.fromDate"/>
+                <entity-condition entity-name="FinAccountRole" list="finAccountRoles">
+                    <order-by field-name="partyId"/>
+                    <order-by field-name="roleTypeId"/>
+                    <order-by field-name="fromDate"/>
+                </entity-condition>
             </actions>
             <widgets>
                 <decorator-screen name="CommonFinAccountDecorator" location="${parameters.finAccountDecoratorLocation}">
                     <decorator-section name="body">
-                        <label style="h1" text="${uiLabelMap.AccountingEditFinAccountRoleFor}"/>
-                        <screenlet id="FinAccountRolePanel" collapsible="true">
-                            <include-form name="AddFinAccountRole" location="component://accounting/widget/FinAccountForms.xml"/>
-                        </screenlet>
-                        <include-grid name="ListFinAccountRoles" location="component://accounting/widget/FinAccountForms.xml"/>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <label style="h1" text="${uiLabelMap.AccountingFinAccount}: ${finAccountId}"></label>
+                                <screenlet id="FinAccountRolePanel" title="${uiLabelMap.PartyAddRole}">
+                                    <include-form name="AddFinAccountRole" location="component://accounting/widget/FinAccountForms.xml"/>
+                                 </screenlet>
+                                 <screenlet title="${uiLabelMap.CommonRoles}">
+                                    <include-grid name="ListFinAccountRoles" location="component://accounting/widget/FinAccountForms.xml"/>
+                                 </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <label style="h1" text="${uiLabelMap.AccountingFinAccount}: ${finAccountId}"></label>
+                                 <screenlet title="${uiLabelMap.CommonRoles}">
+                                    <include-grid name="FinAccountRoles" location="component://accounting/widget/FinAccountForms.xml"/>
+                                 </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the Financial Account Roles screen  sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.

See (test with): https://demo-trunk.ofbiz.apache.org/accounting/control/EditFinAccount?finAccountId=ABN_CHECKING

Modified:
FinAccountScreens.xml - restructured EditFinAccount
FinAccountForms.xml - added FinAccountRoles form, restructured ListFinAccountRoles
