### PR TITLE
Improved: PaymentGroup Payments - VIEW permissions (OFBIZ-12502)

### DIFF
--- a/applications/accounting/widget/PaymentGroupScreens.xml
+++ b/applications/accounting/widget/PaymentGroupScreens.xml
@@ -93,12 +93,30 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonPaymentGroupDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet name="listPaymentGroupMember" title="${uiLabelMap.AccountingPaymentGroupMembers}" collapsible="true">
-                            <include-form name="ListPaymentGroupMember" location="component://accounting/widget/PaymentGroupForms.xml"/>
-                        </screenlet>
-                        <screenlet name="addPaymentGroupMember" title="${uiLabelMap.AccountingAddPaymentGroupMember}" collapsible="true">
-                            <include-form name="AddPaymentGroupMember" location="component://accounting/widget/PaymentGroupForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                        <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                    </or>
+                                    <not><if-empty field="paymentGroupId"/></not>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet name="listPaymentGroupMember" title="${uiLabelMap.CommonPayments}" collapsible="true">
+                                    <include-form name="ListPaymentGroupMember" location="component://accounting/widget/PaymentGroupForms.xml"/>
+                                </screenlet>
+                                <screenlet name="addPaymentGroupMember" title="${uiLabelMap.AccountingAddPaymentGroupMember}" collapsible="true">
+                                    <include-form name="AddPaymentGroupMember" location="component://accounting/widget/PaymentGroupForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet name="listPaymentGroupMember" title="${uiLabelMap.CommonPayments}" collapsible="true">
+                                    <include-form name="PaymentGroupMembers" location="component://accounting/widget/PaymentGroupForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as
demonstrated in trunk demo with userId = auditor,
accessing the Payment Group Payments screen, sees
editable fields and/or triggers (to requests)
reserved for users with 'CREATE' or 'UPDATE' permissions.

To see/test:
https://localhost:8443/accounting/control/EditPaymentGroupMember?paymentGroupId=9000

Modified: PaymentGroupScreens.xml
restructured screen ditPaymentGroupMember to work with permissions