### PR TITLE
Improved: Catalog Screen - VIEW permissions (OFBIZ-12491)

### DIFF
--- a/applications/product/widget/catalog/CatalogScreens.xml
+++ b/applications/product/widget/catalog/CatalogScreens.xml
@@ -59,10 +59,27 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonCatalogDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${groovy: parameters.prodCatalogId ? uiLabelMap.PageTitleEditProductCatalog : uiLabelMap.PageTitleNewProductCatalog}">
-                            <label style="h3">${uiLabelMap.ProductCatalogEmptyWarning}</label>
-                            <include-form name="EditProdCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                                        <if-has-permission permission="CATALOG" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet title="${groovy: parameters.prodCatalogId ? uiLabelMap.PageTitleEditProductCatalog : uiLabelMap.PageTitleNewProductCatalog}">
+                                    <label style="h3">${uiLabelMap.ProductCatalogEmptyWarning}</label>
+                                    <include-form name="EditProdCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet>
+                                    <include-form name="Catalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>

--- a/applications/product/widget/catalog/ProdCatalogForms.xml
+++ b/applications/product/widget/catalog/ProdCatalogForms.xml
@@ -20,6 +20,10 @@ under the License.
 
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
+    <form name="Catalog" type="single" default-map-name="prodCatalog"
+        header-row-style="header-row" default-table-style="basic-table" default-entity-name="ProdCatalog">
+        <auto-fields-entity entity-name="ProdCatalog" default-field-type="display"/>
+    </form>
     <form name="FindCatalog" type="single" target="FindCatalog" title="" default-map-name="catalog"
         header-row-style="header-row" default-table-style="basic-table" >
         <field name="prodCatalogId" title="${uiLabelMap.ProdCatalogId}"><text-find/></field>
@@ -28,7 +32,6 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-
     <grid name="ListCatalog" list-name="listIt" paginate-target="FindCatalog"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" header-row-style="header-row-2">
         <actions>
@@ -56,34 +59,26 @@ under the License.
     </grid>
     <form name="EditProdCatalog" type="single" target="updateProdCatalog" title="" default-map-name="prodCatalog"
         header-row-style="header-row" default-table-style="basic-table" default-entity-name="ProdCatalog">
-
         <alt-target use-when="prodCatalog==null" target="createProdCatalog"/>
-
         <auto-fields-service service-name="updateProdCatalog" map-name=""/>
-
         <field use-when="prodCatalog!=null" name="prodCatalogId" title="${uiLabelMap.ProductCatalogId}" tooltip="${uiLabelMap.ProductNotModificationRecreatingProductCatalog}."><display/></field>
         <field use-when="prodCatalog==null&amp;&amp;prodCatalogId!=null" name="prodCatalogId" title="${uiLabelMap.ProductCatalogId}" tooltip="${uiLabelMap.ProductCouldNotFindProductCatalogWithId} [${prodCatalogId}]"><text size="20" maxlength="20"/></field>
         <!-- this to be taken care of with auto-fields-service as soon as it uses entity field info too -->
         <field use-when="prodCatalog==null&amp;&amp;prodCatalogId==null" name="prodCatalogId" title="${uiLabelMap.ProductCatalogId}"><text size="20" maxlength="20"/></field>
-
         <field name="catalogName" required-field="true"><text size="30" maxlength="60"/></field>
-
         <field name="useQuickAdd" title="${uiLabelMap.ProductUseQuickAdd}">
             <drop-down allow-empty="false" no-current-selected-key="Y"><option key="Y" description="${uiLabelMap.CommonY}"/><option key="N" description="${uiLabelMap.CommonN}"/></drop-down>
         </field>
-
         <field name="styleSheet" title="${uiLabelMap.ProductStyleSheet}"><text size="60" maxlength="250"/></field>
         <field name="headerLogo" title="${uiLabelMap.ProductHeaderLogo}"><text size="60" maxlength="250"/></field>
         <field name="contentPathPrefix" title="${uiLabelMap.ProductContentPathPrefix}" tooltip="${uiLabelMap.ProductPrependedImageContentPaths}"><text size="60" maxlength="250"/></field>
         <field name="templatePathPrefix" title="${uiLabelMap.ProductTemplatePathPrefix}"  tooltip="${uiLabelMap.ProductPrependedTemplatePaths}"><text size="60" maxlength="250"/></field>
-
         <field name="viewAllowPermReqd" title="${uiLabelMap.ProductCategoryViewAllowPermReqd}">
             <drop-down allow-empty="false" no-current-selected-key="N"><option key="Y" description="${uiLabelMap.CommonY}"/><option key="N" description="${uiLabelMap.CommonN}"/></drop-down>
         </field>
         <field name="purchaseAllowPermReqd" title="${uiLabelMap.ProductCategoryPurchaseAllowPermReqd}">
             <drop-down allow-empty="false" no-current-selected-key="N"><option key="Y" description="${uiLabelMap.CommonY}"/><option key="N" description="${uiLabelMap.CommonN}"/></drop-down>
         </field>
-
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
     <form name="AddProdCatalogToParty" type="single" target="addProdCatalogToParty" title=""


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the catalog screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.
See (test with): https://localhost:8443/catalog/control/EditProdCatalog?prodCatalogId=DemoCatalog

modified:
- CatalogScreens.xml
restructured screen EditProductCatalog vis-a-vis permissions
- ProdCatalogForms.xml
added form Catalog for users with VIEW permission