### PR TITLE
Improved: Product Roles - VIEW (OFBIZ-12511)

### DIFF
--- a/applications/product/widget/catalog/ProductForms.xml
+++ b/applications/product/widget/catalog/ProductForms.xml
@@ -2166,13 +2166,25 @@ under the License.
     <form name="EditCommEvent" extends="EditCommEvent" extends-resource="component://party/widget/partymgr/CommunicationEventForms.xml">
         <field name="productId" map-name="parameters"><hidden/></field>
     </form>
+    <grid name="ProductRoles" list-name="productRoles" target="updatePartyToProduct"
+        odd-row-style="alternate-row" default-table-style="basic-table" separate-columns="true">
+        <field name="partyId" title="${uiLabelMap.PartyParty}">
+            <display-entity entity-name="PartyNameView" description="${personalTitle} ${firstName} ${middleName} ${lastName} ${suffix} ${groupName}" also-hidden="true" cache="false">
+                <sub-hyperlink target-type="inter-app" link-style="buttontext" target="/partymgr/control/viewprofile" description="${partyId}">
+                    <parameter param-name="party_id" from-field="partyId"/>
+                </sub-hyperlink>
+            </display-entity>
+        </field>
+        <field name="roleTypeId" title="${uiLabelMap.CommonRole}"><display-entity entity-name="RoleType"/></field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}" red-when="after-now"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}" red-when="before-now"><display type="date-time"/></field>
+    </grid>
     <grid name="UpdateProductRole" list-name="productRoles" target="updatePartyToProduct"
         odd-row-style="alternate-row" default-table-style="basic-table" separate-columns="true">
         <auto-fields-service service-name="updatePartyToProduct"/>
         <field name="productId"><hidden/></field>
         <field name="sequenceNum"><text size="5"/></field>
         <field name="comments"><text size="30"/></field>
-        <!-- three possibilities for the Party: person, partyGroup, neither... just print everything and if it's empty, no biggie -->
         <field name="partyId" title="${uiLabelMap.PartyParty}">
             <display-entity entity-name="PartyNameView" description="${personalTitle} ${firstName} ${middleName} ${lastName} ${suffix} ${groupName}" also-hidden="true" cache="false">
                 <sub-hyperlink target-type="inter-app" link-style="buttontext" target="/partymgr/control/viewprofile" description="${partyId}">

--- a/applications/product/widget/catalog/ProductScreens.xml
+++ b/applications/product/widget/catalog/ProductScreens.xml
@@ -1247,7 +1247,6 @@ under the License.
                 <set field="headerItem" value="product"/>
                 <set field="tabButtonItem" value="EditProductParties"/>
                 <set field="labelTitleProperty" value="PartyParties"/>
-
                 <entity-condition entity-name="ProductRole" list="productRoles">
                     <condition-expr field-name="productId" from-field="parameters.productId"/>
                     <order-by field-name="roleTypeId"/>
@@ -1257,13 +1256,29 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonProductDecorator" location="${parameters.productDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.PageTitleEditProductParties}">
-                            <include-grid name="UpdateProductRole" location="component://product/widget/catalog/ProductForms.xml"/>
-                        </screenlet>
-                        
-                        <screenlet title="${uiLabelMap.ProductAssociatePartyToProduct}">
-                            <include-form name="AddProductRole" location="component://product/widget/catalog/ProductForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                                        <if-has-permission permission="CATALOG" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet title="${uiLabelMap.ProductAssociatePartyToProduct}">
+                                    <include-form name="AddProductRole" location="component://product/widget/catalog/ProductForms.xml"/>
+                                </screenlet>
+                                <screenlet title="${uiLabelMap.CommonRoles}">
+                                    <include-grid name="UpdateProductRole" location="component://product/widget/catalog/ProductForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet title="${uiLabelMap.CommonRoles}">
+                                    <include-grid name="ProductRoles" location="component://product/widget/catalog/ProductForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated
in trunk demo with userId = auditor, accessing the Product Roles
screen, sees editable fields and/or triggers (to requests)
reserved for users with 'CREATE' or 'UPDATE' permissions.

To see/test: https://localhost:8443/catalog/control/EditProductParties?productId=WG-9943

modified:
- ProductScreens.xml - restructured screen EditProductParties to work with permissions
- ProductForms.xml - added grid ProductRoles for users,
- additional cleanup