### PR TITLE
Improved: Have a Menu in Catalog featuring actions to create the main objects (OFBIZ-11774)

### DIFF
--- a/applications/product/widget/catalog/CatalogMenus.xml
+++ b/applications/product/widget/catalog/CatalogMenus.xml
@@ -34,7 +34,48 @@ under the License.
         <menu-item name="shipping" title="${uiLabelMap.ProductShipping}"><link target="ListShipmentMethodTypes"/></menu-item>
         <menu-item name="Imagemanagement" title="${uiLabelMap.ImageManagement}"><link target="Imagemanagement"/></menu-item>
     </menu>
-
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="newProduct" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonProduct}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                    </or>
+                </and>
+            </condition>
+            <link target="EditProduct"/>
+        </menu-item>
+        <menu-item name="newStore" title="${uiLabelMap.CommonNew} ${uiLabelMap.ProductStore}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                    </or>
+                </and>
+            </condition>
+            <link target="EditProductStore"/>
+        </menu-item>
+        <menu-item name="newCatalog" title="${uiLabelMap.CommonNew} ${uiLabelMap.Catalog}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                    </or>
+                </and>
+            </condition>
+            <link target="EditProdCatalog"/>
+        </menu-item>
+        <menu-item name="newCategory" title="${uiLabelMap.CommonNew} ${uiLabelMap.ProductCategory}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                    </or>
+                </and>
+            </condition>
+            <link target="EditCategory"/>
+        </menu-item>
+    </menu>
     <menu name="CatalogShortcutAppBar" title="${uiLabelMap.ProductCatalogManager}">
         <menu-item name="catalogs" title="${uiLabelMap.ProductCatalogs}"><link target="/catalog/control/FindCatalog" url-mode="inter-app"/></menu-item>
         <menu-item name="categories" title="${uiLabelMap.ProductCategories}"><link target="/catalog/control/FindCategory" url-mode="inter-app"/></menu-item>
@@ -76,9 +117,6 @@ under the License.
     </menu>
 
     <menu name="CatalogSubTabBar" menu-container-style="button-bar button-style-2" default-selected-style="selected">
-        <menu-item name="EditProductCatalog" title="${uiLabelMap.ProductNewProdCatalog}" widget-style="buttontext create">
-            <link target="EditProdCatalog"/>
-        </menu-item>
         <menu-item name="CreateSeo" title="${uiLabelMap.ProductCatalogSeoCreate}">
             <condition>
                 <not><if-empty field="prodCatalog"/></not>
@@ -168,9 +206,6 @@ under the License.
     </menu>
 
     <menu name="CategorySubTabBar" menu-container-style="button-bar button-style-2" default-selected-style="selected">
-        <menu-item name="EditCategory" title="${uiLabelMap.ProductNewCategory}" widget-style="buttontext create">
-            <link target="EditCategory"/>
-        </menu-item>
         <menu-item name="createProductInCategoryStart" title="${uiLabelMap.ProductCreateProductInCategory}" widget-style="buttontext create">
             <condition>
                 <not><if-empty field="productCategory"/></not>
@@ -542,9 +577,6 @@ under the License.
     </menu>
 
     <menu name="ProductSubTabBar" menu-container-style="button-bar button-style-2" default-selected-style="selected">
-        <menu-item name="EditProduct" title="${uiLabelMap.ProductNewProduct}" widget-style="buttontext create">
-            <link target="EditProduct"/>
-        </menu-item>
         <menu-item name="CreateVirtualWithVariantsForm" title="${uiLabelMap.ProductNewVirtualProduct}" widget-style="buttontext create">
             <condition>
                 <not><if-empty field="product"/></not>

--- a/applications/product/widget/catalog/CategoryScreens.xml
+++ b/applications/product/widget/catalog/CategoryScreens.xml
@@ -27,6 +27,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
                     </decorator-section>

--- a/applications/product/widget/catalog/CommonScreens.xml
+++ b/applications/product/widget/catalog/CommonScreens.xml
@@ -57,6 +57,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <section>
                             <condition>
@@ -118,6 +121,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <section>
                             <condition>
@@ -153,24 +159,9 @@ under the License.
                                         <section>
                                             <widgets>
                                                 <include-menu name="ProductStoreSubTabBar" location="component://product/widget/catalog/CatalogMenus.xml"/>
-                                                <container style="button-bar button-style-2">
-                                                    <link target="EditProductStore"  text="${uiLabelMap.ProductNewProductStore}" style="buttontext create" url-mode="plain"/>
-                                                </container>
                                             </widgets>
                                         </section>
                                     </widgets>
-                                    <fail-widgets>
-                                        <section>
-                                            <condition>
-                                                <if-compare operator="not-equals" value="EditProductStore" field="tabButtonItem"/>
-                                            </condition>
-                                            <widgets>
-                                                <container style="button-bar button-style-2">
-                                                    <link target="EditProductStore"  text="${uiLabelMap.ProductNewProductStore}" style="buttontext create" url-mode="plain"/>
-                                                </container>
-                                            </widgets>
-                                        </section>
-                                    </fail-widgets>
                                 </section>
                                 <decorator-section-include name="body"/>
                             </widgets>
@@ -191,6 +182,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="ProductStoreGroupTree"/>
                     </decorator-section>
@@ -222,16 +216,9 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
-                    <!--<decorator-section name="pre-body">
-                        <section>
-                            <condition>
-                                <if-has-permission permission="CATALOG" action="_VIEW"/>
-                            </condition>
-                            <widgets>
-                                <include-menu name="ShippingTabBar" location="component://product/widget/catalog/CatalogMenus.xml"/>
-                            </widgets>
-                        </section>
-                    </decorator-section>-->
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar"/>
                     </decorator-section>
@@ -376,6 +363,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <section>
                             <condition>
@@ -406,6 +396,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar"/>
                     </decorator-section>

--- a/applications/product/widget/catalog/ConfigScreens.xml
+++ b/applications/product/widget/catalog/ConfigScreens.xml
@@ -24,9 +24,12 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for CATALOG, _VIEW permission -->

--- a/applications/product/widget/catalog/FeatureScreens.xml
+++ b/applications/product/widget/catalog/FeatureScreens.xml
@@ -24,9 +24,12 @@
         <section>
             <widgets>
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>

--- a/applications/product/widget/catalog/PriceScreens.xml
+++ b/applications/product/widget/catalog/PriceScreens.xml
@@ -24,12 +24,14 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <section>
-                            <!-- do check for CATALOG, _VIEW permission -->
                             <condition>
                                 <if-has-permission permission="CATALOG" action="_VIEW"/>
                             </condition>

--- a/applications/product/widget/catalog/ProductScreens.xml
+++ b/applications/product/widget/catalog/ProductScreens.xml
@@ -36,6 +36,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
                     </decorator-section>
@@ -125,7 +128,6 @@ under the License.
                         <screenlet title="${groovy: parameters.productId ? uiLabelMap.PageTitleEditProduct : uiLabelMap.ProductNewProduct}">
                             <include-form name="EditProduct" location="component://product/widget/catalog/ProductForms.xml"/>
                         </screenlet>
-
                         <section>
                             <condition>
                                 <not><if-empty field="product"/></not>

--- a/applications/product/widget/catalog/PromoScreens.xml
+++ b/applications/product/widget/catalog/PromoScreens.xml
@@ -24,12 +24,14 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <section>
-                            <!-- do check for CATALOG, _VIEW permission -->
                             <condition>
                                 <if-has-permission permission="CATALOG" action="_VIEW"/>
                             </condition>

--- a/applications/product/widget/catalog/ReviewScreens.xml
+++ b/applications/product/widget/catalog/ReviewScreens.xml
@@ -24,9 +24,12 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for CATALOG, _VIEW permission -->

--- a/applications/product/widget/catalog/SubscriptionScreens.xml
+++ b/applications/product/widget/catalog/SubscriptionScreens.xml
@@ -31,9 +31,12 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>

--- a/applications/product/widget/catalog/ThesaurusScreens.xml
+++ b/applications/product/widget/catalog/ThesaurusScreens.xml
@@ -24,9 +24,12 @@ under the License.
         <section>
             <widgets>
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://product/widget/catalog/CatalogMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://product/widget/catalog/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for CATALOG, _VIEW permission -->


### PR DESCRIPTION
Currently the create buttons for the main objects of the catalog components are located within the find and profile widgets/templates of those object.
In order to improve the usability of OFBiz (and thus the appeal of it for adopters and users) these create buttons/links/etc. should be in a main action menu visible at all times when a user is working within the component.

added: main action menu, having menu-items for
- new product process
- new store process
- new catalog process
- new category process
subject to catalog create permissions
added: decorator section for inclusion of main action menu where appropriate
Some cleanup