### PR TITLE
Improved: VIEW permissions show ManufacturingTabBar items (OFBIZ-12442)

### DIFF
--- a/applications/manufacturing/config/ManufacturingUiLabels.xml
+++ b/applications/manufacturing/config/ManufacturingUiLabels.xml
@@ -1514,19 +1514,20 @@
         <value xml:lang="zh-TW">到產品識別</value>
     </property>
     <property key="ManufacturingCostCalcs">
-        <value xml:lang="de">Kosten</value>
-        <value xml:lang="en">Costs</value>
-        <value xml:lang="es">Costos</value>
-        <value xml:lang="fr">Coûts</value>
-        <value xml:lang="it">Costi</value>
-        <value xml:lang="ja">原価</value>
-        <value xml:lang="nl">Kosten</value>
-        <value xml:lang="pt-BR">Custos</value>
-        <value xml:lang="ro">Cost</value>
-        <value xml:lang="th">ราคา</value>
-        <value xml:lang="vi">Chi phí</value>
-        <value xml:lang="zh">费用</value>
-        <value xml:lang="zh-TW">費用</value>
+        <value xml:lang="de">Kostenkalkulationen</value>
+        <value xml:lang="en">Cost Calculations</value>
+        <value xml:lang="es">Cálculos de costos</value>
+        <value xml:lang="fr">Calculs de coûts</value>
+        <value xml:lang="it">Calcoli dei costi </value>
+        <value xml:lang="ja">コスト計算</value>
+        <value xml:lang="nl">Kostencalculaties</value>
+        <value xml:lang="pt">Cálculos de custo</value>
+        <value xml:lang="pt-BR">Cálculos de custo</value>
+        <value xml:lang="ro">Calculele costurilor</value>
+        <value xml:lang="th">การคำนวณต้นทุน</value>
+        <value xml:lang="vi">Tính toán chi phí</value>
+        <value xml:lang="zh">成本计算</value>
+        <value xml:lang="zh-TW">成本計算</value>
     </property>
     <property key="ManufacturingCreateBom">
         <value xml:lang="en">Create Bom</value>
@@ -4747,6 +4748,11 @@
         <value xml:lang="vi">Tác vụ - Đầu việc</value>
         <value xml:lang="zh">规程任务</value>
         <value xml:lang="zh-TW">規程任務</value>
+    </property>
+    <property key="ManufacturingRoutingTasks">
+        <value xml:lang="de">Arbeitsgänge</value>
+        <value xml:lang="en">Routing Tasks</value>
+        <value xml:lang="nl">Schema-taken</value>
     </property>
     <property key="ManufacturingRoutingTaskAssocCreateSuccessfully">
         <value xml:lang="de">Arbeitsgang-Zuordnung erfolgreich erstellt</value>

--- a/applications/manufacturing/widget/manufacturing/ManufacturingMenus.xml
+++ b/applications/manufacturing/widget/manufacturing/ManufacturingMenus.xml
@@ -23,57 +23,30 @@ under the License.
 
     <menu name="ManufacturingAppBar" title="${uiLabelMap.ManufacturingManager}" extends="CommonAppBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="jobshop" title="${uiLabelMap.ManufacturingJobShop}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
             <link target="FindProductionRun"/>
         </menu-item>
-        <menu-item name="routing" title="${uiLabelMap.ManufacturingRouting}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
+        <menu-item name="routing" title="${uiLabelMap.ManufacturingRoutings}">
             <link target="FindRouting"/>
         </menu-item>
-        <menu-item name="routingTask" title="${uiLabelMap.ManufacturingRoutingTask}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
+        <menu-item name="routingTask" title="${uiLabelMap.ManufacturingRoutingTasks}">
             <link target="FindRoutingTask"/>
         </menu-item>
-        <menu-item name="calendar" title="${uiLabelMap.ManufacturingCalendar}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
+        <menu-item name="calendar" title="${uiLabelMap.ManufacturingCalendars}">
             <link target="FindCalendar"/>
         </menu-item>
         <menu-item name="costs" title="${uiLabelMap.ManufacturingCostCalcs}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
             <link target="EditCostCalcs"/>
         </menu-item>
         <menu-item name="bom" title="${uiLabelMap.ManufacturingBillOfMaterials}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
             <link target="FindBom"/>
         </menu-item>
         <menu-item name="mrp" title="${uiLabelMap.ManufacturingMrp}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
             <link target="FindInventoryEventPlan"/>
         </menu-item>
         <menu-item name="ShipmentPlans" title="${uiLabelMap.ManufacturingShipmentPlans}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
             <link target="WorkWithShipmentPlans"/>
         </menu-item>
         <menu-item name="ManufacturingReports" title="${uiLabelMap.ManufacturingReports}">
-            <condition>
-                <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
-            </condition>
             <link target="ManufacturingReports"/>
         </menu-item>
     </menu>


### PR DESCRIPTION
Currently, when a user with only VIEW permissions accesses the manufacturing component menu-items of the ManufacturingAppBar are not shown due to too restrictive conditions.
These menu-items allow users to access various overviews related to manufacturing, like
 * production runs,
 * routings (production schemas),
 * routing task (schema tasks),
 * production calendar,
 * etc.

Improved:
ManufacturingMenus.xml - removed 'CREATE' condition from menu-items in ManufacturingAppBar, additional title improvement(s)
ManufacturingUiLabels.xml - updated labels regarding menu-items in ManufacturingAppBar