### PR TITLE
Improved: Quote - Action Triggers, Permissions & ux (OFBIZ-12499)

### DIFF
--- a/applications/order/widget/ordermgr/OrderMenus.xml
+++ b/applications/order/widget/ordermgr/OrderMenus.xml
@@ -360,7 +360,7 @@ under the License.
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
         </menu-item>
-        <menu-item name="NewItem" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonItem}">
+        <menu-item name="NewItem" title="${uiLabelMap.OrderCreateOrderQuoteItem}">
             <condition>
                 <and>
                     <or>
@@ -374,7 +374,7 @@ under the License.
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
         </menu-item>
-        <menu-item name="NewAttribute" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonAttribute}">
+        <menu-item name="NewAttribute" title="${uiLabelMap.OrderNewQuoteAttribute}">
             <condition>
                 <and>
                     <or>
@@ -402,21 +402,7 @@ under the License.
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
         </menu-item>
-        <menu-item name="NewNote" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonNote}">
-            <condition>
-                <and>
-                    <or>
-                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
-                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
-                    </or>
-                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
-                </and>
-            </condition>
-            <link target="EditQuoteRole">
-                <parameter param-name="quoteId" from-field="quote.quoteId"/>
-            </link>
-        </menu-item>
-        <menu-item name="NewNote" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonNote}">
+        <menu-item name="NewNote" title="${uiLabelMap.OrderAddNote}">
             <condition>
                 <and>
                     <or>
@@ -444,7 +430,7 @@ under the License.
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
         </menu-item>
-        <menu-item name="NewTerm" title="${uiLabelMap.CommonNew} ${uiLabelMap.PartyTerm}">
+        <menu-item name="NewTerm" title="${uiLabelMap.OrderCreateOrderQuoteTerm}">
             <condition>
                 <and>
                     <or>
@@ -458,7 +444,7 @@ under the License.
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
         </menu-item>
-        <menu-item name="NewWorkEffort" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonWorkEffort}">
+        <menu-item name="NewWorkEffort" title="${uiLabelMap.WorkEffortCreate}">
             <condition>
                 <and>
                     <or>
@@ -472,7 +458,7 @@ under the License.
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
         </menu-item>
-        <menu-item name="quoteReport" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonReport}">
+        <menu-item name="quoteReport" title="${uiLabelMap.CommonNew} ${uiLabelMap.OrderOrderQuoteReport}">
             <link target="QuoteReport" target-window="_BLANK">
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>

--- a/applications/order/widget/ordermgr/OrderMenus.xml
+++ b/applications/order/widget/ordermgr/OrderMenus.xml
@@ -311,14 +311,6 @@ under the License.
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
         </menu-item>
-        <menu-item name="QuoteWorkEfforts" title="${uiLabelMap.CommonWorkEfforts}">
-            <condition>
-                <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
-            </condition>
-            <link target="ListQuoteWorkEfforts">
-                <parameter param-name="quoteId" from-field="quote.quoteId"/>
-            </link>
-        </menu-item>
         <menu-item name="ListQuoteNotes" title="${uiLabelMap.CommonNotes}">
             <condition>
                 <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
@@ -343,19 +335,144 @@ under the License.
                 <parameter param-name="quoteId" from-field="parameters.quoteId"/>
             </link>
         </menu-item>
+        <menu-item name="QuoteWorkEfforts" title="${uiLabelMap.CommonWorkEfforts}">
+            <condition>
+                <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+            </condition>
+            <link target="ListQuoteWorkEfforts">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
     </menu>
-
     <menu name="QuoteSubTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml"
         menu-container-style="button-bar button-style-2">
         <menu-item name="EditQuote" title="${uiLabelMap.CommonEdit}">
             <condition>
-                <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
             </condition>
             <link target="EditQuote">
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
         </menu-item>
-        <menu-item name="quoteReport" title="${uiLabelMap.CommonPdf}">
+        <menu-item name="NewItem" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonItem}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
+            </condition>
+            <link target="EditQuoteItem">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
+        <menu-item name="NewAttribute" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonAttribute}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
+            </condition>
+            <link target="EditQuoteAttribute">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
+        <menu-item name="NewCoefficient" title="${uiLabelMap.CommonNew} ${uiLabelMap.OrderOrderQuoteCoefficients}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
+            </condition>
+            <link target="EditQuoteCoefficient">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
+        <menu-item name="NewNote" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonNote}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
+            </condition>
+            <link target="EditQuoteRole">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
+        <menu-item name="NewNote" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonNote}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
+            </condition>
+            <link target="EditQuoteRole">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
+        <menu-item name="NewRole" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonRole}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
+            </condition>
+            <link target="EditQuoteRole">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
+        <menu-item name="NewTerm" title="${uiLabelMap.CommonNew} ${uiLabelMap.PartyTerm}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
+            </condition>
+            <link target="EditQuoteRole">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
+        <menu-item name="NewWorkEffort" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonWorkEffort}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                        <if-has-permission permission="ORDERMGR" action="_UPDATE"/>
+                    </or>
+                    <if-compare operator="equals" value="QUO_CREATED" field="quote.statusId"/>
+                </and>
+            </condition>
+            <link target="EditQuoteRole">
+                <parameter param-name="quoteId" from-field="quote.quoteId"/>
+            </link>
+        </menu-item>
+        <menu-item name="quoteReport" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonReport}">
             <link target="QuoteReport" target-window="_BLANK">
                 <parameter param-name="quoteId" from-field="quote.quoteId"/>
             </link>
@@ -379,7 +496,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="RequestTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="ViewRequest" title="${uiLabelMap.OrderRequestOverview}">
             <link target="ViewRequest">

--- a/applications/order/widget/ordermgr/QuoteScreens.xml
+++ b/applications/order/widget/ordermgr/QuoteScreens.xml
@@ -42,9 +42,10 @@ under the License.
                                         <not><if-empty field="quote"/></not>
                                     </condition>
                                     <widgets>
+                                        <label style="h1">${uiLabelMap.CommonQuote}:${quote.quoteId}</label>
                                         <include-menu name="QuoteTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
+                                        <include-menu name="QuoteSubTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
                                         <container style="page-title">
-                                            <label>${uiLabelMap[titleProperty]} [${uiLabelMap.CommonId}:${quote.quoteId}] ${quote.description}</label>
                                         </container>
                                     </widgets>
                                 </section>
@@ -121,9 +122,6 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <container>
-                            <include-menu name="QuoteSubTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
-                        </container>
                         <include-screen name="ViewQuoteTemplate"/>
                         <screenlet title="${uiLabelMap.OrderCopyQuote}">
                             <platform-specific>
@@ -271,12 +269,7 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.OrderOrderQuoteListRoles}">
-                            <container>
-                                <link target="EditQuoteRole" text="${uiLabelMap.OrderCreateOrderQuoteRole}" style="buttontext">
-                                    <parameter param-name="quoteId" from-field="quote.quoteId"/>
-                                </link>
-                            </container>
+                        <screenlet title="${uiLabelMap.CommonRoles}">
                             <include-form name="ListQuoteRoles" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -289,10 +282,8 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteEditRoles"/>
                 <set field="tabButtonItem" value="ListQuoteRoles"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <set field="quoteItemSeqId" from-field="parameters.quoteItemSeqId"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-one entity-name="QuoteRole" value-field="quoteRole"/>
             </actions>
@@ -300,11 +291,6 @@ under the License.
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.OrderOrderQuoteEditRoles}">
-                            <container>
-                                <link target="EditQuoteRole" text="${uiLabelMap.OrderCreateOrderQuoteRole}" style="buttontext">
-                                    <parameter param-name="quoteId" from-field="quote.quoteId"/>
-                                </link>
-                            </container>
                             <include-form name="EditQuoteRole" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -317,7 +303,6 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteListItems"/>
                 <set field="tabButtonItem" value="ListQuoteItems"/>
-
                 <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer"/>
                 <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
@@ -326,13 +311,11 @@ under the License.
                     <field-map field-name="quoteId" from-field="quote.quoteId"/>
                     <order-by field-name="quoteItemSeqId"/>
                 </entity-and>
-
             </actions>
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <include-menu name="QuoteItemSubTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
-                        <screenlet title="${uiLabelMap.OrderOrderQuoteListItems}">
+                        <screenlet title="${uiLabelMap.CommonItems}">
                             <include-form name="ListQuoteItems" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -345,10 +328,8 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteEditItems"/>
                 <set field="tabButtonItem" value="ListQuoteItems"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <set field="quoteItemSeqId" from-field="parameters.quoteItemSeqId"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-one entity-name="QuoteItem" value-field="quoteItem"/>
                 <entity-and entity-name="QuoteTerm" list="quoteTerms">
@@ -359,26 +340,28 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <container>
-                            <include-menu name="QuoteTermSubTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
-                        </container>
-                        <container style="lefthalf">
-                            <screenlet title="${uiLabelMap.OrderOrderQuoteEditItems}" >
+                        <section>
+                            <condition>
+                                <if-empty field="quoteItemSeqId"/>
+                            </condition>
+                            <widgets>
+                            <screenlet title="${uiLabelMap.CommonItem}">
                                 <include-form name="EditQuoteItem" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                             </screenlet>
-                        </container>
-                        <container style="righthalf">
-                            <section>
-                                <condition>
-                                    <not><if-empty field="quoteItemSeqId"/></not>
-                                </condition>
-                                <widgets>
-                                    <screenlet title="${uiLabelMap.OrderOrderQuoteTermList}">
+                            </widgets>
+                            <fail-widgets>
+                                <container style="lefthalf">
+                                    <screenlet title="${uiLabelMap.CommonItem}">
+                                        <include-form name="EditQuoteItem" location="component://order/widget/ordermgr/QuoteForms.xml"/>
+                                    </screenlet>
+                                </container>
+                                <container style="righthalf">
+                                    <screenlet title="${uiLabelMap.PartyTerms}">
                                         <include-form name="ListQuoteTermItem" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                                     </screenlet>
-                                </widgets>
-                            </section>
-                        </container>
+                                </container>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
@@ -389,7 +372,6 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteListAttributes"/>
                 <set field="tabButtonItem" value="ListQuoteAttributes"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-and entity-name="QuoteAttribute" list="quoteAttributes">
                     <field-map field-name="quoteId" from-field="quote.quoteId"/>
@@ -398,12 +380,7 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.OrderOrderQuoteListAttributes}">
-                            <container style="basic-nav">
-                                <link target="EditQuoteAttribute" text="${uiLabelMap.OrderCreateOrderQuoteAttribute}" style="buttontext">
-                                    <parameter param-name="quoteId" from-field="quote.quoteId"/>
-                                </link>
-                            </container>
+                        <screenlet title="${uiLabelMap.CommonAttributes}">
                             <include-form name="ListQuoteAttributes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -416,22 +393,15 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteEditAttributes"/>
                 <set field="tabButtonItem" value="ListQuoteAttributes"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <set field="attrName" from-field="parameters.attrName"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-one entity-name="QuoteAttribute" value-field="quoteAttribute"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.OrderOrderQuoteEditAttributes}">
-                            <container>
-                                <link target="EditQuoteAttribute" text="${uiLabelMap.OrderCreateOrderQuoteAttribute}" style="buttontext">
-                                    <parameter param-name="quoteId" from-field="quote.quoteId"/>
-                                </link>
-                            </container>
+                        <screenlet title="${uiLabelMap.CommonAttribute}">
                             <include-form name="EditQuoteAttribute" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -444,7 +414,6 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteListCoefficients"/>
                 <set field="tabButtonItem" value="ListQuoteCoefficients"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-and entity-name="QuoteCoefficient" list="quoteCoefficients">
                     <field-map field-name="quoteId" from-field="quote.quoteId"/>
@@ -454,11 +423,6 @@ under the License.
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.OrderOrderQuoteListCoefficients}">
-                            <container style="basic-nav">
-                                <link target="EditQuoteCoefficient" text="${uiLabelMap.OrderCreateOrderQuoteCoefficient}" style="buttontext">
-                                    <parameter param-name="quoteId" from-field="quote.quoteId"/>
-                                </link>
-                            </container>
                             <include-form name="ListQuoteCoefficients" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -471,22 +435,15 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteEditCoefficients"/>
                 <set field="tabButtonItem" value="ListQuoteCoefficients"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <set field="attrName" from-field="parameters.coeffName"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-one entity-name="QuoteCoefficient" value-field="quoteCoefficient"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.OrderOrderQuoteEditCoefficients}">
-                            <container>
-                                <link target="EditQuoteCoefficient" text="${uiLabelMap.OrderCreateOrderQuoteCoefficient}" style="buttontext">
-                                    <parameter param-name="quoteId" from-field="quote.quoteId"/>
-                                </link>
-                            </container>
+                        <screenlet title="${uiLabelMap.CommonCoefficient}">
                             <include-form name="EditQuoteCoefficient" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -502,7 +459,6 @@ under the License.
                 <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer"/>
                 <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-and entity-name="QuoteItem" list="quoteItems">
                     <field-map field-name="quoteId" from-field="quote.quoteId"/>
@@ -514,7 +470,6 @@ under the License.
                     <field-map field-name="quoteId" from-field="quote.quoteId"/>
                 </entity-and>
                 <set from-field="quote.quoteId" field="quoteId"/>
-
                 <script location="component://order/groovyScripts/quote/ManageQuotePrices.groovy"/>
             </actions>
             <widgets>
@@ -544,7 +499,6 @@ under the License.
                 <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer"/>
                 <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-and entity-name="QuoteAdjustment" list="quoteAdjustments">
@@ -575,10 +529,8 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteEditAdjustments"/>
                 <set field="tabButtonItem" value="ListQuoteAdjustments"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <set field="quoteAdjustmentId" from-field="parameters.quoteAdjustmentId"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-one entity-name="QuoteAdjustment" value-field="quoteAdjustment"/>
             </actions>
@@ -606,7 +558,6 @@ under the License.
                 <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer"/>
                 <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-and entity-name="QuoteItem" list="quoteItems">
                     <field-map field-name="quoteId" from-field="quote.quoteId"/>
@@ -618,7 +569,6 @@ under the License.
                     <field-map field-name="quoteId" from-field="quote.quoteId"/>
                 </entity-and>
                 <set from-field="quote.quoteId" field="quoteId"/>
-
                 <script location="component://order/groovyScripts/quote/ViewQuoteProfit.groovy"/>
             </actions>
             <widgets>
@@ -640,7 +590,6 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteEditReportMail"/>
                 <set field="tabButtonItem" value="ViewQuote"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <entity-one entity-name="Quote" value-field="quote"/>
                 <get-related-one value-field="quote" relation-name="Party" to-value-field="party"/>
@@ -666,7 +615,7 @@ under the License.
                 <label text="${note}"/>
                 <include-screen name="ViewQuoteInfo"/>
                 <container style="clear"/>
-                    <include-screen name="ViewQuoteItemInfo"/>
+                <include-screen name="ViewQuoteItemInfo"/>
             </widgets>
             <fail-widgets>
                 <label style="h3">${uiLabelMap.OrderNoQuoteFound}</label>
@@ -702,7 +651,7 @@ under the License.
         <section>
             <actions>
                 <entity-one entity-name="PartyNameView" value-field="toParty">
-                    <field-map field-name="partyId"  from-field="quote.partyId"/>
+                    <field-map field-name="partyId" from-field="quote.partyId"/>
                 </entity-one>
             </actions>
             <widgets>
@@ -838,7 +787,6 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <include-menu name="QuoteTermSubTabBar" location="component://order/widget/ordermgr/OrderMenus.xml"/>
                         <screenlet title="${uiLabelMap.OrderOrderQuoteTermList}">
                             <include-form name="ListQuoteTerms" location="component://order/widget/ordermgr/QuoteForms.xml"/>
                         </screenlet>
@@ -863,12 +811,9 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <container style="button-bar button-style-1">
-                            <link target="createnewquotenote" text="${uiLabelMap.OrderCreateOrderQuoteNote}">
-                                <parameter param-name="quoteId" from-field="quote.quoteId"/>
-                            </link>
-                        </container>
-                        <include-form name="ListQuoteNotes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
+                        <screenlet id="Notes" title="${uiLabelMap.CommonNotes}">
+                            <include-form name="ListQuoteNotes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
+                        </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
@@ -927,5 +872,4 @@ under the License.
             </fail-widgets>
         </section>
     </screen>
-
 </screens>

--- a/applications/order/widget/ordermgr/QuoteWorkEffortScreens.xml
+++ b/applications/order/widget/ordermgr/QuoteWorkEffortScreens.xml
@@ -122,12 +122,7 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.OrderOrderQuoteWorkEfforts}">
-                            <container style="basic-nav">
-                                <link target="AddQuoteWorkEffort" text="${uiLabelMap.OrderCreateQuoteWorkEffort}" style="buttontext">
-                                    <parameter param-name="quoteId"/>
-                                </link>
-                            </container>
+                        <screenlet title="${uiLabelMap.CommonWorkEfforts}">
                             <include-form name="ListQuoteWorkEfforts" location="component://order/widget/ordermgr/QuoteWorkEffortForms.xml"/>
                         </screenlet>
                     </decorator-section>


### PR DESCRIPTION
Currently, as can be seen in https://localhost:8443/ordermgr/control/ViewQuote?quoteId=CQ0001, action triggers (for users with CREATE/UPDATE permissions) are located within screens instead of the action menu for quotes. Also triggers can be seen and invoked by users with VIEW permissions.

modified:
- OrderMenus.xml
added inQuoteSubTabBar menu-items for users with CREATE/UPDATE permissions (move from various quote screens), additional cleanup
- QuoteScreens.xml
added QuoteSubTabBar to CommonQuoteDecorator
moved quote label to above menus in CommonQuoteDecorator
removed QuoteSubTabBar from various quote screens
removed action triggers from various quote screens
additional cleanup, label harmonisation and ux consistency
- QuoteWorkEffortScreens.xml
removed action triggers from various quote screens
additional cleanup, label harmonisation and ux consistency