### PR TITLE
Improved: findParty_Status. (OFBIZ-12677)

### DIFF
--- a/applications/party/servicedef/services_view.xml
+++ b/applications/party/servicedef/services_view.xml
@@ -74,7 +74,6 @@ under the License.
     <service name="performFindParty" engine="java"
         location="org.apache.ofbiz.party.party.PartyServices" invoke="performFindParty">
         <description>General Party Find Service, duplicated for screen widget purpose, Used in the new findparty page in the Party Manager, etc</description>
-        <attribute name="roleTypeId" type="String" mode="IN" optional="true"/> <!-- can be null or ANY to include any -->
         <attribute name="noConditionFind" type="String" mode="IN" optional="true" default-value="N"/>
         <attribute name="extInfo" type="String" mode="IN" optional="true"/>
         <attribute name="extCond" type="org.apache.ofbiz.entity.condition.EntityCondition" mode="IN" optional="true">
@@ -82,6 +81,8 @@ under the License.
         </attribute>
         <attribute name="partyId" type="String" mode="IN" optional="true"/> <!-- does a LIKE compare on this, can do partial, case insensitive, etc -->
         <attribute name="partyTypeId" type="String" mode="IN" optional="true"/>
+        <attribute name="roleTypeId" type="String" mode="IN" optional="true"/>
+        <attribute name="statusId" type="String" mode="IN" optional="true"/>
         <attribute name="userLoginId" type="String" mode="IN" optional="true"/> <!-- does a LIKE compare on this, can do partial, case insensitive, etc -->
         <attribute name="externalId" type="String" mode="IN" optional="true"/>
         <attribute name="groupName" type="String" mode="IN" optional="true"/>

--- a/applications/party/src/main/java/org/apache/ofbiz/party/party/PartyServices.java
+++ b/applications/party/src/main/java/org/apache/ofbiz/party/party/PartyServices.java
@@ -1604,14 +1604,17 @@ public class PartyServices {
                     EntityFunction.upper("%" + partyId + "%")));
         }
 
-        // now the statusId - send ANY for all statuses; leave null for just enabled; or pass a specific status
+        // now the statusId - null for all statuses; "PARTY_ENABLED" finds statusId == null entries also, other passed in values are matched exactly
         if (UtilValidate.isNotEmpty(statusId)) {
-            andExprs.add(EntityCondition.makeCondition("statusId", statusId));
-        } else {
-            // NOTE: _must_ explicitly allow null as it is not included in a not equal in many databases... odd but true
-            andExprs.add(EntityCondition.makeCondition(EntityCondition.makeCondition("statusId", GenericEntity.NULL_FIELD),
-                    EntityOperator.OR, EntityCondition.makeCondition("statusId", EntityOperator.NOT_EQUAL, "PARTY_DISABLED")));
+            if ("PARTY_ENABLED".equals(statusId)) {
+                // NOTE: _must_ explicitly allow null as it is not included in a not equal in many databases... odd but true
+                andExprs.add(EntityCondition.makeCondition(EntityCondition.makeCondition("statusId",
+                        GenericEntity.NULL_FIELD), EntityOperator.OR, EntityCondition.makeCondition("statusId", "PARTY_ENABLED")));
+            } else {
+                andExprs.add(EntityCondition.makeCondition("statusId", statusId));
+            }
         }
+
         // check for partyTypeId
         if (UtilValidate.isNotEmpty(partyTypeId)) {
             andExprs.add(EntityCondition.makeCondition("partyTypeId", partyTypeId));

--- a/applications/party/widget/partymgr/PartyForms.xml
+++ b/applications/party/widget/partymgr/PartyForms.xml
@@ -28,7 +28,6 @@ under the License.
                 <set field="states" value="${groovy: org.apache.ofbiz.common.CommonWorkers.getAssociatedStateList(delegator,requestParameters.CUSTOMER_COUNTRY)}"/>
             -->
         </actions>
-        <field name="statusId"><hidden value="PARTY_ENABLED"/></field>
         <field name="noConditionFind"><hidden value="Y"/></field>
         <field name="extInfo" event="onClick" action="javascript:$('#ListParty' + this.value +'_body').toggle(true);collapseFindPartyOptions('ListParty' + this.value +'_body');" title="${uiLabelMap.PartyContactInformation}">
             <radio>
@@ -55,6 +54,14 @@ under the License.
         <field name="partyTypeId" title="${uiLabelMap.CommonType}">
             <drop-down allow-empty="true">
                 <entity-options entity-name="PartyType"/>
+            </drop-down>
+        </field>
+        <field name="statusId" title="${uiLabelMap.CommonStatus}">
+            <drop-down allow-empty="true">
+                <entity-options entity-name="StatusItem">
+                    <entity-constraint name="statusTypeId" value="PARTY_STATUS"/>
+                    <entity-order-by field-name="sequenceId"/>
+                </entity-options>
             </drop-down>
         </field>
         <field name="idValue"><text size="15"/></field>
@@ -99,6 +106,7 @@ under the License.
             <sort-field name="groupName"/>
             <sort-field name="roleTypeId"/>
             <sort-field name="partyTypeId"/>
+            <sort-field name="statusId"/>
             <sort-field name="partyClassificationGroupId"/>
             <field-group title="${uiLabelMap.PartyPartyIdentification}" initially-collapsed="true">
                 <sort-field name="idValue"/>


### PR DESCRIPTION
Improved: Backend Party Manager: Removed hidden statusId field and added drop-down for status selection in findparty form to be able to find not ENABLED parties too. (OFBIZ-12677)

Central actor search around the static Party.statusId field simplified and the logic behind it fixed. Thus, the statusId value is also available in performPartyFind Service.