### PR TITLE
Improved: Have CommonProduct Label for use with LookupProduct function (OFBIZ-12542)

### DIFF
--- a/framework/common/config/CommonUiLabels.xml
+++ b/framework/common/config/CommonUiLabels.xml
@@ -9455,6 +9455,26 @@
         <value xml:lang="zh-CN">处理中</value>
         <value xml:lang="zh-TW">處理中</value>
     </property>
+    <property key="CommonProduct">
+        <value xml:lang="ar">سلعة</value>
+        <value xml:lang="cs">Výrobek</value>
+        <value xml:lang="de">Produkt</value>
+        <value xml:lang="en">Product</value>
+        <value xml:lang="es">Producto</value>
+        <value xml:lang="fr">Article</value>
+        <value xml:lang="hi-IN">सामान</value>
+        <value xml:lang="it">Prodotto</value>
+        <value xml:lang="ja">製品</value>
+        <value xml:lang="nl">Produkt</value>
+        <value xml:lang="pt-BR">Produto</value>
+        <value xml:lang="pt-PT">Produto</value>
+        <value xml:lang="ro">Produs</value>
+        <value xml:lang="ru">Продукт</value>
+        <value xml:lang="th">สินค้า</value>
+        <value xml:lang="vi">Sản phẩm</value>
+        <value xml:lang="zh">产品</value>
+        <value xml:lang="zh-TW">產品</value>
+    </property>
     <property key="CommonProductRating"><!--  Used to demark the section where ProductRating setting are made. -->
         <value xml:lang="de">Bewertung</value>
         <value xml:lang="en">Rating</value>


### PR DESCRIPTION
The LookupProduct function is used across various applications,
intended to assist users with the need to search, find and select
products in forms where one needs to be added or changed.
Also usable in overviews where a product is referenced.

jleroux: this was used by OFBIZ-12488

modified: CommonUiLabels.xml