### PR TITLE
Fixed: Weird behaviour with currency symbols (OFBIZ-12443)

### DIFF
--- a/applications/accounting/template/finaccount/FinAccountTrans.ftl
+++ b/applications/accounting/template/finaccount/FinAccountTrans.ftl
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<assign accountCurrencyUomId = finAccount.currencyUomId/>
+<#assign accountCurrencyUomId = finAccount.currencyUomId/>
 <#if finAccountTransList?has_content && parameters.noConditionFind?? && parameters.noConditionFind == 'Y'>
   <#if !grandTotal??>
       <div>

--- a/applications/accounting/widget/FinAccountForms.xml
+++ b/applications/accounting/widget/FinAccountForms.xml
@@ -116,8 +116,8 @@ under the License.
         <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
         <field name="thruDate" title="${uiLabelMap.CommonThru}"><display type="date-time"/></field>
         <field name="replenishPaymentId"><display/></field>
-        <field name="actualBalance"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="availableBalance"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="actualBalance"><display type="currency" currency="${finAccount.currencyUomId}"/></field>
+        <field name="availableBalance"><display type="currency" currency="${finAccount.currencyUomId}"/></field>
     </form>
     <form name="EditFinAccount" type="single" target="updateFinAccount" default-map-name="finAccount"
         header-row-style="header-row" default-table-style="basic-table">


### PR DESCRIPTION
In some screens the $ currency symbol is not showing well. I guess it's true for all screens so I put all applications and plugins. I don't know if only trunk is affected.

Modified:
FinAccountTrans.ftl 
- fixed a typo
FinAccountForms.xml
- ensured that for the monetary amount fields (actualBalance and availableBalance) the correct currencyUomId value is taken