### PR TITLE
Improved: Used connection.getCatalog() to include the catalog from the Connection

### DIFF
--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/jdbc/DatabaseUtil.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/jdbc/DatabaseUtil.java
@@ -1019,7 +1019,7 @@ public class DatabaseUtil {
         try {
             String[] types = {"TABLE", "BASE TABLE", "VIEW", "ALIAS", "SYNONYM"};
             lookupSchemaName = getSchemaName(dbData);
-            tableSet = dbData.getTables(null, lookupSchemaName, null, types);
+            tableSet = dbData.getTables(connection.getCatalog(), lookupSchemaName, null, types);
             if (tableSet == null) {
                 Debug.logWarning("getTables returned null set", MODULE);
             }
@@ -1158,7 +1158,7 @@ public class DatabaseUtil {
                 }
 
                 boolean foundCols = false;
-                ResultSet rsCols = dbData.getColumns(null, lookupSchemaName, null, null);
+                ResultSet rsCols = dbData.getColumns(connection.getCatalog(), lookupSchemaName, null, null);
                 if (!rsCols.next()) {
                     try {
                         rsCols.close();
@@ -1167,7 +1167,7 @@ public class DatabaseUtil {
                         Debug.logError(message, MODULE);
                         if (messages != null) messages.add(message);
                     }
-                    rsCols = dbData.getColumns(null, lookupSchemaName, "%", "%");
+                    rsCols = dbData.getColumns(connection.getCatalog(), lookupSchemaName, "%", "%");
                     if (!rsCols.next()) {
                         Debug.logVerbose("Now what to do? I guess try one table name at a time...", MODULE);
                     } else {


### PR DESCRIPTION
Use connection.getCatalog()to include the catalog from the Connection, this is needed for MySQL which does not restrict meta data queries to the current connected database without specifying a catalog on these methods, may cause issues with other databases and needs more testing

Improved:
(OFBIZ-12675)

Explanation:
While using mysql8 driver, ofbiz fails to create tables in newly setup database. 
Steps to reproduce:

- Create ofbiz database, load data (everything works fine)
- Create ofbiz1 database, load data, you will get error, and ofbiz fails to create new tables in ofbiz1. 

After initial debugging found while check db DatabaseMetaData.getTables returns list of existing tables, so it does not create new tables hence fails to load data.

Thanks:
