### PR TITLE
Improved: Store Screen - VIIEW permission (OFBIZ-12492)

### DIFF
--- a/applications/product/widget/catalog/StoreForms.xml
+++ b/applications/product/widget/catalog/StoreForms.xml
@@ -38,7 +38,112 @@ under the License.
         <field name="title" title="${uiLabelMap.ProductTitle}" sort-field="true"><display/></field>
         <field name="subtitle" title="${uiLabelMap.ProductSubTitle}" sort-field="true"><display/></field>
     </grid>
-    
+    <form name="ProductStore" type="single" default-map-name="productStore"
+        header-row-style="header-row" default-table-style="basic-table">
+        <auto-fields-entity entity-name="ProductStore" default-field-type="display"/>
+        <sort-order>
+            <field-group title="${uiLabelMap.ProductStore}">
+                <sort-field name="productStoreId"/>
+                <sort-field name="primaryStoreGroupId"/>
+                <sort-field name="storeName"/>
+                <sort-field name="title"/>
+                <sort-field name="subtitle"/>
+                <sort-field name="companyName"/>
+                <sort-field name="isDemoStore"/>
+                <sort-field name="ecomThemeId"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonInventory}" collapsible="true">
+                <sort-field name="inventoryFacilityId"/>
+                <sort-field name="oneInventoryFacility"/>
+                <sort-field name="isImmediatelyFulfilled"/>
+                <sort-field name="checkInventory"/>
+                <sort-field name="requireInventory"/>
+                <sort-field name="requirementMethodEnumId"/>
+                <sort-field name="reserveInventory"/>
+                <sort-field name="reserveOrderEnumId"/>
+                <sort-field name="balanceResOnOrderCreation"/>
+                <sort-field name="showOutOfStockProducts"/>   
+                <sort-field name="managedByLot"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonShoppingCart}" collapsible="true" initially-collapsed="true">
+                <sort-field name="viewCartOnAdd"/>
+                <sort-field name="autoSaveCart"/>
+                <sort-field name="addToCartReplaceUpsell"/>
+                <sort-field name="addToCartRemoveIncompat"/>
+                <sort-field name="showCheckoutGiftOptions"/>
+                <sort-field name="prodSearchExcludeVariants"/>
+                <sort-field name="orderDecimalQuantity"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonShipping}" collapsible="true" initially-collapsed="true">
+                <sort-field name="prorateShipping"/>
+                <sort-field name="reqShipAddrForDigItems"/>
+                <sort-field name="selectPaymentTypePerItem"/>
+                <sort-field name="shipIfCaptureFails"/>
+                <sort-field name="splitPayPrefPerShpGrp"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonPayments}" collapsible="true" initially-collapsed="true">
+                <sort-field name="payToPartyId"/>
+                <sort-field name="storeCreditAccountEnumId"/>                
+                <sort-field name="manualAuthIsCapture"/>
+                <sort-field name="retryFailedAuths"/>
+                <sort-field name="daysToCancelNonPay"/>
+                <sort-field name="autoOrderCcTryExp"/>
+                <sort-field name="autoOrderCcTryOtherCards"/>
+                <sort-field name="autoOrderCcTryLaterNsf"/>
+                <sort-field name="autoOrderCcTryLaterMax"/>
+                <sort-field name="storeCreditValidDays"/>
+                <sort-field name="setOwnerUponIssuance"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonOrders}" collapsible="true" initially-collapsed="true">
+                <sort-field name="orderNumberPrefix"/>
+                <sort-field name="defaultSalesChannelEnumId"/>
+                <sort-field name="explodeOrderItems"/>
+                <sort-field name="checkGcBalance"/>
+                <sort-field name="autoInvoiceDigitalItems"/>
+                <sort-field name="autoApproveInvoice"/>
+                <sort-field name="autoApproveOrder"/>
+                <sort-field name="reqReturnInventoryReceive"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonLocalisation}" collapsible="true" initially-collapsed="true">
+                <sort-field name="defaultLocaleString"/>
+                <sort-field name="defaultCurrencyUomId"/>
+                <sort-field name="defaultTimeZoneString"/>
+            </field-group>
+            <field-group title="${uiLabelMap.ProductOrdersStatus}" collapsible="true" initially-collapsed="true">
+                <sort-field name="headerApprovedStatus"/>
+                <sort-field name="itemApprovedStatus"/>
+                <sort-field name="digitalItemApprovedStatus"/>
+                <sort-field name="headerDeclinedStatus"/>
+                <sort-field name="itemDeclinedStatus"/>
+                <sort-field name="headerCancelStatus"/>
+                <sort-field name="itemCancelStatus"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonMessages}" collapsible="true" initially-collapsed="true">
+                <sort-field name="authDeclinedMessage"/>
+                <sort-field name="authFraudMessage"/>
+                <sort-field name="authErrorMessage"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonTax}" collapsible="true" initially-collapsed="true">
+                <sort-field name="prorateTaxes"/>
+                <sort-field name="showPricesWithVatTax"/>
+                <sort-field name="showTaxIsExempt"/>
+                <sort-field name="vatTaxAuthGeoId"/>
+                <sort-field name="vatTaxAuthPartyId"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonVisitors}" collapsible="true" initially-collapsed="true">
+                <sort-field name="autoApproveReviews"/>
+                <sort-field name="allowPassword"/>
+                <sort-field name="defaultPassword"/>
+                <sort-field name="usePrimaryEmailUsername"/>
+                <sort-field name="requireCustomerRole"/>
+                <sort-field name="enableAutoSuggestionList"/>
+            </field-group>
+            <field-group title="${uiLabelMap.CommonUpload}" collapsible="true" initially-collapsed="true">
+                <sort-field name="enableDigProdUpload"/>
+                <sort-field name="digProdUploadCategoryId"/>
+            </field-group>
+        </sort-order>
+    </form>
     <form name="EditProductStore" type="single" target="updateProductStore" title="" default-map-name="productStore"
         header-row-style="header-row" default-table-style="basic-table">
         

--- a/applications/product/widget/catalog/StoreScreens.xml
+++ b/applications/product/widget/catalog/StoreScreens.xml
@@ -53,9 +53,26 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonProductStoreDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.ProductProductStore}">
-                            <include-form name="EditProductStore" location="component://product/widget/catalog/StoreForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                                        <if-has-permission permission="CATALOG" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet id="ProductStore">
+                                    <include-form name="EditProductStore" location="component://product/widget/catalog/StoreForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet id="ProductStore">
+                                    <include-form name="ProductStore" location="component://product/widget/catalog/StoreForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the store screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.
See (test with): https://localhost:8443/catalog/control/EditProductStore?productStoreId=9000

mdified:
StoreScreens.xml - restructured screen EditProductStore to work with permissions
StoreForms - added form ProductStore for users with VIEW permissions