### PR TITLE
Improved: Category Products - VIEW permissions (OFBIZ-12490)

### DIFF
--- a/applications/product/widget/catalog/CategoryForms.xml
+++ b/applications/product/widget/catalog/CategoryForms.xml
@@ -38,8 +38,11 @@ under the License.
             </hyperlink>
         </field>
     </grid>
-
-    <!-- Product Category Content Forms  -->
+    <grid name="CategoryProducts" list-name="productCategoryMembers"
+        odd-row-style="alternate-row" default-table-style="basic-table">
+        <auto-fields-entity entity-name="ProductCategoryMember" default-field-type="display"/>
+        <field name="productCategoryId"><hidden/></field>
+    </grid>
     <form name="AddCategoryContentAssoc" type="single" target="addContentToCategory" title="${uiLabelMap.ProductAddProductCategoryContentFromDate}"
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ProductCategoryContent"/>

--- a/applications/product/widget/catalog/CategoryScreens.xml
+++ b/applications/product/widget/catalog/CategoryScreens.xml
@@ -321,17 +321,32 @@ under the License.
                 <set field="titleProperty" value="PageTitleEditCategoryProducts"/>
                 <set field="tabButtonItem" value="EditCategoryProducts"/>
                 <set field="labelTitleProperty" value="ProductProducts"/>
-
                 <set field="productCategoryId" from-field="parameters.productCategoryId"/>
-
                 <script location="component://product/groovyScripts/catalog/category/EditCategoryProducts.groovy"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonCategoryDecorator">
                     <decorator-section name="body">
-                        <platform-specific>
-                            <html><html-template location="component://product/template/category/EditCategoryProducts.ftl"/></html>
-                        </platform-specific>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                                        <if-has-permission permission="CATALOG" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <platform-specific>
+                                    <html><html-template location="component://product/template/category/EditCategoryProducts.ftl"/></html>
+                                </platform-specific>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet>
+                                    <include-grid name="CategoryProducts" location="component://product/widget/catalog/CategoryForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                            </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the category products screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.
See (test with): https://localhost:8443/catalog/control/EditCategoryProducts?productCategoryId=100

modified:
- CategoryScreens.xml
restructured EditCategoryProducts vis-a-vis permissions, additional cleanup
- CategoryForms.xml
added grid CategoryProducts for users with VIEW permissions