### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/product/widget/catalog/PromoForms.xml
+++ b/applications/product/widget/catalog/PromoForms.xml
@@ -20,8 +20,8 @@ under the License.
 
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
-    <form name="ListProductPromos" type="list" title="" list-name="productPromos"
-        paginate-target="FindProductPromo" odd-row-style="alternate-row" default-table-style="basic-table">
+    <grid name="ListProductPromos" list-name="productPromos" paginate-target="FindProductPromo"
+        odd-row-style="alternate-row" default-table-style="basic-table">
         <field name="productPromoId" widget-style="buttontext">
             <hyperlink description="${productPromoId}" target="EditProductPromo" also-hidden="false">
                 <parameter param-name="productPromoId"/>
@@ -31,7 +31,7 @@ under the License.
         <field name="promoText" encode-output="false"><display/></field>
         <field name="requireCode"><display/></field>
         <field name="createdDate"><display/></field>
-    </form>
+    </grid>
     <form name="GoToProductPromoCode" type="single" target="EditProductPromoCode" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <field name="productPromoCodeId"><text/></field>
@@ -41,18 +41,14 @@ under the License.
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="productPromo==null" target="createProductPromo"/>
         <auto-fields-service service-name="updateProductPromo" map-name=""/>
-
         <field name="createdDate"><hidden/></field>
         <field name="createdByUserLogin"><hidden/></field>
         <field name="lastModifiedDate"><hidden/></field>
         <field name="lastModifiedByUserLogin"><hidden/></field>
-
-
         <field use-when="productPromo!=null" name="productPromoId" title="${uiLabelMap.ProductPromotion}" tooltip=""><display/></field>
         <field use-when="productPromo==null&amp;&amp;productPromoId!=null" name="productPromoId" title="${uiLabelMap.ProductPromotion}" tooltip="${uiLabelMap.ProductCouldNotFindProductPromotion} [${productPromoId}]"><display/></field>
         <!-- this to be taken care of with auto-fields-service as soon as it uses entity field info too -->
         <field use-when="productPromo==null&amp;&amp;productPromoId==null" name="productPromoId" title="${uiLabelMap.ProductPromotion}"><ignored/></field>
-
         <field name="promoText" title="${uiLabelMap.ProductPromoText}"><textarea cols="70" rows="5"/></field>
         <field name="userEntered" title="${uiLabelMap.ProductPromoUserEntered}">
             <drop-down allow-empty="false" no-current-selected-key="Y"><option key="Y" description="${uiLabelMap.CommonY}"/><option key="N" description="${uiLabelMap.CommonN}"/></drop-down>
@@ -64,10 +60,8 @@ under the License.
             <drop-down allow-empty="false" no-current-selected-key="N"><option key="N" description="${uiLabelMap.CommonN}"/><option key="Y" description="${uiLabelMap.CommonY}"/></drop-down>
         </field>
         <field name="overrideOrgPartyId"><lookup target-form-name="LookupPartyName"/></field>
-
         <field use-when="productPromo!=null" name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
         <field use-when="productPromo==null" name="submitButton" title="${uiLabelMap.CommonCreate}" widget-style="smallSubmit"><submit button-type="button"/></field>
-
         <field use-when="productPromo!=null" name="lastUpdatedByText" title="${uiLabelMap.ProductLastModifiedBy}:">
             <display description="[${productPromo.lastModifiedByUserLogin}] ${uiLabelMap.CommonOn} ${productPromo.lastModifiedDate}" also-hidden="false"/>
         </field>
@@ -79,7 +73,6 @@ under the License.
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="productPromoCode==null" target="createProductPromoCode"/>
         <auto-fields-service service-name="updateProductPromoCode" map-name=""/>
-
         <field name="productPromoId">
             <drop-down>
                 <entity-options entity-name="ProductPromo" description="[${productPromoId}] ${promoName}">
@@ -91,16 +84,13 @@ under the License.
         <field use-when="productPromoCode==null&amp;&amp;productPromoCodeId!=null" name="productPromoCodeId" tooltip="${uiLabelMap.ProductCouldNotFindProductPromoCode} [${productPromoCodeId}]"><display/></field>
         <!-- this to be taken care of with auto-fields-service as soon as it uses entity field info too -->
         <field use-when="productPromoCode==null&amp;&amp;productPromoCodeId==null" name="productPromoCodeId" tooltip="${uiLabelMap.ProductPromoCodeBlank}"><text/></field>
-
         <field name="userEntered">
             <drop-down allow-empty="false" no-current-selected-key="Y"><option key="Y" description="${uiLabelMap.CommonY}"/><option key="N" description="${uiLabelMap.CommonN}"/></drop-down>
         </field>
         <field name="requireEmailOrParty">
             <drop-down allow-empty="false" no-current-selected-key="N"><option key="N" description="${uiLabelMap.CommonN}"/><option key="Y" description="${uiLabelMap.CommonY}"/></drop-down>
         </field>
-
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
-
         <field use-when="productPromoCode!=null" name="lastUpdatedByText" title="${uiLabelMap.ProductLastModifiedBy}:">
             <display description="[${productPromoCode.lastModifiedByUserLogin}] ${uiLabelMap.CommonOn} ${productPromoCode.lastModifiedDate}" also-hidden="false"/>
         </field>
@@ -108,8 +98,7 @@ under the License.
             <display description="[${productPromoCode.createdByUserLogin}] ${uiLabelMap.CommonOn} ${productPromoCode.createdDate}" also-hidden="false"/>
         </field>
     </form>
-
-    <form name="ListProductPromoCodes" type="list" title="" list-name="productPromoCodes"
+    <grid name="ListProductPromoCodes" list-name="productPromoCodes"
         odd-row-style="alternate-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ProductPromoCode" default-field-type="display"/>
         <field name="productPromoId"><hidden/></field>
@@ -124,8 +113,7 @@ under the License.
                 <parameter param-name="productPromoId"/>
             </hyperlink>
         </field>
-    </form>
-
+    </grid>
     <form name="EditProductPromoContentImage" type="upload" target="addImageContentForProductPromo" default-map-name="productPromoContent">
         <field name="productPromoId"><hidden/></field>
         <field use-when="productPromoContent != null" name="contentId"><display/></field>
@@ -137,8 +125,7 @@ under the License.
         <field use-when="productPromoContent == null" name="submitButton" title="${uiLabelMap.CommonCreate}" widget-style="smallSubmit"><submit button-type="button"/></field>
         <field use-when="productPromoContent != null" name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-
-    <form name="ListProductPromoContent" type="list" list-name="productPromoContents"
+    <grid name="ListProductPromoContent" list-name="productPromoContents"
             odd-row-style="alternate-row" default-table-style="basic-table">
         <field name="editProductPromoContent" title="${uiLabelMap.ProductContent}" widget-style="buttontext">
             <hyperlink description="${description} [${contentId}]" target="EditProductPromoContent" also-hidden="false">
@@ -166,5 +153,5 @@ under the License.
                 <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
 </forms>

--- a/applications/product/widget/catalog/PromoScreens.xml
+++ b/applications/product/widget/catalog/PromoScreens.xml
@@ -26,7 +26,7 @@ under the License.
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for CATALOG, _VIEW permission -->
@@ -46,7 +46,6 @@ under the License.
                                         </container>
                                     </widgets>
                                 </section>
-
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>
@@ -64,7 +63,6 @@ under the License.
                 <set field="titleProperty" value="PageTitleFindProductPromos"/>
                 <set field="headerItem" value="promos"/>
                 <set field="tabButtonItem" value="ProductPromo"/>
-
                 <set field="userEntered" from-field="parameters.userEntered"/>
                 <entity-condition entity-name="ProductPromo" list="productPromos">
                     <condition-expr field-name="userEntered" from-field="userEntered" ignore-if-empty="true"/>
@@ -94,9 +92,8 @@ under the License.
                                 </widgets>
                             </section>
                         </screenlet>
-                    
                         <screenlet title="${uiLabelMap.ProductProductPromotionsList}">
-                            <include-form name="ListProductPromos" location="component://product/widget/catalog/PromoForms.xml"/>
+                            <include-grid name="ListProductPromos" location="component://product/widget/catalog/PromoForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -110,7 +107,6 @@ under the License.
                 <set field="headerItem" value="promos"/>
                 <set field="tabButtonItem" value="EditProductPromo"/>
                 <set field="labelTitleProperty" value="ProductPromotion"/>
-
                 <set field="productPromoId" from-field="parameters.productPromoId"/>
                 <entity-one entity-name="ProductPromo" value-field="productPromo" auto-field-map="true"/>
             </actions>
@@ -132,11 +128,9 @@ under the License.
                 <set field="headerItem" value="promos"/>
                 <set field="tabButtonItem" value="EditProductPromoRules"/>
                 <set field="labelTitleProperty" value="ProductRules"/>
-
                 <property-map resource="OrderUiLabels" map-name="uiLabelMap"/>
                 <set field="productPromoId" from-field="parameters.productPromoId"/>
                 <entity-one entity-name="ProductPromo" value-field="productPromo" auto-field-map="true"/>
-
                 <!-- Data Related to the Promo -->
                 <entity-condition entity-name="ProductPromoRule" list="productPromoRules">
                     <condition-expr field-name="productPromoId" from-field="productPromoId"/>
@@ -158,7 +152,6 @@ under the License.
                         <condition-expr field-name="productPromoCondSeqId" value="_NA_"/>
                     </condition-list>
                 </entity-condition>
-
                 <!-- General Data for Drop-downs, etc -->
                 <entity-condition entity-name="CustomMethod" list="inputParamCustomMethods" use-cache="true">
                     <condition-expr field-name="customMethodTypeId" value="PRODUCT_PROMO_COND"/>
@@ -179,7 +172,6 @@ under the License.
                     <condition-expr field-name="enumTypeId" value="PROD_PROMO_PCAPPL"/>
                     <order-by field-name="sequenceId"/>
                 </entity-condition>
-
                 <entity-condition entity-name="OrderAdjustmentType" list="orderAdjustmentTypes" use-cache="true">
                     <order-by field-name="description"/>
                 </entity-condition>
@@ -206,7 +198,6 @@ under the License.
                 <set field="headerItem" value="promos"/>
                 <set field="tabButtonItem" value="EditProductPromoStores"/>
                 <set field="labelTitleProperty" value="ProductStores"/>
-
                 <set field="productPromoId" from-field="parameters.productPromoId"/>
                 <entity-one entity-name="ProductPromo" value-field="productPromo" auto-field-map="true"/>
                 <entity-condition entity-name="ProductStorePromoAppl" list="productStorePromoAppls">
@@ -214,7 +205,6 @@ under the License.
                     <order-by field-name="sequenceNum"/>
                     <order-by field-name="productPromoId"/>
                 </entity-condition>
-
                 <entity-condition entity-name="ProductStore" list="productStores">
                     <order-by field-name="storeName"/>
                 </entity-condition>
@@ -237,10 +227,8 @@ under the License.
                 <set field="headerItem" value="promos"/>
                 <set field="tabButtonItem" value="FindProductPromoCode"/>
                 <set field="labelTitleProperty" value="ProductPromotionCode"/>
-
                 <set field="productPromoId" from-field="parameters.productPromoId"/>
                 <entity-one entity-name="ProductPromo" value-field="productPromo" auto-field-map="true"/>
-
                 <set field="manualOnly" from-field="parameters.manualOnly" default-value="Y"/>
                 <entity-condition entity-name="ProductPromoCode" list="productPromoCodes">
                     <condition-list combine="and">
@@ -280,7 +268,7 @@ under the License.
                             </fail-widgets>
                         </section>
                         <screenlet title="${uiLabelMap.PageTitleFindProductPromotionCode}">
-                            <include-form name="ListProductPromoCodes" location="component://product/widget/catalog/PromoForms.xml"/>
+                            <include-grid name="ListProductPromoCodes" location="component://product/widget/catalog/PromoForms.xml"/>
                         </screenlet>
                         <platform-specific>
                             <html><html-template location="component://product/template/promo/FindProductPromoCode.ftl"/></html>
@@ -297,7 +285,6 @@ under the License.
                 <set field="headerItem" value="promos"/>
                 <set field="tabButtonItem" value="FindProductPromoCode"/>
                 <set field="labelTitleProperty" value="ProductPromotionCode"/>
-
                 <script location="component://product/groovyScripts/catalog/promo/EditProductPromoCode.groovy"/>
             </actions>
             <widgets>
@@ -306,7 +293,6 @@ under the License.
                         <container>
                             <link target="EditProductPromoCode" text="${uiLabelMap.ProductNewPromotionCode}" style="buttontext"/>
                         </container>
-
                         <screenlet title="${uiLabelMap.PageTitleEditProductPromotionCode}">
                             <include-form name="EditProductPromoCode" location="component://product/widget/catalog/PromoForms.xml"/>
                         </screenlet>
@@ -318,7 +304,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditProductPromoContent">
         <section>
             <actions>
@@ -342,7 +327,7 @@ under the License.
                             <include-form name="EditProductPromoContentImage" location="component://product/widget/catalog/PromoForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.ProductProductPromoContentList}">
-                            <include-form name="ListProductPromoContent" location="component://product/widget/catalog/PromoForms.xml"/>
+                            <include-grid name="ListProductPromoContent" location="component://product/widget/catalog/PromoForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Modified:
PromoScreens.xml: from form ref to grid ref , additional cleanup
PromoForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up