### PR TITLE
Improved: Routing (Task) Screens - consistency in ux (OFBIZ-12500)

### DIFF
--- a/applications/manufacturing/widget/manufacturing/RoutingScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/RoutingScreens.xml
@@ -36,12 +36,10 @@ under the License.
                                         <not><if-empty field="routing"/></not>
                                     </condition>
                                     <widgets>
+                                        <label style="h1">${uiLabelMap.CommonRouting}: ${routing.workEffortId}</label>
                                         <include-menu name="RoutingTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
                                     </widgets>
                                 </section>
-                                <container>
-                                    <label style="h1">[${uiLabelMap.CommonId} ${routing.workEffortId}] ${routing.workEffortName}</label>
-                                </container>
                                 <decorator-section-include name="body"/>
                             </widgets>
                         </section>
@@ -66,12 +64,10 @@ under the License.
                                         <not><if-empty field="routingTask"/></not>
                                     </condition>
                                     <widgets>
+                                        <label style="h1">${uiLabelMap.WorkEffortTask}: ${routingTask.workEffortId}</label>
                                         <include-menu name="RoutingTaskTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
                                     </widgets>
                                 </section>
-                                <container>
-                                    <label style="h1">[${uiLabelMap.CommonId} ${routingTask.workEffortId}] ${routingTask.workEffortName}</label>
-                                </container>
                                 <decorator-section-include name="body"/>
                             </widgets>
                         </section>


### PR DESCRIPTION
Currently, when accessing screens related to production schemas and schema tasks (routing and routing tasks) in Manufacturing, the title of the shown object is below the menu items for that object (as shown in image attached).
To get to a more consistent user experience, this should be above the menu items for the object, like is done in many other screens in OFBiz.

modified: RoutingScreens.xml
CommonRoutingDecorator: moved title of object to above its menu, additional cleanup
CommonRoutingTaskDecorator: moved title of object to above its menu, additional cleanup