### PR TITLE
Improved: Have a Menu in Manufacturing featuring actions to create the main objects (OFBIZ-11782)

### DIFF
--- a/applications/manufacturing/widget/manufacturing/CommonScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/CommonScreens.xml
@@ -55,6 +55,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator">
+                    <decorator-section name="pre-body">
+                         <include-menu location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml" name="MainActionMenu"/>
+                     </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>

--- a/applications/manufacturing/widget/manufacturing/ManufacturingMenus.xml
+++ b/applications/manufacturing/widget/manufacturing/ManufacturingMenus.xml
@@ -107,7 +107,32 @@ under the License.
             <link target="/manufacturing/control/ManufacturingReports" url-mode="inter-app"/>
         </menu-item>
     </menu>
-
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+         <menu-item name="NewProdRun" title="${uiLabelMap.CommonNew} ${uiLabelMap.ManufacturingProductionRun}">
+             <condition>
+                 <or>
+                     <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
+                 </or>
+             </condition>
+             <link target="CreateProductionRun"/>
+         </menu-item>
+         <menu-item name="NewRouting" title="${uiLabelMap.CommonNew} ${uiLabelMap.ManufacturingRouting}">
+             <condition>
+                 <or>
+                     <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
+                 </or>
+             </condition>
+             <link target="EditRouting"/>
+         </menu-item>
+         <menu-item name="NewRoutingTask" title="${uiLabelMap.CommonNew} ${uiLabelMap.ManufacturingRoutingTask}">
+             <condition>
+                 <or>
+                     <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
+                 </or>
+             </condition>
+             <link target="EditRoutingTask"/>
+         </menu-item>
+     </menu>
     <menu name="BomTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="findBom" title="${uiLabelMap.CommonFind}">
             <link target="FindBom"/>
@@ -122,7 +147,6 @@ under the License.
             <link target="EditProductManufacturingRules"/>
         </menu-item>
     </menu>
-
     <menu name="ProductionRunTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="edit" title="${uiLabelMap.ManufacturingEditProductionRun}">
             <condition>


### PR DESCRIPTION
Currently the create buttons for the main objects of the manufacturing application are located within find and profile widgets/templates of those objects.
In order to improve the usability of this application, OFBiz and thus the appeal of it for adopters and users, these create buttons/links/etc. should be in a main action menu visible at all times when a user is working within the appliclation of the component.

modified:
ManufacturingMenus.xml - added MainActionMenu
CommonScreens.xlm - added pre-body decorator-section with MainActionMenu ref.