### PR TITLE
Fixed: PriceRule - values of existing ProductPriceCond record not shown (OFBIZ-12467)

### DIFF
--- a/applications/product/widget/catalog/PriceForms.xml
+++ b/applications/product/widget/catalog/PriceForms.xml
@@ -72,7 +72,7 @@
             </hyperlink>
         </field>
     </grid>
-    <grid name="EditProductPriceRulesCond" list-name="productPriceCond" target="updateProductPriceCond" 
+    <grid name="EditProductPriceRulesCond" list-name="productPriceConds" target="updateProductPriceCond" 
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true">
         <field name="productPriceRuleId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->
         <field name="productPriceCondSeqId"><hidden/></field><!-- Users don't need this information there, the screen is already sufficiently complex! -->


### PR DESCRIPTION
When a price rule is shown in the screen, the associated existing conditions are not shown in the overview for the conditions
Modified: Priceforms.xml
- changed grid 'EditProductPriceRulesCondition' list-name to reflect correct list