### PR TITLE
Fixed: PriceScreens.xml - incorrect reference in screen (OFBIZ-12465)

### DIFF
--- a/applications/product/widget/catalog/PriceScreens.xml
+++ b/applications/product/widget/catalog/PriceScreens.xml
@@ -58,7 +58,7 @@ under the License.
                 <decorator-screen name="CommonPriceDecorator">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.ProductGlobalPriceRules}">
-                            <include-form name="FindProductPriceRules" location="component://product/widget/catalog/PriceForms.xml"/>
+                            <include-grid name="FindProductPriceRules" location="component://product/widget/catalog/PriceForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.ProductAddPriceRule}">
                             <include-form name="AddPriceRules" location="component://product/widget/catalog/PriceForms.xml"/>


### PR DESCRIPTION
With commit 92533b5 the reference in screen FindProductPriceRule was not changed
when the relating object in PriceForms.xml changed from form to grid.

Modified: PriceScreens.xml
changed reference in FindProductPriceRule from include-form to include-grid