### PR TITLE
Improved: list and grid (OFBIZ-11345)

### DIFF
--- a/applications/order/widget/ordermgr/OrderReturnScreens.xml
+++ b/applications/order/widget/ordermgr/OrderReturnScreens.xml
@@ -67,7 +67,7 @@ under the License.
                                 <html><html-template multi-block="true" location="component://common-theme/template/includes/SetMultipleSelectJsList.ftl"/></html>
                             </platform-specific>
                             <include-form name="FindReturns" location="component://order/widget/ordermgr/ReturnForms.xml"/>
-                            <include-form name="ListReturns" location="component://order/widget/ordermgr/ReturnForms.xml"/>
+                            <include-grid name="ListReturns" location="component://order/widget/ordermgr/ReturnForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -168,7 +168,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="OrderReturnHistory">
         <section>
             <actions>
@@ -192,7 +191,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ReturnStatusHistory">
         <section>
             <actions>
@@ -209,7 +207,7 @@ under the License.
                     </condition>
                     <widgets>
                         <screenlet id="ReturnStatusHistoryPanel" title="${uiLabelMap.OrderOrderReturn} ${uiLabelMap.CommonStatusHistory}" collapsible="true">
-                            <include-form name="ReturnStatusHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
+                            <include-grid name="ReturnStatusHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
                         </screenlet>
                     </widgets>
                     <fail-widgets>
@@ -221,7 +219,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ReturnTypeHistory">
         <section>
             <actions>
@@ -237,7 +234,7 @@ under the License.
                     </condition>
                     <widgets>
                         <screenlet id="ReturnTypeHistoryPanel" title="${uiLabelMap.OrderReturnTypeHistory}" collapsible="true">
-                            <include-form name="ReturnTypeHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
+                            <include-grid name="ReturnTypeHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
                         </screenlet>
                     </widgets>
                     <fail-widgets>
@@ -249,7 +246,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ReturnReasonHistory">
         <section>
             <actions>
@@ -265,7 +261,7 @@ under the License.
                     </condition>
                     <widgets>
                         <screenlet id="ReturnReasonHistoryPanel" title="${uiLabelMap.OrderReturnReasonHistory}" collapsible="true">
-                            <include-form name="ReturnReasonHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
+                            <include-grid name="ReturnReasonHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
                         </screenlet>
                     </widgets>
                     <fail-widgets>
@@ -277,7 +273,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ReturnQuantityHistory">
         <section>
             <actions>
@@ -293,7 +288,7 @@ under the License.
                     </condition>
                     <widgets>
                         <screenlet id="ReturnQuantityHistoryPanel" title="${uiLabelMap.OrderReturnQtyHistory}" collapsible="true">
-                            <include-form name="ReturnAndReceivedQuantityHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
+                            <include-grid name="ReturnAndReceivedQuantityHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
                         </screenlet>
                     </widgets>
                     <fail-widgets>
@@ -305,7 +300,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ReceivedQuantityHistory">
         <section>
             <actions>
@@ -333,7 +327,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ReturnPriceHistory">
         <section>
             <actions>
@@ -349,7 +342,7 @@ under the License.
                     </condition>
                     <widgets>
                         <screenlet id="ReturnPriceHistoryPanel" title="${uiLabelMap.OrderReturnPriceHistory}" collapsible="true">
-                            <include-form name="ReturnPriceHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
+                            <include-grid name="ReturnPriceHistory" location="component://order/widget/ordermgr/ReturnForms.xml"/>
                         </screenlet>
                     </widgets>
                     <fail-widgets>

--- a/applications/order/widget/ordermgr/ReturnForms.xml
+++ b/applications/order/widget/ordermgr/ReturnForms.xml
@@ -109,17 +109,6 @@ under the License.
         <field use-when="returnHeader==null&amp;&amp;returnId==null" name="createdBy"><ignored/></field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <!-- UNUSED FORM
-    <form name="ReturnItems" type="multi" list-name="orderItems" target="createReturnItem"
-        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
-        <auto-fields-service service-name="createReturnItem"/>
-        <field name="itemDescription"><display/></field>
-        <field name="returnId"><hidden/></field>
-        <field name="orderId"><hidden/></field>
-        <field name="orderItemSeqId"><hidden/></field>
-        <field name="statusId"><ignored/></field>
-    </form>
-    -->
     <form name="FindReturns" type="single"  target="findreturn" title="" default-map-name="parameters"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="returnHeaderTypeId">
@@ -149,9 +138,8 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-
-    <form name="ListReturns" type="list"  target="findreturn" title="" list-name="listIt"
-        odd-row-style="alternate-row" default-table-style="basic-table hover-bar" paginate-target="findreturn">
+    <grid name="ListReturns" list-name="listIt" target="findreturn" paginate-target="findreturn"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <service service-name="performFind"  result-map="result" result-map-list="listIt">
                 <field-map field-name="inputFields" from-field="requestParameters"/>
@@ -184,25 +172,24 @@ under the License.
         <field name="statusId" title="${uiLabelMap.CommonStatus}">
             <display-entity entity-name="StatusItem" key-field-name="statusId"/>
         </field>
-    </form>
-
-    <form name="ReturnStatusHistory" type="list" list-name="orderReturnStatusHistories"
+    </grid>
+    <grid name="ReturnStatusHistory" list-name="orderReturnStatusHistories"
             odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="returnId"><display/></field>
         <field name="returnItemSeqId"><display/></field>
         <field name="statusId"><display-entity entity-name="StatusItem"/></field>
         <field name="statusDatetime" title="${uiLabelMap.CommonDate}"><display/></field>
         <field name="changeByUserLoginId" title="${uiLabelMap.FormFieldTitle_modifiedByUserLoginId}"><display/></field>
-    </form>
-    <form name="ReturnAndReceivedQuantityHistory" type="list" list-name="orderReturnItemHistories"
+    </grid>
+    <grid name="ReturnAndReceivedQuantityHistory" list-name="orderReturnItemHistories"
             odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="returnId"><display description="${returnId}"/></field>
         <field name="oldValueText"><display/></field>
         <field name="newValueText"><display/></field>
         <field name="changedDate" title="${uiLabelMap.CommonDate}"><display/></field>
         <field name="changedByInfo" title="${uiLabelMap.FormFieldTitle_modifiedByUserLoginId}"><display/></field>
-    </form>
-    <form name="ReturnReasonHistory" type="list" list-name="orderReturnItemHistories"
+    </grid>
+    <grid name="ReturnReasonHistory" list-name="orderReturnItemHistories"
             odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="returnId"><display description="${returnId}"/></field>
         <field name="oldValueText">
@@ -213,8 +200,8 @@ under the License.
         </field>
         <field name="changedDate" title="${uiLabelMap.CommonDate}"><display/></field>
         <field name="changedByInfo" title="${uiLabelMap.FormFieldTitle_modifiedByUserLoginId}"><display/></field>
-    </form>
-    <form name="ReturnTypeHistory" type="list" list-name="orderReturnItemHistories"
+    </grid>
+    <grid name="ReturnTypeHistory" list-name="orderReturnItemHistories"
             odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="returnId"><display description="${returnId}"/></field>
         <field name="oldValueText">
@@ -225,13 +212,13 @@ under the License.
         </field>
         <field name="changedDate" title="${uiLabelMap.CommonDate}"><display/></field>
         <field name="changedByInfo" title="${uiLabelMap.FormFieldTitle_modifiedByUserLoginId}"><display/></field>
-    </form>
-    <form name="ReturnPriceHistory" type="list" list-name="orderReturnItemHistories"
+    </grid>
+    <grid name="ReturnPriceHistory" list-name="orderReturnItemHistories"
             odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="returnId"><display description="${returnId}"/></field>
         <field name="oldValueText"><display type="currency"/></field>
         <field name="newValueText"><display type="currency"/></field>
         <field name="changedDate" title="${uiLabelMap.CommonDate}"><display/></field>
         <field name="changedByInfo" title="${uiLabelMap.FormFieldTitle_modifiedByUserLoginId}"><display/></field>
-    </form>
+    </grid>
 </forms>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Modified:
ReturnForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
OrderReturnScreens.xml: from form ref to grid ref , additional cleanup