### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/product/widget/facility/ShipmentGatewayConfigForms.xml
+++ b/applications/product/widget/facility/ShipmentGatewayConfigForms.xml
@@ -18,8 +18,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
-    
-    <!-- form whose input filters the FindPaymentGatewayConfig -->
     <form name="FindShipmentGatewayConfig" type="single" target="FindShipmentGatewayConfig" header-row-style="header-row" default-table-style="basic-table">
         <field name="shipmentGatewayConfigId" title="${uiLabelMap.FacilityShipmentGatewayConfigId}"><text-find ignore-case="true"/></field>
         <field name="description" title="${uiLabelMap.FacilityShipmentGatewayConfigDescription}"><text-find ignore-case="true"/></field>
@@ -36,8 +34,7 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-    
-    <form name="ListShipmentGatewayConfig" type="list" list-name="listIt" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+    <grid name="ListShipmentGatewayConfig" list-name="listIt" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <service service-name="performFind" result-map="result" result-map-list="listIt">
                 <field-map field-name="inputFields" from-field="parameters"/>
@@ -55,8 +52,7 @@ under the License.
         <field name="shipmentGatewayConfTypeId" title="${uiLabelMap.FacilityShipmentGatewayConfigTypeId}">
             <display-entity entity-name="ShipmentGatewayConfigType" key-field-name="shipmentGatewayConfTypeId"/>
         </field>
-    </form>
-    
+    </grid>
     <form name="EditShipmentGatewayConfig" type="single" target="UpdateShipmentGatewayConfig" default-map-name="shipmentGatewayConfig" header-row-style="header-row" default-table-style="basic-table">
         <field name="shipmentGatewayConfigId"><hidden/></field>
         <field name="description" title="${uiLabelMap.FacilityShipmentGatewayConfigDescription}"><text size="60" maxlength="60"/></field>
@@ -67,7 +63,6 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-    
     <form name="EditShipmentGatewayConfigDhl" type="single" target="updateShipmentGatewayDhl" default-map-name="shipmentGatewayDhl" header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ShipmentGatewayDhl" default-field-type="edit"/>
         <field name="shipmentGatewayConfigId"><hidden/></field>
@@ -111,7 +106,6 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-    
     <form name="EditShipmentGatewayConfigFedex" type="single" target="updateShipmentGatewayFedex" default-map-name="shipmentGatewayFedex" header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ShipmentGatewayFedex" default-field-type="edit"/>
         <field name="shipmentGatewayConfigId"><hidden/></field>
@@ -179,7 +173,6 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-    
     <form name="EditShipmentGatewayConfigUps" type="single" target="updateShipmentGatewayUps" default-map-name="shipmentGatewayUps" header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ShipmentGatewayUps" default-field-type="edit"/>
         <field name="shipmentGatewayConfigId"><hidden/></field>
@@ -273,7 +266,6 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-    
     <form name="EditShipmentGatewayConfigUsps" type="single" target="updateShipmentGatewayUsps" default-map-name="shipmentGatewayUsps" header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ShipmentGatewayUsps" default-field-type="edit"/>
         <field name="shipmentGatewayConfigId"><hidden/></field>
@@ -302,7 +294,6 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-    
     <form name="FindShipmentGatewayConfigTypes" type="single" target="FindShipmentGatewayConfigTypes" header-row-style="header-row" default-table-style="basic-table">
         <field name="shipmentGatewayConfTypeId" title="${uiLabelMap.FacilityShipmentGatewayConfigTypeId}"><text-find ignore-case="true"/></field>
         <field name="description" title="${uiLabelMap.FacilityShipmentGatewayConfigDescription}"><text-find ignore-case="true"/></field>
@@ -312,8 +303,7 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-    
-    <form name="ListShipmentGatewayConfigTypes" type="list" list-name="listIt" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+    <grid name="ListShipmentGatewayConfigTypes" list-name="listIt" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <service service-name="performFind" result-map="result" result-map-list="listIt">
                 <field-map field-name="inputFields" from-field="parameters"/>
@@ -328,8 +318,7 @@ under the License.
         <field name="description" title="${uiLabelMap.FacilityShipmentGatewayConfigTypeDescription}">
             <hyperlink description="${description}" target="EditShipmentGatewayConfigType?shipmentGatewayConfTypeId=${shipmentGatewayConfTypeId}"/>
         </field>
-    </form>
-    
+    </grid>
     <form name="EditShipmentGatewayConfigType" type="single" target="UpdateShipmentGatewayConfigType" default-map-name="shipmentGatewayConfigType" header-row-style="header-row" default-table-style="basic-table">
         <field name="shipmentGatewayConfTypeId"><hidden/></field>
         <field name="description" title="${uiLabelMap.FacilityShipmentGatewayConfigTypeDescription}"><text size="60" maxlength="60"/></field>

--- a/applications/product/widget/facility/ShipmentGatewayConfigScreens.xml
+++ b/applications/product/widget/facility/ShipmentGatewayConfigScreens.xml
@@ -20,7 +20,6 @@ under the License.
 
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
     <screen name="GenericShipmentGatewayConfigDecorator">
         <section>
             <actions>
@@ -32,15 +31,12 @@ under the License.
                     <decorator-section name="pre-body">
                         <include-menu name="ShipmentGatewayConfigTabBar" location="component://product/widget/facility/FacilityMenus.xml"/>
                     </decorator-section>
-                <!-- body is the primary display for this page and is called recursively -->
                     <decorator-section name="body">
                         <section>
                             <widgets>
                                 <container>
                                     <label style="h1">${uiLabelMap[labelTitleProperty]}</label>
                                 </container>
-                                
-                                <!-- Now call the SimpleScreen form -->
                                 <decorator-section-include name="body"/>
                             </widgets>
                         </section>
@@ -49,7 +45,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-    
     <screen name="FindShipmentGatewayConfig">
         <section>
             <actions>
@@ -69,7 +64,7 @@ under the License.
                                         <include-form name="FindShipmentGatewayConfig" location="component://product//widget/facility/ShipmentGatewayConfigForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListShipmentGatewayConfig" location="component://product//widget/facility/ShipmentGatewayConfigForms.xml"/>
+                                        <include-grid name="ListShipmentGatewayConfig" location="component://product//widget/facility/ShipmentGatewayConfigForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -79,13 +74,11 @@ under the License.
             </widgets>
         </section>
     </screen>
-    
     <screen name="EditShipmentGatewayConfig">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleUpdateShipmentGatewayConfig"/>
                 <set field="tabButtonItem" value="shipmentGatewayConfigTab"/> 
-                
                 <set field="shipmentGatewayConfigId" from-field="parameters.shipmentGatewayConfigId"/>
                 <entity-one entity-name="ShipmentGatewayConfig" value-field="shipmentGatewayConfig"/>
                 <entity-one entity-name="ShipmentGatewayDhl" value-field="shipmentGatewayDhl">
@@ -152,7 +145,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-    
     <screen name="FindShipmentGatewayConfigTypes">
         <section>
             <actions>
@@ -172,7 +164,7 @@ under the License.
                                         <include-form name="FindShipmentGatewayConfigTypes" location="component://product//widget/facility/ShipmentGatewayConfigForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListShipmentGatewayConfigTypes" location="component://product//widget/facility/ShipmentGatewayConfigForms.xml"/>
+                                        <include-grid name="ListShipmentGatewayConfigTypes" location="component://product//widget/facility/ShipmentGatewayConfigForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -182,13 +174,11 @@ under the License.
             </widgets>
         </section>
     </screen>
-    
     <screen name="EditShipmentGatewayConfigType">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleUpdateShipmentGatewayConfigType"/>
-                <set field="tabButtonItem" value="shipmentGatewayConfigTypesTab"/> 
-                
+                <set field="tabButtonItem" value="shipmentGatewayConfigTypesTab"/>
                 <set field="shipmentGatewayConfTypeId" from-field="parameters.shipmentGatewayConfTypeId"/>
                 <entity-one entity-name="ShipmentGatewayConfigType" value-field="shipmentGatewayConfigType"/>
             </actions>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Modified:
ShipmentGatewayConfigScreens.xml: from form ref to grid ref , additional cleanup
ShipmentGatewayConfigForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up