### PR TITLE
Improved: Billing Account Terms - VIEW permissions (OFBIZ-12513)

### DIFF
--- a/applications/accounting/widget/BillingAccountForms.xml
+++ b/applications/accounting/widget/BillingAccountForms.xml
@@ -246,13 +246,9 @@ under the License.
         <field name="partyId" title="${uiLabelMap.CommonParty}" required-field="true"><lookup target-form-name="LookupPartyName"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-    <grid name="ListBillingAccountTerms" list-name="billingAccountTermsList" default-entity-name="BillingAccountTerm" paginate-target="EditBillingAccountTerms"
+    <grid name="BillingAccountTerms" list-name="billingAccountTermsList" default-entity-name="BillingAccountTerm" paginate-target="EditBillingAccountTerms"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
-        <actions>
-            <entity-condition entity-name="BillingAccountTerm" list="billingAccountTermsList">
-                <condition-expr field-name="billingAccountId" from-field="billingAccountId"/>
-            </entity-condition>
-        </actions>
+        <auto-fields-entity entity-name="BillingAccountTerm" default-field-type="display"/>
         <field name="billingAccountId"><hidden/></field>
         <field name="termTypeId" title="${uiLabelMap.PartyTermType}">
             <display-entity entity-name="TermType"/>
@@ -261,11 +257,23 @@ under the License.
         <field name="uomId" title="${uiLabelMap.CommonUom}">
             <display-entity entity-name="Uom"/>
         </field>
-        <field name="billingAccountTermId" title=" " widget-style="buttontext">
-            <hyperlink description="${uiLabelMap.CommonEdit}" target="EditBillingAccountTerms">
+    </grid>
+    <grid name="ListBillingAccountTerms" list-name="billingAccountTermsList" default-entity-name="BillingAccountTerm" paginate-target="EditBillingAccountTerms"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <auto-fields-entity entity-name="BillingAccountTerm" default-field-type="edit"/>
+        <field name="billingAccountId"><hidden/></field>
+        <field name="billingAccountTermId">
+            <hyperlink description="${billingAccountTermId}" target="EditBillingAccountTerms">
                 <parameter param-name="billingAccountId"/>
                 <parameter param-name="billingAccountTermId"/>
             </hyperlink>
+        </field>
+        <field name="termTypeId" title="${uiLabelMap.PartyTermType}">
+            <display-entity entity-name="TermType"/>
+        </field>
+        <field name="termValue" title="${uiLabelMap.CommonValue}"><display/></field>
+        <field name="uomId" title="${uiLabelMap.CommonUom}">
+            <display-entity entity-name="Uom"/>
         </field>
         <field name="deleteLink" title=" " widget-style="buttontext">
             <hyperlink description="${uiLabelMap.CommonDelete}" target="removeBillingAccountTerm">

--- a/applications/accounting/widget/BillingAccountScreens.xml
+++ b/applications/accounting/widget/BillingAccountScreens.xml
@@ -194,7 +194,6 @@ under the License.
                                 <include-grid name="BillingAccountRoles" location="component://accounting/widget/BillingAccountForms.xml"/>
                             </fail-widgets>
                         </section>
-                        
                     </decorator-section>
                 </decorator-screen>
             </widgets>
@@ -210,28 +209,31 @@ under the License.
                 <set field="billingAccountId" from-field="parameters.billingAccountId"/>
                 <set field="billingAccountTermId" from-field="parameters.billingAccountTermId"/>
                 <entity-one entity-name="BillingAccount" value-field="billingAccount"/>
+                <entity-condition entity-name="BillingAccountTerm" list="billingAccountTermsList">
+                    <condition-expr field-name="billingAccountId" from-field="billingAccountId"/>
+                </entity-condition>
             </actions>
             <widgets>
                 <decorator-screen name="CommonBillingAccountDecorator" location="${parameters.billingAccountDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.PageTitleEditBillingAccountTerms} - ${uiLabelMap.AccountingAccountId} ${billingAccount.billingAccountId}">
-                            <include-grid name="ListBillingAccountTerms" location="component://accounting/widget/BillingAccountForms.xml"/>
-                        </screenlet>
                         <section>
                             <condition>
-                                <not><if-empty field="parameters.billingAccountTermId"/></not>
+                                <or>
+                                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                                    <if-has-permission permission="ACCOUNTING" action="_UPDATE"/>
+                                </or>
                             </condition>
-                            <actions>
-                                <entity-one entity-name="BillingAccountTerm" value-field="billingAccountTerm"/>
-                            </actions>
                             <widgets>
-                                <screenlet title="${uiLabelMap.PageTitleEditBillingAccountTerms}">
+                                <screenlet title="${uiLabelMap.AccountingCreateBillingAccountTerm}">
                                     <include-form name="EditBillingAccountTerms" location="component://accounting/widget/BillingAccountForms.xml"/>
+                                </screenlet>
+                                <screenlet>
+                                    <include-grid name="ListBillingAccountTerms" location="component://accounting/widget/BillingAccountForms.xml"/>
                                 </screenlet>
                             </widgets>
                             <fail-widgets>
-                                <screenlet title="${uiLabelMap.AccountingCreateBillingAccountTerm}">
-                                    <include-form name="EditBillingAccountTerms" location="component://accounting/widget/BillingAccountForms.xml"/>
+                                <screenlet title="${uiLabelMap.PartyTerms}">
+                                    <include-grid name="BillingAccountTerms" location="component://accounting/widget/BillingAccountForms.xml"/>
                                 </screenlet>
                             </fail-widgets>
                         </section>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the Terms screen of a billing account, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.

To see/test: https://localhost:8443/accounting/control/EditBillingAccountTerms?billingAccountId=9010

Modified:

BillingAccountScreens.xml - restructured screen EditBillingAccountTerms to work with permissions
BillingAccountForms.xml - added grid BillingAccountTerms for users with VIEW permissions
additional cleanup