### PR TITLE
Improved: In UtilHttp, for regex processing of urls, replace Java regex with RE2J (OFBIZ-12599)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -223,6 +223,7 @@ dependencies {
     compile 'net.lingala.zip4j:zip4j:2.6.4'
     compile 'org.apache.commons:commons-imaging:1.0-alpha2' // Alpha but OK, "Imaging was working and was used by a number of projects in production even before reaching its initial release as an Apache Commons component."
     compile 'batik:batik-svg-dom:1.6-1'
+    compile 'com.google.re2j:re2j:1.6'
 
     // ofbiz unit-test compile libs
     testCompile 'org.mockito:mockito-core:2.23.0'

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
@@ -80,6 +80,9 @@ import org.apache.ofbiz.widget.renderer.VisualTheme;
 
 import com.ibm.icu.util.Calendar;
 
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+
 /**
  * HttpUtil - Misc HTTP Utility Functions
  */
@@ -1715,7 +1718,7 @@ public final class UtilHttp {
     public static List<String> extractUrls(String input) {
         List<String> result = new ArrayList<String>();
 
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+        Pattern pattern = Pattern.compile(
                 "\\b(((ht|f)tp(s?)\\:\\/\\/|~\\/|\\/)|www.)" +
                         "(\\w+:\\w+@)?(([-\\w]+\\.)+(com|org|net|gov" +
                         "|mil|biz|info|mobi|name|aero|jobs|museum" +
@@ -1735,7 +1738,7 @@ public final class UtilHttp {
         }
 
         if (result.isEmpty()) {
-            java.util.regex.Matcher matcher = pattern.matcher(input);
+            Matcher matcher = pattern.matcher(input);
             while (matcher.find()) {
                 result.add(matcher.group());
             }


### PR DESCRIPTION
The Main advantage of RE2J is that it guarantees linear time execution.

Note that it has not a complete API: https://github.com/google/re2j#caveats