### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/framework/common/widget/SecurityForms.xml
+++ b/framework/common/widget/SecurityForms.xml
@@ -101,8 +101,7 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}"><submit button-type="button"/></field>
     </form>
-
-    <form name="CertIssuerList" type="list" list-name="issuerProvisions"
+    <grid name="CertIssuerList" list-name="issuerProvisions"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="X509IssuerProvision">
@@ -110,8 +109,7 @@ under the License.
             </entity-condition>
         </actions>
         <auto-fields-entity entity-name="X509IssuerProvision" default-field-type="display"/>
-    </form>
-
+    </grid>
     <form name="CreateSecurityGroup" type="single" target="createSecurityGroup" default-map-name="securityGroup">
         <field name="groupId" title="${uiLabelMap.CommonSecurityGroupId}" required-field="true"><text size="20" maxlength="20"/></field>
         <field name="groupName" title="${uiLabelMap.CommonName}"><text/></field>
@@ -130,8 +128,7 @@ under the License.
         <field name="groupName" title="${uiLabelMap.CommonName}"><text/></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}"><submit button-type="button"/></field>
     </form>
-
-    <form name="ListSecurityGroupPermissions" type="list" list-name="securityGroupPermissions"
+    <grid name="ListSecurityGroupPermissions" list-name="securityGroupPermissions"
         paginate-target="EditSecurityGroupPermissions" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="SecurityGroupPermission">
@@ -150,9 +147,8 @@ under the License.
                 <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
-
-    <form name="ListSecurityGroupProtectedViews" type="list" list-name="securityGroupProtectedViewsList" target="updateProtectedViewToSecurityGroup"
+    </grid>
+    <grid name="ListSecurityGroupProtectedViews" list-name="securityGroupProtectedViewsList" target="updateProtectedViewToSecurityGroup"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="ProtectedView">
@@ -172,10 +168,9 @@ under the License.
                 <parameter param-name="viewNameId"/>
             </hyperlink>
         </field>
-    </form>
-
-    <form name="ListSecurityGroups" type="list" list-name="securityGroups"
-        paginate-target="FindSecurityGroup" odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
+    </grid>
+    <grid name="ListSecurityGroups" list-name="securityGroups" paginate-target="FindSecurityGroup"
+        odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="SecurityGroup">
                 <order-by field-name="groupId"/>
@@ -187,9 +182,8 @@ under the License.
             </hyperlink>
         </field>
         <field name="description" title="${uiLabelMap.CommonDescription}"><display/></field>
-    </form>
-
-    <form name="ListSecurityGroupUserLogins" type="list" list-name="userLoginSecurityGroups" target="updateUserLoginToSecurityGroup"
+    </grid>
+    <grid name="ListSecurityGroupUserLogins" list-name="userLoginSecurityGroups" target="updateUserLoginToSecurityGroup"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
             <set field="sortField" from-field="parameters.sortField" default-value="userLoginId"/>
@@ -214,9 +208,8 @@ under the License.
                 <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
-
-    <form name="ListUserLogins" type="list" list-name="securityGroups"
+    </grid>
+    <grid name="ListUserLogins" list-name="securityGroups"
         paginate-target="FindUserLogin" header-row-style="header-row-2" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <set field="sortField" from-field="parameters.sortField" default-value="userLoginId"/>
@@ -232,11 +225,9 @@ under the License.
         <field name="enabled" sort-field="true"><display/></field>
         <field name="hasLoggedOut" sort-field="true"><display/></field>
         <field name="disabledDateTime" sort-field="true"><display/></field>
-    </form>
-
-    <form name="ListUserLoginSecurityGroups" type="list"
-        list-name="userLoginSecurityGroups" header-row-style="header-row-2" target="${updateUserLoginSecurityGroupURI}"
-        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+    </grid>
+    <grid name="ListUserLoginSecurityGroups" list-name="userLoginSecurityGroups"  target="${updateUserLoginSecurityGroupURI}"
+        header-row-style="header-row-2" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="UserLoginAndSecurityGroup">
                 <condition-expr field-name="userLoginId" from-field="userLoginId"/>
@@ -264,33 +255,12 @@ under the License.
                 <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
-
+    </grid>
     <form name="LookupUserLogin" type="single" target="LookupUserLogin">
         <field name="userLoginId" title="${uiLabelMap.CommonUserLoginId}"><text-find/></field>
         <field name="noConditionFind"><hidden value="Y"/><!-- if this isn't there then with all fields empty no query will be done --></field>
         <field name="submitButton" title="${uiLabelMap.CommonFind}"><submit button-type="button"/></field>
     </form>
-
-    <form name="ListLookedUpUserLogins" type="list" list-name="listIt" paginate-target="LookupUserLogin"
-        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
-        <actions>
-            <service service-name="performFind" result-map="result" result-map-list="listIt">
-                <field-map field-name="inputFields" from-field="parameters"/>
-                <field-map field-name="orderBy" value="userLoginId"/>
-                <field-map field-name="entityName" value="UserLogin"/>
-                <field-map field-name="viewIndex" from-field="viewIndex"/>
-                <field-map field-name="viewSize" from-field="viewSize"/>
-            </service>
-        </actions>
-        <field name="userLoginId" title="${uiLabelMap.CommonUserLoginId}" widget-style="smallSubmit">
-            <hyperlink description="${userLoginId}" target="javascript:set_value('${userLoginId}', '${userLoginId}', '${parameters.webSitePublishPoint}')" also-hidden="false" target-type="plain"/>
-        </field>
-        <field name="enabled"><display/></field>
-        <field name="hasLoggedOut"><display/></field>
-        <field name="disabledDateTime"><display/></field>
-    </form>
-
     <form name="UpdatePassword" type="single" target="${updatePasswordURI}"
         focus-field-name="currentPassword" header-row-style="header-row" default-table-style="basic-table">
         <actions>
@@ -350,8 +320,7 @@ under the License.
             <display/>
         </field>
     </form>
-    
-    <form name="CertToKeystore" type="list" list-name="stores" use-row-submit="true"
+    <grid name="CertToKeystore"  list-name="stores" use-row-submit="true"
         separate-columns="true" target="importIssuerProvision" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="certString"><hidden/></field>
         <field name="componentName" title="${uiLabelMap.CertComponent}"><display/></field>
@@ -361,6 +330,5 @@ under the License.
         <field name="submitButton" title="${uiLabelMap.CommonSave}" widget-style="buttontext" >
             <submit button-type="button"/>
         </field>
-    </form>
-
+    </grid>
 </forms>

--- a/framework/common/widget/SecurityScreens.xml
+++ b/framework/common/widget/SecurityScreens.xml
@@ -112,7 +112,7 @@ under the License.
                             <include-form name="AddSecurityGroupPermissionManual" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.Permissions}">
-                            <include-form name="ListSecurityGroupPermissions" location="component://common/widget/SecurityForms.xml"/>
+                            <include-grid name="ListSecurityGroupPermissions" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -138,7 +138,7 @@ under the License.
                             <include-form name="AddSecurityGroupProtectedView" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                         <screenlet>
-                          <include-form name="ListSecurityGroupProtectedViews" location="component://common/widget/SecurityForms.xml"/>
+                          <include-grid name="ListSecurityGroupProtectedViews" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -164,7 +164,7 @@ under the License.
                             <include-form name="AddSecurityGroupUserLogin" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                         <screenlet>
-                            <include-form name="ListSecurityGroupUserLogins" location="component://common/widget/SecurityForms.xml"/>
+                            <include-grid name="ListSecurityGroupUserLogins" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -220,7 +220,7 @@ under the License.
                             <include-form name="AddUserLoginSecurityGroup" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                         <screenlet>
-                          <include-form name="ListUserLoginSecurityGroups" location="component://common/widget/SecurityForms.xml"/>
+                          <include-grid name="ListUserLoginSecurityGroups" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -247,7 +247,7 @@ under the License.
                             <include-form name="EditCertificate" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.CertIssuers}">
-                            <include-form name="CertIssuerList" location="component://common/widget/SecurityForms.xml"/>
+                            <include-grid name="CertIssuerList" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -274,7 +274,7 @@ under the License.
                             <link target="CreateNewSecurityGroup" style="buttontext create" text="${uiLabelMap.CommonCreate}"/>
                         </container>
                         <screenlet>
-                            <include-form name="ListSecurityGroups" location="component://common/widget/SecurityForms.xml"/>
+                            <include-grid name="ListSecurityGroups" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -301,7 +301,7 @@ under the License.
                             <link target="createnewlogin" style="buttontext create" text="${uiLabelMap.CommonCreate}"/>
                         </container>
                         <screenlet>
-                            <include-form name="ListUserLogins" location="component://common/widget/SecurityForms.xml"/>
+                            <include-grid name="ListUserLogins" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -362,7 +362,7 @@ under the License.
                         </screenlet>
                         <screenlet title="${uiLabelMap.CertSaveToKeyStore}">
                             <include-form name="ViewCertificate" location="component://common/widget/SecurityForms.xml"/>
-                            <include-form name="CertToKeystore" location="component://common/widget/SecurityForms.xml"/>
+                            <include-grid name="CertToKeystore" location="component://common/widget/SecurityForms.xml"/>
                         </screenlet>
                         </container>
                     </decorator-section>


### PR DESCRIPTION
According to the definition in widget-form.xsd the
use of a combination of a form with type="list" is
deprecated in favour of a grid.

Refactor various list forms into grids.
Refactor various list form references in screens.

modified:
- SecurityForms.xml: from form definition with list
ref to grid definition with list ref, additional clean-up
- SecurityScreens.xml: from form ref to grid ref , additional cleanup