### PR TITLE
Improved: Manufacturing Rules - move menu-item to ManufacturingAppBar (OFBIZ-12525)

### DIFF
--- a/applications/manufacturing/widget/manufacturing/BomScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/BomScreens.xml
@@ -71,11 +71,8 @@ under the License.
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleEditProductManufacturingRules"/>
-                <set field="tabButtonItem" value="productManufacturingRules"/>
                 <set field="helpAnchor" value="_manufacturing_rules"/>
-                <!--<set field="labelTitleProperty" value="ProductProductBom"/>-->
-                <set field="headerItem" value="bom"/>
-
+                <set field="headerItem" value="ManufacturingRules"/>
                 <set field="ruleId" from-field="parameters.ruleId"/>
                 <entity-one entity-name="ProductManufacturingRule" value-field="manufacturingRule"/>
                 <entity-condition entity-name="ProductManufacturingRule" list="manufacturingRules">
@@ -102,16 +99,13 @@ under the License.
                 <set field="tabButtonItem" value="bomSimulation"/>
                 <set field="headerItem" value="bom"/>
                 <set field="helpAnchor" value="_bom_simulation"/>
-
                 <set field="bomType" from-field="parameters.bomType"/>
                 <set field="productId" from-field="parameters.productId"/>
                 <set field="type" from-field="parameters.type"/>
                 <set field="quantity" from-field="parameters.quantity"/>
                 <set field="amount" from-field="parameters.amount"/>
-
                 <set field="productFeatureApplTypeId" value="STANDARD_FEATURE"/>
                 <property-to-field field="defaultCurrencyUomId" resource="general" property="currency.uom.id.default" default="USD"/>
-
                 <entity-and entity-name="ProductFeatureAndAppl" list="selectedFeatures">
                     <field-map field-name="productId" from-field="productId"/>
                     <field-map field-name="productFeatureApplTypeId" from-field="productFeatureApplTypeId"/>
@@ -133,7 +127,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindBom">
         <section>
             <actions>

--- a/applications/manufacturing/widget/manufacturing/ManufacturingMenus.xml
+++ b/applications/manufacturing/widget/manufacturing/ManufacturingMenus.xml
@@ -40,6 +40,9 @@ under the License.
         <menu-item name="bom" title="${uiLabelMap.ManufacturingBillOfMaterials}">
             <link target="FindBom"/>
         </menu-item>
+        <menu-item name="ManufacturingRules" title="${uiLabelMap.ManufacturingManufacturingRules}">
+            <link target="EditProductManufacturingRules"/>
+        </menu-item>
         <menu-item name="mrp" title="${uiLabelMap.ManufacturingMrp}">
             <link target="FindInventoryEventPlan"/>
         </menu-item>
@@ -142,9 +145,6 @@ under the License.
         </menu-item>
         <menu-item name="EditProductBom" title="${uiLabelMap.ManufacturingEditProductBom}">
             <link target="EditProductBom"/>
-        </menu-item>
-        <menu-item name="productManufacturingRules" title="${uiLabelMap.ManufacturingManufacturingRules}">
-            <link target="EditProductManufacturingRules"/>
         </menu-item>
     </menu>
     <menu name="ProductionRunTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">


### PR DESCRIPTION
Currently the menu-item to access manufacturing rules is located within menu BomTabBar. For a consistent user experience this should be located in the AppBar of the component.

modified: ManufacturingMenus.xml
- removed menu-item ProductManufacturingRules from BomTabBar
- added menu-item ManufacturingRules to ManufacturingAppBar
- additional change vis-a-vis header and cleanup in BomScreens.xnl