### PR TITLE
Improved: Have a Menu in SFA featuring actions to create the main objects (OFBIZ-12527)

### DIFF
--- a/applications/marketing/config/MarketingUiLabels.xml
+++ b/applications/marketing/config/MarketingUiLabels.xml
@@ -3379,13 +3379,27 @@
         <value xml:lang="zh">请输入人员的姓或名，或机构名称</value>
         <value xml:lang="zh-TW">請輸入人員的姓或名,或機構名稱</value>
     </property>
-    <property key="SfaForecasts">
+    <property key="SfaForecast">
         <value xml:lang="de">Prognose</value>
         <value xml:lang="en">Forecast</value>
         <value xml:lang="es">Previsión</value>
         <value xml:lang="fr">Prévision</value>
         <value xml:lang="it">Previsioni</value>
         <value xml:lang="ja">予測</value>
+        <value xml:lang="nl">Prognose</value>
+        <value xml:lang="pt-BR">Previsão</value>
+        <value xml:lang="vi">Dự báo</value>
+        <value xml:lang="zh">预测</value>
+        <value xml:lang="zh-TW">預測</value>
+    </property>
+    <property key="SfaForecasts">
+        <value xml:lang="de">Prognosen</value>
+        <value xml:lang="en">Forecasts</value>
+        <value xml:lang="es">Previsións</value>
+        <value xml:lang="fr">Prévision</value>
+        <value xml:lang="it">Previsioni</value>
+        <value xml:lang="ja">予測</value>
+        <value xml:lang="nl">Prognoses</value>
         <value xml:lang="pt-BR">Previsão</value>
         <value xml:lang="vi">Dự báo</value>
         <value xml:lang="zh">预测</value>
@@ -3682,6 +3696,14 @@
         <value xml:lang="vi">Truyền thông</value>
         <value xml:lang="zh">机会的沟通</value>
         <value xml:lang="zh-TW">機會的通訊</value>
+    </property>
+    <property key="SfaOpportunity">
+        <value xml:lang="en">Opportunity</value>
+        <value xml:lang="nl">Kans</value>
+    </property>
+    <property key="SfaOpportunities">
+        <value xml:lang="en">Opportunities</value>
+        <value xml:lang="nl">Kansen</value>
     </property>
     <property key="SfaOpportunityId">
         <value xml:lang="de">Opportunity ID</value>

--- a/applications/marketing/widget/sfa/AccountScreens.xml
+++ b/applications/marketing/widget/sfa/AccountScreens.xml
@@ -33,6 +33,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <widgets>

--- a/applications/marketing/widget/sfa/CommonScreens.xml
+++ b/applications/marketing/widget/sfa/CommonScreens.xml
@@ -61,6 +61,10 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                        <decorator-section-include name="pre-body"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar"/>
                     </decorator-section>
@@ -110,6 +114,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="OpportunityTabBar" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="left-column">
@@ -216,9 +221,7 @@ under the License.
                 <set field="titleProperty" value="PageTitleViewPartyProfile"/>
                 <set field="tabButtonItem" value="profile"/>
                 <set field="labelTitleProperty" value="PartyTaxAuthInfos"/>
-
                 <set field="layoutSettings.javaScripts[]" value="/partymgr/static/PartyProfileContent.js" global="true"/>
-
                 <script location="component://party/groovyScripts/party/ViewProfile.groovy"/>
                 <script location="component://party/groovyScripts/party/SetRoleVars.groovy"/>
                 <set field="parameters.partyId" from-field="partyId"/>
@@ -750,6 +753,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="AccountTabBar" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="left-column">
@@ -768,6 +772,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="ContactTabBar" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="left-column">
@@ -794,6 +799,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="LeadTabBar" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="body">
@@ -812,6 +818,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="EventTabBar" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                     </decorator-section>
                     <decorator-section name="left-column">

--- a/applications/marketing/widget/sfa/CommonScreens.xml
+++ b/applications/marketing/widget/sfa/CommonScreens.xml
@@ -49,7 +49,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="main">
         <section>
             <actions>
@@ -75,7 +74,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ShortcutApp">
         <section>
             <actions>
@@ -395,9 +393,7 @@ under the License.
                 <set field="tabButtonItem" value="profile"/>
                 <set field="labelTitleProperty" value="PartyTaxAuthInfos"/>
                 <set field="parameters.roleTypeId" value="CONTACT"/>
-
                 <set field="layoutSettings.javaScripts[]" value="/partymgr/static/PartyProfileContent.js" global="true"/>
-
                 <script location="component://party/groovyScripts/party/ViewProfile.groovy"/>
                 <script location="component://party/groovyScripts/party/SetRoleVars.groovy"/>
                 <set field="parameters.partyId" from-field="partyId"/>
@@ -477,7 +473,6 @@ under the License.
                 <set field="labelTitleProperty" value="PartyTaxAuthInfos"/>
                 <set field="parameters.roleTypeId" value="ACCOUNT"/>
                 <set field="layoutSettings.javaScripts[]" value="/partymgr/static/PartyProfileContent.js" global="true"/>
-
                 <script location="component://party/groovyScripts/party/ViewProfile.groovy"/>
                 <script location="component://party/groovyScripts/party/SetRoleVars.groovy"/>
                 <set field="parameters.partyId" from-field="partyId"/>
@@ -554,9 +549,7 @@ under the License.
                 <set field="tabButtonItem" value="profile"/>
                 <set field="labelTitleProperty" value="PartyTaxAuthInfos"/>
                 <set field="parameters.roleTypeId" value="ACCOUNT_LEAD"/>
-
                 <set field="layoutSettings.javaScripts[]" value="/partymgr/static/PartyProfileContent.js" global="true"/>
-
                 <script location="component://party/groovyScripts/party/ViewProfile.groovy"/>
                 <script location="component://party/groovyScripts/party/SetRoleVars.groovy"/>
                 <set field="parameters.partyId" from-field="partyId"/>

--- a/applications/marketing/widget/sfa/ContactScreens.xml
+++ b/applications/marketing/widget/sfa/ContactScreens.xml
@@ -33,6 +33,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
                     </decorator-section>
@@ -55,12 +58,10 @@ under the License.
                                                     </or>
                                                 </condition>
                                                 <widgets>
-                                                    <!-- list all contacts -->
                                                     <label style="h1" text="${uiLabelMap.SfaAllContacts}"/>
                                                     <include-form name="ListContacts" location="component://marketing/widget/sfa/forms/ContactForms.xml"/>
                                                 </widgets>
                                                 <fail-widgets>
-                                                    <!-- list my contacts -->
                                                     <label style="h1" text="${uiLabelMap.SfaMyContacts}"/>
                                                     <include-form name="ListMyContacts" location="component://marketing/widget/sfa/forms/ContactForms.xml"/>
                                                 </fail-widgets>
@@ -127,7 +128,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="NewContactFromVCard">
         <section>
             <actions>

--- a/applications/marketing/widget/sfa/ForecastScreens.xml
+++ b/applications/marketing/widget/sfa/ForecastScreens.xml
@@ -28,9 +28,12 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section> 
                     <decorator-section name="body">
                         <section>
                             <widgets>
@@ -50,7 +53,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindSalesForecast">
         <section>
             <actions>
@@ -59,9 +61,12 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
-                    </decorator-section>                    
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <widgets>
@@ -89,7 +94,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditSalesForecast">
         <section>
             <actions>
@@ -117,7 +121,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditSalesForecastDetail">
         <section>
             <actions>

--- a/applications/marketing/widget/sfa/LeadScreens.xml
+++ b/applications/marketing/widget/sfa/LeadScreens.xml
@@ -33,6 +33,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
                     </decorator-section>
@@ -75,7 +78,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="NewLead">
         <section>
             <actions>
@@ -94,7 +96,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ConvertLead">
         <section>
             <actions>
@@ -125,7 +126,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="CloneLead">
         <section>
             <actions>
@@ -144,7 +144,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="MergeLeads">
         <section>
             <actions>
@@ -176,7 +175,6 @@ under the License.
              </widgets>
          </section>
     </screen>
-
     <screen name="NewLeadFromVCard">
         <section>
             <actions>
@@ -195,7 +193,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="LeadPartyDataSource">
         <section>
             <actions>
@@ -212,7 +209,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="AddRelatedCompany">
         <section>
             <actions>

--- a/applications/marketing/widget/sfa/OpportunityScreens.xml
+++ b/applications/marketing/widget/sfa/OpportunityScreens.xml
@@ -20,7 +20,6 @@ under the License.
 
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
     <screen name="FindSalesOpportunity">
         <section>
             <actions>
@@ -30,6 +29,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
                     </decorator-section>
@@ -48,7 +50,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditSalesOpportunity">
         <section>
             <actions>
@@ -86,7 +87,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ViewSalesOpportunity">
         <section>
             <actions>
@@ -118,7 +118,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="OpportunityCommEvent">
         <section>
             <actions>

--- a/applications/marketing/widget/sfa/SfaMenus.xml
+++ b/applications/marketing/widget/sfa/SfaMenus.xml
@@ -31,7 +31,32 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="NewAccount" title="${uiLabelMap.CommonNew} ${uiLabelMap.PartyAccount}">
+            <condition>
+                <if-has-permission permission="SFA" action="CREATE"/>
+            </condition>
+            <link target="NewAccount"/>
+        </menu-item>
+        <menu-item name="NewContact" title="${uiLabelMap.CommonNew} ${uiLabelMap.SfaContact}">
+            <condition>
+                <if-has-permission permission="SFA" action="CREATE"/>
+            </condition>
+            <link target="NewContact"/>
+        </menu-item>
+        <menu-item name="NewOpportunity" title="${uiLabelMap.CommonNew} ${uiLabelMap.SfaOpportunity}">
+            <condition>
+                <if-has-permission permission="SFA" action="CREATE"/>
+            </condition>
+            <link target="EditSalesOpportunity"/>
+        </menu-item>
+        <menu-item name="NewForeCast" title="${uiLabelMap.CommonNew} ${uiLabelMap.SfaForecast}">
+            <condition>
+                <if-has-permission permission="SFA" action="CREATE"/>
+            </condition>
+            <link target="EditSalesForecast"/>
+        </menu-item>
+    </menu>
     <menu name="SfaShortcutAppBar" title="${uiLabelMap.SfaManager}">
         <menu-item name="Accounts" title="${uiLabelMap.SfaAcccounts}"><link target="/sfa/control/FindAccounts" url-mode="inter-app"/></menu-item>
         <menu-item name="Contacts" title="${uiLabelMap.SfaContacts}"><link target="/sfa/control/FindContacts" url-mode="inter-app"/></menu-item>
@@ -45,7 +70,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="OpportunityTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="ViewSalesOpportunity" title="${uiLabelMap.SfaOpportunitySummary}">
             <link target="ViewSalesOpportunity">
@@ -73,7 +97,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="OpportunitySubTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml"
           menu-container-style="button-bar button-style-2 no-clear">
         <menu-item name="NewCommEvent" title="${uiLabelMap.PartyNewEmail}">
@@ -142,7 +165,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="AccountTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="find" title="${uiLabelMap.CommonFind}"><link target="FindAccounts"/></menu-item>
         <menu-item name="profile" title="${uiLabelMap.PartyProfile}">
@@ -191,7 +213,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="LeadTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="find" title="${uiLabelMap.CommonFind}"><link target="FindLeads"/></menu-item>
         <menu-item name="profile" title="${uiLabelMap.PartyProfile}">
@@ -233,7 +254,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="LeadSubTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml"
           menu-container-style="button-bar button-style-2 no-clear">
         <menu-item name="NewLead" title="${uiLabelMap.CommonCreate}">
@@ -264,7 +284,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-    
     <menu name="LeadFindTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="all" title="${uiLabelMap.SfaAllLeads}">
             <condition>
@@ -286,7 +305,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="ContactTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="find" title="${uiLabelMap.CommonFind}"><link target="FindContacts"/></menu-item>
         <menu-item name="profile" title="${uiLabelMap.PartyProfile}">


### PR DESCRIPTION
Currently the create buttons for the main objects of the SFA application are located within find and profile widgets/templates of those objects.
In order to improve the usability of this application, OFBiz and thus the appeal of it for adopters and users, these create buttons/links/etc. should be in a main action menu visible at all times when a user with CREATE permissions is working within the application

modified:
- SfaMenus.xml - Added menu MainActionMenu
- included MainActionMenu in various screens to ensure that it is visible to user with CREATE permissions
- additional cleanup