### PR TITLE
Improved: Request - Move new item action to menu (OFBIZ-12508)

### DIFF
--- a/applications/order/widget/ordermgr/CustRequestScreens.xml
+++ b/applications/order/widget/ordermgr/CustRequestScreens.xml
@@ -286,10 +286,7 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonRequestDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.PageTitleRequestItems}">
-                            <link target="requestitem" text="${uiLabelMap.OrderNewRequestItem}" style="buttontext">
-                                <parameter param-name="custRequestId"/>
-                            </link>
+                        <screenlet title="${uiLabelMap.CommonItems}">
                             <include-form name="ListRequestItems" location="component://order/widget/ordermgr/CustRequestForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -315,11 +312,6 @@ under the License.
                 <decorator-screen name="CommonRequestDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.CommonId}:${custRequestItem.custRequestItemSeqId} ${custRequestItem.description}">
-                            <container>
-                                <link target="requestitem" text="${uiLabelMap.OrderNewRequestItem}" style="buttontext">
-                                    <parameter param-name="custRequestId"/>
-                                </link>
-                            </container>
                             <include-form name="EditCustRequestItem" location="component://order/widget/ordermgr/CustRequestForms.xml"/>
                             <platform-specific>
                                 <html><html-template location="component://order/template/request/CopyRequestItem.ftl"/></html>

--- a/applications/order/widget/ordermgr/OrderMenus.xml
+++ b/applications/order/widget/ordermgr/OrderMenus.xml
@@ -542,6 +542,21 @@ under the License.
                 <parameter param-name="custRequestId" from-field="custRequest.custRequestId"/>
             </link>
         </menu-item>
+        <menu-item name="NewRequestItem" title="${uiLabelMap.ProductNewItem}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="ORDERMGR" action="_CREATE"/>
+                    </or>
+                    <not><if-empty field="custRequest"/></not>
+                    <if-compare field="custRequest.statusId" operator="not-equals" value="CRQ_CANCELLED"/>
+                    <if-compare field="custRequest.statusId" operator="not-equals" value="CRQ_COMPLETED"/>
+                </and>
+            </condition>
+            <link target="requestitem">
+                <parameter param-name="custRequestId"/>
+            </link>
+        </menu-item>
         <menu-item name="createQuoteFromRequest" title="${uiLabelMap.OrderCreateQuoteFromRequest}">
             <condition>
                 <and>


### PR DESCRIPTION
Currently the action trigger for adding a new item to
a Request, by users with CREATE permissions is l
ocated in screens related to a Request.
This action trigger should be located in the
Action Menu for the request.

modified:
- CustRequestScreens.xml - removed action trigger(s) and surrounding style elements
from screens, additional cleanup
- OrderMenus.xml - adding NewRequestItem menu-item for users with
CREATE permissions to add new request items to a request.