### PR TITLE
Improved: Party - MainActionMenus (OFBIZ-12482)

### DIFF
--- a/applications/party/widget/partymgr/CommonScreens.xml
+++ b/applications/party/widget/partymgr/CommonScreens.xml
@@ -68,6 +68,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
                         <section>
                             <condition>
                                 <and>

--- a/applications/party/widget/partymgr/CommunicationEventScreens.xml
+++ b/applications/party/widget/partymgr/CommunicationEventScreens.xml
@@ -29,6 +29,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
                         <section>
                             <condition>
                                 <if-has-permission permission="PARTYMGR" action="_VIEW"/>

--- a/applications/party/widget/partymgr/PartyClassificationScreens.xml
+++ b/applications/party/widget/partymgr/PartyClassificationScreens.xml
@@ -60,6 +60,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="partyBasePermissionCheck" main-action="VIEW"/>

--- a/applications/party/widget/partymgr/PartyInvitationScreens.xml
+++ b/applications/party/widget/partymgr/PartyInvitationScreens.xml
@@ -30,6 +30,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -80,6 +81,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -118,6 +122,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>

--- a/applications/party/widget/partymgr/PartyMenus.xml
+++ b/applications/party/widget/partymgr/PartyMenus.xml
@@ -37,7 +37,28 @@
         <menu-item name="partyinv" title="${uiLabelMap.PartyInvitation}"><link target="partyInvitation"/></menu-item>
         <menu-item name="importexport" title="${uiLabelMap.CommonImportExport}"><link target="ImportExport"/></menu-item>
     </menu>
-
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="newPerson" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonPerson}">
+             <condition>
+                 <or>
+                     <if-has-permission permission="PARTYMGR" action="_CREATE"/>
+                 </or>
+             </condition>
+             <link target="editperson">
+                <parameter param-name="create_new" value="Y"/>
+             </link>
+         </menu-item>
+         <menu-item name="newPartyGroup" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonGroup}">
+             <condition>
+                 <or>
+                     <if-has-permission permission="PARTYMGR" action="_CREATE"/>
+                 </or>
+             </condition>
+             <link target="editpartygroup">
+                <parameter param-name="create_new" value="Y"/>
+             </link>
+         </menu-item>
+    </menu>
     <menu name="PartyShortcutAppBar" title="${uiLabelMap.PartyManager}">
         <menu-item name="find" title="${uiLabelMap.PartyParties}"><link target="/partymgr/control/findparty" url-mode="inter-app"/></menu-item>
         <menu-item name="mycomm" title="${uiLabelMap.PartyMyCommunications}"><link target="/partymgr/control/MyCommunicationEvents" url-mode="inter-app"/></menu-item>

--- a/applications/party/widget/partymgr/PartyMenus.xml
+++ b/applications/party/widget/partymgr/PartyMenus.xml
@@ -38,7 +38,7 @@
         <menu-item name="importexport" title="${uiLabelMap.CommonImportExport}"><link target="ImportExport"/></menu-item>
     </menu>
     <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
-        <menu-item name="newPerson" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonPerson}">
+        <menu-item name="newPerson" title="${uiLabelMap.PartyCreateNewPerson}">
              <condition>
                  <or>
                      <if-has-permission permission="PARTYMGR" action="_CREATE"/>

--- a/applications/party/widget/partymgr/PartyScreens.xml
+++ b/applications/party/widget/partymgr/PartyScreens.xml
@@ -41,6 +41,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <platform-specific><html><html-template multi-block="true" location="component://common-theme/template/includes/SetMultipleSelectJs.ftl"/></html></platform-specific>
                         <section>

--- a/applications/party/widget/partymgr/VisitScreens.xml
+++ b/applications/party/widget/partymgr/VisitScreens.xml
@@ -30,6 +30,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <!-- do check for PARTYMGR, _VIEW permission -->


### PR DESCRIPTION
Currently the create buttons for the main objects of the party component are located within the find and other widgets/templates of those objects.
In order to improve the usability of OFBiz (and thus the appeal of it for adopters and users) these create buttons/links/etc. should be in a main action menu visible at all times when a user is working within the component.

Modified:
PartyMenus.xml: added MainActionMenu
CommonScreens.xml: included MainActionMenu where appropriate
CommunicationEventScreens.xml: included MainActionMenu where appropriate
PartyClassificationScreens.xml: included MainActionMenu where appropriate
PartyInvitationScreens.xml: included MainActionMenu where appropriate
VisitScreens.xml: included MainActionMenu where appropriate