### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -47,7 +47,7 @@ under the License.
         <field name="searchButton" title="${uiLabelMap.CommonFind}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
 
-    <form name="ListInvoices" type="list" separate-columns="true" title="Invoice List" list-name="listIt" target="" default-entity-name="Invoice" paginate-target="findInvoices"
+    <grid name="ListInvoices" list-name="listIt" separate-columns="true" default-entity-name="Invoice" paginate-target="findInvoices"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
             <set field="parameters.sortField" from-field="parameters.sortField" default-value="-invoiceDate"/>
@@ -73,7 +73,6 @@ under the License.
             <set field="amountToApply" value="${groovy:org.apache.ofbiz.accounting.invoice.InvoiceWorker.getInvoiceNotApplied(delegator,invoiceId)}"/>
             <set field="total" value="${groovy:org.apache.ofbiz.accounting.invoice.InvoiceWorker.getInvoiceTotal(delegator,invoiceId)}"/>
         </row-actions>
-
         <field name="invoiceId" widget-style="buttontext" sort-field="true">
             <hyperlink description="${invoiceId}" target="invoiceOverview">
                 <parameter param-name="invoiceId"/>
@@ -95,7 +94,7 @@ under the License.
         </field>
         <field name="total" widget-area-style="align-text"><display type="currency" currency="${currencyUomId}"/></field>
         <field name="amountToApply" widget-area-style="align-text"><display type="currency" currency="${currencyUomId}"/></field>
-    </form>
+    </grid>
 
     <form name="InvoiceHeader" type="single" title="Invoice header information" default-map-name="invoice"
         header-row-style="header-row" default-table-style="basic-table">
@@ -156,7 +155,7 @@ under the License.
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <auto-fields-entity entity-name="InvoiceNote" default-field-type="display"/>
     </grid>
-    <form name="InvoiceItems" list-name="invItemAndOrdItems" target="" title="" type="list" separate-columns="true" paginate-target="invoiceOverview"
+    <grid name="InvoiceItems" list-name="invItemAndOrdItems" separate-columns="true" paginate-target="invoiceOverview"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <row-actions>
             <set field="quantity" value="${groovy: quantity ?: 1}" type="BigDecimal"/>
@@ -186,9 +185,8 @@ under the License.
                 <parameter param-name="glAccountId" from-field="overrideGlAccountId"/>
             </hyperlink>
         </field>
-    </form>
-
-    <form name="InvoiceRoles" type="list" use-row-submit="true" title="" list-name="invoiceRoles" paginate-target="invoiceRoles"
+    </grid>
+    <grid name="InvoiceRoles" list-name="invoiceRoles" paginate-target="invoiceRoles" use-row-submit="true" 
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <!--auto-fields-entity entity-name="InvoiceRole" default-field-type="display"/-->
         <field name="invoiceId"><hidden/></field>
@@ -205,9 +203,8 @@ under the License.
         </field>
         <field name="percentage"><display/></field>
         <field name="datetimePerformed"><display/></field>
-    </form>
-
-    <form name="ListInvoiceApplications" type="list"  list-name="invoiceApplications" default-entity-name="InvoiceItem" use-row-submit="true"
+    </grid>
+    <grid name="ListInvoiceApplications" list-name="invoiceApplications" default-entity-name="InvoiceItem" use-row-submit="true"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar"
         target="updatePaymentApplication" title="Apply payments to invoices" separate-columns="false">
         <field name="invoiceItemSeqId"><display/></field>
@@ -223,8 +220,8 @@ under the License.
         <field name="billingAccountId"><hidden/></field>
         <field name="paymentApplicationId"><hidden/></field>
         <field name="amountApplied" widget-area-style="align-text"><display type="currency" currency="${invoice.currencyUomId}"/></field>
-    </form>
-    <form name="AcctgTransAndEntries" type="list" title="Accounting Transactions" list-name="acctgTransAndEntries"
+    </grid>
+    <grid name="AcctgTransAndEntries" list-name="acctgTransAndEntries"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <auto-fields-entity entity-name="AcctgTransAndEntries" default-field-type="display"/>
         <field name="invoiceId"><hidden/></field>
@@ -250,7 +247,7 @@ under the License.
             <sort-field name="acctgTransId"/>
             <sort-field name="acctgTransEntrySeqId"/>
         </sort-order>
-    </form>
+    </grid>
 
     <form name="NewSalesInvoice" type="single" target="createInvoice" title="Edit Invoice Header" default-map-name="invoice"
         header-row-style="header-row" default-table-style="basic-table">
@@ -460,16 +457,14 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-
-    <form name="ListInvoiceStatus" list-name="invoiceStatus" target="" title="" type="list" paginate-target="ListInvoiceStatus"
+    <grid name="ListInvoiceStatus" list-name="invoiceStatus" paginate-target="ListInvoiceStatus"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="invoiceId"><hidden/></field>
         <field name="statusDate"><display description="${groovy:statusDate.toString().substring(0,10)}"/></field>
         <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
         <field name="changeByUserLoginId"><display /></field>
-    </form>
-
-    <form name="ListInvoiceTerms" list-name="invoiceTerms" target="" title="" type="list"
+    </grid>
+    <grid name="ListInvoiceTerms" list-name="invoiceTerms" 
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <auto-fields-entity entity-name="InvoiceTerm" default-field-type="display"/>
         <field name="invoiceId"><hidden/></field>
@@ -495,8 +490,7 @@ under the License.
                 <parameter param-name="invoiceId"/>
             </hyperlink>
         </field>
-    </form>
-    
+    </grid>
     <grid name="InvoiceTerms" list-name="invoiceTerms" 
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="invoiceId"><hidden/></field>
@@ -540,8 +534,7 @@ under the License.
         </field>
         <field name="submitButton" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    
-    <form name="EditInvoiceApplications" type="list"  list-name="invoiceApplications" default-entity-name="InvoiceItem" use-row-submit="true" target="updateInvoiceApplication" title="Apply payments to invoices" separate-columns="true"
+    <grid name="EditInvoiceApplications" list-name="invoiceApplications" default-entity-name="InvoiceItem" use-row-submit="true" target="updateInvoiceApplication" separate-columns="true"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="statusId"><hidden/></field>
         <field name="paymentApplicationId"><hidden/></field>
@@ -562,8 +555,7 @@ under the License.
                 <parameter param-name="viewSize"/>
             </hyperlink>
         </field>
-    </form>
-
+    </grid>
     <form name="AddPayment" type="single" target="updateInvoiceApplication" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <field name="invoiceId"><hidden/></field>
@@ -574,8 +566,7 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-
-    <form name="ListPaymentsNotApplied" type="list" list-name="payments" target="updateInvoiceApplication" title=""
+    <grid name="ListPaymentsNotApplied" list-name="payments" target="updateInvoiceApplication"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="invoiceId"><hidden/></field>
         <field name="paymentId" widget-style="buttontext">
@@ -590,11 +581,9 @@ under the License.
         <field name="applyButton" widget-style="smallSubmit">
             <submit button-type="button"/>
         </field>
-    </form>
-
-    <form name="ListPaymentsNotAppliedForeignCurrency" extends="ListPaymentsNotApplied" list-name="paymentsActualCurrency"/>
-
-    <form name="ListInvoiceRoles" type="list" use-row-submit="true" title="" list-name="invoiceRoles" paginate-target="invoiceRoles"
+    </grid>
+    <grid name="ListPaymentsNotAppliedForeignCurrency" extends="ListPaymentsNotApplied" list-name="paymentsActualCurrency"/>
+    <grid name="ListInvoiceRoles" list-name="invoiceRoles" use-row-submit="true" paginate-target="invoiceRoles"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <!--auto-fields-entity entity-name="InvoiceRole" default-field-type="display"/-->
         <field name="invoiceId"><hidden/></field>
@@ -620,8 +609,7 @@ under the License.
                 <parameter param-name="viewSize"/>
             </hyperlink>
         </field>
-    </form>
-    
+    </grid>
     <form name="EditInvoiceRole" type="single" target="createInvoiceRole" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="InvoiceRole"/>
@@ -658,12 +646,10 @@ under the License.
         <field name="bodyText"><textarea/></field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <form name="EditTimeEntries" type="list" list-name="timeEntries"
+    <grid name="EditTimeEntries" list-name="timeEntries"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <auto-fields-service service-name="updateTimeEntry" default-field-type="display"/>
-
         <field name="invoiceId"><hidden/></field>
-
         <field name="deleteLink" title=" " widget-style="buttontext">
             <hyperlink description="${uiLabelMap.CommonDelete}" target="unlinkInvoiceFromTimeEntry" also-hidden="false">
                 <parameter param-name="timeEntryId"/>
@@ -673,8 +659,8 @@ under the License.
                 <parameter param-name="viewSize"/>
             </hyperlink>
         </field>
-    </form>
-    <form name="ListTimeEntries" type="list" list-name="timeEntries"
+    </grid>
+    <grid name="ListTimeEntries" list-name="timeEntries"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <row-actions>
             <entity-one entity-name="Timesheet" value-field="timesheet">
@@ -715,7 +701,7 @@ under the License.
         <field name="fromDate"><display type="date"/></field>
         <field name="thruDate"><display type="date"/></field>
         <field name="comments"><display/></field>
-    </form>
+    </grid>
     <form name="LookupInvoicesStatus" type="single" target="BillingAccountInvoices" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <field name="billingAccountId"><hidden/></field>
@@ -729,8 +715,7 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}"><submit button-type="button"/></field>
     </form>
-
-    <form name="ListInvoicePaymentInfo" type="list" list-name="invoicePaymentInfoList"
+    <grid name="ListInvoicePaymentInfo" list-name="invoicePaymentInfoList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <service service-name="getInvoicePaymentInfoList" result-map-list="invoicePaymentInfoList">
@@ -745,17 +730,15 @@ under the License.
         <field name="amount"><display type="currency" currency="${invoice.currencyUomId}"/></field>
         <field name="paidAmount"><display type="currency" currency="${invoice.currencyUomId}"/></field>
         <field name="outstandingAmount"><display type="currency" currency="${invoice.currencyUomId}"/></field>
-    </form>
-
-    <form name="ListCustomerInvoices" extends="ListInvoices" list-name="invoices"
+    </grid>
+    <grid name="ListCustomerInvoices" extends="ListInvoices" list-name="invoices"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="partyIdFrom"><ignored/></field>
         <field name="partyIdTo"><ignored/></field>
-    </form>
-    
-    <form name="ListSupplierInvoices" extends="ListInvoices" list-name="invoiceslistexternal"
+    </grid>
+    <grid name="ListSupplierInvoices" extends="ListInvoices" list-name="invoiceslistexternal"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="partyIdFrom"><ignored/></field>
         <field name="partyIdTo"><ignored/></field>
-    </form>
+    </grid>
 </forms>

--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -249,7 +249,7 @@ under the License.
                                     </screenlet>
                                     <screenlet title="${uiLabelMap.PartyTerms}">
                                         <include-grid name="InvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
-                                        <include-form name="ListInvoicePaymentInfo" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="ListInvoicePaymentInfo" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                 </container>
                                 <container style="clear"/>
@@ -289,7 +289,7 @@ under the License.
                                     </screenlet>
                                     <screenlet title="${uiLabelMap.PartyTerms}">
                                         <include-grid name="ListInvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
-                                        <include-form name="ListInvoicePaymentInfo" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="ListInvoicePaymentInfo" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                 </container>
                                 <container style="clear"/>

--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -102,7 +102,7 @@ under the License.
                                         <include-form name="FindInvoices" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListInvoices"  location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="ListInvoices" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -236,16 +236,16 @@ under the License.
                                 </screenlet>
                                 <container style="lefthalf">
                                     <screenlet title="${uiLabelMap.CommonStatus}" navigation-form-name="ListInvoiceStatus">
-                                        <include-form name="ListInvoiceStatus" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="ListInvoiceStatus" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                     <screenlet title="${uiLabelMap.AccountingAppliedPayments} ${appliedAmount?currency(${invoice.currencyUomId})} ${uiLabelMap.AccountingOpenPayments} ${notAppliedAmount?currency(${invoice.currencyUomId})}"
                                         navigation-form-name="ListInvoiceApplications">
-                                        <include-form name="ListInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="ListInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                 </container>
                                 <container style="righthalf">
                                     <screenlet title="${uiLabelMap.AccountingInvoiceRoles}" navigation-form-name="InvoiceRoles">
-                                        <include-form name="InvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="InvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                     <screenlet title="${uiLabelMap.PartyTerms}">
                                         <include-grid name="InvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
@@ -254,7 +254,7 @@ under the License.
                                 </container>
                                 <container style="clear"/>
                                 <screenlet title="${uiLabelMap.AccountingInvoiceItems}" navigation-form-name="InvoiceItems">
-                                    <include-form name="InvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
+                                    <include-grid name="InvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
                                 </screenlet>
                                 <section>
                                     <condition>
@@ -267,7 +267,7 @@ under the License.
                                     </widgets>
                                 </section>
                                 <screenlet title="${uiLabelMap.AccountingTransactions}" navigation-form-name="AcctgTransAndEntries">
-                                    <include-form name="AcctgTransAndEntries" location="component://accounting/widget/InvoiceForms.xml"/>
+                                    <include-grid name="AcctgTransAndEntries" location="component://accounting/widget/InvoiceForms.xml"/>
                                 </screenlet>
                             </widgets>
                             <fail-widgets>
@@ -276,25 +276,25 @@ under the License.
                                 </screenlet>
                                 <container style="lefthalf">
                                     <screenlet title="${uiLabelMap.CommonStatus}" navigation-form-name="ListInvoiceStatus">
-                                        <include-form name="ListInvoiceStatus" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="ListInvoiceStatus" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                     <screenlet title="${uiLabelMap.AccountingAppliedPayments} ${appliedAmount?currency(${invoice.currencyUomId})} ${uiLabelMap.AccountingOpenPayments} ${notAppliedAmount?currency(${invoice.currencyUomId})}"
                                         navigation-form-name="ListInvoiceApplications">
-                                        <include-form name="ListInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="ListInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                 </container>
                                 <container style="righthalf">
                                     <screenlet title="${uiLabelMap.AccountingInvoiceRoles}" navigation-form-name="InvoiceRoles">
-                                        <include-form name="InvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="InvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                     <screenlet title="${uiLabelMap.PartyTerms}">
-                                        <include-form name="ListInvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <include-grid name="ListInvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
                                         <include-form name="ListInvoicePaymentInfo" location="component://accounting/widget/InvoiceForms.xml"/>
                                     </screenlet>
                                 </container>
                                 <container style="clear"/>
                                 <screenlet title="${uiLabelMap.AccountingInvoiceItems}" navigation-form-name="InvoiceItems">
-                                    <include-form name="InvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
+                                    <include-grid name="InvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
                                 </screenlet>
                                 <section>
                                     <condition>
@@ -307,7 +307,7 @@ under the License.
                                     </widgets>
                                 </section>
                                 <screenlet title="${uiLabelMap.AccountingTransactions}" navigation-form-name="AcctgTransAndEntries">
-                                    <include-form name="AcctgTransAndEntries" location="component://accounting/widget/InvoiceForms.xml"/>
+                                    <include-grid name="AcctgTransAndEntries" location="component://accounting/widget/InvoiceForms.xml"/>
                                 </screenlet>
                             </fail-widgets>
                                 </section>
@@ -338,7 +338,7 @@ under the License.
                 <decorator-screen name="CommonInvoiceDecorator" location="${parameters.invoiceDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingInvoiceStatusHistory}">
-                            <include-form name="ListInvoiceStatus" location="component://accounting/widget/InvoiceForms.xml"/>
+                            <include-grid name="ListInvoiceStatus" location="component://accounting/widget/InvoiceForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -380,7 +380,7 @@ under the License.
                                         <widgets>
                                             <screenlet title="${uiLabelMap.AccountingPaymentsApplied} ${appliedAmount?currency(${invoice.currencyUomId})} 
                                                 ${uiLabelMap.AccountingOpenPayments} ${notAppliedAmount?currency(${invoice.currencyUomId})}">
-                                                <include-form name="EditInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
+                                                <include-grid name="EditInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
                                             </screenlet>
                                             <section>
                                                 <condition>
@@ -405,7 +405,7 @@ under the License.
                                                                 <not><if-empty field="payments"/></not>
                                                             </condition>
                                                             <widgets>
-                                                                <include-form name="ListPaymentsNotApplied" location="component://accounting/widget/InvoiceForms.xml"/>
+                                                                <include-grid name="ListPaymentsNotApplied" location="component://accounting/widget/InvoiceForms.xml"/>
                                                             </widgets>
                                                         </section>
                                                         <section>
@@ -413,7 +413,7 @@ under the License.
                                                                 <not><if-empty field="paymentsActualCurrency"/></not>
                                                             </condition>
                                                             <widgets>
-                                                                <include-form name="ListPaymentsNotAppliedForeignCurrency" location="component://accounting/widget/InvoiceForms.xml"/>
+                                                                <include-grid name="ListPaymentsNotAppliedForeignCurrency" location="component://accounting/widget/InvoiceForms.xml"/>
                                                             </widgets>
                                                         </section>
                                                     </screenlet>
@@ -426,7 +426,7 @@ under the License.
                                         <fail-widgets>
                                             <screenlet title="${uiLabelMap.AccountingPaymentsApplied} ${appliedAmount?currency(${invoice.currencyUomId})} 
                                                 ${uiLabelMap.AccountingOpenPayments} ${notAppliedAmount?currency(${invoice.currencyUomId})}">
-                                                <include-form name="EditInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
+                                                <include-grid name="EditInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
                                             </screenlet>
                                             <section>
                                                 <condition>
@@ -446,7 +446,7 @@ under the License.
                                     title="${uiLabelMap.AccountingAppliedPayments} ${appliedAmount?currency(${invoice.currencyUomId})} 
                                         ${uiLabelMap.AccountingOpenPayments} ${notAppliedAmount?currency(${invoice.currencyUomId})}"
                                         navigation-form-name="ListInvoiceApplications">
-                                    <include-form name="ListInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
+                                    <include-grid name="ListInvoiceApplications" location="component://accounting/widget/InvoiceForms.xml"/>
                                 </screenlet>
                             </fail-widgets>
                         </section>
@@ -521,7 +521,9 @@ under the License.
                                         <not><if-compare field="invoice.invoiceTypeId" operator="equals" value="PAYROL_INVOICE"/></not>
                                     </condition>
                                     <widgets>
-                                <include-form name="InvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        <screenlet>
+                                            <include-grid name="InvoiceItems" location="component://accounting/widget/InvoiceForms.xml"/>
+                                        </screenlet>
                                     </widgets>
                                     <fail-widgets>
                                         <platform-specific>
@@ -568,10 +570,10 @@ under the License.
                                 </and>
                             </condition>
                             <widgets>
-                                <include-form name="EditTimeEntries" location="component://accounting/widget/InvoiceForms.xml"/>
+                                <include-grid name="EditTimeEntries" location="component://accounting/widget/InvoiceForms.xml"/>
                             </widgets>
                             <fail-widgets>
-                                <include-form name="ListTimeEntries" location="component://accounting/widget/InvoiceForms.xml"/>
+                                <include-grid name="ListTimeEntries" location="component://accounting/widget/InvoiceForms.xml"/>
                             </fail-widgets>
                         </section>
                         </screenlet>
@@ -717,10 +719,14 @@ under the License.
                                 <screenlet id="PartyInvoiceRolePanel" title="${uiLabelMap.AccountingPartyRoleAdd}" collapsible="true">
                                     <include-form name="EditInvoiceRole" location="component://accounting/widget/InvoiceForms.xml"/>
                                 </screenlet>
-                                <include-form name="ListInvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                                <screenlet>
+                                    <include-grid name="ListInvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                                </screenlet>
                             </widgets>
                             <fail-widgets>
-                                <include-form name="InvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                                <screenlet>
+                                    <include-grid name="InvoiceRoles" location="component://accounting/widget/InvoiceForms.xml"/>
+                                </screenlet>
                             </fail-widgets>
                         </section>
                     </decorator-section>
@@ -769,7 +775,7 @@ under the License.
                                         </screenlet>
                                     </widgets>
                                 </section>
-                                <include-form name="ListInvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
+                                <include-grid name="ListInvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
                             </widgets>
                             <fail-widgets>
                                 <include-grid name="InvoiceTerms" location="component://accounting/widget/InvoiceForms.xml"/>
@@ -829,13 +835,12 @@ under the License.
                 </entity-condition>
             </actions>
             <widgets>
-                <screenlet title="${uiLabelMap.PageTitleListInvoices}" navigation-form-name="ListInvoices">
-                    <include-form name="ListCustomerInvoices"  location="component://accounting/widget/InvoiceForms.xml"/>
+                <screenlet title="${uiLabelMap.AccountingInvoices}" navigation-form-name="ListInvoices">
+                    <include-grid name="ListCustomerInvoices" location="component://accounting/widget/InvoiceForms.xml"/>
                 </screenlet>
             </widgets>
         </section>
     </screen>
-
     <screen name="ListSupplierInvoices">
         <section>
             <actions>
@@ -855,8 +860,8 @@ under the License.
                 </entity-condition>
             </actions>
             <widgets>
-                <screenlet title="${uiLabelMap.PageTitleListInvoices}" navigation-form-name="ListInvoices">
-                    <include-form name="ListSupplierInvoices"  location="component://accounting/widget/InvoiceForms.xml"/>
+                <screenlet title="${uiLabelMap.AccountingInvoices}" navigation-form-name="ListInvoices">
+                    <include-grid name="ListSupplierInvoices" location="component://accounting/widget/InvoiceForms.xml"/>
                 </screenlet>
             </widgets>
         </section>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Modified:
InvoiceScreens.xml: from form ref to grid ref , additional cleanup
InvoiceForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up