### PR TITLE
Improved: Accounting remove create trigger for objects (OFBIZ-12447)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -261,16 +261,6 @@ under the License.
     </menu>
     
     <menu name="InvoiceSubTabBar" menu-container-style="button-bar button-style-2" default-selected-style="selected">
-        <menu-item name="createNew" title="${uiLabelMap.AccountingCreateNewInvoice}" widget-style="buttontext create">
-            <condition>
-                <and>
-                    <or>
-                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
-                    </or>
-                </and>
-            </condition>
-            <link target="newInvoice"/>
-        </menu-item>
         <menu-item name="copyInvoice" title="${uiLabelMap.CommonCopy}">
             <condition>
                 <and>
@@ -566,17 +556,6 @@ under the License.
         <actions>
             <set field="isDisbursement" value="${groovy:if(context.payment != null) return org.apache.ofbiz.accounting.util.UtilAccounting.isDisbursement(context.payment)}"/>
         </actions>
-        <menu-item name="createNew" title="${uiLabelMap.CommonCreate}" widget-style="buttontext create" >
-            <condition>
-                <and>
-                    <or>
-                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
-                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
-                    </or>
-                </and>
-            </condition>
-            <link target="newPayment"/>
-        </menu-item>
         <menu-item name="editPayment" title="${uiLabelMap.CommonEdit}">
             <condition>
                 <and>

--- a/applications/accounting/widget/GlScreens.xml
+++ b/applications/accounting/widget/GlScreens.xml
@@ -78,9 +78,6 @@ under the License.
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingAcctgTrans}">
                             <container>
-                                <link text="${uiLabelMap.AccountingCreateAnAccountingTransaction}" style="buttontext" target="newAcctgTrans">
-                                    <parameter param-name="organizationPartyId"/>
-                                </link>
                                 <link text="${uiLabelMap.AccountingCreateAcctgTransAndEntries}" style="buttontext" target="CreateAcctgTransAndEntries">
                                     <parameter param-name="organizationPartyId"/>
                                 </link>


### PR DESCRIPTION
With the implementation of the Accounting MainActionMenu, various menu-items and/or other triggers to create an object are now obsolete

modified:
AccountingMenus.xml
- removed 'create' menu-items for invoice and payment
GlScreens.xml
- removed trigger for a new gl transaction