### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/product/widget/catalog/ShippingForms.xml
+++ b/applications/product/widget/catalog/ShippingForms.xml
@@ -21,8 +21,8 @@
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
     <!-- QuantityBreak forms -->
-    <form name="ListQuantityBreaks" target="" title="" type="list"  list-name="quantityBreaks"
-        paginate-target="ListQuantityBreaks" odd-row-style="alternate-row" default-table-style="basic-table">
+    <grid name="ListQuantityBreaks" list-name="quantityBreaks" paginate-target="ListQuantityBreaks"
+        odd-row-style="alternate-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="QuantityBreak" default-field-type="display"/>
         <field name="quantityBreakId" widget-style="buttontext">
             <hyperlink description="${quantityBreakId}" target="ListQuantityBreaks" also-hidden="false">
@@ -35,7 +35,7 @@
                 <parameter param-name="quantityBreakId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="EditQuantityBreak" type="single" target="createQuantityBreak" title="" default-map-name="quantityBreak"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="quantityBreak!=null" target="updateQuantityBreak"/>
@@ -50,8 +50,8 @@
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <form name="ListShipmentMethodTypes" target="" title="" type="list"  list-name="shipmentMethodTypes"
-        paginate-target="ListShipmentMethodTypes" odd-row-style="alternate-row" default-table-style="basic-table">
+    <grid name="ListShipmentMethodTypes" list-name="shipmentMethodTypes" paginate-target="ListShipmentMethodTypes"
+        odd-row-style="alternate-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ShipmentMethodType" default-field-type="display"/>
         <field name="shipmentMethodTypeId" widget-style="buttontext">
             <hyperlink description="${shipmentMethodTypeId}" target="ListShipmentMethodTypes" also-hidden="false">
@@ -63,7 +63,7 @@
                 <parameter param-name="shipmentMethodTypeId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="EditShipmentMethodType" type="single" target="createShipmentMethodType" title="" default-map-name="shipmentMethodType"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="shipmentMethodType!=null" target="updateShipmentMethodType"/>
@@ -71,8 +71,8 @@
         <field name="shipmentMethodTypeId" use-when="shipmentMethodType!=null"><display/></field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <form name="ListCarrierShipmentMethods" target="" title="" type="list"  list-name="carrierShipmentMethods"
-        paginate-target="ListCarrierShipmentMethods" odd-row-style="alternate-row" default-table-style="basic-table">
+    <grid name="ListCarrierShipmentMethods" list-name="carrierShipmentMethods" paginate-target="ListCarrierShipmentMethods"
+        odd-row-style="alternate-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="CarrierShipmentMethod" default-field-type="display"/>
         <field name="shipmentMethodTypeId"><display-entity also-hidden="false" entity-name="ShipmentMethodType"/></field>
         <field name="roleTypeId"><display-entity also-hidden="false" entity-name="RoleType"/></field>
@@ -90,7 +90,7 @@
                 <parameter param-name="roleTypeId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="EditCarrierShipmentMethod" type="single" target="createCarrierShipmentMethod" title="" default-map-name="carrierShipmentMethod"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="carrierShipmentMethod!=null" target="updateCarrierShipmentMethod"/>
@@ -119,8 +119,8 @@
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
 
-    <form name="ListShipmentTimeEstimates" target="" title="" type="list"  list-name="shipmentTimeEstimates"
-        paginate-target="ListShipmentTimeEstimates" odd-row-style="alternate-row" default-table-style="basic-table">
+    <grid name="ListShipmentTimeEstimates" list-name="shipmentTimeEstimates" paginate-target="ListShipmentTimeEstimates"
+        odd-row-style="alternate-row" default-table-style="basic-table">
         <field name="shipmentMethodTypeId"><display-entity entity-name="ShipmentMethodType" description="${description} [${shipmentMethodTypeId}]"/></field>
         <field name="partyId"><display-entity entity-name="PartyNameView" description="${firstName} ${middleName} ${lastName} ${groupName} [${partyId}]"/></field>
         <field name="roleTypeId"><display-entity entity-name="RoleType"/></field>
@@ -140,7 +140,7 @@
                 <auto-parameters-service service-name="expireShipmentTimeEstimate"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="EditShipmentTimeEstimate" type="single" target="createShipmentTimeEstimate" title="" default-map-name="shipmentTimeEstimate"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="shipmentTimeEstimate != null" target="updateShipmentTimeEstimate"/>

--- a/applications/product/widget/catalog/ShippingScreens.xml
+++ b/applications/product/widget/catalog/ShippingScreens.xml
@@ -28,7 +28,6 @@ under the License.
                 <set field="titleProperty" value="PageTitleListQuantityBreaks"/>
                 <set field="headerItem" value="shipping"/>
                 <set field="tabButtonItem" value="ListQuantityBreaks"/>
-
                 <entity-condition entity-name="QuantityBreak" list="quantityBreaks">
                     <order-by field-name="quantityBreakId"/>
                 </entity-condition>
@@ -54,7 +53,6 @@ under the License.
                 <set field="titleProperty" value="PageTitleListShipmentMethodTypes"/>
                 <set field="headerItem" value="shipping"/>
                 <set field="tabButtonItem" value="ListShipmentMethodTypes"/>
-
                 <entity-condition entity-name="ShipmentMethodType" list="shipmentMethodTypes">
                     <order-by field-name="sequenceNum"/>
                     <order-by field-name="description"/>
@@ -65,7 +63,7 @@ under the License.
                 <decorator-screen name="CommonShippingDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleListShipmentMethodTypes}">
-                            <include-form name="ListShipmentMethodTypes" location="component://product/widget/catalog/ShippingForms.xml"/>
+                            <include-grid name="ListShipmentMethodTypes" location="component://product/widget/catalog/ShippingForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.PageTitleEditShipmentMethodTypes}">
                             <include-form name="EditShipmentMethodType" location="component://product/widget/catalog/ShippingForms.xml"/>
@@ -82,7 +80,6 @@ under the License.
                 <set field="titleProperty" value="PageTitleListCarrierShipmentMethods"/>
                 <set field="headerItem" value="shipping"/>
                 <set field="tabButtonItem" value="ListCarrierShipmentMethods"/>
-
                 <entity-condition entity-name="CarrierShipmentMethod" list="carrierShipmentMethods">
                     <order-by field-name="sequenceNumber"/>
                 </entity-condition>
@@ -92,7 +89,7 @@ under the License.
                 <decorator-screen name="CommonShippingDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleListCarrierShipmentMethods}">
-                            <include-form name="ListCarrierShipmentMethods" location="component://product/widget/catalog/ShippingForms.xml"/>
+                            <include-grid name="ListCarrierShipmentMethods" location="component://product/widget/catalog/ShippingForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.PageTitleEditCarrierShipmentMethods}">
                             <include-form name="EditCarrierShipmentMethod" location="component://product/widget/catalog/ShippingForms.xml"/>
@@ -114,14 +111,11 @@ under the License.
                     <order-by field-name="shipmentMethodTypeId"/>
                 </entity-condition>
                 <entity-one entity-name="ShipmentTimeEstimate" value-field="shipmentTimeEstimate"/>
-
                 <entity-condition entity-name="CarrierShipmentMethod" list="carrierShipmentMethods">
                     <order-by field-name="sequenceNumber"/>
                 </entity-condition>
                 <set field="targetUrl" value="prepareCreateShipmentTimeEstimate"/><!-- Necessary for SelectShipmentMethod.ftl -->
-
                 <entity-one entity-name="CarrierShipmentMethod" value-field="carrierShipmentMethod"/>
-
                 <set field="dependentForm" value="EditShipmentTimeEstimate"/>
                 <set field="paramKey" value="shipmentMethodTypeId"/>
                 <set field="mainId" value="shipmentMethodTypeId"/>
@@ -136,7 +130,7 @@ under the License.
                 <decorator-screen name="CommonShippingDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleListShipmentTimeEstimates}">
-                            <include-form name="ListShipmentTimeEstimates" location="component://product/widget/catalog/ShippingForms.xml"/>
+                            <include-grid name="ListShipmentTimeEstimates" location="component://product/widget/catalog/ShippingForms.xml"/>
                         </screenlet>
                         <section>
                             <condition>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Modified:
ShippingScreens.xml: from form ref to grid ref , additional cleanup
ShippingForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up