### PR TITLE
Improved: Product Prices - VIEW permissions (OFBIZ-12489)

### DIFF
--- a/applications/product/widget/catalog/ProductForms.xml
+++ b/applications/product/widget/catalog/ProductForms.xml
@@ -470,6 +470,26 @@ under the License.
             </hyperlink>
         </field>
     </grid>
+    
+    <grid name="ProductPrices" list-name="productPrices" paginate-target="EditProductPrices" separate-columns="true"
+        odd-row-style="alternate-row" default-table-style="basic-table">
+        <auto-fields-entity entity-name="ProductPrice" default-field-type="display"/>
+        <field name="productId"><hidden/></field>
+        <field name="productPriceTypeId" title="${uiLabelMap.CommonType}"><display-entity entity-name="ProductPriceType"/></field>
+        <field name="productPricePurposeId" title="${uiLabelMap.CommonPurpose}"><display-entity entity-name="ProductPricePurpose"/></field>
+        <field name="currencyUomId" title="${uiLabelMap.CommonCurrency}" ><display/></field>
+        <field name="productStoreGroupId" title="${uiLabelMap.CommonGroup}"><display-entity entity-name="ProductStoreGroup" description="${productStoreGroupName}"/></field>
+        <field name="price" title="${uiLabelMap.CommonPrice}" widget-area-style="align-right" title-area-style="align-right"><display type="accounting-number"/></field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><display/></field>
+        <field name="viewHistoryLink" title=" " widget-style="buttontext">
+            <hyperlink description="${uiLabelMap.ProductHistory}" target="ProductPriceHistory" also-hidden="false">
+                <parameter param-name="productId"/>
+                <parameter param-name="productPriceTypeId"/>
+                <parameter param-name="fromDate"/>
+            </hyperlink>
+        </field>
+    </grid>
     <form name="AddProductPaymentMethodType" type="single" target="createProductPaymentMethodType" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createProductPaymentMethodType"/>

--- a/applications/product/widget/catalog/ProductForms.xml
+++ b/applications/product/widget/catalog/ProductForms.xml
@@ -480,8 +480,8 @@ under the License.
         <field name="currencyUomId" title="${uiLabelMap.CommonCurrency}" ><display/></field>
         <field name="productStoreGroupId" title="${uiLabelMap.CommonGroup}"><display-entity entity-name="ProductStoreGroup" description="${productStoreGroupName}"/></field>
         <field name="price" title="${uiLabelMap.CommonPrice}" widget-area-style="align-right" title-area-style="align-right"><display type="accounting-number"/></field>
-        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display/></field>
-        <field name="thruDate" title="${uiLabelMap.CommonThru}"><display/></field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><display type="date-time"/></field>
         <field name="viewHistoryLink" title=" " widget-style="buttontext">
             <hyperlink description="${uiLabelMap.ProductHistory}" target="ProductPriceHistory" also-hidden="false">
                 <parameter param-name="productId"/>

--- a/applications/product/widget/catalog/ProductScreens.xml
+++ b/applications/product/widget/catalog/ProductScreens.xml
@@ -167,7 +167,6 @@ under the License.
                 <set field="titleProperty" value="PageTitleEditProductPrices"/>
                 <set field="tabButtonItem" value="EditProductPrices"/>
                 <set field="labelTitleProperty" value="ProductPrices"/>
-
                 <entity-and entity-name="ProductPrice" list="productPrices">
                     <field-map field-name="productId" from-field="parameters.productId"/>
                     <order-by field-name="productStoreGroupId"/>
@@ -176,19 +175,35 @@ under the License.
                     <order-by field-name="currencyUomId"/>
                     <order-by field-name="fromDate"/>
                 </entity-and>
-
                 <property-to-field field="defaultCurrencyUomId" resource="general" property="currency.uom.id.default" default="USD"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonProductDecorator" location="${parameters.productDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.PageTitleEditProductPrices}">
-                            <include-grid name="UpdateProductPrice" location="component://product/widget/catalog/ProductForms.xml"/>
-                        </screenlet>
-                        <screenlet title="${uiLabelMap.PageTitleAddProductPrices}">
-                            <label style="h3" text="${uiLabelMap.ProductPricesWarning}"/>
-                            <include-form name="AddProductPrice" location="component://product/widget/catalog/ProductForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                                        <if-has-permission permission="CATALOG" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet title="${uiLabelMap.PageTitleEditProductPrices}">
+                                    <include-grid name="UpdateProductPrice" location="component://product/widget/catalog/ProductForms.xml"/>
+                                </screenlet>
+                                <screenlet title="${uiLabelMap.PageTitleAddProductPrices}">
+                                    <label style="h3" text="${uiLabelMap.ProductPricesWarning}"/>
+                                    <include-form name="AddProductPrice" location="component://product/widget/catalog/ProductForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet id="ProductPrices">
+                                    <include-grid name="ProductPrices" location="component://product/widget/catalog/ProductForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the product prices screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.
See (test with): https://localhost:8443/catalog/control/EditProductPrices?productId=WG-9943

Modified:
- ProductScreens.xml - restructured for working with permissions
- ProductForms.xml - added grid ProductPrices for users with VIEW permissions