### PR TITLE
Improved: Move edit of invoice header to InvoiceSubTabBar (OFBIZ-12440)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -125,24 +125,6 @@ under the License.
                 <parameter param-name="invoiceId" from-field="invoice.invoiceId"/>
             </link>
         </menu-item>
-        <menu-item name="editInvoice" title="${uiLabelMap.AccountingInvoiceHeader}">
-            <condition>
-                <and>
-                    <not><if-empty field="invoice.invoiceId"/></not>
-                    <or>
-                        <if-compare field="invoice.statusId" operator="equals" value="INVOICE_IN_PROCESS"/>
-                        <if-compare field="invoice.statusId" operator="equals" value="INVOICE_RECEIVED"/>
-                    </or>
-                    <or>
-                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
-                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
-                    </or>
-                </and>
-            </condition>
-            <link target="editInvoice">
-                <parameter param-name="invoiceId" from-field="invoice.invoiceId"/>
-            </link>
-        </menu-item>
         <menu-item name="invoiceAttributes" title="${uiLabelMap.CommonAttributes}">
             <condition>
                 <and>
@@ -261,6 +243,24 @@ under the License.
     </menu>
     
     <menu name="InvoiceSubTabBar" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="editInvoice" title="${uiLabelMap.CommonEdit}">
+            <condition>
+                <and>
+                    <not><if-empty field="invoice.invoiceId"/></not>
+                    <or>
+                        <if-compare field="invoice.statusId" operator="equals" value="INVOICE_IN_PROCESS"/>
+                        <if-compare field="invoice.statusId" operator="equals" value="INVOICE_RECEIVED"/>
+                    </or>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
+                </and>
+            </condition>
+            <link target="editInvoice">
+                <parameter param-name="invoiceId" from-field="invoice.invoiceId"/>
+            </link>
+        </menu-item>
         <menu-item name="copyInvoice" title="${uiLabelMap.CommonCopy}">
             <condition>
                 <and>


### PR DESCRIPTION
In general, a <object>TabBar menu is intended to give users access to overview related to the <object>. And a <object>SubTabBar menu is intended to give users to actions to be performed on the <object>, like status changes, adding new records, etc.
The menu-item for editing the invoice header (aptly translated as 'Header') is currently located in the InvoiceTabBar menu in AccountingMenus.xml.
Given that this menu-item is intended for users with UPDATE permissions and to give those users access to a screen to edit the data, this menu-item must move to the InvoiceSubTabBar menu

Modified: AccountingMenus.xml
- moved 'edit' menu-item for invoice from InvoiceTabBar menu to InvoiceSubTabBar menu. adjusted label.