### PR TITLE
Improved: Biling Account Payment - VIEW Permissions (OFBIZ-12565)

### DIFF
--- a/applications/accounting/widget/BillingAccountScreens.xml
+++ b/applications/accounting/widget/BillingAccountScreens.xml
@@ -305,9 +305,16 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonBillingAccountDecorator" location="${parameters.billingAccountDecoratorLocation}">
                     <decorator-section name="body">
-                        <screenlet id="BillingAccountPaymentPanel" title="${uiLabelMap.AccountingCreatePayment}" collapsible="true">
-                            <include-form name="CreateIncomingBillingAccountPayment" location="component://accounting/widget/BillingAccountForms.xml"/>
-                        </screenlet>
+                        <section>
+                            <condition>
+                                <if-has-permission permission="ACCOUNTING" action="CREATE"/>
+                            </condition>
+                            <widgets>
+                                <screenlet id="BillingAccountPaymentPanel" title="${uiLabelMap.AccountingCreatePayment}" collapsible="true">
+                                    <include-form name="CreateIncomingBillingAccountPayment" location="component://accounting/widget/BillingAccountForms.xml"/>
+                                </screenlet>
+                            </widgets>
+                        </section>
                         <include-grid name="ListBillingAccountPayments" location="component://accounting/widget/BillingAccountForms.xml"/>
                     </decorator-section>
                 </decorator-screen>


### PR DESCRIPTION
When accessing
[https://localhost:8443/accounting/control/BillingAccountPayments?billingAccountId=9010]
as a user with only VIEW permissions (e.g. userid=auditor),
the screen shows a form to create a payment.
This should not be visible to such a user as it leads
to a undesired effect and diminished user experience.

modified: BillingAccountScreens.xml
reworked screen BillingAccountPayments to work with
CREATE permissions