### PR TITLE
 Improved: Updated mysql jdbc-driver class from com.mysql.jdbc.Driver to com.mysql.cj.jdbc.Driver (OFBIZ-12675)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -837,7 +837,7 @@ options:
 
 * Search for the JDBC driver in https://bintray.com/bintray/jcenter[jcenter] and
 place it in build.gradle dependencies e.g.
-`runtime 'mysql:mysql-connector-java:5.1.36'`
+`runtime 'mysql:mysql-connector-java:8.0.30'`
 +
 OR
 * Download the JDBC driver jar and place it in $OFBIZ_HOME/lib or the lib

--- a/framework/entity/config/entityengine.xml
+++ b/framework/entity/config/entityengine.xml
@@ -357,7 +357,7 @@ access. For a detailed description see the core/docs/entityconfig.html file.
         <read-data reader-name="ext-test"/>
         <read-data reader-name="ext-demo"/>
         <inline-jdbc
-                jdbc-driver="com.mysql.jdbc.Driver"
+                jdbc-driver="com.mysql.cj.jdbc.Driver"
                 jdbc-uri="jdbc:mysql://127.0.0.1/ofbiz?autoReconnect=true&amp;characterEncoding=UTF-8"
                 jdbc-username="ofbiz"
                 jdbc-password="ofbiz"
@@ -391,7 +391,7 @@ access. For a detailed description see the core/docs/entityconfig.html file.
         <read-data reader-name="ext-test"/>
         <read-data reader-name="ext-demo"/>
         <inline-jdbc
-                jdbc-driver="com.mysql.jdbc.Driver"
+                jdbc-driver="com.mysql.cj.jdbc.Driver"
                 jdbc-uri="jdbc:mysql://127.0.0.1/ofbizolap?autoReconnect=true&amp;characterEncoding=UTF-8"
                 jdbc-username="ofbiz"
                 jdbc-password="ofbiz"
@@ -425,7 +425,7 @@ access. For a detailed description see the core/docs/entityconfig.html file.
         <read-data reader-name="ext-test"/>
         <read-data reader-name="ext-demo"/>
         <inline-jdbc
-                jdbc-driver="com.mysql.jdbc.Driver"
+                jdbc-driver="com.mysql.cj.jdbc.Driver"
                 jdbc-uri="jdbc:mysql://127.0.0.1/ofbiztenant?autoReconnect=true&amp;characterEncoding=UTF-8"
                 jdbc-username="ofbiz"
                 jdbc-password="ofbiz"
@@ -454,7 +454,7 @@ access. For a detailed description see the core/docs/entityconfig.html file.
         <read-data reader-name="tenant"/>
         <read-data reader-name="seed"/>
         <inline-jdbc
-                jdbc-driver="com.mysql.jdbc.Driver"
+                jdbc-driver="com.mysql.cj.jdbc.Driver"
                 jdbc-uri="jdbc:mysql://127.0.0.1/ofbiz_odbc?autoReconnect=true&amp;characterEncoding=UTF-8"
                 jdbc-username="ofbiz"
                 jdbc-password="ofbiz"


### PR DESCRIPTION
Improved: Updated mysql jdbc-driver class from com.mysql.jdbc.Driver to com.mysql.cj.jdbc.Driver (OFBIZ-12675)


MySQL Connector/J 8.0 is highly recommended for use with MySQL Server 8.0 and 5.7. Please upgrade to MySQL Connector/J 8.0.
https://dev.mysql.com/doc/connector-j/8.0/en/

