### PR TITLE
Improved: Have a Menu in Content featuring actions to create the main objects (OFBIZ-12541)

### DIFF
--- a/applications/content/widget/CommonScreens.xml
+++ b/applications/content/widget/CommonScreens.xml
@@ -17,14 +17,11 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
     <screen name="main-decorator">
         <section>
             <actions>
-                <!-- base/top/specific map first, then more common map added for shared labels -->
                 <property-map resource="ContentUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="WorkEffortUiLabels" map-name="uiLabelMap" global="true"/>
@@ -68,6 +65,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
@@ -94,7 +92,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="commonContentDecorator">
         <section>
             <actions>
@@ -103,6 +100,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
@@ -145,7 +143,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="contentDecorator">
         <section>
             <actions>
@@ -154,6 +151,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
@@ -182,8 +180,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
-
     <screen name="commonDataResourceDecorator">
         <section>
             <actions>
@@ -193,6 +189,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
@@ -231,7 +228,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="commonContentSetupDecorator">
         <section>
             <actions>
@@ -240,6 +236,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="component://content/widget/CommonScreens.xml">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
@@ -266,7 +263,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="commonDataResourceSetupDecorator">
         <section>
             <actions>
@@ -275,6 +271,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="component://content/widget/CommonScreens.xml">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
@@ -301,7 +298,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="CommonWebSiteDecorator">
         <section>
             <actions>
@@ -310,14 +306,16 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="component://content/widget/CommonScreens.xml">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
                                     <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
-                                    <not><if-empty field="parameters.webSiteId"/></not>
+                                    <not><if-empty field="webSiteId"/></not>
                                 </and>
                             </condition>
                             <widgets>
+                                <label style="h1" text="${uiLabelMap.CommonWebsite}: ${webSiteId} "/>
                                 <include-menu name="website" location="component://content/widget/content/ContentMenus.xml"/>
                             </widgets>
                         </section>
@@ -328,13 +326,6 @@ under the License.
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
                             </condition>
                             <widgets>
-                                <!--<container style="button-bar">
-                                    <link  text="${uiLabelMap.CommonCreate}" target="EditWebSite" style="buttontext create"/>
-                                </container>-->
-                                <container>
-                                    <include-menu name="websiteMenu" location="component://content/widget/content/ContentMenus.xml"/>
-                                </container>
-                                <label style="h1" text="${uiLabelMap[labelTitleProperty]} ${uiLabelMap.CommonFor}: ${webSite.siteName} [${webSite.webSiteId}]  ${${extraFunctionName}}"/>
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>
@@ -346,7 +337,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="CommonWebSitePathAliasDecorator">
         <section>
             <actions>
@@ -355,6 +345,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="component://content/widget/CommonScreens.xml">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -373,9 +364,6 @@ under the License.
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
                             </condition>
                             <widgets>
-                                <!--<container style="button-bar">
-                                    <link  text="${uiLabelMap.CommonCreate}" target="EditWebSite" style="buttontext create"/>
-                                </container>-->
                                 <container>
                                     <include-menu name="websitePathAliasMenu" location="component://content/widget/content/ContentMenus.xml"/>
                                 </container>
@@ -391,7 +379,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="commonLayoutDecorator">
         <section>
             <actions>
@@ -400,6 +387,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="component://content/widget/CommonScreens.xml">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <if-has-permission permission="CONTENTMGR" action="_VIEW"/>
@@ -408,12 +396,6 @@ under the License.
                                 <include-menu name="layout" location="component://content/widget/layout/LayoutMenus.xml"/>
                             </widgets>
                         </section>
-                        <container>
-                            <link target="EditLayoutSubContent" text="${uiLabelMap.CommonCreate}" style="buttontext">
-                                <parameter param-name="mode" value="add"/>
-                                <parameter param-name="contentIdTo" value="TEMPLATE_MASTER"/>
-                            </link>
-                        </container>
                     </decorator-section>
                     <decorator-section name="body">
                         <section>
@@ -432,11 +414,13 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="main">
         <section>
             <widgets>
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.ContentMain}">
                             <container><label text="${uiLabelMap.ContentWelcome}"/></container>
@@ -503,7 +487,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="CommonWebAnalyticsDecorator">
         <section>
             <actions>
@@ -512,6 +495,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator"  location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -542,5 +526,4 @@ under the License.
             </widgets>
         </section>
     </screen>
-
 </screens>

--- a/applications/content/widget/SurveyMenus.xml
+++ b/applications/content/widget/SurveyMenus.xml
@@ -21,7 +21,7 @@ under the License.
 <menus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://ofbiz.apache.org/Widget-Menu" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Menu http://ofbiz.apache.org/dtds/widget-menu.xsd">
     <menu name="SurveyTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml"
           default-menu-item-name="Survey">
-        <menu-item name="Survey" title="${uiLabelMap.ContentSurveySurveyId}">
+        <menu-item name="Survey" title="${uiLabelMap.ContentSurvey}">
             <link target="EditSurvey">
                 <parameter param-name="surveyId"/>
             </link>

--- a/applications/content/widget/SurveyScreens.xml
+++ b/applications/content/widget/SurveyScreens.xml
@@ -17,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
     <screen name="FindSurvey">
@@ -36,9 +35,6 @@ under the License.
                             </condition>
                             <widgets>
                                 <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                                    <decorator-section name="menu-bar">
-                                        <container style="button-bar"><link  text="${uiLabelMap.ContentSurveyCreate}" target="EditSurvey" style="buttontext create"/></container>
-                                    </decorator-section>
                                     <decorator-section name="search-options">
                                         <include-form name="FindSurvey" location="component://content/widget/survey/SurveyForms.xml"/>
                                     </decorator-section>
@@ -56,7 +52,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="CommonSurveyDecorator">
         <section>
             <actions>
@@ -66,6 +61,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="component://content/widget/CommonScreens.xml">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -74,8 +70,8 @@ under the License.
                                 </and>
                             </condition>
                             <widgets>
+                                <label style="h1" text="${uiLabelMap.ContentSurvey}: ${surveyId}"/>
                                 <include-menu name="SurveyTabBar" location="component://content/widget/SurveyMenus.xml"/>
-                                <container><link  text="${uiLabelMap.ContentSurveyCreate}" target="EditSurvey" style="buttontext"/></container>
                             </widgets>
                         </section>
                     </decorator-section>
@@ -102,7 +98,6 @@ under the License.
                 <set field="titleProperty" value="PageTitleEditSurvey"/>
                 <set field="tabButtonItem" value="Survey"/>
                 <set field="labelTitleProperty" value="PageTitleEditSurvey"/>
-
                 <set field="surveyId" from-field="parameters.surveyId"/>
                 <entity-one entity-name="Survey" value-field="survey"/>
             </actions>
@@ -119,8 +114,10 @@ under the License.
                                 </screenlet>
                             </widgets>
                             <fail-widgets>
-                                <screenlet title="${uiLabelMap.PageTitleEditSurvey} ${uiLabelMap.ContentSurveySurveyId} ${surveyId}">
+                                <screenlet title="${uiLabelMap.PageTitleEditSurvey}">
                                     <include-form name="EditSurvey" location="component://content/widget/survey/SurveyForms.xml"/>
+                                </screenlet>
+                                <screenlet>
                                     <include-form name="BuildSurveyFromPdf" location="component://content/widget/survey/SurveyForms.xml"/>
                                 </screenlet>
                             </fail-widgets>
@@ -136,7 +133,6 @@ under the License.
                 <set field="titleProperty" value="PageTitleEditSurveyMultiResps"/>
                 <set field="tabButtonItem" value="SurveyMultiResps"/>
                 <set field="labelTitleProperty" value="PageTitleEditSurveyMultiResps"/>
-
                 <set field="surveyId" from-field="parameters.surveyId"/>
                 <entity-one entity-name="Survey" value-field="survey"/>
                 <entity-condition entity-name="SurveyMultiResp" list="surveyMultiRespList">
@@ -172,26 +168,18 @@ under the License.
     <screen name="EditSurveyQuestions">
         <section>
             <actions>
-
                 <set field="titleProperty" value="PageTitleEditSurveyQuestions"/>
                 <set field="tabButtonItem" value="SurveyQuestions"/>
                 <set field="labelTitleProperty" value="PageTitleEditSurveyQuestions"/>
-
                 <set field="newCategory" from-field="parameters.newCategory" default-value="N"/>
                 <set field="surveyId" from-field="parameters.surveyId"/>
                 <entity-one entity-name="Survey" value-field="survey"/>
-
                 <script location="component://content/groovyScripts/survey/EditSurveyQuestions.groovy"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonSurveyDecorator">
                     <decorator-section name="body">
                         <platform-specific><html><html-template location="component://content/template/survey/EditSurveyQuestions.ftl"/></html></platform-specific>
-
-                        <!-- This page is a bit of a mess, so will cleanup/modernize later...
-                        <include-form name="ListSurveyQuestions" location="component://content/widget/survey/SurveyForms.xml"/>
-                        <include-form name="CreateSurveyQuestion" location="component://content/widget/survey/SurveyForms.xml"/>
-                        -->
                         <section>
                             <condition>
                                 <if-compare operator="equals" value="Y" field="newCategory"/>
@@ -287,12 +275,10 @@ under the License.
                 <set field="titleProperty" value="PageTitleFindSurveyResponse"/>
                 <set field="tabButtonItem" value="FindSurveyResponse"/>
                 <set field="labelTitleProperty" value="PageTitleFindSurveyResponse"/>
-
                 <set field="queryString" from-field="result.queryString"/>
                 <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer"/>
                 <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
-
                 <set field="surveyId" from-field="parameters.surveyId"/>
                 <entity-one entity-name="Survey" value-field="survey"/>
             </actions>
@@ -324,10 +310,8 @@ under the License.
                 <set field="titleProperty" value="PageTitleViewSurveyResponses"/>
                 <set field="tabButtonItem" value="SurveyResponses"/>
                 <set field="labelTitleProperty" value="PageTitleViewSurveyResponses"/>
-
                 <set field="surveyId" from-field="parameters.surveyId"/>
                 <entity-one entity-name="Survey" value-field="survey"/>
-
                 <script location="component://content/groovyScripts/survey/ViewSurveyResponses.groovy"/>
             </actions>
             <widgets>
@@ -352,10 +336,8 @@ under the License.
                 <set field="titleProperty" value="PageTitleEditSurveyResponse"/>
                 <set field="tabButtonItem" value="SurveyResponses"/>
                 <set field="labelTitleProperty" value="PageTitleEditSurveyResponse"/>
-
                 <set field="surveyId" from-field="parameters.surveyId"/>
                 <entity-one entity-name="Survey" value-field="survey"/>
-
                 <set field="surveyResponseId" from-field="parameters.surveyResponseId"/>
                 <entity-one entity-name="SurveyResponse" value-field="surveyResponse"/>
                 <script location="component://content/groovyScripts/survey/EditSurveyResponse.groovy"/>
@@ -371,7 +353,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="LookupSurvey">
         <section>
             <condition>

--- a/applications/content/widget/WebSiteScreens.xml
+++ b/applications/content/widget/WebSiteScreens.xml
@@ -17,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
     <screen name="FindWebSite">
@@ -29,6 +28,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="component://content/widget/CommonScreens.xml">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -36,9 +38,6 @@ under the License.
                             </condition>
                             <widgets>
                                 <screenlet title="${uiLabelMap.PageTitleListWebSite}">
-                                    <container style="button-bar">
-                                        <link  text="${uiLabelMap.CommonCreate}" target="EditWebSite" style="buttontext create"/>
-                                    </container>
                                     <include-form name="ListWebSites" location="component://content/widget/website/WebSiteForms.xml"/>
                                 </screenlet>
                             </widgets>
@@ -51,7 +50,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWebSite">
         <section>
             <actions>
@@ -76,7 +74,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WebSiteContent">
         <section>
             <actions>
@@ -110,7 +107,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWebSiteParties">
         <section>
             <actions>
@@ -138,7 +134,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WebSiteCMS">
         <section>
             <actions>
@@ -147,7 +142,6 @@ under the License.
                 <set field="labelTitleProperty" value="PageTitleEditWebSiteCMS"/>
                 <set field="webSiteId" from-field="parameters.webSiteId"/>
                 <entity-one entity-name="WebSite" value-field="webSite"/>
-
                 <script location="component://content/groovyScripts/website/WebSitePublishPoint.groovy"/>
             </actions>
             <widgets>
@@ -178,7 +172,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WebSiteCMSNav">
         <section>
             <widgets>
@@ -188,14 +181,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WebSiteCMSContent">
         <section>
             <actions>
                 <property-map resource="ContentUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="WorkEffortUiLabels" map-name="uiLabelMap" global="true"/>
-
                 <set field="dataResourceTypeId" from-field="parameters.dataResourceTypeId"/>
                 <set field="newContentId" from-field="contentId" />
                 <set field="contentIdFrom" from-field="parameters.contentIdFrom"/>
@@ -253,7 +244,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WebSiteCMSEditor">
         <section>
             <actions>
@@ -278,7 +268,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WebSiteCMSMetaInfo">
         <section>
             <actions>
@@ -302,7 +291,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-    
     <screen name="WebSiteCMSPathAlias">
         <section>
             <actions>
@@ -353,8 +341,7 @@ under the License.
                 </decorator-screen>
             </widgets>
         </section>
-    </screen> 
-      
+    </screen>
     <screen name="WebSiteAliases">
         <section>
             <actions>
@@ -382,7 +369,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-    
     <screen name="WebSiteAliasesSearchResults">
         <section>
             <actions>
@@ -393,7 +379,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WebSiteSEO">
         <section>
             <actions>

--- a/applications/content/widget/content/ContentMenus.xml
+++ b/applications/content/widget/content/ContentMenus.xml
@@ -18,7 +18,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 <menus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://ofbiz.apache.org/Widget-Menu" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Menu http://ofbiz.apache.org/dtds/widget-menu.xsd">
-
     <menu name="ContentAppBar" title="${uiLabelMap.ContentContentManager}" extends="CommonAppBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="websites" title="${uiLabelMap.ContentWebSites}"><link target="FindWebSite"/></menu-item>
         <menu-item name="survey" title="${uiLabelMap.ContentSurvey}"><link target="FindSurvey"/></menu-item>
@@ -31,7 +30,56 @@ under the License.
         <menu-item name="Layout" title="${uiLabelMap.ContentTemplate}"><link target="LayoutMenu"/></menu-item>
         <menu-item name="CMS" title="${uiLabelMap.ContentCMS}"><link target="CMSContentFind"/></menu-item>
     </menu>
-
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2">
+        <menu-item name="NewContent" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonContent}">
+            <condition>
+                <or>
+                    <if-has-permission permission="CONTENT" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditContent"/>
+        </menu-item>
+        <menu-item name="NewBlog" title="${uiLabelMap.CommonNew} ${uiLabelMap.ContentBlog}">
+            <condition>
+                <or>
+                    <if-has-permission permission="CONTENT" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditContent"/>
+        </menu-item>
+        <menu-item name="NewDataResource" title="${uiLabelMap.CommonNew} ${uiLabelMap.DataSource}">
+            <condition>
+                <or>
+                    <if-has-permission permission="CONTENT" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditDataResource"/>
+        </menu-item>
+        <menu-item name="NewSurvey" title="${uiLabelMap.CommonNew} ${uiLabelMap.ContentSurvey}">
+            <condition>
+                <or>
+                    <if-has-permission permission="CONTENT" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditSurvey"/>
+        </menu-item>
+        <menu-item name="NewTemplate" title="${uiLabelMap.CommonNew} ${uiLabelMap.ContentTemplate}">
+            <condition>
+                <or>
+                    <if-has-permission permission="CONTENT" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditLayoutSubContent"/>
+        </menu-item>
+        <menu-item name="NewWebSite" title="${uiLabelMap.CommonNew} ${uiLabelMap.CommonWebsite}">
+            <condition>
+                <or>
+                    <if-has-permission permission="CONTENT" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditWebSite"/>
+        </menu-item>
+    </menu>
     <menu name="ContentShortcutAppBar" title="${uiLabelMap.ContentContentManager}">
         <menu-item name="websites" title="${uiLabelMap.ContentWebSites}"><link target="FindWebSite" url-mode="inter-app"/></menu-item>
         <menu-item name="survey" title="${uiLabelMap.ContentSurvey}"><link target="FindSurvey" url-mode="inter-app"/></menu-item>
@@ -44,11 +92,9 @@ under the License.
         <menu-item name="Layout" title="${uiLabelMap.ContentTemplate}"><link target="LayoutMenu" url-mode="inter-app"/></menu-item>
         <menu-item name="CMS" title="${uiLabelMap.ContentCMS}"><link target="CMSContentFind" url-mode="inter-app"/></menu-item>
     </menu>
-
     <menu name="content"  menu-container-style="button-bar tab-bar" default-selected-style="selected" default-menu-item-name="content" default-permission-operation="HAS_AUTHOR_ROLE|CONTENT_ADMIN"
         default-permission-entity-action="_ADMIN" default-associated-content-id="${userLogin.userLoginId}" selected-menuitem-context-field-name="tabButtonItem"
         title="" type="simple">
-
         <menu-item name="content" title="${uiLabelMap.ContentContent}">
             <condition>
                 <not><if-empty field="currentValue.contentId"/></not>
@@ -57,7 +103,6 @@ under the License.
                 <parameter param-name="contentId" from-field="parameters.contentId"/>
             </link>
         </menu-item>
-
         <menu-item name="association" title="${uiLabelMap.ContentAssociation}">
             <condition>
                 <not><if-empty field="currentValue.contentId"/></not>
@@ -66,8 +111,7 @@ under the License.
                 <parameter param-name="contentId" from-field="parameters.contentId"/>
             </link>
         </menu-item>
-
-        <menu-item name="role" title="${uiLabelMap.FormFieldTitle_roles}" >
+        <menu-item name="role" title="${uiLabelMap.CommonRoles}" >
             <condition>
                 <not><if-empty field="currentValue.contentId"/></not>
             </condition>
@@ -75,7 +119,6 @@ under the License.
                 <parameter param-name="contentId" from-field="parameters.contentId"/>
             </link>
         </menu-item>
-
         <menu-item name="purpose" title="${uiLabelMap.FormFieldTitle_purposes}" >
             <condition>
                 <not>
@@ -86,8 +129,7 @@ under the License.
                 <parameter param-name="contentId" from-field="parameters.contentId"/>
             </link>
         </menu-item>
-
-        <menu-item name="attribute" title="${uiLabelMap.ContentAttribute}" >
+        <menu-item name="attribute" title="${uiLabelMap.CommonAttributes}" >
             <condition>
                 <not><if-empty field="currentValue.contentId"/></not>
             </condition>
@@ -95,7 +137,6 @@ under the License.
                 <parameter param-name="contentId" from-field="parameters.contentId"/>
             </link>
         </menu-item>
-
         <menu-item name="websites" title="${uiLabelMap.ContentWebSites}">
             <condition>
                 <not><if-empty field="currentValue.contentId"/></not>
@@ -104,7 +145,6 @@ under the License.
                 <parameter param-name="contentId" from-field="parameters.contentId"/>
             </link>
         </menu-item>
-
         <menu-item name="metaData" title="${uiLabelMap.ContentMetadata}" >
             <condition>
                 <not><if-empty field="currentValue.contentId"/></not>
@@ -113,7 +153,6 @@ under the License.
                 <parameter param-name="contentId" from-field="parameters.contentId"/>
             </link>
         </menu-item>
-
         <menu-item name="workEffort" title="${uiLabelMap.WorkEffortWorkEffort}" >
             <condition>
                 <not><if-empty field="currentValue.contentId"/></not>
@@ -122,7 +161,6 @@ under the License.
                 <parameter param-name="contentId" from-field="parameters.contentId"/>
             </link>
         </menu-item>
-        
         <menu-item name="keywords" title="${uiLabelMap.ContentKeywords}" >
             <condition>
                 <not><if-empty field="currentValue.contentId"/></not>
@@ -132,17 +170,9 @@ under the License.
             </link>
         </menu-item>
     </menu>
-    
     <menu name="contentSub" menu-container-style="button-bar button-style-2" default-menu-item-name="content" default-permission-operation="HAS_AUTHOR_ROLE|CONTENT_ADMIN"
         default-permission-entity-action="_ADMIN" default-associated-content-id="${userLogin.userLoginId}" selected-menuitem-context-field-name="currentMenuItemName"
         title="" type="simple">
-
-        <menu-item name="NewContent" title="${uiLabelMap.CommonCreate}">
-            <condition>
-                <not><if-empty field="currentValue.contentId"/></not>
-            </condition>
-            <link target="EditContent"/>
-        </menu-item>
         <menu-item name="NewContentAssoc" title="${uiLabelMap.CommonCreate} ${uiLabelMap.ContentAssociation}">
             <condition>
                 <if-compare field="tabButtonItem" operator="equals" value="association"/>
@@ -152,7 +182,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="website"  menu-container-style="button-bar tab-bar" default-selected-style="selected" default-menu-item-name="content" default-permission-operation="CONTENT_ADMIN"
         default-permission-entity-action="_ADMIN" default-associated-content-id="${userLogin.userLoginId}" selected-menuitem-context-field-name="tabButtonItem"
         title="" type="simple">
@@ -208,24 +237,20 @@ under the License.
                 <parameter param-name="blogContentId" from-field="parameters.blogContentId"/>
             </link>
         </menu-item>
-        <menu-item name="Articles" title="${uiLabelMap.ContentBlogArticleList}">
+        <menu-item name="Articles" title="${uiLabelMap.CommonContent}">
             <link target="blogContent">
                 <parameter param-name="blogContentId" from-field="parameters.blogContentId"/>
             </link>
         </menu-item>
-        <menu-item name="Owners" title="${uiLabelMap.FormFieldTitle_roles}">
+        <menu-item name="Owners" title="${uiLabelMap.CommonRoles}">
             <link target="EditContentRole">
                 <parameter param-name="contentId" from-field="parameters.blogContentId"/>
             </link>
         </menu-item>
     </menu>
-
     <menu name="blogSub" menu-container-style="button-bar" default-menu-item-name="content" default-permission-operation="HAS_AUTHOR_ROLE|CONTENT_ADMIN"
         default-permission-entity-action="_ADMIN" default-associated-content-id="${userLogin.userLoginId}" selected-menuitem-context-field-name="currentMenuItemName"
         title="" type="simple">
-        <menu-item name="NewBlog" title="${uiLabelMap.ContentCreateNewBlog}" widget-style="buttontext create">
-            <link target="editBlog"/>
-        </menu-item>
         <menu-item name="NewBlogArticle" title="${uiLabelMap.ContentCreateNewBlogArticle}" widget-style="buttontext create">
             <condition>
                 <if-compare field="tabButtonItem" operator="equals" value="Articles"/>
@@ -235,7 +260,6 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
     <menu name="blogArt"  menu-container-style="button-bar tab-bar" default-selected-style="selected" default-menu-item-name="content" default-permission-operation="CONTENT_ADMIN"
         default-permission-entity-action="_ADMIN" default-associated-content-id="${userLogin.userLoginId}" selected-menuitem-context-field-name="tabButtonItem"
         title="" type="simple">
@@ -256,7 +280,7 @@ under the License.
                 <parameter param-name="blogContentId" from-field="parameters.blogContentId"/>
             </link>
         </menu-item>
-        <menu-item name="Owners" title="${uiLabelMap.FormFieldTitle_roles}">
+        <menu-item name="Owners" title="${uiLabelMap.CommonRoles}">
             <link target="EditContentRole">
                 <parameter param-name="contentId" from-field="parameters.articleContentId"/>
             </link>
@@ -288,9 +312,6 @@ under the License.
         </menu-item>
     </menu>
     <menu name="contentMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
-        <menu-item name="EditContent" title="${uiLabelMap.CommonCreate}" widget-style="buttontext create">
-            <link target="EditContent"/>
-        </menu-item>
         <menu-item name="ContentSearchOptions" title="${uiLabelMap.CommonAdvancedSearch}" widget-style="buttontext">
             <link target="ContentSearchOptions"/>
         </menu-item>
@@ -298,27 +319,16 @@ under the License.
             <link target="updateContentAllKeywords"/>
         </menu-item>
     </menu>
-    <menu name="websiteMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
-        <menu-item name="EditWebSite" title="${uiLabelMap.CommonCreate}" widget-style="buttontext create">
-            <link target="EditWebSite"/>
-        </menu-item>
-    </menu>
     <menu name="websitePathAliasMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
         <menu-item name="EditWebSitePathAlias" title="${uiLabelMap.ContentWebSitePathAliasCreate}" widget-style="buttontext create">
             <link target="EditWebSitePathAlias?webSiteId=${webSiteId}"/>
         </menu-item>
-    </menu>    
-    <!-- Web Analytics -->
+    </menu>
     <menu name="WebAnalyticsConfigButtonBar" extends="CommonButtonBarMenu" extends-resource="component://common/widget/CommonMenus.xml" selected-menuitem-context-field-name="tabButtonItem2">
         <menu-item name="EditWebAnalyticsConfig" title="${uiLabelMap.CommonCreate}">
             <link target="EditWebAnalyticsConfig" style="buttontext create">
                 <parameter param-name="webSiteId" from-field="parameters.webSiteId"/>
             </link>
         </menu-item>
-        <!--<menu-item name="WebAnalyticsTypes" title="Create ${uiLabelMap.CatalogWebAnalyticsTypes}">
-            <link target="EditWebAnalyticsType" style="buttontext create">
-                <parameter param-name="webSiteId" from-field="parameters.webSiteId"/>
-            </link>
-        </menu-item>-->
     </menu>
 </menus>

--- a/applications/content/widget/content/ContentScreens.xml
+++ b/applications/content/widget/content/ContentScreens.xml
@@ -20,7 +20,6 @@ under the License.
 
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
     <screen name="FindContent">
         <section>
             <condition>
@@ -161,13 +160,9 @@ under the License.
                 <set field="contentId" from-field="parameters.contentId"/>
                 <set field="viewSize" value="${parameters.VIEW_SIZE}" default-value="30" type="Integer"/>
                 <set field="viewIndex" value="${parameters.VIEW_INDEX}" default-value="0" type="Integer"/>
-               <!-- <entity-condition entity-name="ContentAssocViewTo" list="contentAssoc">
-                    <condition-expr field-name="contentIdStart" operator="equals" from-field="contentId"/>
-                    </entity-condition>-->
                 <script location="component://content/groovyScripts/content/GetContentLookupList.groovy"/>
             </actions>
             <widgets>
-<!--                <include-form name="ListDocument" location="component://content/widget/content/ContentForms.xml"/>-->
                 <platform-specific>
                     <html>
                         <html-template location="component://content/template/lookup/ContentTreeLookupList.ftl"/>
@@ -287,14 +282,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentRole">
         <section>
             <actions>
                 <script location="component://content/groovyScripts/cms/GetMenuContext.groovy"/>
                 <set field="titleProperty" value="PageTitleEditContentRole"/>
                 <set field="tabButtonItem" value="role"/>
-
                 <set field="contentId" from-field="parameters.contentId"/>
                 <set field="contentRoleTarget" value=""/>
                 <entity-one entity-name="Content" value-field="currentValue">
@@ -315,7 +308,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentPurpose">
         <section>
             <actions>
@@ -341,7 +333,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentAttribute">
         <section>
             <actions>
@@ -367,7 +358,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWebSite">
         <section>
             <actions>
@@ -403,7 +393,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentMetaData">
         <section>
             <actions>
@@ -429,7 +418,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentWorkEfforts">
         <section>
             <actions>
@@ -455,7 +443,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="LookupContent">
         <section>
             <actions>
@@ -478,7 +465,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListContentTree">
         <section>
             <actions>
@@ -502,7 +488,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="LookupContentTree">
         <section>
             <actions>
@@ -540,7 +525,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="LookupDetailContentTree">
         <section>
             <actions>
@@ -580,7 +564,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ViewContentDetail">
         <section>
             <actions>
@@ -611,7 +594,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ContentSearchOptions">
         <section>
             <actions>
@@ -629,7 +611,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ContentSearchResults">
         <section>
             <actions>
@@ -647,7 +628,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentKeywords">
         <section>
             <actions>

--- a/applications/content/widget/contentsetup/ContentSetupScreens.xml
+++ b/applications/content/widget/contentsetup/ContentSetupScreens.xml
@@ -17,11 +17,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
-
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
     <screen name="EditContentType">
         <section>
             <actions>
@@ -43,7 +40,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentTypeAttr">
         <section>
             <actions>
@@ -65,7 +61,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentAssocType">
         <section>
             <actions>
@@ -87,7 +82,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentPurposeType">
         <section>
             <actions>
@@ -109,7 +103,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentAssocPredicate">
         <section>
             <actions>
@@ -131,7 +124,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditContentPurposeOperation">
         <section>
             <actions>
@@ -153,7 +145,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="UserPermissions">
         <section>
             <actions>

--- a/applications/content/widget/forum/BlogScreens.xml
+++ b/applications/content/widget/forum/BlogScreens.xml
@@ -17,10 +17,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
     <screen name="commonBlogDecorator">
         <section>
             <actions>
@@ -29,6 +27,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -46,7 +47,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="blogDecorator">
         <section>
             <widgets>
@@ -61,12 +61,9 @@ under the License.
                                 <entity-one entity-name="Content" value-field="blogContent"/>
                             </actions>
                             <widgets>
+                                <label style="h1" text="${uiLabelMap.ContentBlog}: ${contentId}"/>
                                 <include-menu name="blog" location="component://content/widget/content/ContentMenus.xml"/>
                                 <include-menu name="blogSub" location="component://content/widget/content/ContentMenus.xml"/>
-                                <label style="h1" text="${blogContent.contentName}"/>
-                                <link style="h1" text=" [${blogContent.contentId}]" target="blogContent">
-                                    <parameter param-name="blogContentId" from-field="parameters.blogContentId"/>
-                                </link>
                             </widgets>
                         </section>
                         <decorator-section-include name="body"/>
@@ -75,7 +72,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="blogArtDecorator">
         <section>
             <widgets>
@@ -90,12 +86,9 @@ under the License.
                                 <entity-one entity-name="Content" value-field="blogContent"/>
                             </actions>
                             <widgets>
+                                <label style="h1" text="${uiLabelMap.ContentBlog}: ${blogContent.contentName}"/>
                                 <include-menu name="blogArt" location="component://content/widget/content/ContentMenus.xml"/>
                                 <include-menu name="blogArtSub" location="component://content/widget/content/ContentMenus.xml"/>
-                                <label style="h1" text="${blogContent.contentName}"/>
-                                <link style="h1" text=" [${blogContent.contentId}]" target="blogContent">
-                                    <parameter param-name="blogContentId" from-field="parameters.blogContentId"/>
-                                </link>
                             </widgets>
                         </section>
                         <decorator-section-include name="body"/>
@@ -104,7 +97,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="BlogMain">
         <section>
             <actions>
@@ -154,7 +146,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="BlogContent">
         <section>
             <actions>
@@ -171,7 +162,7 @@ under the License.
             <widgets>
                 <decorator-screen name="blogDecorator">
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.ContentBlogArticleList}" navigation-form-name="BlogContent">
+                        <screenlet title="${uiLabelMap.CommonContent}" navigation-form-name="BlogContent">
                             <include-form name="BlogContent" location="component://content/widget/forum/BlogForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -179,7 +170,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditArticle">
         <section>
             <actions>
@@ -192,9 +182,6 @@ under the License.
             </actions>
             <widgets>
                 <section>
-                    <!--condition>
-                        <if-service-permission service-name="genericContentPermission" main-action="UPDATE"/>
-                        </condition-->
                     <actions>
                         <service service-name="getBlogEntry" result-map="blogEntry" auto-field-map="true"/>
                     </actions>

--- a/applications/content/widget/forum/ForumScreens.xml
+++ b/applications/content/widget/forum/ForumScreens.xml
@@ -17,10 +17,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
     <screen name="commonForumDecorator">
         <section>
             <actions>
@@ -31,6 +29,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://content/widget/content/ContentMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -61,7 +60,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindForumGroups">
         <section>
             <actions>
@@ -85,7 +83,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindForums">
         <section>
             <actions>
@@ -114,7 +111,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ForumGroupRoles">
         <section>
             <actions>
@@ -143,7 +139,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ForumGroupPurposes">
         <section>
             <actions>
@@ -172,7 +167,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindForumMessages">
         <section>
             <actions>
@@ -205,7 +199,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindForumThreads">
         <section>
             <actions>
@@ -273,7 +266,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditForumMessage">
         <section>
             <actions>
@@ -295,7 +287,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="AddForumMessage">
         <section>
             <actions>
@@ -320,7 +311,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="AddForumThreadMessage">
         <section>
             <actions>
@@ -345,5 +335,4 @@ under the License.
             </widgets>
         </section>
     </screen>
-
 </screens>


### PR DESCRIPTION
Currently the create buttons for the main objects of the Content application are located within find and profile widgets/templates of those objects.
In order to improve the usability of this application, OFBiz and thus the appeal of it for adopters and users, these create buttons/links/etc. should be in a main action menu visible at all times when a user with CREATE permissions is working within the application

modified:
ContentMenuxs.xml - added MainActionMenu for users with CREATE permissions in the Content application
Various screens in the content component - added MainActionMenu where appropriate
additional cleanup