### PR TITLE
Improved: Config Screen - VIEW permission (OFBIZ-12493)

### DIFF
--- a/applications/product/widget/catalog/ConfigForms.xml
+++ b/applications/product/widget/catalog/ConfigForms.xml
@@ -56,6 +56,10 @@ under the License.
         <field name="noConditionFind"><hidden value="Y"/><!-- if this isn't there then with all fields empty no query will be done --></field>
         <field name="submitButton" title="${uiLabelMap.CommonFind}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
+    <form name="ProductConfigItem" type="single" default-map-name="configItem"
+        header-row-style="header-row" default-table-style="basic-table">
+        <auto-fields-entity entity-name="ProductConfigItem" default-field-type="display"/>
+    </form>
     <form name="EditProductConfigItem" type="single" target="updateProductConfigItem" title="" default-map-name="configItem"
         header-row-style="header-row" default-table-style="basic-table">
 

--- a/applications/product/widget/catalog/ConfigScreens.xml
+++ b/applications/product/widget/catalog/ConfigScreens.xml
@@ -94,16 +94,32 @@ under the License.
                 <set field="headerItem" value="configs"/>
                 <set field="tabButtonItem" value="EditProductConfigItem"/>
                 <set field="labelTitleProperty" value="ProductConfigItem"/>
-
                 <set field="configItemId" from-field="parameters.configItemId"/>
                 <entity-one entity-name="ProductConfigItem" value-field="configItem" auto-field-map="true"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonConfigDecorator">
                     <decorator-section name="body">
-                        <screenlet title="${groovy: configItemId ? uiLabelMap.PageTitleEditConfigItem : uiLabelMap.PageTitleNewConfigItem}">
-                            <include-form name="EditProductConfigItem" location="component://product/widget/catalog/ConfigForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                                        <if-has-permission permission="CATALOG" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet title="${groovy: configItemId ? uiLabelMap.PageTitleEditConfigItem : uiLabelMap.PageTitleNewConfigItem}">
+                                    <include-form name="EditProductConfigItem" location="component://product/widget/catalog/ConfigForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet id="ConfigItem">
+                                    <include-form name="ProductConfigItem" location="component://product/widget/catalog/ConfigForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the config item screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.
See (test with): https://localhost:8443/catalog/control/EditProductConfigItem?configItemId=SC00000

modified:
- ConfigScreens.xml - restructured screen EditProductConfigItem to work with permissions
- ConfigForms.xml - added form ProductConfigItem for users with VIEW permission