### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/workeffort/widget/WorkEffortForms.xml
+++ b/applications/workeffort/widget/WorkEffortForms.xml
@@ -32,7 +32,7 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonFind}"><submit button-type="button"/></field>
     </form>
-    <form name="UserJobsList" list-name="userJobs" title="" type="list"
+    <grid name="UserJobsList" list-name="userJobs"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <auto-fields-entity entity-name="JobSandbox" default-field-type="display"/>
         <field name="statusId">
@@ -47,7 +47,7 @@ under the License.
         <field name="runByInstanceId"><hidden/></field>
         <field name="runtimeDataId"><hidden/></field>
         <field name="recurrenceInfoId"><hidden/></field>
-    </form>
+    </grid>
 
     <form name="EditWorkEffort" default-map-name="workEffort" target="updateWorkEffort" title="" type="single"
         header-row-style="header-row" default-table-style="basic-table">
@@ -482,7 +482,7 @@ under the License.
         </field>
     </form>
 
-    <form name="DisplayWorkEffortPartyAssigns" type="list" list-name="partyAssignments"
+    <grid name="DisplayWorkEffortPartyAssigns" list-name="partyAssignments"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="partyId" title="${uiLabelMap.PartyParty}">
             <display-entity entity-name="PartyNameView" description="${firstName} ${lastName} ${groupName}">
@@ -496,7 +496,7 @@ under the License.
         <field name="thruDate"><display/></field>
         <field name="assignmentStatusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem" key-field-name="statusId"/></field>
         <field name="expectationEnumId" title="${uiLabelMap.WorkEffortExpectation}"><display-entity entity-name="Enumeration" key-field-name="enumId"/></field>
-    </form>
+    </grid>
 
     <form name="ListPreferredContactMech" target="" title="" type="list"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
@@ -648,7 +648,7 @@ under the License.
         <field name="mustRsvp"><ignored/></field>
     </form>
 
-    <form name="ListIcalendars" list-name="listIt" type="list"
+    <grid name="ListIcalendars" list-name="listIt"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
             <entity-and entity-name="WorkEffortAndPartyAssign" list="listIt" filter-by-date="true">
@@ -667,7 +667,7 @@ under the License.
             <hyperlink description="${serverRootUrl}/iCalendar/${workEffortId}/" target="${serverRootUrl}/iCalendar/${workEffortId}/" also-hidden="false" target-type="plain"/>
         </field>
         <field name="workEffortName" title="${uiLabelMap.WorkEffortICalendarName}"><display/></field>
-    </form>
+    </grid>
 
     <form name="EditICalendarFixedAssetAssign" extends="EditWorkEffortFixedAssetAssign" target="createICalendarFixedAssetAssign">
         <actions>

--- a/applications/workeffort/widget/WorkEffortRelatedSummaryScreens.xml
+++ b/applications/workeffort/widget/WorkEffortRelatedSummaryScreens.xml
@@ -89,7 +89,7 @@ under the License.
                                     <label text="${uiLabelMap.PageTitleListWorkEffortPartyAssigns}"/>
                                 </container>
                                 <container style="screenlet-body">
-                                    <include-form name="DisplayWorkEffortPartyAssigns" location="component://workeffort/widget/WorkEffortForms.xml"/>
+                                    <include-grid name="DisplayWorkEffortPartyAssigns" location="component://workeffort/widget/WorkEffortForms.xml"/>
                                 </container>
                             </widgets>
                         </section>

--- a/applications/workeffort/widget/WorkEffortScreens.xml
+++ b/applications/workeffort/widget/WorkEffortScreens.xml
@@ -43,7 +43,7 @@ under the License.
                             <widgets>
                                 <screenlet title="${uiLabelMap.WorkEffortJobList}">
                                     <include-form name="FilterUserJobs" location="component://workeffort/widget/WorkEffortForms.xml"/>
-                                    <include-form name="UserJobsList" location="component://workeffort/widget/WorkEffortForms.xml"/>
+                                    <include-grid name="UserJobsList" location="component://workeffort/widget/WorkEffortForms.xml"/>
                                 </screenlet>
                             </widgets>
                             <fail-widgets>
@@ -758,7 +758,7 @@ under the License.
                                     <link text="${uiLabelMap.CommonCreate}" target="EditICalendar" style="buttontext"/>
                                     <link text="${uiLabelMap.CommonHelp}" target="ICalendarHelp" style="buttontext"/>
                                 </container>
-                                <include-form name="ListIcalendars" location="component://workeffort/widget/WorkEffortForms.xml"/>
+                                <include-grid name="ListIcalendars" location="component://workeffort/widget/WorkEffortForms.xml"/>
                             </widgets>
                             <fail-widgets>
                                 <label style="h3">${uiLabelMap.WorkEffortViewPermissionError}</label>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Modified:
WorkEffortScreens.xml and CommonScreens.xml in product: from form ref to grid ref , additional cleanup
WorkEffortRelatedSummary.xml and CommonScreens.xml in product: from form ref to grid ref , additional cleanup
WorkEffortForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up