### PR TITLE
Improved: Catalog Stores - VIEW permissions (OFBIZ-12512)

### DIFF
--- a/applications/product/widget/catalog/CatalogScreens.xml
+++ b/applications/product/widget/catalog/CatalogScreens.xml
@@ -176,12 +176,29 @@ under the License.
             <widgets>
                  <decorator-screen name="CommonCatalogDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.PageTitleEditProductCatalogStores}">
-                            <include-grid name="UpdateProductStoreCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
-                        </screenlet>
-                        <screenlet title="${uiLabelMap.PageTitleAddProductCatalogStores}">
-                            <include-form name="CreateProductStoreCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="CATALOG" action="_CREATE"/>
+                                        <if-has-permission permission="CATALOG" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                                <screenlet title="${uiLabelMap.PageTitleAddProductCatalogStores}">
+                                    <include-form name="CreateProductStoreCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                                </screenlet>
+                                <screenlet title="${uiLabelMap.ProductStores}">
+                                    <include-grid name="UpdateProductStoreCatalog" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet title="${uiLabelMap.ProductStores}">
+                                    <include-grid name="Stores" location="component://product/widget/catalog/ProdCatalogForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>

--- a/applications/product/widget/catalog/ProdCatalogForms.xml
+++ b/applications/product/widget/catalog/ProdCatalogForms.xml
@@ -133,19 +133,33 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <grid name="UpdateProductStoreCatalog" list-name="productStoreCatalogList" target="updateProdCatalogStore"
+    <grid name="CatalogStores" list-name="productStoreCatalogList" target="updateProdCatalogStore"
         odd-row-style="alternate-row" default-table-style="basic-table" separate-columns="true">
-        <auto-fields-service service-name="updateProductStoreCatalog"/>
+        <auto-fields-entity entity-name="ProductStoreCatalog" default-field-type="display"/>
         <field name="prodCatalogId"><hidden/></field>
-        <field name="productStoreId" title="${uiLabelMap.ProductStoreId}">
+        <field name="productStoreId" title="${uiLabelMap.ProductStore}">
             <display-entity entity-name="ProductStore" description="${storeName}" also-hidden="true" cache="true">
                 <sub-hyperlink link-style="buttontext" target="EditProductStore" description="${productStoreId}">
                     <parameter param-name="productStoreId"/>
                 </sub-hyperlink>
             </display-entity>
         </field>
-        <field name="fromDate" title="${uiLabelMap.CommonFromDateTime}"><display/></field>
-        <field name="thruDate" title="${uiLabelMap.CommonThruDateTime}"></field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display type="date-time"/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"><display type="date-time"/></field>
+    </grid>
+    <grid name="UpdateProductStoreCatalog" list-name="productStoreCatalogList" target="updateProdCatalogStore"
+        odd-row-style="alternate-row" default-table-style="basic-table" separate-columns="true">
+        <auto-fields-entity entity-name="ProductStoreCatalog" default-field-type="edit"/>
+        <field name="prodCatalogId"><hidden/></field>
+        <field name="productStoreId" title="${uiLabelMap.ProductStore}">
+            <display-entity entity-name="ProductStore" description="${storeName}" also-hidden="true" cache="true">
+                <sub-hyperlink link-style="buttontext" target="EditProductStore" description="${productStoreId}">
+                    <parameter param-name="productStoreId"/>
+                </sub-hyperlink>
+            </display-entity>
+        </field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}"><display/></field>
+        <field name="thruDate" title="${uiLabelMap.CommonThru}"></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}" widget-style="smallSubmit"><submit button-type="button"/></field>
         <field name="deleteLink" title=" " widget-style="buttontext">
             <hyperlink description="${uiLabelMap.CommonDelete}" target="deleteProdCatalogStore" also-hidden="false">


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the Catalog Stores screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.

To see/test: https://localhost:8443/catalog/control/EditProdCatalogStores?prodCatalogId=DemoCatalog

Modified:
- CatalogScreens.xml - restructured screen EditProdCatalogStores to work with permissions
- ProdCatalogForms.xml - added grid ProductRoles for users with VIEW permissions
additional cleanup