### PR TITLE
Improved: Rename invoiceApplications menu-item label to Payments (OFBIZ-12405)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -117,7 +117,7 @@ under the License.
         <menu-item name="find" title="${uiLabelMap.CommonFind}">
             <link target="findInvoices"/>
         </menu-item>
-        <menu-item name="invoiceOverview" title="${uiLabelMap.AccountingInvoiceOverview}">
+        <menu-item name="invoiceOverview" title="${uiLabelMap.CommonOverview}">
             <condition>
                 <not><if-empty field="invoice.invoiceId"/></not>
             </condition>
@@ -197,7 +197,7 @@ under the License.
                 <parameter param-name="invoiceId" from-field="invoice.invoiceId"/>
             </link>
         </menu-item>
-        <menu-item name="editInvoiceApplications" title="${uiLabelMap.AccountingPaymentsApplications}">
+        <menu-item name="editInvoiceApplications" title="${uiLabelMap.CommonPayments}">
             <condition>
                 <and>
                     <not><if-empty field="invoice.invoiceId"/></not>
@@ -518,7 +518,7 @@ under the License.
         <menu-item name="findPayment" title="${uiLabelMap.CommonFind}" >
             <link target="findPayments"/>
         </menu-item>
-        <menu-item name="paymentOverview" title="${uiLabelMap.AccountingPaymentTabOverview}">
+        <menu-item name="paymentOverview" title="${uiLabelMap.CommonOverview}">
             <condition>
                 <not><if-empty field="payment.paymentId"/></not>
             </condition>
@@ -690,7 +690,7 @@ under the License.
     </menu>
 
     <menu name="PaymentGroupTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
-        <menu-item name="PaymentGroupOverview" title="${uiLabelMap.AccountingPaymentTabOverview}">
+        <menu-item name="PaymentGroupOverview" title="${uiLabelMap.CommonOverview}">
             <link target="PaymentGroupOverview">
                 <parameter param-name="paymentGroupId" from-field="paymentGroup.paymentGroupId"/>
             </link>
@@ -861,7 +861,7 @@ under the License.
         <menu-item name="ListBudgets" title="${uiLabelMap.AccountingBudgetFind}">
             <link target="ListBudgets"/>
         </menu-item>
-        <menu-item name="BudgetOverview" title="${uiLabelMap.AccountingBudgetOverview}">
+        <menu-item name="BudgetOverview" title="${uiLabelMap.CommonOverview}">
             <link target="BudgetOverview">
                 <parameter param-name="budgetId"/>
             </link>


### PR DESCRIPTION
With commit 4aa2d71 ambiguity was introduced into the label AccountingApplications and subsequently
applied to the menu-item for payments in the menu for invoices. fixing the applicable menu-item

Modified: AccountingMenus.xml
- label reference in the title for the menu-item for invoice payments
addtionally: setting the labels for titles of 'overview' menu-items to that in CommonUiLabels.xml, for:
- budget overview
- invoice overview
- payment overview
- payment group overview