### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/product/widget/facility/InventoryItemLabelForms.xml
+++ b/applications/product/widget/facility/InventoryItemLabelForms.xml
@@ -35,7 +35,7 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonCreate}"><submit button-type="button"/></field>
     </form>
-    <form name="UpdateInventoryItemLabelTypes" type="list" target="updateInventoryItemLabelType" title="" list-name="inventoryItemLabelTypes"
+    <grid name="UpdateInventoryItemLabelTypes" list-name="inventoryItemLabelTypes" target="updateInventoryItemLabelType"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar" separate-columns="true">
         <auto-fields-service service-name="updateInventoryItemLabelType"/>
         <field name="inventoryItemLabelTypeId"><display/></field>
@@ -52,8 +52,8 @@ under the License.
                 <parameter param-name="inventoryItemLabelTypeId"/>
             </hyperlink>
         </field>
-    </form>
-    <form name="ListInventoryItemLabels" type="list" title="" list-name="inventoryItemLabels"
+    </grid>
+    <grid name="ListInventoryItemLabels" list-name="inventoryItemLabels"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <auto-fields-entity entity-name="InventoryItemLabel" default-field-type="display"/>
         <field name="inventoryItemLabelId" widget-style="buttontext">
@@ -69,7 +69,7 @@ under the License.
                 <parameter param-name="inventoryItemLabelId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="EditInventoryItemLabel" type="single" target="createInventoryItemLabel" title="" default-map-name="inventoryItemLabel"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target target="updateInventoryItemLabel" use-when="inventoryItemLabel!=null"/>
@@ -87,7 +87,7 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}"><submit button-type="button"/></field>
     </form>
-    <form name="UpdateInventoryItemLabelAppls" type="list" target="updateInventoryItemLabelAppl" title="" list-name="inventoryItemLabelAppls"
+    <grid name="UpdateInventoryItemLabelAppls" list-name="inventoryItemLabelAppls" target="updateInventoryItemLabelAppl"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <auto-fields-service service-name="updateInventoryItemLabelAppl"/>
         <field name="inventoryItemLabelId"><hidden/></field>
@@ -107,7 +107,7 @@ under the License.
                 <parameter param-name="inventoryItemLabelId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="AddInventoryItemLabelAppl" type="single" target="createInventoryItemLabelAppl" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createInventoryItemLabelAppl"/>

--- a/applications/product/widget/facility/InventoryItemLabelScreens.xml
+++ b/applications/product/widget/facility/InventoryItemLabelScreens.xml
@@ -36,7 +36,7 @@ under the License.
                             <link target="EditInventoryItemLabel" text="${uiLabelMap.CommonNew}" style="buttontext create"/>
                         </container>
                         <screenlet title="${uiLabelMap.PageTitleFindInventoryItemLabels}">
-                            <include-form name="ListInventoryItemLabels" location="component://product/widget/facility/InventoryItemLabelForms.xml"/>
+                            <include-grid name="ListInventoryItemLabels" location="component://product/widget/facility/InventoryItemLabelForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -57,7 +57,7 @@ under the License.
                         <screenlet id="AddInventoryItemLabelTypePanel" title="${uiLabelMap.PageTitleAddInventoryItemLabelTypes}" collapsible="true">
                             <include-form name="AddInventoryItemLabelType" location="component://product/widget/facility/InventoryItemLabelForms.xml"/>
                         </screenlet>
-                        <include-form name="UpdateInventoryItemLabelTypes" location="component://product/widget/facility/InventoryItemLabelForms.xml"/>
+                        <include-grid name="UpdateInventoryItemLabelTypes" location="component://product/widget/facility/InventoryItemLabelForms.xml"/>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
@@ -120,7 +120,7 @@ under the License.
                         <screenlet id="AddInventoryItemLabelApplPanel" title="${uiLabelMap.PageTitleAddInventoryItemLabelAppls}" collapsible="true">
                             <include-form name="AddInventoryItemLabelAppl" location="component://product/widget/facility/InventoryItemLabelForms.xml"/>
                         </screenlet>
-                        <include-form name="UpdateInventoryItemLabelAppls" location="component://product/widget/facility/InventoryItemLabelForms.xml"/>
+                        <include-grid name="UpdateInventoryItemLabelAppls" location="component://product/widget/facility/InventoryItemLabelForms.xml"/>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Modified
InventoryItemLabelForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
InventoryItemLabelScreens.xml: from form ref to grid ref , additional cleanup