### PR TITLE
OFBIZ-12630_Configure_usability_of_after_login_Events

### DIFF
--- a/framework/security/config/security.properties
+++ b/framework/security/config/security.properties
@@ -291,3 +291,5 @@ allowedProtocols=localhost,127.0.0.1
 #-- eg: allowedURIsForFreemarkerInterpolation=createTextContentCms,updateTextContentCms,...
 allowedURIsForFreemarkerInterpolation=
 
+#-- Configure if after-login events are run in doMainLogin (default) or in do BasicLogin
+security.login.loginEventsAfterBasicLogin=N

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ExternalLoginKeysManager.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ExternalLoginKeysManager.java
@@ -144,7 +144,7 @@ public class ExternalLoginKeysManager {
             request.getSession().setAttribute("userLogin", userLogin);
             userLogin = LoginWorker.checkLogout(request, response);
 
-            LoginWorker.doBasicLogin(userLogin, request);
+            LoginWorker.doBasicLogin(userLogin, request, response);
 
             // Create a secured cookie with the correct userLoginId
             LoginWorker.createSecuredLoginIdCookie(request, response);

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/JWTManager.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/JWTManager.java
@@ -120,7 +120,7 @@ public class JWTManager {
             return "success";
         }
 
-        LoginWorker.doBasicLogin(userLogin, request);
+        LoginWorker.doBasicLogin(userLogin, request, response);
         return "success";
     }
 


### PR DESCRIPTION
Improved: Configure usability of after-login Events in BasicLogin. (OFBIZ-12630)

In the LoginWorker, a distinction is made between MainLogin and BasicLogin. However, after-login events configured for a webapp only run after a MainLogin. Now we have the option of configuring a property in such a way that after-login events are carried out either after the MainLogin (default) or also with a BasicLogin.