### PR TITLE
Improved: Strip data to maximum column length for initialRequest and initialReferrer (OFBIZ-12672)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/stats/VisitHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/stats/VisitHandler.java
@@ -150,8 +150,14 @@ public class VisitHandler {
                             visit.set("fromDate", new Timestamp(session.getCreationTime()));
 
                             visit.set("initialLocale", initialLocale);
-                            visit.set("initialRequest", initialRequest);
-                            visit.set("initialReferrer", initialReferrer);
+                            if (initialRequest != null) {
+                                visit.set("initialRequest", initialRequest.length() > 2000 ? initialRequest.substring(0, 1999)
+                                        : initialRequest);
+                            }
+                            if (initialReferrer != null) {
+                                visit.set("initialReferrer", initialReferrer.length() > 2000 ? initialReferrer.substring(0, 1999)
+                                        : initialReferrer);
+                            }
                             if (initialUserAgent != null) {
                                 visit.set("initialUserAgent", initialUserAgent.length() > 250 ? initialUserAgent.substring(0, 250)
                                         : initialUserAgent);


### PR DESCRIPTION
Analogous to the existing limitation of the "initialUserAgent" to 250 characters, implementation of a limitation to 2000 characters for initialRequest and initialReferrer, in order not to exit with very long requests by "MysqlDataTruncation: Data truncation: Data too long for column 'INITIAL_REFERRER' at row 1"