### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/framework/webtools/widget/EntityForms.xml
+++ b/framework/webtools/widget/EntityForms.xml
@@ -33,16 +33,15 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}"><submit button-type="button"/></field>
     </form>
-
-    <form name="ListPerformanceResults" type="list" list-name="performanceList" paginate-target="EntityPerformanceTest" separate-columns="true" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+    <grid name="ListPerformanceResults" list-name="performanceList" paginate-target="EntityPerformanceTest"
+        separate-columns="true" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="operation" title="${uiLabelMap.WebtoolsPerformanceOperation}"><display/></field>
         <field name="entity" title="${uiLabelMap.WebtoolsEntity}"><display/></field>
         <field name="calls" title="${uiLabelMap.WebtoolsPerformanceCalls}"><display/></field>
         <field name="seconds" title="${uiLabelMap.WebtoolsPerformanceSeconds}"><display/></field>
         <field name="secsPerCall" title="${uiLabelMap.WebtoolsPerformanceSecondsCall}"><display/></field>
         <field name="callsPerSecond" title="${uiLabelMap.WebtoolsPerformanceCallsSecond}"><display/></field>
-    </form>
-    
+    </grid>
     <form name="FilterEntities" default-table-style="condensed-table" target="entitymaint">
         <field name="filterByGroupName">
             <drop-down>

--- a/framework/webtools/widget/EntityScreens.xml
+++ b/framework/webtools/widget/EntityScreens.xml
@@ -452,7 +452,7 @@ under the License.
                     <decorator-section name="body">
                         <screenlet>
                             <label>${uiLabelMap.WebtoolsNotePerformanceResultsMayVary}</label>
-                            <include-form name="ListPerformanceResults" location="component://webtools/widget/EntityForms.xml"/>
+                            <include-grid name="ListPerformanceResults" location="component://webtools/widget/EntityForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>

--- a/framework/webtools/widget/EntitySyncForms.xml
+++ b/framework/webtools/widget/EntitySyncForms.xml
@@ -20,8 +20,8 @@ under the License.
 
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
-    <form name="EntitySyncStatus" type="list" list-name="entitySyncList" target=""
-        paginate-target="EntitySyncStatus" view-size="20" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+    <grid name="EntitySyncStatus" list-name="entitySyncList" paginate-target="EntitySyncStatus" 
+        view-size="20" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <entity-condition entity-name="EntitySync" list="entitySyncList" use-cache="false">
                 <!-- No conditions, is a find all -->
@@ -30,11 +30,9 @@ under the License.
             </entity-condition>
         </actions>
         <auto-fields-entity entity-name="EntitySync" default-field-type="display"/>
-
         <field name="runStatusId">
             <display-entity entity-name="StatusItem" key-field-name="statusId"/>
         </field>
-
         <field use-when="&quot;ESR_RUNNING&quot;.equals(runStatusId)" name="resetStatus" title=" " widget-style="smallSubmit">
             <hyperlink description="${uiLabelMap.WebtoolsSyncResetRunStatus}" target="resetEntitySyncStatus" also-hidden="false">
                 <parameter param-name="entitySyncId"/>
@@ -57,8 +55,7 @@ under the License.
                 <parameter param-name="updateType" value="REJECT"/>
             </hyperlink>
         </field>
-    </form>
-
+    </grid>
     <form name="EntitySyncLoadOffline" type="single" target="loadOfflineEntitySyncData" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="loadOfflineEntitySyncData"/>

--- a/framework/webtools/widget/EntitySyncScreens.xml
+++ b/framework/webtools/widget/EntitySyncScreens.xml
@@ -61,7 +61,7 @@ under the License.
                            <link target="EntitySyncStatus" style="buttontext refresh" text="${uiLabelMap.CommonRefresh}"/>
                         </container>
                         <screenlet>
-                            <include-form name="EntitySyncStatus" location="component://webtools/widget/EntitySyncForms.xml"/>
+                            <include-grid name="EntitySyncStatus" location="component://webtools/widget/EntitySyncForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.WebtoolsLoadOfflineData}">
                             <include-form name="EntitySyncLoadOffline" location="component://webtools/widget/EntitySyncForms.xml"/>

--- a/framework/webtools/widget/GeoManagementForms.xml
+++ b/framework/webtools/widget/GeoManagementForms.xml
@@ -66,7 +66,7 @@
             </hyperlink>
         </field>
     </form>
-    <form name="ListGeoPoints" paginate-target="${currentUrl}" type="list" separate-columns="true" default-entity-name="GeoPoint" list-name="listIt" paginate="true"
+    <grid name="ListGeoPoints" list-name="listIt" paginate-target="${currentUrl}" separate-columns="true" default-entity-name="GeoPoint" paginate="true"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <service service-name="performFind" result-map="result" result-map-list="listIt">
@@ -90,8 +90,7 @@
             <display-entity entity-name="Uom" key-field-name="uomId" description="${abbreviation}"/>
         </field>
         <field name="information"><display/></field>
-    </form>
-    
+    </grid>
     <form name="EditGeo" type="single" target="updateGeo" title="" default-map-name="geo"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="geo==null" target="createGeo"/>

--- a/framework/webtools/widget/GeoManagementScreens.xml
+++ b/framework/webtools/widget/GeoManagementScreens.xml
@@ -90,7 +90,7 @@
                                 </decorator-section>
                                 <decorator-section name="search-results">
                                     <screenlet title="${uiLabelMap.WebtoolsGeoPoints}">
-                                        <include-form name="ListGeoPoints" location="component://webtools/widget/GeoManagementForms.xml"/>
+                                        <include-grid name="ListGeoPoints" location="component://webtools/widget/GeoManagementForms.xml"/>
                                     </screenlet>
                                 </decorator-section>
                             </decorator-screen>

--- a/framework/webtools/widget/LogScreens.xml
+++ b/framework/webtools/widget/LogScreens.xml
@@ -66,7 +66,7 @@ under the License.
                 <decorator-screen name="log-decorator">
                     <decorator-section name="body">
                         <screenlet>
-                            <include-form name="ListServices" location="component://webtools/widget/ServiceForms.xml"/>
+                            <include-grid name="ListServices" location="component://webtools/widget/ServiceForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>

--- a/framework/webtools/widget/ServiceForms.xml
+++ b/framework/webtools/widget/ServiceForms.xml
@@ -76,8 +76,7 @@ under the License.
             <submit button-type="button"/>
         </field>
     </form>
-
-    <form name="ListJobs" type="list" list-name="listIt" paginate-target="FindJob" default-entity-name="JobSandbox" separate-columns="true"
+    <grid name="ListJobs" list-name="listIt" paginate-target="FindJob" default-entity-name="JobSandbox" separate-columns="true"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar" view-size="50">
         <actions>
             <set field="orderBy" default-value="-runTime" from-field="parameters.sortField"/>
@@ -110,14 +109,14 @@ under the License.
                 <parameter param-name="jobId"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="JobDetails" type="single">
         <auto-fields-entity entity-name="JobSandbox" map-name="job" default-field-type="display"/>
     </form>
-    <form name="JobRuntimeDataInfo" type="list" list-name="runtimeInfoList" default-table-style="basic-table hover-bar" paginate="false">
+    <grid name="JobRuntimeDataInfo" list-name="runtimeInfoList" default-table-style="basic-table hover-bar" paginate="false">
         <field name="key"><display/></field>
         <field name="value"><display/></field>
-    </form>
+    </grid>
     <form name="PoolState" type="single" default-map-name="poolState">
         <field name="keepAliveTimeInSeconds"><display/></field>
         <field name="numberOfCoreInvokerThreads"><display/></field>
@@ -127,22 +126,22 @@ under the License.
         <field name="greatestNumberOfInvokerThreads"><display/></field>
         <field name="numberOfCompletedTasks"><display/></field>
     </form>
-    <form name="ListJavaThread" type="list" list-name="threads" paginate-target="threadList" separate-columns="true"
+    <grid name="ListJavaThread" list-name="threads" paginate-target="threadList" separate-columns="true"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="id" title="${uiLabelMap.WebtoolsThread}"><display description="${threadId} ${threadName}"/></field>
         <field name="name" title="${uiLabelMap.WebtoolsJob}"><display default-value="${uiLabelMap.CommonNone}"/></field>
         <field name="serviceName" title="${uiLabelMap.WebtoolsService}"><display default-value="${uiLabelMap.CommonNone}"/></field>
         <field name="time" title="${uiLabelMap.CommonStartDateTime}"><display/></field>
         <field name="runTime" title="${uiLabelMap.CommonTime} (ms)"><display/></field>
-    </form>
-    <form name="ListServices" type="list" list-name="services" paginate-target="ServiceLog" separate-columns="true"
+    </grid>
+    <grid name="ListServices" list-name="services" paginate-target="ServiceLog" separate-columns="true"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" header-row-style="header-row-2">
         <field name="serviceName" title="${uiLabelMap.WebtoolsServiceName}" sort-field="true"><display/></field>
         <field name="localName" title="${uiLabelMap.WebtoolsDispatcherName}" sort-field="true"><display/></field>
         <field name="modeStr" title="${uiLabelMap.WebtoolsMode}" sort-field="true"><display default-value="${uiLabelMap.CommonNone}"/></field>
         <field name="startTime" title="${uiLabelMap.CommonStartDateTime}" sort-field="true"><display/></field>
         <field name="endTime" title="${uiLabelMap.CommonEndDateTime}" sort-field="true"><display default-value="${uiLabelMap.WebtoolsStatusRunning}"/></field>
-    </form>
+    </grid>
     <form name="FindJobManagerLock" type="single" target="FindJobManagerLock" default-entity-name="JobManagerLock">
         <field name="noConditionFind"><hidden value="Y"/><!-- if this isn't there then with all fields empty no query will be done --></field>
         <field name="instanceId">
@@ -163,7 +162,7 @@ under the License.
         </field>
         <field name="searchButton"><submit/></field>
     </form>
-    <form name="ListJobManagerLock" type="list" list-name="listIt" paginate-target="FindJobManagerLock" default-entity-name="JobManagerLock" separate-columns="true"
+    <grid name="ListJobManagerLock" list-name="listIt" paginate-target="FindJobManagerLock" default-entity-name="JobManagerLock" separate-columns="true"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
             <service service-name="performFind" result-map="result" result-map-list="listIt">
@@ -190,7 +189,7 @@ under the License.
                 <parameter param-name="thruDate" value="${nowTimestamp}"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="AddJobManagerLock" type="single" target="createJobManagerLock" default-entity-name="JobManagerLock">
         <field name="instanceId">
             <drop-down>

--- a/framework/webtools/widget/ServiceScreens.xml
+++ b/framework/webtools/widget/ServiceScreens.xml
@@ -64,7 +64,7 @@ under the License.
                                         <include-form name="FindJobs" location="component://webtools/widget/ServiceForms.xml"/>
                                     </decorator-section>
                                     <decorator-section name="search-results">
-                                        <include-form name="ListJobs" location="component://webtools/widget/ServiceForms.xml"/>
+                                        <include-grid name="ListJobs" location="component://webtools/widget/ServiceForms.xml"/>
                                     </decorator-section>
                                 </decorator-screen>
                             </widgets>
@@ -88,7 +88,7 @@ under the License.
                             <include-form name="JobDetails" location="component://webtools/widget/ServiceForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.WebtoolsRunTimeDataInfo}">
-                            <include-form name="JobRuntimeDataInfo" location="component://webtools/widget/ServiceForms.xml"/>
+                            <include-grid name="JobRuntimeDataInfo" location="component://webtools/widget/ServiceForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -108,7 +108,7 @@ under the License.
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.WebtoolsServiceEngineThreads}">
                             <include-form name="PoolState" location="component://webtools/widget/ServiceForms.xml"/>
-                            <include-form name="ListJavaThread" location="component://webtools/widget/ServiceForms.xml"/>
+                            <include-grid name="ListJavaThread" location="component://webtools/widget/ServiceForms.xml"/>
                         </screenlet>
                         <screenlet title="${uiLabelMap.WebtoolsGeneralJavaThreads}">
                             <platform-specific>

--- a/framework/webtools/widget/ServiceScreens.xml
+++ b/framework/webtools/widget/ServiceScreens.xml
@@ -250,7 +250,7 @@ under the License.
                         <screenlet padded="false">
                             <label style="h3" text="${uiLabelMap.CommonSearchResults}"/>
                             <container id="search-results">
-                                <include-form name="ListJobManagerLock" location="component://webtools/widget/ServiceForms.xml"/>
+                                <include-grid name="ListJobManagerLock" location="component://webtools/widget/ServiceForms.xml"/>
                             </container>
                         </screenlet>
                     </decorator-section>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.
Modified:
EntityForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
EntityScreens.xml: from form ref to grid ref , additional cleanup
EntitySyncForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
EntitySyncScreens.xml: from form ref to grid ref , additional cleanup
GeoManagementForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
GeoManagementScreens.xml: from form ref to grid ref , additional cleanup
ServiceForms.xml: from form definition with list ref to grid definition with list ref, additional clean-up
ServiceScreens.xml: from form ref to grid ref , additional cleanup
LogScreens.xml: from form ref to grid ref , additional cleanup