### PR TITLE
Improved: WorkEffort - MainActionMenu (OFBIZ-12557)

### DIFF
--- a/applications/workeffort/widget/CommonScreens.xml
+++ b/applications/workeffort/widget/CommonScreens.xml
@@ -70,6 +70,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
                         <section>
                             <condition>
                                 <and>
@@ -129,6 +130,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -164,6 +168,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -213,6 +220,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <platform-specific>
                             <html><html-template location="component://workeffort/template/Main.ftl"/></html>

--- a/applications/workeffort/widget/CustRequestScreens.xml
+++ b/applications/workeffort/widget/CustRequestScreens.xml
@@ -36,6 +36,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.WorkEffortMyRequestList}">
                             <include-grid name="ListRequests" location="component://workeffort/widget/CustRequestForms.xml"/>

--- a/applications/workeffort/widget/TimesheetScreens.xml
+++ b/applications/workeffort/widget/TimesheetScreens.xml
@@ -43,6 +43,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.WorkEffortMyCurrentTimesheets}">
                             <container style="button-bar">

--- a/applications/workeffort/widget/WorkEffortMenus.xml
+++ b/applications/workeffort/widget/WorkEffortMenus.xml
@@ -31,7 +31,22 @@ under the License.
         <menu-item name="userJobs" title="${uiLabelMap.WorkEffortJobList}"><link target="UserJobs"/></menu-item>
         <menu-item name="WorkEffortICalendar" title="${uiLabelMap.WorkEffortICalendar}"><link target="FindICalendars"/></menu-item>
     </menu>
-
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="NewWorkEffort" title="${uiLabelMap.WorkEffortCreate}">
+            <condition>
+                <and>
+                    <or>
+                        <if-has-permission permission="WORKEFFORTMGR" action="_CREATE"/>
+                    </or>
+                </and>
+            </condition>
+            <link text="${uiLabelMap.WorkEffortCreate}" target="WorkEffort/Edit" link-type="layered-modal">
+                <set-callback area-target="WorkEffortSummary" area-id="window">
+                    <parameter param-name="workEffortId" from-event-result="workEffortId"/>
+                </set-callback>
+            </link>
+        </menu-item>
+    </menu>
     <menu name="WorkEffortShortcutAppBar" title="${uiLabelMap.WorkEffortManager}" default-menu-item-name="task" >
         <menu-item name="task" title="${uiLabelMap.WorkEffortTaskList}"><link target="/workeffort/control/mytasks" url-mode="inter-app"/></menu-item>
         <menu-item name="calendar" title="${uiLabelMap.WorkEffortCalendar}"><link target="/workeffort/control/calendar" url-mode="inter-app"/></menu-item>

--- a/applications/workeffort/widget/WorkEffortScreens.xml
+++ b/applications/workeffort/widget/WorkEffortScreens.xml
@@ -35,6 +35,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -60,7 +63,6 @@ under the License.
             <actions>
                 <set field="headerItem" value="task"/>
                 <set field="titleProperty" value="PageTitleViewActivityAndTaskList"/>
-
                 <service service-name="getWorkEffortAssignedActivities"/>
                 <service service-name="getWorkEffortAssignedActivitiesByRole"/>
                 <service service-name="getWorkEffortAssignedActivitiesByGroup"/>
@@ -68,6 +70,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -85,7 +90,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWorkEffort">
         <section>
             <actions>
@@ -143,7 +147,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindWorkEffort">
         <section>
             <actions>
@@ -154,6 +157,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <include-screen name="FindWorkEfforts" location="component://workeffort/widget/workeffort/WorkEffortCpd.xml"/>
                     </decorator-section>
@@ -161,7 +167,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ChildWorkEfforts">
         <section>
             <actions>
@@ -193,7 +198,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="AddWorkEffortAndAssoc">
         <section>
             <actions>
@@ -217,7 +221,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWorkEffortAndAssoc">
         <section>
             <actions>
@@ -243,7 +246,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="AddWorkEffortAssoc">
         <section>
             <actions>
@@ -290,7 +292,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortPartyAssigns">
         <section>
             <actions>
@@ -307,7 +308,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortFixedAssetAssigns">
         <section>
             <actions>
@@ -325,14 +325,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWorkEffortRates">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleListWorkEffortAssignmentRates"/>
                 <set field="tabButtonItem" value="WorkEffortRates"/>
                 <set field="labelTitleProperty" value="PageTitleListWorkEffortAssignmentRates"/>
-
                 <set field="workEffortId" from-field="parameters.workEffortId"/>
             </actions>
             <widgets>
@@ -344,7 +342,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortCommEvents">
         <section>
             <actions>
@@ -361,14 +358,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortShopLists">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleListWorkEffortShopLists"/>
                 <set field="tabButtonItem" value="WorkEffortShopLists"/>
                 <set field="labelTitleProperty" value="PageTitleListWorkEffortShopLists"/>
-
                 <set field="workEffortId" from-field="parameters.workEffortId"/>
             </actions>
             <widgets>
@@ -380,14 +375,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortRequests">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleListWorkEffortRequests"/>
                 <set field="tabButtonItem" value="WorkEffortRequests"/>
                 <set field="labelTitleProperty" value="PageTitleListWorkEffortRequests"/>
-
                 <set field="workEffortId" from-field="parameters.workEffortId"/>
             </actions>
             <widgets>
@@ -400,7 +393,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortRequirements">
         <section>
             <actions>
@@ -417,14 +409,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortQuotes">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleListWorkEffortQuotes"/>
                 <set field="tabButtonItem" value="WorkEffortQuotes"/>
                 <set field="labelTitleProperty" value="PageTitleListWorkEffortQuotes"/>
-
                 <set field="workEffortId" from-field="parameters.workEffortId"/>
             </actions>
             <widgets>
@@ -437,14 +427,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortOrderHeaders">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleListWorkEffortOrderHeaders"/>
                 <set field="tabButtonItem" value="WorkEffortOrderHeaders"/>
                 <set field="labelTitleProperty" value="PageTitleListWorkEffortOrderHeaders"/>
-
                 <set field="workEffortId" from-field="parameters.workEffortId"/>
             </actions>
             <widgets>
@@ -456,14 +444,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWorkEffortTimeEntries">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleListWorkEffortTimeEntries"/>
                 <set field="tabButtonItem" value="WorkEffortTimeEntries"/>
                 <set field="labelTitleProperty" value="PageTitleListWorkEffortTimeEntries"/>
-
                 <set field="workEffortId" from-field="parameters.workEffortId"/>
             </actions>
             <widgets>
@@ -475,7 +461,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWorkEffortNotes">
         <section>
             <actions>
@@ -495,7 +480,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWorkEffortContents">
         <section>
             <actions>
@@ -511,7 +495,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWorkEffortGoodStandards">
         <section>
             <actions>
@@ -528,15 +511,11 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditWorkEffortReviews">
         <section>
             <actions>
                 <set field="titleProperty" value="PageTitleListWorkEffortReviews"/>
                 <set field="tabButtonItem" value="WorkEffortReviews"/>
-                <!--<set field="labelTitleProperty" value="PageTitleListWorkEffortReviews"/>
-                <set field="defaultUserLoginId" from-field="parameters.userLogin.userLoginId"/>
-                <set field="partyId" from-field="parameters.userLogin.partyId"/> -->
             </actions>
             <widgets>
                 <decorator-screen name="CommonWorkEffortDecorator" location="${parameters.mainDecoratorLocation}">
@@ -580,7 +559,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WorkEffortSearchResults">
         <section>
             <actions>
@@ -598,7 +576,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WorkEffortSearchOptions">
         <section>
             <actions>
@@ -631,7 +608,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortAttributes">
         <section>
             <actions>
@@ -648,7 +624,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ListWorkEffortEventReminders">
         <section>
             <actions>
@@ -666,7 +641,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="WorkEffortEventReminderEmail">
         <section>
             <actions>
@@ -692,7 +666,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="iCalendarDecorator">
         <section>
             <actions>
@@ -701,6 +674,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
                         <section>
                             <condition>
                                 <not><if-empty field="workEffort"/></not>
@@ -736,7 +710,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindICalendars">
         <section>
             <actions>
@@ -745,6 +718,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://workeffort/widget/WorkEffortMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <condition>
@@ -769,7 +745,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditICalendar">
         <section>
             <actions>
@@ -814,7 +789,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditICalendarData">
         <section>
             <actions>
@@ -838,7 +812,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ICalendarChildren">
         <section>
             <actions>
@@ -862,7 +835,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ICalendarParties">
         <section>
             <actions>
@@ -886,7 +858,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ICalendarFixedAssets">
         <section>
             <actions>
@@ -910,7 +881,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="ICalendarHelp">
         <section>
             <actions>
@@ -939,5 +909,4 @@ under the License.
             </widgets>
         </section>
     </screen>
-
 </screens>


### PR DESCRIPTION
Currently the create buttons for the main objects of the work effort  are located within the find and other widgets/templates of those objects.
In order to improve the usability of OFBiz (and thus the appeal of it for adopters and users) these create buttons/links/etc. should be in a main action menu visible at all times when a user is working within the component.

modified:
WorkEffortMenus.xml - added MainActionMenu for users with CREATE permission in the component
CommonScreens.xml - added MainActionMenu as an 'include-menu' ref in various common decorator screens.
Added MainActionMenu as an 'include-menu' in screen definitions in various other Screen.xml files where appropriate
additional cleanup