### PR TITLE
Fixed: Quote Edit - wrong decorator screen used (OFBIZ-12554)

### DIFF
--- a/applications/order/widget/ordermgr/QuoteScreens.xml
+++ b/applications/order/widget/ordermgr/QuoteScreens.xml
@@ -241,7 +241,7 @@ under the License.
                 <property-to-field field="defaultCurrencyUomId" resource="general" property="currency.uom.id.default" default="USD"/>
             </actions>
             <widgets>
-                <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                <decorator-screen name="CommonQuoteDecorator">
                     <decorator-section name="body">
                         <screenlet title="${groovy: parameters.quoteId ? uiLabelMap.OrderOrderQuoteEdit : uiLabelMap.OrderNewQuote}">
                             <include-form name="EditQuote" location="component://order/widget/ordermgr/QuoteForms.xml"/>


### PR DESCRIPTION
Currently, the EditQuote screen in QuoteScreens.xml is using 'main-decorator' as the decorator-screen reference screen.
To demo/test: https://localhost:8443/ordermgr/control/EditQuote?quoteId=CQ0001
Because of this, the menus for the quote (being edited) are not shown to the user.

modified: QuoteScreens.xml
changed decorator-screen ref in screen EditQuote from 'main-decorator' to 'CommonQuoteDecorator