### PR TITLE
Improved: CostComponent - VIEW permissions (OFBIZ-12528)

### DIFF
--- a/applications/manufacturing/widget/manufacturing/CostForms.xml
+++ b/applications/manufacturing/widget/manufacturing/CostForms.xml
@@ -20,6 +20,21 @@ under the License.
 
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
+    <grid name="CostComponentCalc" title="" list-name="allCostComponentCalcs"
+        odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
+        <auto-fields-entity entity-name="CostComponentCalc" default-field-type="display"/>
+        <field name="costComponentCalcId" widget-style="buttontext">
+            <hyperlink description="${costComponentCalcId}" target="EditCostCalcs" also-hidden="false">
+                <parameter param-name="costComponentCalcId"/>
+            </hyperlink>
+        </field>
+        <field name="costGlAccountTypeId"><hidden/></field>
+        <field name="offsettingGlAccountTypeId"><hidden/></field>
+        <field name="currencyUomId" title="${uiLabelMap.CommonCurrency}"><display/></field>
+        <field name="costCustomMethodId" title="${uiLabelMap.CommonMethod}">
+            <display-entity entity-name="CustomMethod" key-field-name="customMethodId"/>
+        </field>
+    </grid>
     <grid name="ListCostComponentCalc" title="" list-name="allCostComponentCalcs"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <auto-fields-entity entity-name="CostComponentCalc" default-field-type="display"/>
@@ -30,10 +45,8 @@ under the License.
         </field>
         <field name="costGlAccountTypeId"><hidden/></field>
         <field name="offsettingGlAccountTypeId"><hidden/></field>
-        <field name="currencyUomId" title="${uiLabelMap.CommonCurrency}">
-            <display-entity entity-name="Uom" key-field-name="uomId"/>
-        </field>
-        <field name="costCustomMethodId">
+        <field name="currencyUomId" title="${uiLabelMap.CommonCurrency}"><display/></field>
+        <field name="costCustomMethodId" title="${uiLabelMap.CommonMethod}">
             <display-entity entity-name="CustomMethod" key-field-name="customMethodId"/>
         </field>
         <field name="removeCostComponentCalc" title=" " widget-style="buttontext">
@@ -42,7 +55,6 @@ under the License.
             </hyperlink>
         </field>
     </grid>
-    
     <form name="EditCostComponentCalc" type="single" target="updateCostComponentCalc" title="" default-map-name="costComponentCalc"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="costComponentCalc==null" target="createCostComponentCalc"/>

--- a/applications/manufacturing/widget/manufacturing/CostScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/CostScreens.xml
@@ -30,20 +30,38 @@ under the License.
                 <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
                 <property-to-field field="defaultCurrencyUomId" resource="general" property="currency.uom.id.default" default="USD"/>
-
                 <entity-condition entity-name="CostComponentCalc" list="allCostComponentCalcs"/>
                 <entity-one entity-name="CostComponentCalc" value-field="costComponentCalc"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonManufacturingDecorator" location="${parameters.commonManufacturingDecoratorLocation}">
                     <decorator-section name="body">
-                        <container>
-                            <label style="h1">${uiLabelMap.ManufacturingManageCostComponentCalc}</label>
-                        </container>
-                        <screenlet id="ManufacturingCostComponentCalcPanel" title="${uiLabelMap.ManufacturingEditCostComponentCalc}" collapsible="true">
-                            <include-form name="EditCostComponentCalc" location="component://manufacturing/widget/manufacturing/CostForms.xml"/>
-                        </screenlet>
-                        <include-grid name="ListCostComponentCalc" location="component://manufacturing/widget/manufacturing/CostForms.xml"/>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="MANUFACTURING" action="_CREATE"/>
+                                        <if-has-permission permission="MANUFACTURING" action="_UPDATE"/>
+                                    </or>
+                                </and>
+                            </condition>
+                            <widgets>
+                               <container>
+                                    <label style="h1">${uiLabelMap.ManufacturingManageCostComponentCalc}</label>
+                                </container>
+                                <screenlet id="ManufacturingCostComponentCalcPanel" title="${uiLabelMap.ManufacturingEditCostComponentCalc}" collapsible="true">
+                                    <include-form name="EditCostComponentCalc" location="component://manufacturing/widget/manufacturing/CostForms.xml"/>
+                                </screenlet>
+                                <screenlet>
+                                    <include-grid name="ListCostComponentCalc" location="component://manufacturing/widget/manufacturing/CostForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet>
+                                    <include-grid name="CostComponentCalc" location="component://manufacturing/widget/manufacturing/CostForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the Cost Component screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.

To see/test: https://localhost:8443/manufacturing/control/EditCostCalcs

modified:
- CostScreens.xml - restructured screen EditCostCalcs to work with permissions
- CostForms.xml - added grid CostComponentCalc for users with VIEW permissions
additional cleanup