### PR TITLE
Fixed: Price Rules: Price rules configurations are not syncing with eCommerce storefront (OFBIZ-12450)

### DIFF
--- a/applications/datamodel/data/demo/OrderDemoData.xml
+++ b/applications/datamodel/data/demo/OrderDemoData.xml
@@ -2309,6 +2309,7 @@ under the License.
     <Party partyId="EuroCustomer" partyTypeId="PERSON" statusId="PARTY_ENABLED" preferredCurrencyUomId="EUR"/>
     <Person partyId="EuroCustomer" firstName="Euro" lastName="Customer"/>
     <UserLogin partyId="EuroCustomer" userLoginId="EuroCustomer" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a" lastLocale="nl_NL"/>
+    <PartyClassification partyId="EuroCustomer" partyClassificationGroupId="EMEA" fromDate="2001-01-01 00:00:00.0"/>
     <PartyRole partyId="EuroCustomer" roleTypeId="CUSTOMER"/>
     <PartyRole partyId="EuroCustomer" roleTypeId="BILL_TO_CUSTOMER"/>
     <PartyRole partyId="EuroCustomer" roleTypeId="SHIP_TO_CUSTOMER"/>
@@ -2336,6 +2337,7 @@ under the License.
     <Party partyId="FrenchCustomer" partyTypeId="PERSON" statusId="PARTY_ENABLED" preferredCurrencyUomId="EUR"/>
     <Person partyId="FrenchCustomer" firstName="French" lastName="Customer"/>
     <UserLogin partyId="FrenchCustomer" userLoginId="FrenchCustomer" currentPassword="{SHA}47b56994cbc2b6d10aa1be30f70165adb305a41a" lastLocale="fr_FR"/>
+    <PartyClassification partyId="FrenchCustomer" partyClassificationGroupId="EMEA" fromDate="2001-01-01 00:00:00.0"/>
     <PartyRole partyId="FrenchCustomer" roleTypeId="CUSTOMER"/>
     <PartyRole partyId="FrenchCustomer" roleTypeId="BILL_TO_CUSTOMER"/>
     <PartyStatus partyId="FrenchCustomer" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>

--- a/applications/datamodel/data/demo/PartyDemoData.xml
+++ b/applications/datamodel/data/demo/PartyDemoData.xml
@@ -123,4 +123,7 @@ under the License.
     <PartyGroup partyId="DemoGovAgency" groupName="Demo Government Agency"/>
     <PartyRole partyId="DemoGovAgency" roleTypeId="GOV_AGENCY"/>
 
+    <!-- PartyClassification data -->
+    <PartyClassificationGroup partyClassificationGroupId="EMEA" description="Europe and Middle East" partyClassificationTypeId="REGION"/>
+    <PartyClassificationGroup partyClassificationGroupId="APAC" description="Asia and Pacific" partyClassificationTypeId="REGION"/>
 </entity-engine-xml>

--- a/applications/datamodel/data/demo/ProductDemoData.xml
+++ b/applications/datamodel/data/demo/ProductDemoData.xml
@@ -118,15 +118,18 @@ under the License.
     <!-- PriceRule data -->
     <ProductPriceRule productPriceRuleId="PR4FC" ruleName="PR4FC" description="PriceRule 4 French Customer" isSale="Y" fromDate="2001-01-01 12:00:00.0"/>
     <ProductPriceCond inputParamEnumId="PRIP_PARTY_ID" operatorEnumId="PRC_EQ" condValue="EuroCustomer" productPriceCondSeqId="01" productPriceRuleId="PR4FC"/>
+    <ProductPriceAction productPriceActionTypeId="PRICE_POD" productPriceActionSeqId="00001" productPriceRuleId="PR4FC" amount="98.000000"/>
 
     <ProductPriceRule productPriceRuleId="PR4PC" ruleName="PR4PC" description="PriceRule 4 Party Classification" isSale="Y" fromDate="2001-01-01 12:00:00.0"/>
-    <ProductPriceCond inputParamEnumId="PRIP_PARTY_CLASS" operatorEnumId="PRC_EQ" condValue="EMEA" productPriceCondSeqId="01" productPriceRuleId="PR4PC"/>
-    <ProductPriceAction productPriceActionTypeId="PRICE_POD" productPriceActionSeqId="00001" productPriceRuleId="PR4PC" amount="98.000000"/>
+    <ProductPriceCond productPriceRuleId="PR4PC" inputParamEnumId="PRIP_PARTY_CLASS" operatorEnumId="PRC_EQ" condValue="EMEA" productPriceCondSeqId="01"/>
+    <ProductPriceAction productPriceRuleId="PR4PC" productPriceActionTypeId="PRICE_POD" productPriceActionSeqId="00001" amount="98.000000"/>
 
     <ProductPriceRule productPriceRuleId="PR4P" ruleName="PR4P" description="PriceRule 4 Product" isSale="Y" fromDate="2001-01-01 12:00:00.0"/>
-    <ProductPriceCond inputParamEnumId="PRIP_PRODUCT_ID" operatorEnumId="PRC_EQ" condValue="FAJITA_BEEF" productPriceCondSeqId="01" productPriceRuleId="PR4P"/>
+    <ProductPriceCond productPriceRuleId="PR4P" inputParamEnumId="PRIP_PRODUCT_ID" operatorEnumId="PRC_EQ" condValue="FAJITA_BEEF" productPriceCondSeqId="01"/>
+    <ProductPriceAction productPriceRuleId="PR4P" productPriceActionTypeId="PRICE_POD" productPriceActionSeqId="00001" amount="98.000000"/>
 
     <ProductPriceRule productPriceRuleId="PR4C" ruleName="PR4C" description="PriceRule 4 Category" isSale="Y" fromDate="2001-01-01 12:00:00.0"/>
-    <ProductPriceCond  inputParamEnumId="PRIP_PROD_CAT_ID" operatorEnumId="PRC_EQ" condValue="GB_LUGGAGE" productPriceCondSeqId="01" productPriceRuleId="PR4C"/>
-
+    <ProductPriceCond productPriceRuleId="PR4C" inputParamEnumId="PRIP_PROD_CAT_ID" operatorEnumId="PRC_EQ" condValue="GB_LUGGAGE" productPriceCondSeqId="01"/>
+    <ProductPriceAction productPriceRuleId="PR4C" productPriceActionTypeId="PRICE_POD" productPriceActionSeqId="00001" amount="98.000000"/>
+    
 </entity-engine-xml>

--- a/applications/datamodel/data/demo/ProductDemoData.xml
+++ b/applications/datamodel/data/demo/ProductDemoData.xml
@@ -115,4 +115,18 @@ under the License.
     <!-- Product store group management demo -->
     <ProductStoreGroupType productStoreGroupTypeId="PSGT_AREA" description="Area cover"/>
 
+    <!-- PriceRule data -->
+    <ProductPriceRule productPriceRuleId="PR4FC" ruleName="PR4FC" description="PriceRule 4 French Customer" isSale="Y" fromDate="2001-01-01 12:00:00.0"/>
+    <ProductPriceCond inputParamEnumId="PRIP_PARTY_ID" operatorEnumId="PRC_EQ" condValue="EuroCustomer" productPriceCondSeqId="01" productPriceRuleId="PR4FC"/>
+
+    <ProductPriceRule productPriceRuleId="PR4PC" ruleName="PR4PC" description="PriceRule 4 Party Classification" isSale="Y" fromDate="2001-01-01 12:00:00.0"/>
+    <ProductPriceCond inputParamEnumId="PRIP_PARTY_CLASS" operatorEnumId="PRC_EQ" condValue="EMEA" productPriceCondSeqId="01" productPriceRuleId="PR4PC"/>
+    <ProductPriceAction productPriceActionTypeId="PRICE_POD" productPriceActionSeqId="00001" productPriceRuleId="PR4PC" amount="98.000000"/>
+
+    <ProductPriceRule productPriceRuleId="PR4P" ruleName="PR4P" description="PriceRule 4 Product" isSale="Y" fromDate="2001-01-01 12:00:00.0"/>
+    <ProductPriceCond inputParamEnumId="PRIP_PRODUCT_ID" operatorEnumId="PRC_EQ" condValue="FAJITA_BEEF" productPriceCondSeqId="01" productPriceRuleId="PR4P"/>
+
+    <ProductPriceRule productPriceRuleId="PR4C" ruleName="PR4C" description="PriceRule 4 Category" isSale="Y" fromDate="2001-01-01 12:00:00.0"/>
+    <ProductPriceCond  inputParamEnumId="PRIP_PROD_CAT_ID" operatorEnumId="PRC_EQ" condValue="GB_LUGGAGE" productPriceCondSeqId="01" productPriceRuleId="PR4C"/>
+
 </entity-engine-xml>

--- a/applications/datamodel/data/seed/PartySeedData.xml
+++ b/applications/datamodel/data/seed/PartySeedData.xml
@@ -274,6 +274,7 @@ under the License.
     <PartyClassificationType description="Value Rating" hasTable="N" partyClassificationTypeId="VALUE_RATING"/>
     <PartyClassificationType description="SIC Code" hasTable="N" partyClassificationTypeId="SIC_CODE"/>
     <PartyClassificationType description="Ownership" hasTable="N" partyClassificationTypeId="OWNERSHIP"/>
+    <PartyClassificationType description="Region" hasTable="N" partyClassificationTypeId="REGION"/>
 
     <PartyQualType description="Work experience" hasTable="N" partyQualTypeId="EXPERIENCE"/>
     <PartyQualType description="Certification" hasTable="N" partyQualTypeId="CERTIFICATION"/>


### PR DESCRIPTION
When adding a Price Rule, whether it be a Product Category, Product, Party, Party Classification, the system doesn't show a price difference.
The price rules work with the Database as they do get changed when saved. But their functionality doesn't work, it won't give a price increase or decrease or restriction.

Modified:
Various data files to enhance demonstration of price rule functionality