### PR TITLE
Fixed: Wrong Field Name Definition in RequirementForms (OFBIZ-12505)

### DIFF
--- a/applications/order/widget/ordermgr/RequirementForms.xml
+++ b/applications/order/widget/ordermgr/RequirementForms.xml
@@ -282,7 +282,7 @@ under the License.
             </drop-down>
         </field>
         <field name="productId" title="${uiLabelMap.ProductProductId}"><lookup target-form-name="LookupProduct"/></field>
-        <field name="requirementByDate"><date-find type="date"/></field>
+        <field name="requiredByDate"><date-find type="date"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonFind}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
     <form name="ApprovedProductRequirementsList" type="list" title="" list-name="requirementsForSupplier" paginate-target="RequirementsForSupplier"


### PR DESCRIPTION
The issue exists also in the older version.
The field "requirementByDate" form "FindApprovedProductRequirements" in RequirementForms.xml has been set wrongly and it should be "requiredByDate".
This causes the result could not be queried out properly as indicated as below:
The result is governed by the service "getRequirementsForSupplier", where reads the list from the view "RequirementAndRole".
In the view entity definition, the field is defined as
`<alias entity-alias="RQ" name="requiredByDate"/>, but it is not the case in the form "FindApprovedProductRequirements" `above.

Modified: RequirementForms.xml
- changed field requirementByDate into requiredByDate as per entity definition for Requirement

Thanks to Schumann Ye for reporting
