### PR TITLE
Improved: Quote Search-Find - Consistency in UX (OFBIZ-12506)

### DIFF
--- a/applications/order/widget/ordermgr/QuoteScreens.xml
+++ b/applications/order/widget/ordermgr/QuoteScreens.xml
@@ -60,8 +60,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
-    <!-- list all assets in a tabular format -->
     <screen name="FindQuote">
         <section>
             <actions>
@@ -82,13 +80,17 @@ under the License.
                         <include-menu name="MainActionMenu" location="component://order/widget/ordermgr/OrderMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.OrderOrderQuotes}">
-                            <platform-specific>
-                                <html><html-template multi-block="true" location="component://common-theme/template/includes/SetMultipleSelectJsList.ftl"/></html>
-                            </platform-specific>
-                            <include-form name="FindQuotes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
-                            <include-form name="ListQuotes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
-                        </screenlet>
+                        <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
+                            <decorator-section name="search-options">
+                                <platform-specific>
+                                    <html><html-template multi-block="true" location="component://common-theme/template/includes/SetMultipleSelectJsList.ftl"/></html>
+                                </platform-specific>
+                                <include-form name="FindQuotes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
+                            </decorator-section>
+                            <decorator-section name="search-results">
+                                <include-form name="ListQuotes" location="component://order/widget/ordermgr/QuoteForms.xml"/>
+                            </decorator-section>
+                        </decorator-screen>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
@@ -99,7 +101,6 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderViewQuote"/>
                 <set field="tabButtonItem" value="ViewQuote"/>
-
                 <set field="showQuoteManagementLinks" value="Y"/>
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <entity-one entity-name="Quote" value-field="quote"/>
@@ -108,7 +109,6 @@ under the License.
                 <get-related-one value-field="quote" relation-name="SalesChannelEnumeration" to-value-field="salesChannel"/>
                 <get-related-one value-field="quote" relation-name="Uom" to-value-field="currency"/>
                 <get-related-one value-field="quote" relation-name="ProductStore" to-value-field="store"/>
-
                 <set field="listOrderBy[]" value="quoteItemSeqId"/>
                 <get-related value-field="quote" relation-name="QuoteItem" list="quoteItems" order-by-list="listOrderBy"/>
                 <get-related value-field="quote" relation-name="QuoteAdjustment" list="quoteAdjustments"/>
@@ -143,11 +143,9 @@ under the License.
                 <get-related-one value-field="quote" relation-name="StatusItem" to-value-field="statusItem"/>
                 <get-related-one value-field="quote" relation-name="Uom" to-value-field="currency"/>
                 <get-related-one value-field="quote" relation-name="ProductStore" to-value-field="store"/>
-
                 <get-related value-field="quote" relation-name="QuoteItem" list="quoteItems"/>
                 <get-related value-field="quote" relation-name="QuoteAdjustment" list="quoteAdjustments"/>
                 <get-related value-field="quote" relation-name="QuoteRole" list="quoteRoles"/>
-
                 <property-map resource="OrderUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="AccountingUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="ProductUiLabels" map-name="uiLabelMap" global="true"/>
@@ -158,17 +156,14 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="QuoteReport">
         <section>
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteReport"/>
-
                 <property-map resource="OrderUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="AccountingUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="ProductUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <entity-one entity-name="Quote" value-field="quote"/>
                 <get-related-one value-field="quote" relation-name="QuoteType" to-value-field="quoteType"/>
@@ -177,11 +172,9 @@ under the License.
                 <get-related-one value-field="quote" relation-name="ProductStore" to-value-field="store"/>
                 <get-related-one value-field="quote" relation-name="Party" to-value-field="party"/>
                 <get-related value-field="quote" relation-name="QuoteTerm" list="quoteTerms"/>
-
                 <set field="listOrderBy[]" value="quoteItemSeqId"/>
                 <get-related value-field="quote" relation-name="QuoteItem" list="quoteItems" order-by-list="listOrderBy"/>
                 <get-related value-field="quote" relation-name="QuoteAdjustment" list="quoteAdjustments"/>
-
                 <script location="component://order/groovyScripts/quote/GetPartyAddress.groovy"/>
                 <!--
                 <get-related value-name="quote" relation-name="QuoteRole" list-name="quoteRoles"/>
@@ -227,17 +220,14 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditQuote">
         <section>
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteEdit"/>
                 <set field="headerItem" value="quote"/>
                 <set field="tabButtonItem" value="EditQuote"/>
-
                 <set field="quoteId" from-field="parameters.quoteId"/>
                 <entity-one entity-name="Quote" value-field="quote"/>
-
                 <property-to-field field="defaultCurrencyUomId" resource="general" property="currency.uom.id.default" default="USD"/>
             </actions>
             <widgets>
@@ -259,12 +249,10 @@ under the License.
             <actions>
                 <set field="titleProperty" value="OrderOrderQuoteListRoles"/>
                 <set field="tabButtonItem" value="ListQuoteRoles"/>
-
                 <entity-one entity-name="Quote" value-field="quote" auto-field-map="true"/>
                 <entity-and entity-name="QuoteRole" list="quoteRoles">
                     <field-map field-name="quoteId" from-field="quote.quoteId"/>
                 </entity-and>
-
             </actions>
             <widgets>
                 <decorator-screen name="CommonQuoteDecorator">


### PR DESCRIPTION
Throughout the various components the screens to find a particular record (or multiple) are structured the same way with a decorator-screen called 'FindScreenDecorator' and in there decorator section for 'search-options' and 'search-results', bringing to the users a consistent experience.
The search and find functionality for quotes does not adhere to that paradigm.

modified: QuoteScreens.xml
restructured FindQuote screen to align with paradigm applied to the same vis-a-vis
searching and finding other kinds of records, additional cleanup.