### PR TITLE
Improved: PaymentGroup - action items visible to viewer (OFBIZ-12486)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -708,18 +708,27 @@ under the License.
             </link>
         </menu-item>
     </menu>
-    
     <menu name="PaymentGroupSubTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml"
             menu-container-style="button-bar button-style-2">
         <menu-item name="createNew" title="${uiLabelMap.CommonCreate}" widget-style="buttontext create">
             <condition>
-                <not><if-empty field="paymentGroup"/></not>
+                <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
+                    <not><if-empty field="paymentGroup"/></not>
+                </and>
             </condition>
             <link target="EditPaymentGroup"/>
         </menu-item>
         <menu-item name="depositSlip" title="${uiLabelMap.AccountingDepositSlip}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <if-compare field="display" operator="equals" value="true"/>
                     <if-compare field="paymentGroup.paymentGroupTypeId" operator="equals" value="BATCH_PAYMENT"/>
                     <not><if-empty field="paymentGroupMembers"/></not>
@@ -732,6 +741,10 @@ under the License.
         <menu-item name="printCheck" title="${uiLabelMap.AccountingPrintChecks}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <if-compare field="display" operator="equals" value="true"/>
                     <if-compare field="paymentGroup.paymentGroupTypeId" operator="equals" value="CHECK_RUN"/>
                     <not><if-empty field="paymentGroupMembers"/></not>
@@ -744,6 +757,10 @@ under the License.
         <menu-item name="cancelpaymentGroup" title="${uiLabelMap.AccountingCancelBatchPayments}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <not><if-empty field="paymentGroupMembers"/></not>
                     <not><if-empty field="paymentGroup"/></not>
                     <if-empty field="glReconciliationId"/>
@@ -757,6 +774,10 @@ under the License.
         <menu-item name="cancelCheckRunPayments" title="${uiLabelMap.AccountingCancelCheckRun}">
             <condition>
                 <and>
+                    <or>
+                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                    </or>
                     <not><if-empty field="paymentGroupMembers"/></not>
                     <not><if-empty field="paymentGroup"/></not>
                     <if-compare field="paymentGroup.paymentGroupTypeId" operator="equals" value="CHECK_RUN"/>


### PR DESCRIPTION
Menu items to perform actions in PaymentGroupSubTabBar are visible to users with only VIEW permissions. As shows when logged in with userId = auditor.

Modified: AccountingMenus.xml
added permissions rules to menu-items of PaymentGroupSubTabBar