### PR TITLE
Fixed: Party Main: duplicate action trigger (Person/Group) (OFBIZ-12560)

### DIFF
--- a/applications/party/widget/partymgr/PartyMenus.xml
+++ b/applications/party/widget/partymgr/PartyMenus.xml
@@ -257,22 +257,6 @@
         </menu-item>
     </menu>
     <menu name="CreateNewParty" menu-container-style="basic-nav">
-        <menu-item name="create-party-group" title="${uiLabelMap.PartyCreateNewPartyGroup}">
-            <condition>
-                <if-has-permission permission="PARTYMGR" action="_CREATE"/>
-            </condition>
-            <link target="editpartygroup">
-                <parameter param-name="create_new" value="Y"/>
-            </link>
-        </menu-item>
-        <menu-item name="create-person" title="${uiLabelMap.PartyCreateNewPerson}">
-            <condition>
-                <if-has-permission permission="PARTYMGR" action="_CREATE"/>
-            </condition>
-            <link target="editperson">
-                <parameter param-name="create_new" value="Y"/>
-            </link>
-        </menu-item>
         <menu-item name="create-customer" title="${uiLabelMap.PartyCreateNewCustomer}">
             <condition>
                 <if-has-permission permission="PARTYMGR" action="_CREATE"/>


### PR DESCRIPTION
When accessing
https://localhost:8443/partymgr/control/main the
screen shows duplicate action triggers for the
creation of a new party of type=PERSON or
of type=PARTYGROUP.
These action triggers come from the MainActionMenu
for the a component, and from the 'CreateNewParty'
menu.

modified: PartyMenus.xml
removed from menu CreateNewParty:
- menu-item for the creation of a PartyGroup
- menu-item for the creation of a Person
as these already exists in the MainActionMenu of
the component.