### PR TITLE
Improved: Updated apache tika library to 2.4.1 (OFBIZ-12572)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,8 +234,11 @@ dependencies {
     implementation 'org.apache.sshd:sshd-sftp:2.8.0'
     // Note: The Apache Tika PMC has set September 30, 2022 as the End Of Life for the Tika 1.x branch.
     //       The PMC will make security fixes for the 1.x branch until that date.
-    implementation 'org.apache.tika:tika-core:1.28.5'
-    implementation 'org.apache.tika:tika-parsers:1.28.5' //  2.4.1 does not work,
+    implementation 'org.apache.tika:tika-core:2.4.1'
+    implementation 'org.apache.tika:tika-parsers:2.4.1'
+    implementation 'org.apache.commons:commons-csv:1.9.0'
+    implementation 'org.apache.tika:tika-parser-pdf-module:2.4.1'
+    implementation 'org.apache.cxf:cxf-rt-frontend-jaxrs:3.5.3'
     implementation 'org.apache.tomcat:tomcat-catalina-ha:9.0.60' // Remember to change the version number (9 now) in javadoc block if needed.
     implementation 'org.apache.tomcat:tomcat-jasper:9.0.60'
     implementation 'org.apache.axis2:axis2-kernel:1.8.1'


### PR DESCRIPTION
Included common csv and apache cxf dependency as they were removed from tika 2.4

Improved:Updated apache tika library to 2.4.1 
(OFBIZ-12572)

Explanation
The Apache Tika PMC has set September 30, 2022 as the End Of Life for the Tika 1.x branch, so need to update apache tika to latest version, 

