### PR TITLE
Improved: List and Grid (OFBIZ-11345)

### DIFF
--- a/applications/content/widget/forum/ForumForms.xml
+++ b/applications/content/widget/forum/ForumForms.xml
@@ -17,10 +17,9 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
-    <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xmlns="http://ofbiz.apache.org/Widget-Form" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
-    <form name="ListForumGroups" type="list" list-name="forumGroups" separate-columns="true" target="updateForumGroup"
+    <grid name="ListForumGroups" list-name="forumGroups" separate-columns="true" target="updateForumGroup"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="select" widget-style="buttontext" entry-name="contentId" parameter-name="contentId">
             <hyperlink description="${uiLabelMap.FormFieldTitle_forums}" target="findForums">
@@ -30,7 +29,7 @@ under the License.
         <field name="forumGroupName" entry-name="contentName" parameter-name="contentName"><text/></field>
         <field name="forumGroupDescription" entry-name="description" parameter-name="description"><text/></field>
         <field name="updateButton" title="${uiLabelMap.CommonUpdate}" widget-style="buttontext"><submit button-type="text-link"/></field>
-    </form>
+    </grid>
     <form name="AddForumGroup" type="single" target="createForumGroup" title="" default-map-name="forumGroup"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="forumGroupName" parameter-name="contentName" required-field="true"><text/></field>
@@ -38,7 +37,6 @@ under the License.
         <field name="contentTypeId"><hidden value="FORUM_ROOT"/></field>
         <field name="submitButton" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-
     <form name="ListForums" type="list" list-name="forums"  separate-columns="true" target="updateForum"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <field name="forumGroupId"><hidden value="${parameters.forumGroupId}"/></field>
@@ -81,15 +79,14 @@ under the License.
         <field name="caContentAssocTypeId"><hidden value="SUBSITE"/></field>
         <field name="addButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-
-    <form name="ForumGroupPurposes" type="list" list-name="forumPurposes" target="deleteForumGroupPurpose" separate-columns="true"
+    <grid name="ForumGroupPurposes" list-name="forumPurposes" target="deleteForumGroupPurpose" separate-columns="true"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <auto-fields-entity entity-name="ContentPurpose" default-field-type="edit"/>
         <field name="forumGroupId"><hidden value="${parameters.forumGroupId}"/></field>
         <field name="contentId"><hidden value="${parameters.forumGroupId}"/></field>
         <field name="contentPurposeTypeId"><display-entity entity-name="ContentPurposeType"/></field>
         <field name="deleteButton" title="${uiLabelMap.CommonDelete}" widget-style="smallSubmit"><submit button-type="button"/></field>
-    </form>
+    </grid>
     <form name="AddForumGroupPurpose" type="single" target="createForumGroupPurpose" title=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ContentPurpose" default-field-type="edit"/>
@@ -101,8 +98,7 @@ under the License.
             </drop-down></field>
         <field name="addButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-
-    <form name="ForumGroupRoles" type="list" list-name="forumRoles" target="updateForumGroupRole" separate-columns="true"
+    <grid name="ForumGroupRoles" list-name="forumRoles" target="updateForumGroupRole" separate-columns="true"
         odd-row-style="alternate-row" header-row-style="header-row-2" default-table-style="basic-table hover-bar">
         <auto-fields-entity entity-name="ContentRole" default-field-type="edit"/>
         <field name="forumGroupId"><hidden value="${parameters.forumGroupId}"/></field>
@@ -121,7 +117,7 @@ under the License.
                 <parameter param-name="fromDate"/>
             </hyperlink>
         </field>
-    </form>
+    </grid>
     <form name="AddForumGroupRole" type="single" target="createForumGroupRole" default-map-name=""
         header-row-style="header-row" default-table-style="basic-table">
         <auto-fields-entity entity-name="ContentRole" default-field-type="edit"/>
@@ -137,8 +133,7 @@ under the License.
         <field name="fromDate"><date-time default-value="${nowTimestamp}"/></field>
         <field name="addButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
-
-    <form name="ListForumMessages" type="list" list-name="forumMessages" separate-columns="true" target="updateForumMessage"
+    <grid name="ListForumMessages" list-name="forumMessages" separate-columns="true" target="updateForumMessage"
         odd-row-style="alternate-row" default-table-style="basic-table">
         <row-actions>
             <service service-name="getContentAndDataResource" result-map="contentData">
@@ -178,8 +173,7 @@ under the License.
                 <parameter param-name="contentAssocTypeId" value="RESPONSE"/>
             </hyperlink>
         </field>
-    </form>
-
+    </grid>
     <form name="EditForumMessage" type="single" target="updateForumMessage" default-map-name="message"
         header-row-style="header-row" default-table-style="basic-table">
         <actions>
@@ -232,7 +226,6 @@ under the License.
     </form>
     <form name="AddForumThreadMessage" type="single" extends="AddForumMessage" target="updateForumThreadMessage"
         header-row-style="header-row" default-table-style="basic-table"/>
-
     <form name="EditForumThreadMessage" type="single" target="updateForumThreadMessage"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="forumGroupId"><hidden value="${parameters.forumGroupId}"/></field>
@@ -250,4 +243,4 @@ under the License.
         <field name="textData" title="${uiLabelMap.FormFieldTitle_textDataTitle}"><textarea rows="8"/></field>
         <field name="updateButton" title="${uiLabelMap.CommonUpdate}"><submit button-type="button"/></field>
     </form>
-    </forms>
+</forms>

--- a/applications/content/widget/forum/ForumScreens.xml
+++ b/applications/content/widget/forum/ForumScreens.xml
@@ -17,10 +17,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <screens xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
-
+    xmlns="http://ofbiz.apache.org/Widget-Screen" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Screen http://ofbiz.apache.org/dtds/widget-screen.xsd">
     <screen name="commonForumDecorator">
         <section>
             <actions>
@@ -61,7 +59,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="FindForumGroups">
         <section>
             <actions>
@@ -79,13 +76,14 @@ under the License.
                         <screenlet id="ForumGroupPanel" title="${uiLabelMap.ContentForumGroupCreate}" collapsible="true">
                             <include-form name="AddForumGroup" location="component://content/widget/forum/ForumForms.xml"/>
                         </screenlet>
-                        <include-form name="ListForumGroups" location="component://content/widget/forum/ForumForms.xml"/>
+                        <screenlet>
+                            <include-grid name="ListForumGroups" location="component://content/widget/forum/ForumForms.xml"/>
+                        </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
         </section>
     </screen>
-
     <screen name="FindForums">
         <section>
             <actions>
@@ -108,13 +106,14 @@ under the License.
                         <screenlet id="AddForumToForumGroupPanel" title="${uiLabelMap.ContentForumAddTo} ${forumGroup.contentName}" collapsible="true">
                             <include-form name="AddForum" location="component://content/widget/forum/ForumForms.xml"/>
                         </screenlet>
-                        <include-form name="ListForums" location="component://content/widget/forum/ForumForms.xml"/>
+                        <screenlet>
+                            <include-grid name="ListForums" location="component://content/widget/forum/ForumForms.xml"/>
+                        </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
         </section>
     </screen>
-
     <screen name="ForumGroupRoles">
         <section>
             <actions>
@@ -137,13 +136,14 @@ under the License.
                         <screenlet id="ForumGroupRolePanel" title="${uiLabelMap.ContentForumAddRoleTo} ${forumGroup.contentName} [${forumGroup.contentId}]" collapsible="true">
                             <include-form name="AddForumGroupRole" location="component://content/widget/forum/ForumForms.xml"/>
                         </screenlet>
-                        <include-form name="ForumGroupRoles" location="component://content/widget/forum/ForumForms.xml"/>
+                        <screenlet>
+                            <include-grid name="ForumGroupRoles" location="component://content/widget/forum/ForumForms.xml"/>
+                        </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
         </section>
     </screen>
-
     <screen name="ForumGroupPurposes">
         <section>
             <actions>
@@ -166,13 +166,14 @@ under the License.
                         <screenlet id="ForumGroupPurposePanel" title="${uiLabelMap.ContentForumAddPurposeTo} ${forumGroup.contentName} [${forumGroup.contentId}]" collapsible="true">
                             <include-form name="AddForumGroupPurpose" location="component://content/widget/forum/ForumForms.xml"/>
                         </screenlet>
-                        <include-form name="ForumGroupPurposes" location="component://content/widget/forum/ForumForms.xml"/>
+                        <screenlet>
+                            <include-grid name="ForumGroupPurposes" location="component://content/widget/forum/ForumForms.xml"/>
+                        </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
         </section>
     </screen>
-
     <screen name="FindForumMessages">
         <section>
             <actions>
@@ -196,16 +197,17 @@ under the License.
             <widgets>
                 <decorator-screen name="commonForumDecorator" location="${parameters.forumDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-form name="ListForumMessages" location="component://content/widget/forum/ForumForms.xml"/>
                         <screenlet title="${uiLabelMap.ContentForumAddThreadTo} ${forum.description}">
                             <include-form name="AddForumMessage" location="component://content/widget/forum/ForumForms.xml"/>
+                        </screenlet>
+                        <screenlet>
+                            <include-grid name="ListForumMessages" location="component://content/widget/forum/ForumForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
         </section>
     </screen>
-
     <screen name="FindForumThreads">
         <section>
             <actions>
@@ -273,7 +275,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="EditForumMessage">
         <section>
             <actions>
@@ -295,7 +296,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="AddForumMessage">
         <section>
             <actions>
@@ -320,7 +320,6 @@ under the License.
             </widgets>
         </section>
     </screen>
-
     <screen name="AddForumThreadMessage">
         <section>
             <actions>
@@ -345,5 +344,4 @@ under the License.
             </widgets>
         </section>
     </screen>
-
 </screens>


### PR DESCRIPTION
According to the definition in widget-form.xsd the use of a combination of a form with type="list" is deprecated in favour of a grid.
Refactor various list forms into grids.
Refactor various list form references in screens.

Modified:
InvoiceScreens.xml: from form ref to grid ref
InvoiceForms.xml: from form definition with list ref to grid definition with list ref
additional cleanup