### PR TITLE
Fixed: GlSetupScreens.xml - MainActionMenu not shown (OFBIZ-12559)

### DIFF
--- a/applications/accounting/widget/GlSetupScreens.xml
+++ b/applications/accounting/widget/GlSetupScreens.xml
@@ -67,6 +67,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://accounting/widget/AccountingMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingAvailableInternalOrganizations}" navigation-menu-name="NewAccountOrganization">
                             <include-menu name="NewAccountOrganization" location="component://accounting/widget/AccountingMenus.xml"/>
@@ -84,6 +87,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://accounting/widget/AccountingMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingNewCompany}">
                             <include-form name="AddCompany" location="component://accounting/widget/GlSetupForms.xml"/>
@@ -103,6 +109,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://accounting/widget/AccountingMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingInvoice} ${uiLabelMap.CommonImportExport} ${uiLabelMap.CommonFor}: ${partyGroup.groupName} [${organizationPartyId}]">
                             <container style="lefthalf">


### PR DESCRIPTION
The MainActionMenu of the Accounting component is
intended to provide the users with CREATE permissions
a direct way to create the main objects of the
Accounting components (Gl transaction, invoice,
payment), instead of - as such a user - have to go
through multiple screens to get to the action
trigger to create such objects.
The MainActionMenu is applied in various decorator
screens. It is, however, not applied in the
GlSetupScreen.xml file.

Modified: GlSetupScreens.xml
added pre-body decorator section, including ref to
MainActionMenu, to:
- screen ListCompanies
- screen AddCompany
- screen ImportExport