### PR TITLE
Improved: Production Run - VIEW permissions (OFBIZ-12524)

### DIFF
--- a/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
@@ -90,7 +90,6 @@ under the License.
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
                 <script location="component://manufacturing/groovyScripts/jobshopmgt/ViewProductionRun.groovy"/>
                 <script location="component://manufacturing/groovyScripts/jobshopmgt/ProductionRunAllFixedAssets.groovy"/>
-
                 <set field="productionRunId" from-field="parameters.productionRunId"/>
                 <entity-one entity-name="WorkEffort" value-field="productionRun">
                     <field-map field-name="workEffortId" from-field="productionRunId"/>
@@ -113,45 +112,62 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonJobshopDecorator" location="${parameters.commonJobshopDecorator}">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.ManufacturingProductionRunId} ${productionRunId}"  navigation-menu-name="ProductionRunStatusAction">
-                            <include-menu name="ProductionRunStatusTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
-                            <include-form name="UpdateProductionRun" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
-                        </screenlet>
                         <section>
                             <condition>
-                                <not><if-empty field="mandatoryWorkEfforts"/></not>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
+                                        <if-has-permission permission="MANUFACTURING" action="_UPDATE"/>
+                                    </or>
+                                </and>
                             </condition>
                             <widgets>
-                                <screenlet title="${uiLabelMap.ManufacturingPrecedingProductionRun}">
-                                    <include-grid name="MandatoryWorkEfforts" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                                <screenlet title="${uiLabelMap.ManufacturingProductionRunId} ${productionRunId}"  navigation-menu-name="ProductionRunStatusAction">
+                                    <include-menu name="ProductionRunStatusTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                                    <include-form name="UpdateProductionRun" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                                </screenlet>
+                                <section>
+                                    <condition>
+                                        <not><if-empty field="mandatoryWorkEfforts"/></not>
+                                    </condition>
+                                    <widgets>
+                                        <screenlet title="${uiLabelMap.ManufacturingPrecedingProductionRun}">
+                                            <include-grid name="MandatoryWorkEfforts" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                                        </screenlet>
+                                    </widgets>
+                                </section>
+                                <section>
+                                    <condition>
+                                        <not><if-empty field="dependentWorkEfforts"/></not>
+                                    </condition>
+                                    <widgets>
+                                        <screenlet title="${uiLabelMap.ManufacturingSucceedingProductionRun}">
+                                            <include-grid name="DependentWorkEfforts" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                                        </screenlet>
+                                    </widgets>
+                                </section>
+                                <screenlet title="${uiLabelMap.ManufacturingOrderItems}">
+                                    <include-grid name="ListProductionRunOrderItems" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                                </screenlet>
+                                <screenlet title="${uiLabelMap.ManufacturingListOfProductionRunRoutingTasks}">
+                                    <include-grid name="ViewListProductionRunRoutingTasks" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                                </screenlet>
+                                <screenlet title="${uiLabelMap.ManufacturingMaterials}">
+                                    <include-grid name="ListProductionRunComponents" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                                </screenlet>
+                                <screenlet title="${uiLabelMap.ManufacturingListOfProductionRunFixedAssets}">
+                                    <include-grid name="ListProductionRunTaskFixedAssets" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                                </screenlet>
+                                <screenlet title="${uiLabelMap.ManufacturingListOfProductionRunNotes}">
+                                    <include-grid name="ListProductionRunNotes" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
                                 </screenlet>
                             </widgets>
-                        </section>
-                        <section>
-                            <condition>
-                                <not><if-empty field="dependentWorkEfforts"/></not>
-                            </condition>
-                            <widgets>
-                                <screenlet title="${uiLabelMap.ManufacturingSucceedingProductionRun}">
-                                    <include-grid name="DependentWorkEfforts" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                            <fail-widgets>
+                                <screenlet>
+                                    <include-form name="ShowProductionRun" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
                                 </screenlet>
-                            </widgets>
+                            </fail-widgets>
                         </section>
-                        <screenlet title="${uiLabelMap.ManufacturingOrderItems}">
-                            <include-grid name="ListProductionRunOrderItems" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
-                        </screenlet>
-                        <screenlet title="${uiLabelMap.ManufacturingListOfProductionRunRoutingTasks}">
-                            <include-grid name="ViewListProductionRunRoutingTasks" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
-                        </screenlet>
-                        <screenlet title="${uiLabelMap.ManufacturingMaterials}">
-                            <include-grid name="ListProductionRunComponents" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
-                        </screenlet>
-                        <screenlet title="${uiLabelMap.ManufacturingListOfProductionRunFixedAssets}">
-                            <include-grid name="ListProductionRunTaskFixedAssets" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
-                        </screenlet>
-                        <screenlet title="${uiLabelMap.ManufacturingListOfProductionRunNotes}">
-                            <include-grid name="ListProductionRunNotes" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
-                        </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
@@ -167,10 +183,8 @@ under the License.
                 <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer"/>
                 <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
-
                 <script location="component://manufacturing/groovyScripts/jobshopmgt/ProductionRunDeclaration.groovy"/>
                 <script location="component://manufacturing/groovyScripts/jobshopmgt/ProductionRunAllFixedAssets.groovy"/>
-
                 <set field="productionRunId" from-field="parameters.productionRunId" default-value="${parameters.workEffortId}"/>
                 <entity-one entity-name="WorkEffort" value-field="productionRun">
                     <field-map field-name="workEffortId" from-field="productionRunId"/>

--- a/applications/manufacturing/widget/manufacturing/ProductionRunForms.xml
+++ b/applications/manufacturing/widget/manufacturing/ProductionRunForms.xml
@@ -70,7 +70,7 @@ under the License.
     <form name="FindProductionRun" target="FindProductionRun" title="" type="single" default-map-name="parameters"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="workEffortTypeId"><hidden value="PROD_ORDER_HEADER"/></field>
-        <field name="workEffortId" title="${uiLabelMap.ManufacturingProductionRunId}"><text-find/></field>
+        <field name="workEffortId" title="${uiLabelMap.CommonId}"><text-find/></field>
         <field name="currentStatusId" title="${uiLabelMap.CommonStatus}">
             <drop-down allow-multiple="true">
                 <entity-options entity-name="StatusItem" key-field-name="statusId">
@@ -78,10 +78,10 @@ under the License.
                 </entity-options>
             </drop-down>
         </field>
-        <field name="productId" title="${uiLabelMap.ProductProductId}"><lookup target-form-name="LookupProduct"/></field>
-        <field name="workEffortName" title="${uiLabelMap.ManufacturingProductionRunName}"><text-find/></field>
-        <field name="estimatedStartDate" title="${uiLabelMap.ManufacturingStartDate}"><date-find default-value="${nowTimestamp}"/></field>
-        <field name="facilityId" title="${uiLabelMap.ProductFacilityId}">
+        <field name="productId" title="${uiLabelMap.ProductProduct}"><lookup target-form-name="LookupProduct"/></field>
+        <field name="workEffortName" title="${uiLabelMap.CommonName}"><text-find/></field>
+        <field name="estimatedStartDate" title="${uiLabelMap.ManufacturingStartDate}"><date-find/></field>
+        <field name="facilityId" title="${uiLabelMap.CommonFacility}">
             <drop-down allow-empty="true">
                 <entity-options entity-name="Facility" key-field-name="facilityId" description="${facilityName} [${facilityId}]">
                     <!--<entity-constraint name="facilityTypeId" value="WAREHOUSE"/>-->
@@ -108,46 +108,46 @@ under the License.
                 <field-map field-name="uomId" from-field="product.quantityUomId"/>
             </entity-one>
         </row-actions>
-        <field name="workEffortId" title=" " widget-style="buttontext">
+        <field name="workEffortId" title="${uiLabelMap.CommonId}" widget-style="buttontext">
             <hyperlink description="${workEffortId}" target="ShowProductionRun" also-hidden="false">
                 <parameter param-name="productionRunId" from-field="workEffortId"/>
             </hyperlink>
         </field>
-        <field name="workEffortName" title="${uiLabelMap.ManufacturingProductionRunName}"><display/></field>
-        <field name="productId" title="${uiLabelMap.ProductProductId}"><display/></field>
-        <field name="estimatedQuantity" title="${uiLabelMap.ManufacturingQuantity}"><display/></field>
-        <field name="QuantityUom" title="${uiLabelMap.ProductQuantityUom}"><display description="${uom.abbreviation}"></display></field>
+        <field name="workEffortName" title="${uiLabelMap.CommonName}"><display/></field>
+        <field name="productId" title="${uiLabelMap.ProductProduct}"><display/></field>
+        <field name="estimatedQuantity" title="${uiLabelMap.CommonQuantity}"><display/></field>
+        <field name="QuantityUom" title="${uiLabelMap.CommonUom}"><display description="${uom.abbreviation}"></display></field>
         <field name="currentStatusId" title="${uiLabelMap.CommonStatus}">
             <display-entity entity-name="StatusItem" key-field-name="statusId"/>
         </field>
-        <field name="estimatedStartDate" title="${uiLabelMap.ManufacturingStartDate}"><display/></field>
+        <field name="estimatedStartDate" title="${uiLabelMap.CommonStartDate}"><display/></field>
         <field name="description" title="${uiLabelMap.CommonDescription}"><display/></field>
-        <field name="facilityId" title="${uiLabelMap.ProductFacilityId}"><display/></field>
+        <field name="facilityId" title="${uiLabelMap.CommonFacility}"><display/></field>
     </grid>
      <form name="UpdateProductionRun" type="single" target="updateProductionRun" title="" default-map-name="productionRunData"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="productionRunId"><hidden/></field>
-        <field name="productId" title="${uiLabelMap.ProductProductName}">
+        <field name="productId" title="${uiLabelMap.ProductProduct}">
             <display-entity entity-name="Product" description="${internalName} [${productId}]"/>
         </field>
-        <field name="currentStatusId">
+        <field name="currentStatusId" title="${uiLabelMap.CommonStatus}">
             <display-entity entity-name="StatusItem" key-field-name="statusId"/>
         </field>
         <field name="manufacturerId">
             <display-entity entity-name="PartyNameView" key-field-name="partyId" description="${groupName} ${firstName} ${lastName} [${partyId}]"/>
         </field>
-        <field name="facilityId" title="${uiLabelMap.ProductFacilityId}">
+        <field name="facilityId" title="${uiLabelMap.CommonFacility}">
             <drop-down>
                 <entity-options entity-name="Facility" key-field-name="facilityId" description="${facilityName} [${facilityId}]">
                     <entity-constraint name="facilityTypeId" value="WAREHOUSE"/>
                 </entity-options>
              </drop-down>
         </field>
-        <field name="quantity"  title="${uiLabelMap.ManufacturingQuantity}"><text size="10"/></field>
-        <field name="estimatedStartDate"  title="${uiLabelMap.ManufacturingStartDate}"><date-time default-value="${nowTimestamp}"/></field>
-        <field name="estimatedCompletionDate" title="${uiLabelMap.ManufacturingEstimatedCompletionDate}"><display/></field>
-        <field name="workEffortName"  title="${uiLabelMap.ManufacturingProductionRunName}"><text/></field>
-        <field name="description"><text/></field>
+        <field name="quantity"  title="${uiLabelMap.CommonQuantity}"><text size="10"/></field>
+        <field name="estimatedStartDate"  title="${uiLabelMap.CommonStartDate}"><date-time default-value="${nowTimestamp}"/></field>
+        <field name="estimatedCompletionDate" title="${uiLabelMap.CommonEstimatedCompletionDate}"><display/></field>
+        <field name="workEffortName" title="${uiLabelMap.CommonName}"><text/></field>
+        <field name="description" title="${uiLabelMap.CommonDescription}"><text/></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}"><submit/></field>
     </form>
     <grid name="ListProductionRunOrderItems"  list-name="orderItems" target="EditProductionRun" 
@@ -275,22 +275,21 @@ under the License.
             <set field="useRequestParameters" value="false" type="Boolean"/>
         </actions>
         <field name="workEffortId"><hidden/></field>
-        <field name="productId" title="${uiLabelMap.ProductProductName}">
+        <field name="productId" title="${uiLabelMap.ProductProduct}">
             <display-entity entity-name="Product" description="${internalName} [${productId}]"/>
         </field>
-        <field name="currentStatusId">
+        <field name="currentStatusId" title="${uiLabelMap.CommonStatus}">
             <display-entity entity-name="StatusItem" key-field-name="statusId"/>
         </field>
         <field name="quantityToProduce" title="${uiLabelMap.ManufacturingQuantityToProduce}">
             <display/>
         </field>
-        <field name="estimatedStartDate" title="${uiLabelMap.ManufacturingEstimatedStartDate}"><display/></field>
+        <field name="estimatedStartDate" title="${uiLabelMap.CommonEstimatedStartDate}"><display/></field>
         <field name="actualStartDate" title="${uiLabelMap.CommonActualStartDate}"><display/></field>
-        <field name="estimatedCompletionDate" title="${uiLabelMap.ManufacturingEstimatedCompletionDate}"><display/></field>
-        <field name="actualCompletionDate" title="${uiLabelMap.ManufacturingActualCompletionDate}"><display/></field>
-        <field name="productionRunName"  title="${uiLabelMap.ManufacturingProductionRunName}"><display/></field>
+        <field name="estimatedCompletionDate" title="${uiLabelMap.CommonEstimatedCompletionDate}"><display/></field>
+        <field name="actualCompletionDate" title="${uiLabelMap.CommonCompleted}"><display/></field>
+        <field name="productionRunName"  title="${uiLabelMap.CommonName}"><display/></field>
         <field name="description" title="${uiLabelMap.CommonDescription}"><display/></field>
-        
         <field name="manufacturerId">
             <display-entity entity-name="PartyNameView" key-field-name="partyId" description="${groupName} ${firstName} ${lastName} [${partyId}]"/>
         </field>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the Production run screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.

Modified:
JobshopScreens.xml - restructured screens to work with permissions
additional cleanup