### PR TITLE
Improved: VIEW permissions - BillingAccount roles (OFBIZ-12487)

### DIFF
--- a/applications/accounting/widget/BillingAccountForms.xml
+++ b/applications/accounting/widget/BillingAccountForms.xml
@@ -185,18 +185,18 @@ under the License.
         </actions>
         <auto-fields-service service-name="updateBillingAccountRole" default-field-type="edit"/>
         <field name="billingAccountId"><hidden/></field>
-        <field name="partyId" title="${uiLabelMap.PartyPartyId}">
+        <field name="partyId" title="${uiLabelMap.CommonParty}">
             <display-entity entity-name="PartyNameView" description="${firstName} ${middleName} ${lastName} ${groupName}">
                 <sub-hyperlink description="${partyId}" target="/partymgr/control/viewprofile" target-type="inter-app" link-style="buttontext">
                     <parameter param-name="partyId"/>
                 </sub-hyperlink>
             </display-entity>
         </field>
-        <field name="roleTypeId" title="${uiLabelMap.PartyRoleTypeId}">
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}">
             <display-entity entity-name="RoleType"/>
         </field>
-        <field name="fromDate" title="${uiLabelMap.CommonFromDate}"><display/></field>
-
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><date-time/></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
         <field name="deleteLink" title=" " widget-style="buttontext">
             <hyperlink description="${uiLabelMap.CommonDelete}" target="deleteBillingAccountRole" also-hidden="false">
@@ -207,19 +207,43 @@ under the License.
             </hyperlink>
         </field>
     </grid>
+    <grid name="BillingAccountRoles" list-name="billingAccountRoleList"
+        odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar"
+        paginate-target="EditBillingAccountRoles" separate-columns="true">
+        <actions>
+            <entity-condition entity-name="BillingAccountRole" list="billingAccountRoleList">
+                <condition-expr field-name="billingAccountId" from-field="billingAccountId"/>
+                <order-by field-name="roleTypeId"/>
+            </entity-condition>
+        </actions>
+        <field name="billingAccountId"><hidden/></field>
+        <field name="partyId" title="${uiLabelMap.CommonParty}">
+            <display-entity entity-name="PartyNameView" description="${firstName} ${middleName} ${lastName} ${groupName}">
+                <sub-hyperlink description="${partyId}" target="/partymgr/control/viewprofile" target-type="inter-app" link-style="buttontext">
+                    <parameter param-name="partyId"/>
+                </sub-hyperlink>
+            </display-entity>
+        </field>
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}">
+            <display-entity entity-name="RoleType"/>
+        </field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><display type="date-time"/></field>
+    </grid>
     <form name="AddBillingAccountRole" type="single" target="createBillingAccountRole" default-map-name="billingAccountRole"
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createBillingAccountRole"/>
         <field name="billingAccountId"><hidden/></field>
-        <field name="roleTypeId" title="${uiLabelMap.PartyRoleTypeId}">
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}">
             <drop-down allow-empty="false" no-current-selected-key="BILL_TO_CUSTOMER">
                 <entity-options entity-name="RoleType">
                     <entity-order-by field-name="description"/>
                 </entity-options>
             </drop-down>
         </field>
-        <field name="fromDate"><date-time default-value="${nowTimestamp}"/></field>
-        <field name="partyId" title="${uiLabelMap.PartyPartyId}" required-field="true"><lookup target-form-name="LookupPartyName"/></field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><date-time default-value="${nowTimestamp}"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><date-time/></field>
+        <field name="partyId" title="${uiLabelMap.CommonParty}" required-field="true"><lookup target-form-name="LookupPartyName"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
     <grid name="ListBillingAccountTerms" list-name="billingAccountTermsList" default-entity-name="BillingAccountTerm" paginate-target="EditBillingAccountTerms"

--- a/applications/accounting/widget/BillingAccountScreens.xml
+++ b/applications/accounting/widget/BillingAccountScreens.xml
@@ -169,17 +169,32 @@ under the License.
                 <set field="headerItem" value="billingaccount"/>
                 <set field="tabButtonItem" value="EditBillingAccountRoles"/>
                 <set field="helpAnchor" value="_help_for_billing_account_roles"/>
-
                 <set field="billingAccountId" from-field="parameters.billingAccountId"/>
                 <entity-one entity-name="BillingAccount" value-field="billingAccount"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonBillingAccountDecorator" location="${parameters.billingAccountDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet id="BllingAccountRolePanel" title="${uiLabelMap.PageTitleAddBillingAccountRoles}" collapsible="true">
-                            <include-form name="AddBillingAccountRole" location="component://accounting/widget/BillingAccountForms.xml"/>
-                        </screenlet>
-                        <include-grid name="ListBillingAccountRoles" location="component://accounting/widget/BillingAccountForms.xml"/>
+                        <section>
+                            <condition>
+                                <or>
+                                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                    <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                </or>
+                            </condition>
+                            <widgets>
+                                <screenlet id="BllingAccountRolePanel" title="${uiLabelMap.PageTitleAddBillingAccountRoles}" collapsible="true">
+                                    <include-form name="AddBillingAccountRole" location="component://accounting/widget/BillingAccountForms.xml"/>
+                                </screenlet>
+                                <screenlet>
+                                    <include-grid name="ListBillingAccountRoles" location="component://accounting/widget/BillingAccountForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <include-grid name="BillingAccountRoles" location="component://accounting/widget/BillingAccountForms.xml"/>
+                            </fail-widgets>
+                        </section>
+                        
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the billing account roles screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.
See (test with): https://localhost:8443/accounting/control/EditBillingAccountRoles?billingAccountId=9010

Modified:
BillingAccountScreens.xml, re EditBillingAccountRoles:
- added permission rules for CREATE/UPDATE
- restructured section and widget/fail-widget elements, additional cleanup
BillingAccountForms.xml
- added grid BillingAccountRoles (based on ListBillingAccountRoles)
- additional cleanup/label harmonisation