### PR TITLE
Improved: Have a Menu in Humanres featuring actions to create the main objects (OFBIZ-11777)

### DIFF
--- a/applications/humanres/widget/CommonScreens.xml
+++ b/applications/humanres/widget/CommonScreens.xml
@@ -54,6 +54,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -128,6 +131,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -147,9 +151,6 @@ under the License.
                                 <if-has-permission permission="HUMANRES" action="_VIEW"/>
                             </condition>
                             <widgets>
-                                <container style="button-bar">
-                                    <link target="EditEmplPosition" text="${uiLabelMap.HumanResNewEmplPosition}" style="buttontext create"/>
-                                </container>
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>
@@ -173,6 +174,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for Employment, _VIEW permission -->
@@ -199,9 +203,6 @@ under the License.
                                             </condition>
                                             <widgets>
                                                 <include-menu name="EmploymentBar" location="component://humanres/widget/HumanresMenus.xml"/>
-                                                <container style="button-bar">
-                                                    <link target="EditEmployment" text="${uiLabelMap.HumanResNewEmployment}" style="buttontext"/>
-                                                </container>
                                                 <label style="h1" text="${emplName.lastName},${emplName.firstName} ${emplName.middleName} [${emplName.partyId}] ${uiLabelMap.CommonFor}"></label>
                                                 <label style="h1" text="${orgName.groupName} [${orgName.partyId}]"></label>
                                             </widgets>
@@ -227,6 +228,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -270,6 +274,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -288,9 +293,6 @@ under the License.
                                     <if-has-permission permission="HUMANRES" action="_VIEW"/>
                             </condition>
                             <widgets>
-                                <container style="button-bar">
-                                    <link target="NewEmployee" text="${uiLabelMap.HumanResNewEmployee}" style="buttontext create"/>
-                                </container>
                                 <section>
                                     <condition><not><if-empty field="partyId"/></not></condition>
                                     <widgets>
@@ -314,7 +316,6 @@ under the License.
                             </fail-widgets>
                         </section>
                     </decorator-section>
-
                 </decorator-screen>
             </widgets>
         </section>
@@ -389,6 +390,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                         <include-menu name="GlobalHRSettingMenus" location="component://humanres/widget/HumanresMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">
@@ -407,6 +409,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                         <include-menu name="RecruitmentTypeMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">
@@ -425,6 +428,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                         <include-menu name="TrainingTypeMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">
@@ -442,6 +446,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                         <include-menu name="EmployeeProfileTabBar" location="component://humanres/widget/HumanresMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">

--- a/applications/humanres/widget/EmplLeaveScreens.xml
+++ b/applications/humanres/widget/EmplLeaveScreens.xml
@@ -43,6 +43,7 @@
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
                         <include-menu name="EmplLeaveTabBar" location="component://humanres/widget/HumanresMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">

--- a/applications/humanres/widget/EmployeeScreens.xml
+++ b/applications/humanres/widget/EmployeeScreens.xml
@@ -29,6 +29,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <actions>
@@ -36,9 +39,6 @@ under the License.
                                 <set field="tabButtonItem" value="Employee"/>
                             </actions>
                             <widgets>
-                                <container style="button-bar">
-                                    <link target="NewEmployee" text="${uiLabelMap.HumanResNewEmployee}" style="buttontext create"/>
-                                </container>
                                 <section>
                                     <widgets>
                                         <platform-specific>

--- a/applications/humanres/widget/EmploymentScreens.xml
+++ b/applications/humanres/widget/EmploymentScreens.xml
@@ -35,17 +35,11 @@
             </actions>
             <widgets>
                 <decorator-screen name="CommonEmploymentDecorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                            <decorator-section name="menu-bar">
-                                <section>
-                                    <widgets>
-                                        <container style="button-bar">
-                                            <link target="EditEmployment" text="${uiLabelMap.HumanResNewEmployment}" style="buttontext create"/>
-                                        </container>
-                                    </widgets>
-                                </section>
-                            </decorator-section>
                             <decorator-section name="search-options">
                                 <include-form name="FindEmployments" location="component://humanres/widget/forms/EmploymentForms.xml"/>
                             </decorator-section>

--- a/applications/humanres/widget/HumanresMenus.xml
+++ b/applications/humanres/widget/HumanresMenus.xml
@@ -34,6 +34,48 @@
         <menu-item name="Leave" title="${uiLabelMap.HumanResEmplLeave}"><link target="FindEmplLeaves"/></menu-item>
         <menu-item name="GlobalHRSettings" title="${uiLabelMap.HumanResGlobalHRSettings}" selected-style="selected"><link target="globalHRSettings"/></menu-item>
     </menu>
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="NewEmployee" title="${uiLabelMap.CommonNew} ${uiLabelMap.Employee}">
+            <condition>
+                <or>
+                    <if-has-permission permission="HUMANRES" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="NewEmployee"/>
+        </menu-item>
+        <menu-item name="NewPosition" title="${uiLabelMap.CommonNew} ${uiLabelMap.Position}">
+            <condition>
+                <or>
+                    <if-has-permission permission="HUMANRES" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditEmplPosition"/>
+        </menu-item>
+        <menu-item name="NewFulfilmennt" title="${uiLabelMap.CommonNew} ${uiLabelMap.Fulfilmnent}">
+            <condition>
+                <or>
+                    <if-has-permission permission="HUMANRES" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditEmplPositionFulfillments"/>
+        </menu-item>
+        <menu-item name="NewPerformanceReview" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonReview}">
+            <condition>
+                <or>
+                    <if-has-permission permission="HUMANRES" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditPerfReview"/>
+        </menu-item>
+        <menu-item name="NewLeave" title="${uiLabelMap.CommonNew} ${uiLabelMap.HumanResEmplLeave}">
+            <condition>
+                <or>
+                    <if-has-permission permission="HUMANRES" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditEmplLeave"/>
+        </menu-item>
+    </menu>
     <menu name="HumanResShortcutAppBar" title="${uiLabelMap.HumanResManager}">
         <menu-item name="Employees" title="${uiLabelMap.HumanResEmployees}"><link target="/humanres/control/findEmployees" url-mode="inter-app"/></menu-item>
         <menu-item name="Employment" title="${uiLabelMap.HumanResEmployment}"><link target="/humanres/control/FindEmployments" url-mode="inter-app"/></menu-item>

--- a/applications/humanres/widget/PartyQualScreens.xml
+++ b/applications/humanres/widget/PartyQualScreens.xml
@@ -37,6 +37,9 @@
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                             <decorator-section name="menu-bar">

--- a/applications/humanres/widget/PartyResumeScreens.xml
+++ b/applications/humanres/widget/PartyResumeScreens.xml
@@ -30,6 +30,9 @@
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                             <decorator-section name="menu-bar">

--- a/applications/humanres/widget/PartySkillScreens.xml
+++ b/applications/humanres/widget/PartySkillScreens.xml
@@ -30,6 +30,9 @@
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                             <decorator-section name="menu-bar">

--- a/applications/humanres/widget/PerfReviewScreens.xml
+++ b/applications/humanres/widget/PerfReviewScreens.xml
@@ -32,6 +32,9 @@
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://humanres/widget/HumanresMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                             <decorator-section name="menu-bar">


### PR DESCRIPTION
Currently the create buttons for the main objects of the humanres plugin are located within find and profile widgets/templates of those objects.

In order to improve the usability of this plugin, OFBiz (and thus the appeal of it for adopters and users) these create buttons/links/etc. should be in a main action menu visible at all times when a user is working within the web appliclation of the component.

Modified:
HumanresMenus.xml - added MainActionMenu
To following screens - added ref to MainActionMenu, clean-up
CommonScreens.xml
EmplLeaveScreens.xml
EmployeeScreens.xml
EmploymentScreens.xml
PartyQualScreens.xml
PartyResumeScreens.xml
PartySkillsScreens.xml
PerfReviewScreens.xml