### PR TITLE
Improved: VIEW permissions FinAccount mutations (OFBIZ-12451)

### DIFF
--- a/applications/accounting/template/finaccount/Mutations.ftl
+++ b/applications/accounting/template/finaccount/Mutations.ftl
@@ -1,0 +1,45 @@
+<#--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<#if paymentList?has_content>
+    <table class="basic-table">
+        <tr class="header-row-2">
+            <td>${uiLabelMap.CommonPayment}</td>
+            <td align="right">${uiLabelMap.CommonAmount}</td>
+            <td>${uiLabelMap.CommonDate}</td>
+            <td>${uiLabelMap.CommonType}</td>
+            <td>${uiLabelMap.CommonFrom}</td>
+            <td>${uiLabelMap.CommonTo}</td>
+        </tr>
+        <#assign alt_row = false>
+        <#list paymentList as payment>
+            <tr <#if alt_row> class="alternate-row"</#if>>
+                <td><a href="<@ofbizUrl>paymentOverview?paymentId=${payment.paymentId}</@ofbizUrl>">${payment.paymentId}</a></td>
+                <td align="right"><@ofbizCurrency amount=payment.amount isoCode=payment.currencyUomId/></td>
+                <td>${payment.effectiveDate!}</td>
+                <td>${payment.paymentTypeDesc!}</td>
+                <td>${(payment.partyFromFirstName)!} ${(payment.partyFromLastName)!} ${(payment.partyFromGroupName)!}</td>
+                <td>${(payment.partyToFirstName)!} ${(payment.partyToLastName)!} ${(payment.partyToGroupName)!}</td>
+            </tr>
+            <#assign alt_row = !alt_row>
+        </#list>
+    </table>
+<#else>
+    <span class="label">${uiLabelMap.CommonNoRecordFound}</span>
+</#if>

--- a/applications/accounting/widget/FinAccountScreens.xml
+++ b/applications/accounting/widget/FinAccountScreens.xml
@@ -298,9 +298,28 @@ under the License.
                                         <include-form name="PaymentsDepositWithdraw" location="component://accounting/widget/FinAccountForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <platform-specific>
-                                            <html><html-template multi-block="true" location="component://accounting/template/payment/DepositWithdrawPayments.ftl"/></html>
-                                        </platform-specific>
+                                        <section>
+                                            <condition>
+                                                <and>
+                                                    <or>
+                                                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                                       <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                                    </or>
+                                                </and>
+                                            </condition>
+                                            <widgets>
+                                                <platform-specific>
+                                                    <html><html-template multi-block="true" location="component://accounting/template/payment/DepositWithdrawPayments.ftl"/></html>
+                                                </platform-specific>
+                                            </widgets>
+                                            <fail-widgets>
+                                                <screenlet>
+                                                    <platform-specific>
+                                                        <html><html-template multi-block="true" location="component://accounting/template/finaccount/Mutations.ftl"/></html>
+                                                    </platform-specific>
+                                                </screenlet>
+                                            </fail-widgets>
+                                        </section>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the Financial Account mutations screen  sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.
See (test with):
https://demo-trunk.ofbiz.apache.org/accounting/control/EditFinAccount?finAccountId=ABN_CHECKING
https://demo-trunk.ofbiz.apache.org/accounting/control/FindPaymentsForDepositOrWithdraw

Modified:
- FinAccountScreens.xml: work with permissions, added ref to mutations template for user with VIEW permission
Added:
- Mutations.ftl template