### PR TITLE
Improved: In UtilHttp, for regex processing of urls, replace Java regex with RE2J (OFBIZ-12599)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,6 +242,7 @@ dependencies {
     implementation 'wsdl4j:wsdl4j:1.6.3'
     implementation 'com.auth0:java-jwt:3.18.1'
     implementation 'org.jdom:jdom:1.1.3' // don't upgrade above 1.1.3, makes a lot of not obvious and useless complications, see last commits of OFBIZ-12092 for more
+    implementation 'com.google.re2j:re2j:1.6'
 
     testImplementation 'org.hamcrest:hamcrest-library:2.2' // Enable junit4 to not depend on hamcrest-1.3
     testImplementation 'org.mockito:mockito-core:3.12.4'

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
@@ -61,8 +61,6 @@ import java.util.StringTokenizer;
 import java.util.TimeZone;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -90,6 +88,9 @@ import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 import org.apache.ofbiz.webapp.control.SameSiteFilter;
 import org.apache.ofbiz.webapp.event.FileUploadProgressListener;
 import org.apache.ofbiz.widget.renderer.VisualTheme;
+
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
 
 /**
  * HttpUtil - Misc HTTP Utility Functions


### PR DESCRIPTION
The Main advantage of RE2J is that it guarantees linear time execution.

Note that it has not a complete API: https://github.com/google/re2j#caveats