### PR TITLE
Improved: Have a menu in Marketing featuring actions to create main objects (OFBIZ-11783)

### DIFF
--- a/applications/marketing/widget/CommonScreens.xml
+++ b/applications/marketing/widget/CommonScreens.xml
@@ -28,7 +28,6 @@ under the License.
                 <property-map resource="PartyUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="ProductUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
-
                 <set field="layoutSettings.companyName" from-field="uiLabelMap.MarketingCompanyName" global="true"/>
                 <set field="layoutSettings.companySubtitle" from-field="uiLabelMap.MarketingCompanySubtitle" global="true"/>
                 <!-- layoutSettings.headerImageUrl can be used to specify an application specific logo; if not set,
@@ -60,8 +59,8 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
                         <section>
-                            <!-- do check for MARKETING, _VIEW permission -->
                             <condition>
                                 <and>
                                     <if-has-permission permission="MARKETING" action="_VIEW"/>
@@ -83,11 +82,6 @@ under the License.
                                 <section>
                                     <condition><not><if-empty field="contactListId"/></not></condition>
                                     <widgets>
-                                        <container style="button-bar">
-                                            <link  text="${uiLabelMap.MarketingContactListCreate}" target="EditContactList" style="buttontext create">
-                                                <parameter param-name="DONE_PAGE" from-field="donePage"/>
-                                            </link>
-                                        </container>
                                         <container>
                                             <label style="h1">${uiLabelMap.MarketingContactList} ${contactList.contactListName} [${contactListId}]</label>
                                         </container>
@@ -111,6 +105,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.MarketingManagerApplication}">
                             <container><label style="label" text="${uiLabelMap.MarketingManagerWelcome}"/></container>

--- a/applications/marketing/widget/ContactListScreens.xml
+++ b/applications/marketing/widget/ContactListScreens.xml
@@ -34,15 +34,11 @@ under the License.
            </actions>
            <widgets>
                <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                    <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                            <decorator-section name="menu-bar">
-                                <container style="button-bar">
-                                    <link  text="${uiLabelMap.MarketingContactListCreate}" target="EditContactList" style="buttontext create">
-                                        <parameter param-name="DONE_PAGE" from-field="donePage"/>
-                                    </link>
-                                </container>
-                            </decorator-section>
                             <decorator-section name="search-options">
                                 <include-form name="FindContactLists" location="component://marketing/widget/ContactListForms.xml"/>
                             </decorator-section>

--- a/applications/marketing/widget/DataSourceScreens.xml
+++ b/applications/marketing/widget/DataSourceScreens.xml
@@ -32,6 +32,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <!-- do check for MARKETING, _VIEW permission -->
                             <condition>

--- a/applications/marketing/widget/MarketingCampaignScreens.xml
+++ b/applications/marketing/widget/MarketingCampaignScreens.xml
@@ -32,6 +32,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <!-- do check for MARKETING, _VIEW permission -->
                             <condition>
@@ -52,11 +53,6 @@ under the License.
                                 <if-has-permission permission="MARKETING" action="_VIEW"/>
                             </condition>
                             <widgets>
-                                <container style="button-bar">
-                                    <link text="${uiLabelMap.MarketingCampaignCreate}" target="EditMarketingCampaign" style="buttontext create">
-                                        <parameter param-name="DONE_PAGE" from-field="donePage" />
-                                    </link>
-                                </container>
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>

--- a/applications/marketing/widget/MarketingMenus.xml
+++ b/applications/marketing/widget/MarketingMenus.xml
@@ -26,6 +26,25 @@ under the License.
         <menu-item name="ContactList" title="${uiLabelMap.MarketingContactList}"><link target="FindContactLists"/></menu-item>
         <menu-item name="Reports" title="${uiLabelMap.MarketingReports}"><link target="MarketingReport"/></menu-item>
     </menu>
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="NewCampaign" title="${uiLabelMap.CommonNew} ${uiLabelMap.MarketingCampaign}">
+            <condition>
+                <or>
+                    <if-has-permission permission="MARKETING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditMarketingCampaign"/>
+        </menu-item>
+        <menu-item name="NewContactList" title="${uiLabelMap.CommonNew} ${uiLabelMap.MarketingContactList}">
+            <condition>
+                <or>
+                    <if-has-permission permission="MARKETING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditContactList"/>
+        </menu-item>
+    </menu>
+    
     <menu name="MarketingShortcutAppBar" title="${uiLabelMap.MarketingManager}">
         <menu-item name="DataSource" title="${uiLabelMap.DataSource}"><link target="/marketing/control/FindDataSource" url-mode="inter-app"/></menu-item>
         <menu-item name="Campaign" title="${uiLabelMap.MarketingCampaign}"><link target="/marketing/control/FindMarketingCampaign" url-mode="inter-app"/></menu-item>

--- a/applications/marketing/widget/MarketingReportScreens.xml
+++ b/applications/marketing/widget/MarketingReportScreens.xml
@@ -26,6 +26,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for MARKETING, _VIEW permission -->

--- a/applications/marketing/widget/SegmentScreens.xml
+++ b/applications/marketing/widget/SegmentScreens.xml
@@ -42,6 +42,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for MARKETING, _VIEW permission -->
@@ -78,6 +81,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <!-- do check for MARKETING, _VIEW permission -->
                             <condition>

--- a/applications/marketing/widget/TrackingCodeScreens.xml
+++ b/applications/marketing/widget/TrackingCodeScreens.xml
@@ -31,6 +31,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://marketing/widget/MarketingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <!-- do check for MARKETING, _VIEW permission -->
                             <condition>


### PR DESCRIPTION
Currently the create buttons for the main objects of the marketing application are located
within find and profile widgets/templates of those objects.

In order to improve the usability of this application, OFBiz,
and thus the appeal of it for adopters and users, these create buttons/links/etc.
should be in a main action menu visible at all times when a user is working within
the application of the component.

Modified:
MarketingMenus.xml - added MainActionMenu
To following screens - added ref to MainActionMenu, clean-up
CommonScreens.xml
ContactListScreens.xml
DataSourceScreens.xml
MarketingCampaignScreens.xml
MarketingReportScreens.xml
SegmentScreens.xml
TrackingCodeScreens.xml
