### PR TITLE
Improved: Have a Menu in Accounting featuring actions to create the main objects (OFBIZ-11780)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -52,6 +52,34 @@ under the License.
         <menu-item name="GlobalGLSettings" title="${uiLabelMap.AccountingGlobalGLSettings}"><link target="globalGLSettings"/></menu-item>
         <menu-item name="companies" title="${uiLabelMap.AccountingOrgGlSettings}"><link target="ListCompanies"/></menu-item>
     </menu>
+        <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="NewGLTransaction" title="${uiLabelMap.CommonNew} ${uiLabelMap.GlTransaction}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="newAcctgTrans">
+                <parameter param-name="organizationPartyId"/>
+            </link>
+        </menu-item>
+        <menu-item name="NewInvoice" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonInvoice}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="newInvoice"/>
+        </menu-item>
+        <menu-item name="NewPayment" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonPayment}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="newPayment"/>
+        </menu-item>
+    </menu>
 
     <menu name="AccountingShortcutAppBar" title="${uiLabelMap.AccountingManager}">
         <menu-item name="invoices" title="${uiLabelMap.AccountingInvoicesMenu}"><link target="/accounting/control/findInvoices" url-mode="inter-app"/></menu-item>

--- a/applications/accounting/widget/AgreementScreens.xml
+++ b/applications/accounting/widget/AgreementScreens.xml
@@ -34,6 +34,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <and>

--- a/applications/accounting/widget/BillingAccountScreens.xml
+++ b/applications/accounting/widget/BillingAccountScreens.xml
@@ -26,6 +26,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <!-- do check for ACCOUNTING, _VIEW permission -->
                             <condition>

--- a/applications/accounting/widget/BudgetScreens.xml
+++ b/applications/accounting/widget/BudgetScreens.xml
@@ -30,6 +30,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                             <decorator-section name="menu-bar">
@@ -87,6 +90,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <not><if-empty field="budgetId"/></not>

--- a/applications/accounting/widget/CommonScreens.xml
+++ b/applications/accounting/widget/CommonScreens.xml
@@ -71,6 +71,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="acctgFinAcctPermissionCheck" main-action="VIEW"/>
@@ -112,6 +113,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="acctgBasePermissionCheck" main-action="VIEW"/>
@@ -165,6 +167,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <and>
@@ -310,6 +313,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingMainPage}">
                             <platform-specific><html><html-template location="component://accounting/template/Main.ftl"/></html></platform-specific>
@@ -336,6 +342,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <include-menu name="GlobalGLSettingMenus" location="component://accounting/widget/AccountingMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">

--- a/applications/accounting/widget/FinAccountScreens.xml
+++ b/applications/accounting/widget/FinAccountScreens.xml
@@ -32,6 +32,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="acctgFinAcctPermissionCheck" main-action="VIEW"/>

--- a/applications/accounting/widget/FixedAssetScreens.xml
+++ b/applications/accounting/widget/FixedAssetScreens.xml
@@ -31,6 +31,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                             <decorator-section name="menu-bar">
@@ -83,6 +86,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <not><if-empty field="fixedAssetId"/></not>

--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -33,6 +33,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="acctgInvoicePermissionCheck" main-action="VIEW"/>

--- a/applications/accounting/widget/PaymentGatewayConfigScreens.xml
+++ b/applications/accounting/widget/PaymentGatewayConfigScreens.xml
@@ -30,6 +30,7 @@ under the License.
                 <!-- main defines the regions of the HTML page -->
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <include-menu name="PaymentGatewayConfigTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">

--- a/applications/accounting/widget/PaymentGroupScreens.xml
+++ b/applications/accounting/widget/PaymentGroupScreens.xml
@@ -33,6 +33,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <widgets>

--- a/applications/accounting/widget/PaymentScreens.xml
+++ b/applications/accounting/widget/PaymentScreens.xml
@@ -29,6 +29,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <widgets>
                                 <container style="leftclear">

--- a/applications/accounting/widget/TaxAuthorityScreens.xml
+++ b/applications/accounting/widget/TaxAuthorityScreens.xml
@@ -33,6 +33,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for ACCOUNTING, _VIEW permission -->

--- a/applications/accounting/widget/TransactionScreens.xml
+++ b/applications/accounting/widget/TransactionScreens.xml
@@ -31,6 +31,7 @@ under the License.
                 <!-- main defines the regions of the HTML page -->
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <include-menu name="TransactionsTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
                     </decorator-section>
 


### PR DESCRIPTION
Currently the create buttons for the main objects of the accounting application are located within find and profile widgets/templates of those objects.
In order to improve the usability of this application, OFBiz and thus the appeal of it for adopters and users, these create buttons/links/etc. should be in a main action menu visible at all times when a user (with the CREATE permission) is working within the application of the component.

Modified:
- AccountingMenus.xml: added MainActionMenu for users with CREATE permission
- AgreementScreens.xml: added ref to MainActionMenu in CommonAgreementDecorator
- BillingAccountScreens.xml: added ref to MainActionMenu in CommonBillingAccountDecorator
- BudgetScreens.xml: added ref to MainActionMenu in various appropriate screens
- CommonScreens.xml: added ref to MainActionMenu in various appropriate screens
- FinAccountScreens.xml: added ref to MainActionMenu in CommonFinAccountDecorator
- FixedAssetScreens.xml: added ref to MainActionMenu in various appropriate screens
- InvoiceScreens.xml: added ref to MainActionMenu in CommonInvoiceDecorator
- PaymentGatewayConfigScreens.xml: added ref to MainActionMenu in GenericPaymentGatewayConfigDecorator
- PaymentGroupScreens.xml: added ref to MainActionMenu in FindPaymentGroup
- PaymentScreens.xml: added ref to MainActionMenu in CommonPaymentDecorator
- TaxAuthorityScreens.xml: added ref to MainActionMenu in CommonTaxAuthorityDecorator
- TransactionScreens.xml: added ref to MainActionMenu in GenericTransactionDecorator