### PR TITLE
Fixed: Unable to build in M1 Mac (OFBIZ-12460)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ javadoc {
 
 node {
     download = true
-    version = "12.18.1"
+    version = "16.13.1"
     // npmVersion will be the one that comes default with node
 
     // https://github.com/node-gradle/gradle-node-plugin/blob/2.2.4/README.md


### PR DESCRIPTION
Following error occurs when building in M1 Mac with Node.js version 12.18.1:

> Could not determine the dependencies of task ':nodeSetup'.
\> Failed to query the value of task ':nodeSetup' property 'nodeArchiveFile'.
  \> Could not resolve all files for configuration ':detachedConfiguration1'.
     \> Could not find node-12.18.1-darwin-arm64.tar.gz (org.nodejs:node:12.18.1).
        Searched in the following locations:
            https://nodejs.org/dist/v12.18.1/node-v12.18.1-darwin-arm64.tar.gz

Solved by upgrading Node.js from 12.18.1 to 16.13.1.
16.13.1 is the latest version with long-term support and has build for M1 Mac.

