### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/content/widget/forum/BlogForms.xml
+++ b/applications/content/widget/forum/BlogForms.xml
@@ -17,10 +17,9 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
-    <form name="ListBlogs" type="list" list-name="blogs" separate-columns="true" paginate-target="blogMain"
+    <grid name="ListBlogs" list-name="blogs" separate-columns="true" paginate-target="blogMain"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="contentId"><hidden/></field>
         <field name="contentName" widget-style="buttontext">
@@ -34,9 +33,8 @@ under the License.
         <field name="contentTypeId"><display-entity entity-name="ContentType"></display-entity></field>
         <field name="lastModifiedDate"><display type="date"/></field>
         <field name="lastModifiedByUserLogin"><display/></field>
-    </form>
-
-    <form name="BlogContent" type="list" list-name="blogContent" separate-columns="true" paginate-target="blogContent"
+    </grid>
+    <grid name="BlogContent" list-name="blogContent" separate-columns="true" paginate-target="blogContent"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="contentId"><hidden/></field>
         <field name="contentName">
@@ -49,8 +47,7 @@ under the License.
         <field name="statusId"><display-entity entity-name="StatusItem"></display-entity></field>
         <field name="localeString"><display-entity entity-name="CountryCode" key-field-name="countryCode" description="${countryName}[${countryCode}]"></display-entity></field>
         <field name="contentTypeId"><display-entity entity-name="ContentType"></display-entity></field>
-    </form>
-
+    </grid>
     <form name="EditBlog" type="single" target="updateBlog" title="" default-map-name="content"
         header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="content==null" target="newBlog"/>
@@ -62,7 +59,6 @@ under the License.
         <field name="description" title="${uiLabelMap.ContentBlogDescription}"><text size="30" maxlength="60"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}"><submit button-type="button"/></field>
     </form>
-
     <form name="EditArticle" target="createBlogArticle" title="" type="upload" skip-end="true" default-map-name="blogEntry"
         default-title-style="treeHeader" default-widget-style="inputBox">
         <alt-target use-when="contentId!=void&amp;&amp;contentId!=null" target="updateBlogArticle"/>
@@ -86,7 +82,5 @@ under the License.
             </drop-down>
         </field>
         <field name="submitButton" title="${uiLabelMap.CommonSubmit}" widget-style="smallSubmit"><submit button-type="button"/></field>
-    </form>
-
-
+    </form
 </forms>

--- a/applications/content/widget/forum/BlogScreens.xml
+++ b/applications/content/widget/forum/BlogScreens.xml
@@ -129,7 +129,7 @@ under the License.
                     <decorator-section name="body">
                         <include-menu name="blogSub" location="component://content/widget/content/ContentMenus.xml"/>
                         <screenlet title="${uiLabelMap.ContentBlogList}" navigation-form-name="ListBlogs">
-                            <include-form name="ListBlogs" location="component://content/widget/forum/BlogForms.xml"/>
+                            <include-grid name="ListBlogs" location="component://content/widget/forum/BlogForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -154,7 +154,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="BlogContent">
         <section>
             <actions>
@@ -172,14 +171,13 @@ under the License.
                 <decorator-screen name="blogDecorator">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.ContentBlogArticleList}" navigation-form-name="BlogContent">
-                            <include-form name="BlogContent" location="component://content/widget/forum/BlogForms.xml"/>
+                            <include-grid name="BlogContent" location="component://content/widget/forum/BlogForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
         </section>
     </screen>
-
     <screen name="EditArticle">
         <section>
             <actions>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Improved:
BlogScreens.xml: from form ref to grid ref
BlogForms.xml: from form definition with list ref to grid definition with list ref
additional cleanup