### PR TITLE
Improved: Party Rates - VIEW permissions (OFBIZ-12529)

### DIFF
--- a/applications/party/widget/partymgr/PartyForms.xml
+++ b/applications/party/widget/partymgr/PartyForms.xml
@@ -20,7 +20,6 @@ under the License.
 
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
-
     <form name="LookupParty" type="single" target="findparty" focus-field-name="partyId">
         <actions>
             <set field="states" value="${groovy: org.apache.ofbiz.common.CommonWorkers.getStateList(delegator)}"/>
@@ -127,7 +126,6 @@ under the License.
             <sort-field name="searchButton"/>
         </sort-order>
     </form>
-
     <grid name="ListParty" target="expirePartyRate" list-name="listIt"
           odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
@@ -170,7 +168,6 @@ under the License.
              <last-field name="partyAction"/>
         </sort-order>
     </grid>
-
     <grid name="ListPartyN" extends="ListParty"/>
     <grid name="ListPartyI" extends="ListParty">
         <field name="idValue" sort-field="true"><display/></field>
@@ -191,7 +188,6 @@ under the License.
         <field name="enabled"><display/></field>
         <field name="disabledDateTime"><display type="date"/></field>
     </grid>
-
     <form name="EditPerson" type="single" target="updatePerson" default-map-name="personInfo"
         focus-field-name="salutation" header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="personInfo==null" target="createPerson"/>
@@ -266,7 +262,6 @@ under the License.
             </hyperlink>
         </field>
     </form>
-
     <form name="EditPartyGroup" type="single" target="updatePartyGroup" default-map-name="partyGroup"
         focus-field-name="groupName" header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="partyGroup==null" target="createPartyGroup"/>
@@ -299,13 +294,11 @@ under the License.
             <hyperlink description="${uiLabelMap.CommonCancelDone}" target="backHome" also-hidden="false"/>
         </field>
     </form>
-
     <form name="EditPartyGroup2" type="single" target="createPartyGroup" default-map-name="partyGroup"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="groupName"><text size="6" maxlength="10"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonCreate}"><submit button-type="button"/></field>
     </form>
-
     <form name="ViewPartyGroup" type="single" default-map-name="lookupGroup">
         <auto-fields-entity entity-name="PartyGroup" default-field-type="display"/>
         <field name="logo" use-when="partyGroupLogoLinkUrl!=null" title="${uiLabelMap.CommonOrganizationLogo}"><image alternate="${uiLabelMap.CommonOrganizationLogo}" value="${partyGroupLogoLinkUrl}" style="cssImgStandard"/></field>
@@ -331,7 +324,6 @@ under the License.
             <sort-field name="statusId"/>
         </sort-order>
     </form>
-
     <form name="ViewPartyPerson" type="single" default-map-name="lookupPerson">
         <field name="personalImage" use-when="partyContentId!=null" title="${uiLabelMap.FormFieldTitle_personalImage}"><image value="${personalImage}" style="cssImgStandard"/></field>
         <field name="partyId"><display/></field>
@@ -340,19 +332,16 @@ under the License.
         <field name="externalId"><display/></field>
         <field name="statusId"><display-entity entity-name="StatusItem" key-field-name="statusId"/></field>
     </form>
-
     <form name="ViewPartyPersonHistory" type="list" list-name="partyNameHistoryList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="was" title="${uiLabelMap.PartyHistoryWas}"><display description="${personalTitle} ${firstName} ${middleName} ${lastName} ${suffix}"/></field>
         <field name="changed" title="${uiLabelMap.PartyHistoryChanged}"><display description="${changeDate}"/></field>
     </form>
-
     <form name="ViewPartyGroupHistory" type="list" list-name="partyNameHistoryList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <field name="was" title="${uiLabelMap.PartyHistoryWas}"><display description="${groupName}"/></field>
         <field name="changed" title="${uiLabelMap.PartyHistoryChanged}"><display description="${changeDate}"/></field>
     </form>
-
     <form name="AddUserLogin" type="single" target="createUserLogin"
         focus-field-name="userLoginId" header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createUserLogin"/>
@@ -366,7 +355,6 @@ under the License.
         <field name="submitButton" title="${uiLabelMap.CommonSave}" widget-style="smallSubmit"><submit button-type="text-link"/></field>
         <field name="cancelLink" title=" " widget-style="smallSubmit"><hyperlink description="${uiLabelMap.CommonCancelDone}" target="backHome" also-hidden="false"/></field>
     </form>
-
     <form name="UpdatePassword" type="single" target="updatePassword"
         focus-field-name="currentPassword" header-row-style="header-row" default-table-style="basic-table">
         <actions>
@@ -385,7 +373,6 @@ under the License.
             </hyperlink>
         </field>
     </form>
-
     <form name="UpdateUserLoginSecurity" type="single" target="updateUserLoginSecurity" default-map-name="editUserLogin"
         header-row-style="header-row" default-table-style="basic-table">
         <actions>
@@ -403,7 +390,6 @@ under the License.
             </hyperlink>
         </field>
     </form>
-
     <form name="EditVendor" type="single" target="updateVendor" default-map-name="vendor"
         focus-field-name="manifestCompanyName" header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="vendor==null" target="createVendor"/>
@@ -415,15 +401,12 @@ under the License.
         <field name="manifestPolicies" title="${uiLabelMap.PartyManifestPolicies}"><textarea cols="60" rows="15"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}"><submit button-type="button"/></field>
     </form>
-
     <form name="PartyLink" type="single" target="setPartyLink"
         focus-field-name="partyId" header-row-style="header-row" default-table-style="basic-table">
         <field position="1" name="partyId"><lookup target-form-name="LookupPartyName"/></field>
         <field position="2" name="partyIdTo"><lookup target-form-name="LookupPartyName"/></field>
       <field name="submitButton" title="${uiLabelMap.PartyLink}"><submit button-type="button" request-confirmation="true" confirmation-message="${uiLabelMap.PartyLinkMessage1}"/></field>
     </form>
-
-    <!-- PartyRelationship -->
     <form name="AddPartyRelationshipType" type="single" target="createPartyRelationshipType"
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createPartyRelationshipType"/>
@@ -452,8 +435,6 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonCreate}"><submit button-type="button"/></field>
     </form>
-
-    <!-- PartyTaxAuthInfo -->
     <form name="AddPartyTaxAuthInfo" type="single" target="createPartyTaxAuthInfo"
         focus-field-name="taxAuthGeoId" header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createPartyTaxAuthInfo"/>
@@ -495,7 +476,6 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonCreate}"><submit button-type="button"/></field>
     </form>
-
     <form name="UpdatePartyTaxAuthInfo" type="list" list-name="partyTaxInfos" target="updatePartyTaxAuthInfo"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <auto-fields-service service-name="updatePartyTaxAuthInfo"/>
@@ -525,7 +505,6 @@ under the License.
             <drop-down allow-empty="false"><option key="Y" description="${uiLabelMap.CommonY}"/><option key="N" description="${uiLabelMap.CommonN}"/></drop-down>
         </field>
     </form>
-
     <form name="AddPartyNote" type="single" target="createPartyNote"
         focus-field-name="noteId" header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createPartyNote"/>
@@ -540,8 +519,6 @@ under the License.
             </hyperlink>
         </field>
     </form>
-
-    <!-- PartyRate -->
     <form name="AddPartyRate" type="single" target="updatePartyRate"
         focus-field-name="rateTypeId" header-row-style="header-row" default-table-style="basic-table">
         <actions>
@@ -572,7 +549,6 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonCreate}"><submit button-type="button"/></field>
     </form>
-
     <grid name="ListPartyRates" target="expirePartyRate"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
@@ -603,7 +579,33 @@ under the License.
         <field name="percentageUsed"><display/></field>
         <field name="deleteButton" widget-style="smallSubmit"><submit /></field>
     </grid>
-
+    <grid name="PartyRates"
+        odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
+        <actions>
+            <entity-condition entity-name="PartyRate" filter-by-date="true">
+                <condition-expr field-name="partyId" from-field="partyId"/>
+                <order-by field-name="rateTypeId"/>
+            </entity-condition>
+        </actions>
+        <row-actions>
+            <service service-name="getRateAmount" result-map="rateResult"/>
+            <set field="rateDefaultAmount" from-field="rateResult.rateAmount"/>
+            <set field="periodTypeId" from-field="rateResult.periodTypeId"/>
+            <set field="rateCurrencyUomId" from-field="rateResult.rateCurrencyUomId"/>
+            <set field="rateLevel" from-field="rateResult.level"/>
+            <set field="rateAmountFromDate" from-field="rateResult.fromDate"/>
+        </row-actions>
+        <field name="partyId"><hidden/></field>
+        <field name="rateAmountFromDate"><hidden/></field>
+        <field name="rateTypeId" title="${uiLabelMap.CommonRate}"><display-entity entity-name="RateType" also-hidden="true"/></field>
+        <field name="periodTypeId" title="${uiLabelMap.CommonType}"><display-entity entity-name="PeriodType"/></field>
+        <field name="rateCurrencyUomId" title="${uiLabelMap.CommonCurrency}"><display/></field>
+        <field name="rateDefaultAmount" title="${uiLabelMap.CommonAmount}"><display type="accounting-number"/></field>
+        <field name="defaultRate"><display/></field>
+        <field name="percentageUsed"><display/></field>
+        <field name="fromDate" title="${uiLabelMap.CommonFrom}" red-when="after-now"><display type="date-time"/></field>
+        <field name="trueDate" title="${uiLabelMap.CommonThru}" red-when="before-now"><display type="date-time"/></field>
+    </grid>
     <form name="NewUser" type="single" target="${target}${previousParams}"
         focus-field-name="USER_TITLE" header-row-style="header-row" default-table-style="basic-table">
         <field name="USER_PARTY_ID" title="${uiLabelMap.PartyPartyId}" tooltip="${uiLabelMap.CommonIdGeneratedIfEmpty}"><text/></field>
@@ -664,7 +666,6 @@ under the License.
         <field use-when="displayPassword=='Y'" name="CONFIRM_PASSWORD" title="${uiLabelMap.CommonPassword}" tooltip="* ${uiLabelMap.CommonConfirm}" required-field="true"><password size="15" maxlength="250"/></field>
         <field use-when="displayPassword!='Y'" name="USERNAME" title="${uiLabelMap.CommonUsername}" tooltip="* ${uiLabelMap.PartyTemporaryPassword}" required-field="true"><text size="30" maxlength="250"/></field>
         <!--<field name="RequiredNote" title=" "><display description="${uiLabelMap.PartyRequiredNote}" also-hidden="false"/></field> -->
-
         <field name="PRODUCT_STORE_ID" title="Product Store" tooltip="${uiLabelMap.CommonRequired}" widget-style="required">
             <drop-down>
                 <entity-options entity-name="ProductStore" key-field-name="productStoreId" description="${storeName} (${productStoreId})">
@@ -674,7 +675,6 @@ under the License.
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonSave}" widget-style="smallSubmit"><submit button-type="text-link"/></field>
     </form>
-
     <grid name="ListSegmentRoles" target="updateSegmentGroupRole"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
@@ -700,7 +700,6 @@ under the License.
             </hyperlink>
         </field>
     </grid>
-
     <form name="AddSegmentRole" type="single" target="createSegmentRole" default-map-name="segmentGroupRole"
         focus-field-name="segmentGroupId" header-row-style="header-row" default-table-style="basic-table">
         <field name="segmentGroupId" title="${uiLabelMap.PartySegmentGroupId}">
@@ -721,7 +720,6 @@ under the License.
             </hyperlink>
         </field> -->
     </form>
-
     <form name="EditPartyAttribute" type="single" target="updatePartyAttribute" default-map-name="attribute"
         focus-field-name="attrName" header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="attribute==null" target="createPartyAttribute"/>
@@ -734,9 +732,6 @@ under the License.
             </hyperlink>
         </field>
     </form>
-
-    <!-- Party Content Form -->
-
     <form name="AddPartyContent" target="updatePartyContent" type="upload" default-map-name="content"
         focus-field-name="contentTypeId" header-row-style="header-row" default-table-style="basic-table">
         <actions>
@@ -747,7 +742,6 @@ under the License.
                 <field-map field-name="dataResourceId" from-field="content.dataResourceId"/>
             </entity-one>
         </actions>
-
         <alt-target use-when="content==null" target="createPartyContent"/>
         <!-- <auto-fields-entity entity-name="Content"/> -->
         <field name="partyId" map-name="parameters"><hidden/></field>
@@ -761,10 +755,6 @@ under the License.
                 <entity-options entity-name="PartyContentType"/>
             </drop-down>
         </field>
-        <!-- note sure if these two are necessray, but they are kind of confusing in this context:
-        <field name="ownerContentId"><lookup target-form-name="LookupContent"/></field>
-        <field name="dataResourceId" title="${uiLabelMap.ContentDataResourceId}"><lookup target-form-name="LookupDataResource"/></field>
-        -->
         <field name="contentTypeId">
             <drop-down allow-empty="false" no-current-selected-key="DOCUMENT">
                 <entity-options entity-name="ContentType"/>
@@ -813,7 +803,6 @@ under the License.
         <field name="createButton" use-when="content==null"><submit button-type="button"/></field>
         <field name="updateButton" use-when="content!=null"><submit button-type="button"/></field>
     </form>
-
     <grid name="ListPartyContents" separate-columns="false"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
@@ -862,7 +851,6 @@ under the License.
             </hyperlink>
         </field>
     </grid>
-
     <form name="ApplyServiceCredit" type="single" target="applyServiceCredit" default-map-name="serviceCredit" focus-field-name="amount"
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createServiceCredit" map-name="serviceCredit"/>
@@ -895,7 +883,6 @@ under the License.
         <field name="finAccountTypeId"><ignored/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}"><submit button-type="button"/></field>
     </form>
-
     <form name="ListCarrierAccounts" type="list" target="updatePartyCarrierAccount" list-name="carrierAccounts"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar"
         paginate="true"  view-size="3" paginate-target="viewprofile" paginate-target-anchor="ListCarrierAccounts">
@@ -919,7 +906,6 @@ under the License.
             </hyperlink>
         </field>
     </form>
-
     <form name="EditCarrierAccount" type="single" target="createPartyCarrierAccount" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-service service-name="createPartyCarrierAccount"/>
@@ -936,7 +922,6 @@ under the License.
         <field name="accountNumber" title="${uiLabelMap.AccountingAccountNumber}" required-field="true"/>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}"><submit button-type="button"/></field>
     </form>
-
     <form name="ListSubscriptions" type="list" list-name="subscriptionList" default-table-style="basic-table">
         <field name="subscriptionId">
             <display-entity entity-name="Subscription">
@@ -962,7 +947,6 @@ under the License.
         <field name="fromDate"><display/></field>
         <field name="thruDate"><display/></field>
     </form>
-
     <form name="ListRelatedContacts" type="list" list-name="contacts" default-table-style="basic-table">
         <field name="partyIdTo">
             <display-entity entity-name="PartyNameView" description="${firstName} ${middleName} ${lastName} ${groupName}" key-field-name="partyId">
@@ -974,7 +958,6 @@ under the License.
         <field name="partyRelationshipTypeId" title="${uiLabelMap.CommonType}"><display-entity entity-name="PartyRelationshipType" description="${partyRelationshipName}"/></field>
         <field name="comments"><display/></field>
     </form>
-
     <form name="ListRelatedAccounts" type="list" list-name="accounts" default-table-style="basic-table">
         <field name="partyIdFrom">
             <display-entity entity-name="PartyNameView" description="${firstName} ${middleName} ${lastName} ${groupName}" key-field-name="partyId">
@@ -986,7 +969,6 @@ under the License.
         <field name="partyRelationshipTypeId" title="${uiLabelMap.CommonType}"><display-entity entity-name="PartyRelationshipType" description="${partyRelationshipName}"/></field>
         <field name="comments"><display/></field>
     </form>
-
     <grid name="ListPartyRelationships" list-name="partyRelationships" default-table-style="basic-table" target="updatePartyRelationship" odd-row-style="alternate-row">
         <field name="partyId"><hidden value="${parameters.partyId}"/></field>
         <field name="partyIdTo" title="${uiLabelMap.PartyPartyId}">
@@ -1023,7 +1005,6 @@ under the License.
                 <parameter param-name="fromDate"/>
             </hyperlink></field>
     </grid>
-
     <form name="AddOtherPartyRelationship" type="single" target="createPartyRelationship">
         <field name="partyId"><hidden value="${parameters.partyId}"/></field>
         <field name="partyIdTo" entry-name="parameters.partyId"><display/></field>
@@ -1071,7 +1052,6 @@ under the License.
         <field name="comments"><text/></field>
         <field name="submitButton"><submit button-type="button"/></field>
     </form>
-
     <form name="AddAccount" type="single" target="createPartyRelationshipContactAccount">
         <field name="partyId"><hidden value="${parameters.partyId}"/></field>
         <field name="accountPartyId"><lookup target-form-name="LookupAccount"/></field>
@@ -1079,7 +1059,6 @@ under the License.
         <field name="comments"><text/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}"><submit button-type="button"/></field>
     </form>
-
     <form name="AddContact" type="single" target="createPartyRelationshipContactAccount">
         <field name="partyId"><hidden value="${parameters.partyId}"/></field>
         <field name="accountPartyId"><hidden value="${parameters.partyId}"/></field>
@@ -1087,7 +1066,6 @@ under the License.
         <field name="comments"><text/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}"><submit button-type="button"/></field>
     </form>
-
     <grid name="ListInvoicesApplPayments" list-name="ListInvoicesApplPayments"
         default-title-style="tableheadtext" odd-row-style="alternate-row" default-table-style="basic-table hover-bar"
        >
@@ -1123,10 +1101,8 @@ under the License.
         <field name="pmAmount" title="${uiLabelMap.AccountingPaymentAmount}" use-when="actualCurrency==false"><display type="currency" currency="${actualCurrencyUomId}"/></field>
         <field name="pmAmount" title="${uiLabelMap.AccountingPaymentAmount}" entry-name="pmActualCurrencyAmount" use-when="actualCurrency==true"><display type="currency" currency="${actualCurrencyUomId}"/></field>
     </grid>
-    
     <grid name="ListUnAppliedInvoices" list-name="ListUnAppliedInvoices"
-        default-title-style="tableheadtext" odd-row-style="alternate-row" default-table-style="basic-table hover-bar"
-       >
+        default-title-style="tableheadtext" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <set field="actualCurrency" from-field="actualCurrency" default-value="true" type="Boolean"/>
             <script location="component://party/groovyScripts/party/UnAppliedInvoicesForParty.groovy"/>
@@ -1145,10 +1121,8 @@ under the License.
         <field name="amount"><display type="currency" currency="${invoiceCurrencyUomId}"/></field>
         <field name="unAppliedAmount"><display type="currency" currency="${invoiceCurrencyUomId}"/></field>
     </grid>
-    
     <grid name="ListUnAppliedPayments" list-name="paymentList"
-        default-title-style="tableheadtext" odd-row-style="alternate-row" default-table-style="basic-table hover-bar"
-       >
+        default-title-style="tableheadtext" odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <actions>
             <set field="actualCurrency" from-field="actualCurrency" default-value="true" type="Boolean"/>
             <script location="component://party/groovyScripts/party/UnAppliedPaymentsForParty.groovy"/>
@@ -1171,7 +1145,6 @@ under the License.
         <field name="amount"><display type="currency" currency="${paymentCurrencyUomId}"/></field>
         <field name="unAppliedAmount"><display type="currency" currency="${paymentCurrencyUomId}"/></field>
     </grid>
-    
     <form name="PartyFinancialSummary" type="single" title="Financial summary" default-map-name="finanSummary"
         default-title-style="tableheadtext">
         <actions>
@@ -1188,7 +1161,6 @@ under the License.
         <field position="1" name="totalToBePaid" use-when="finanSummary.get(&quot;totalToBePaid&quot;)!=null" title="${uiLabelMap.PartyToBeReceivedFrom} ${parameters.partyId}"><display type="currency" currency="${actualCurrencyUomId}"/></field>
         <field position="1" name="totalToBeReceived" use-when="finanSummary.get(&quot;totalToBeReceived&quot;)!=null" title="${uiLabelMap.PartyToBePaidTo} ${parameters.partyId}"><display type="currency" currency="${actualCurrencyUomId}"/></field>
     </form>
-    
     <grid name="ViewPartyRoles" list-name="partyRoles" target="viewroles"
         default-title-style="tableheadtext"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
@@ -1202,7 +1174,6 @@ under the License.
             </hyperlink>
         </field>
     </grid>
-    
     <form name="AddPartyRole" type="single" title="Add a role to party" target="addrole">
         <field name="partyId"><hidden value="${parameters.partyId}"/></field>
         <field name="roleTypeId">
@@ -1249,7 +1220,6 @@ under the License.
         <field name="description" title="${uiLabelMap.CommonDescription}" required-field="true"><text/></field>
         <field name="save" title="${uiLabelMap.CommonSave}"><submit/></field>
     </form>
-    
     <grid name="ListPreference" target="removePreference" list-name="enumTypeChildAndEnums"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" separate-columns="true" use-row-submit="true" >
         <row-actions>
@@ -1267,21 +1237,18 @@ under the License.
         <field name="userPrefValue" title="${uiLabelMap.CommonValue}"><display/></field>
         <field name="submit" title="${uiLabelMap.CommonRemove}" use-when="userPrefValue!=null"><submit/></field>
     </grid>
-    
     <grid name="PartyBillingAccount" list-name="billingAccounts" default-table-style="basic-table hover-bar">
         <field name="billingAccountId"><display/></field>
         <field name="accountLimit"><display type="currency"/></field>
         <field name="accountBalance"><display type="currency"/></field>
         <field name="description"><display/></field>
     </grid>
-    
     <grid name="PartyReturns" list-name="returnList" default-table-style="basic-table hover-bar">
         <field name="returnId"><display/></field>
         <field name="statusId"><display-entity entity-name="StatusItem"/></field>
         <field name="fromPartyId"><display/></field>
         <field name="toPartyId"><display/></field>
     </grid>
-    
     <form name="PartySalesOpportunities" type="list" list-name="salesOpportunities" default-table-style="basic-table hover-bar">
         <field name="opportunityName" title="${uiLabelMap.SfaOpportunityName}">
             <hyperlink description="${opportunityName} [${salesOpportunityId}]" target="ViewSalesOpportunity">
@@ -1292,7 +1259,6 @@ under the License.
         <field name="estimatedAmount" title="${uiLabelMap.SfaEstimatedAmount}"><display/></field>
         <field name="partyId"><display/></field>
     </form>
-
     <!-- For an unknown reason yet grid can't be used here see OFBIZ-9405 -->
     <form name="ListPartyIdentification" list-name="listIt" type="list"
                  default-table-style="basic-table" target="EditPartyIdentification">
@@ -1313,7 +1279,6 @@ under the License.
         </field>
         <field name="submit" title="${uiLabelMap.CommonUpdate}"><submit /></field>
     </form>
-    
     <form name="EditPartyIdentification" type="single" list-name="partyIdents"
                  default-table-style="basic-table" target="createPartyIdentification" focus-field-name="idValue">
         <alt-target use-when="partyIdentification !=null" target="updatePartyIdentification"/>
@@ -1332,7 +1297,6 @@ under the License.
         <field name="submit" title="${uiLabelMap.CommonCreate}" use-when="partyIdentification == null"><submit /></field>
         <field name="submit" title="${uiLabelMap.CommonUpdate}" use-when="partyIdentification != null"><submit /></field>
     </form>
-    
     <form name="EditProductStoreRole" type="single" extends="EditProductStoreRole" extends-resource="component://product/widget/catalog/StoreForms.xml">
         <field name="partyId"><hidden/></field>
         <field name="productStoreId" use-when="productStoreRole==null" title="${uiLabelMap.ProductStoreId}" required-field="true">
@@ -1354,7 +1318,6 @@ under the License.
             </drop-down>
         </field>
     </form>
-    
     <grid name="ListProductStoreRole" list-name="listIt" paginate-target="FindProductStoreRoles" default-entity-name="ProductStoreRole" separate-columns="true"
             odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <actions>
@@ -1394,12 +1357,10 @@ under the License.
             </hyperlink>
         </field>
     </grid>
-
     <form name="ExportParty" type="single" target="ExportPartyCsv.csv" title="" >
         <field name="partyId" tooltip="blank for all"><lookup target-form-name="LookupPartyName"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}"><submit button-type="button"/></field>
     </form>
-
     <grid name="ExportPartyCsv" list-name="listIt" target="" title="" view-size="99999"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar" paginate="false">
         <actions>
@@ -1438,12 +1399,8 @@ under the License.
         <field name="postalCode" title="postalCode"><display/></field>
         <field name="countryGeoId" title="countryGeoId"><display/></field>
     </grid>
-    
     <form name="ImportParty" type="upload" target="uploadParty" title="" >
         <field name="uploadedFile" title="${uiLabelMap.ContentFile}"><file/></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpload}"><submit button-type="button"/></field>
     </form>
-    
-
-    
 </forms>

--- a/applications/party/widget/partymgr/PartyScreens.xml
+++ b/applications/party/widget/partymgr/PartyScreens.xml
@@ -20,8 +20,6 @@ under the License.
 
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
-    <!-- Party Find Screen -->
     <screen name="findparty">
         <section>
             <actions>
@@ -35,7 +33,6 @@ under the License.
                 <set field="asm_formSize" value="700"/>
                 <set field="asm_listItemPercentOfForm" value="95"/>
                 <set field="asm_sortable" value="false"/>
-
                 <set field="initialyCollapsed" value="${groovy:'Y'.equals(parameters.hideFields)}" type="String"/>
                 <script location="component://party/groovyScripts/party/FindParty.groovy"/>
             </actions>
@@ -70,8 +67,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-    <!-- Party Profile Screens -->
-
     <screen name="viewprofile">
         <section>
             <actions>
@@ -260,7 +255,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditPartyRelationships">
         <section>
             <actions>
@@ -322,16 +316,13 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="viewvendor">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleViewVendorParty"/>
                 <set field="headerItem" value="find"/>
                 <set field="tabButtonItem" value="viewvendor"/>
-
                 <set field="labelTitleProperty" value="PartyVendorInformation"/>
-
                 <set field="partyId" from-field="parameters.partyId"/>
                 <entity-one entity-name="Party" value-field="party"/>
                 <entity-one entity-name="Vendor" value-field="vendor"/>
@@ -347,16 +338,13 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditPartyAttribute">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleEditPartyAttribute"/>
                 <set field="headerItem" value="find"/>
                 <set field="tabButtonItem" value="viewvendor"/>
-
                 <set field="labelTitleProperty" value="PartyAttribute"/>
-
                 <set field="cancelPage" from-field="parameters.CANCEL_PAGE" default-value="viewprofile"/>
                 <set field="partyId" from-field="parameters.partyId"/>
                 <set field="attrName" from-field="parameters.attrName"/>
@@ -374,7 +362,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditPartyTaxAuthInfos">
         <section>
             <actions>
@@ -382,7 +369,6 @@ under the License.
                 <set field="headerItem" value="find"/>
                 <set field="tabButtonItem" value="EditPartyTaxAuthInfos"/>
                 <set field="labelTitleProperty" value="PartyTaxAuthInfos"/>
-
                 <set field="partyId" from-field="parameters.partyId"/>
                 <entity-one entity-name="Party" value-field="party"/>
                 <entity-and entity-name="PartyTaxAuthInfo" list="partyTaxInfos">
@@ -410,9 +396,7 @@ under the License.
                 <set field="titleProperty" value="PageTitleShoppingList"/>
                 <set field="headerItem" value="find"/>
                 <set field="tabButtonItem" value="editShoppingList"/>
-
                 <set field="labelTitleProperty" value="PartyShoppingLists"/>
-
                 <script location="component://party/groovyScripts/party/EditShoppingList.groovy"/>
             </actions>
             <widgets>
@@ -426,19 +410,15 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="editcontactmech">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleEditContactMech"/>
                 <set field="headerItem" value="find"/>
                 <set field="tabButtonItem" value="editcontactmech"/>
-
                 <set field="labelTitleProperty" value="PageTitleEditContactMech"/>
-
                 <script location="component://party/groovyScripts/HasPartyPermissions.groovy"/>
                 <script location="component://party/groovyScripts/party/EditContactMech.groovy"/>
-
                 <set field="dependentForm" value="editcontactmechform"/>
                 <set field="paramKey" value="countryGeoId"/>
                 <set field="mainId" value="countryGeoId"/>
@@ -484,7 +464,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditPerson">
         <section>
             <actions>
@@ -492,7 +471,6 @@ under the License.
                 <set field="tabButtonItem" value="viewprofile"/>
                 <set field="headerItem" value="find"/>
                 <set field="labelTitleProperty" value="PageTitleEditPersonalInformation"/>
-
                 <set field="donePage" from-field="parameters.DONE_PAGE" default-value="viewprofile"/>
                 <set field="partyId" from-field="parameters.partyId"/>
                 <entity-one entity-name="PartyAndPerson" value-field="personInfo"/>
@@ -515,7 +493,6 @@ under the License.
                 <set field="tabButtonItem" value="viewprofile"/>
                 <set field="headerItem" value="find"/>
                 <set field="labelTitleProperty" value="PageTitleEditGroupInformation"/>
-
                 <set field="donePage" from-field="parameters.DONE_PAGE" default-value="viewprofile"/>
                 <set field="partyId" from-field="parameters.partyId"/>
                 <entity-one entity-name="PartyAndGroup" value-field="partyGroup"/>
@@ -580,7 +557,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="CreatePartyRelatedAccount">
         <section>
             <actions>
@@ -600,7 +576,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="CreateAccountRelatedContact">
         <section>
             <actions>
@@ -620,7 +595,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditUserLoginSecurityGroups">
         <section>
             <actions>
@@ -646,14 +620,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="AddPartyNote">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleNewPartyNote"/>
                 <set field="tabButtonItem" value="viewprofile"/>
                 <set field="labelTitleProperty" value="PageTitleNewPartyNote"/>
-
                 <set field="donePage" from-field="parameters.DONE_PAGE" default-value="viewprofile"/>
                 <set field="partyId" from-field="parameters.partyId"/>
             </actions>
@@ -668,7 +640,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditPartyRates">
         <section>
             <actions>
@@ -676,33 +647,46 @@ under the License.
                 <set field="headerItem" value="find"/>
                 <set field="tabButtonItem" value="EditPartyRates"/>
                 <set field="labelTitleProperty" value="PageTitleEditPartyRates"/>
-
                 <set field="partyId" from-field="parameters.partyId"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonPartyDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet id="AddPartyRatesPanel" title="${uiLabelMap.PageTitleEditPartyRates}" collapsible="true">
-                            <include-form name="AddPartyRate" location="component://party/widget/partymgr/PartyForms.xml"/>
-                        </screenlet>
-                        <screenlet>
-                            <include-grid name="ListPartyRates" location="component://party/widget/partymgr/PartyForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <and>
+                                    <or>
+                                        <if-has-permission permission="PARTYMGR" action="CREATE"/>
+                                        <if-has-permission permission="PARTYMGR" action="UPDATE"/>
+                                    </or>
+                                </and>
+                                </condition>
+                            <widgets>
+                                <screenlet id="AddPartyRatesPanel" title="${uiLabelMap.PageTitleEditPartyRates}" collapsible="true">
+                                    <include-form name="AddPartyRate" location="component://party/widget/partymgr/PartyForms.xml"/>
+                                </screenlet>
+                                <screenlet>
+                                    <include-grid name="ListPartyRates" location="component://party/widget/partymgr/PartyForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                            <fail-widgets>
+                                <screenlet>
+                                    <include-grid name="PartyRates" location="component://party/widget/partymgr/PartyForms.xml"/>
+                                </screenlet>
+                            </fail-widgets>
+                        </section>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
         </section>
     </screen>
-
     <screen name="ViewSegmentRoles">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleViewPartySegmentRoles"/>
                 <set field="headerItem" value="find"/>
                 <set field="tabButtonItem" value="ViewSegmentRoles"/>
-
                 <set field="labelTitleProperty" value="ViewSegmentRoles"/>
-
                 <set field="partyId" from-field="parameters.partyId"/>
                 <entity-one entity-name="Party" value-field="party"/>
             </actions>
@@ -720,8 +704,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
-    <!-- New Customer Party Screen -->
     <screen name="NewCustomer">
         <section>
             <actions>
@@ -767,8 +749,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
-    <!-- New Prospect Party Screen -->
     <screen name="NewProspect">
         <section>
             <actions>
@@ -812,8 +792,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
-    <!-- New Emplyee Party Screen -->
     <screen name="NewEmployee">
         <section>
             <actions>
@@ -857,8 +835,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
-    <!-- Address Match Map Screen -->
     <screen name="AddressMatchMap">
         <section>
             <actions>
@@ -879,7 +855,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindAddressMatch">
         <section>
             <actions>
@@ -898,8 +873,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
-    <!-- Party Content Screen -->
     <screen name="EditPartyContents">
         <section>
             <actions>
@@ -999,7 +972,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="PartyFinancialHistory">
         <section>
             <actions>
@@ -1292,17 +1264,13 @@ under the License.
             </widgets>
         </section>
     </screen>
-
-    <!-- PartyIdentification Screen -->
     <screen name="ListPartyIdentifications">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleListPartyIdentifications"/>
                 <set field="headerItem" value="find"/>
                 <set field="tabButtonItem" value="viewidentifications"/>
-
                 <set field="labelTitleProperty" value="PartyIdentification"/>
-
                 <set field="partyId" from-field="parameters.partyId"/>
                 <entity-one entity-name="Party" value-field="party" use-cache="true"/>
                 <entity-one entity-name="PartyIdentification" value-field="partyIdentification"/>
@@ -1322,7 +1290,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ViewProductStoreRoles">
         <section>
             <actions>
@@ -1422,5 +1389,4 @@ under the License.
             </widgets>
         </section>
     </screen>
-
 </screens>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing the Party Rates screen, sees editable fields and/or triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions.
To see:/test:
for DemoEmployee (rates in demo data): https://localhost:8443/partymgr/control/EditPartyRates?partyId=DemoEmployee
for DemoEmployee2 (after merge of PR74 in plugins): https://localhost:8443/partymgr/control/EditPartyRates?partyId=DemoEmployee2

Modified:
- PartyScreens.xml - restructured screen EditPartyRates to work with permissions
- PartyForms.xml - added grid PartyRates for users with VIEW permissions
additional cleanup