### PR TITLE
Improved: Use FlexibleStringExpander for disabled attribute on fields

### DIFF
--- a/framework/widget/dtd/widget-form.xsd
+++ b/framework/widget/dtd/widget-form.xsd
@@ -857,7 +857,15 @@ under the License.
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="disabled" type="xs:boolean" default="false"/>
+            <xs:attribute type="xs:string" name="disabled">
+                <xs:annotation>
+                    <xs:documentation>
+                        Set a field as disabled : not mutable, not focusable, not submitted if in a form.
+                        Accepts ${} notation to allow use of expressions.
+                        Expressions must evaluate to the strings 'true', 'false' (without quotes) or empty (equivalent to false)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -160,7 +160,7 @@ public final class ModelFormField {
     private final String parentFormName;
     private final String tabindex;
     private final String conditionGroup;
-    private final boolean disabled;
+    private final FlexibleStringExpander disabled;
 
     private ModelFormField(ModelFormFieldBuilder builder) {
         this.action = builder.getAction();
@@ -215,7 +215,7 @@ public final class ModelFormField {
         this.parentFormName = builder.getParentFormName();
         this.tabindex = builder.getTabindex();
         this.conditionGroup = builder.getConditionGroup();
-        this.disabled = builder.getDisabled();
+        this.disabled = builder.getDisabledSpec();
     }
 
     public FlexibleStringExpander getAction() {
@@ -483,8 +483,15 @@ public final class ModelFormField {
         return conditionGroup;
     }
 
-    public boolean getDisabled() {
+    public FlexibleStringExpander getDisabledSpec() {
         return disabled;
+    }
+
+    public boolean getDisabled(Map<String, Object> context) {
+        if (UtilValidate.isNotEmpty(this.disabled)) {
+            return "true".equals(disabled.expandString(context));
+        }
+        return false;
     }
 
     public Map<String, ? extends Object> getMap(Map<String, ? extends Object> context) {
@@ -2738,25 +2745,30 @@ public final class ModelFormField {
      */
     public static class HiddenField extends FieldInfo {
         private final FlexibleStringExpander value;
+        private final FlexibleStringExpander disabled;
 
         public HiddenField(Element element, ModelFormField modelFormField) {
             super(element, modelFormField);
             this.value = FlexibleStringExpander.getInstance(element.getAttribute("value"));
+            this.disabled = FlexibleStringExpander.getInstance(element.getAttribute("disabled"));
         }
 
         private HiddenField(HiddenField original, ModelFormField modelFormField) {
             super(original.getFieldSource(), original.getFieldType(), modelFormField);
             this.value = original.value;
+            this.disabled = original.disabled;
         }
 
         public HiddenField(int fieldSource, ModelFormField modelFormField) {
             super(fieldSource, FieldInfo.HIDDEN, modelFormField);
             this.value = FlexibleStringExpander.getInstance("");
+            this.disabled = FlexibleStringExpander.getInstance("");
         }
 
         public HiddenField(ModelFormField modelFormField) {
             super(FieldInfo.SOURCE_EXPLICIT, FieldInfo.HIDDEN, modelFormField);
             this.value = FlexibleStringExpander.getInstance("");
+            this.disabled = FlexibleStringExpander.getInstance("");
         }
 
         @Override
@@ -2797,6 +2809,18 @@ public final class ModelFormField {
                 return valueEnc;
             }
             return getModelFormField().getEntry(context);
+        }
+
+        /**
+         *
+         * @param context the context
+         * @return evaluated value
+         */
+        public boolean getDisabled(Map<String, Object> context) {
+            if (UtilValidate.isNotEmpty(this.disabled)) {
+                return "true".equals(disabled.expandString(context));
+            }
+            return false;
         }
 
         @Override

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormFieldBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormFieldBuilder.java
@@ -116,7 +116,7 @@ public class ModelFormFieldBuilder {
     private String parentFormName = "";
     private String tabindex = "";
     private String conditionGroup = "";
-    private boolean disabled = false;
+    private FlexibleStringExpander disabled = FlexibleStringExpander.getInstance("");
 
     protected static final List<String> NUMERIC_FIELD_TYPES = Collections.unmodifiableList(UtilMisc.toList(
             "floating-point", "numeric", "fixed-point",
@@ -206,7 +206,7 @@ public class ModelFormFieldBuilder {
         this.parentFormName = fieldElement.getAttribute("form-name");
         this.tabindex = fieldElement.getAttribute("tabindex");
         this.conditionGroup = fieldElement.getAttribute("condition-group");
-        this.disabled = "true".equals(fieldElement.getAttribute("disabled"));
+        this.disabled = FlexibleStringExpander.getInstance(fieldElement.getAttribute("disabled"));
         Element childElement = null;
         List<? extends Element> subElements = UtilXml.childElementList(fieldElement);
         for (Element subElement : subElements) {
@@ -323,7 +323,7 @@ public class ModelFormFieldBuilder {
         this.parentFormName = modelFormField.getParentFormName();
         this.tabindex = modelFormField.getTabindex();
         this.conditionGroup = modelFormField.getConditionGroup();
-        this.disabled = modelFormField.getDisabled();
+        this.disabled = modelFormField.getDisabledSpec();
     }
 
     public ModelFormFieldBuilder(ModelFormFieldBuilder builder) {
@@ -366,7 +366,7 @@ public class ModelFormFieldBuilder {
         this.parentFormName = builder.getParentFormName();
         this.tabindex = builder.getTabindex();
         this.conditionGroup = builder.getConditionGroup();
-        this.disabled = builder.getDisabled();
+        this.disabled = builder.getDisabledSpec();
     }
 
     /**
@@ -729,7 +729,7 @@ public class ModelFormFieldBuilder {
      * Gets disabled.*
      * @return the disabled
      */
-    public boolean getDisabled() {
+    public FlexibleStringExpander getDisabledSpec() {
         return disabled;
     }
 
@@ -1048,7 +1048,7 @@ public class ModelFormFieldBuilder {
         this.position = builder.getPosition();
         this.requiredField = builder.getRequiredField();
         this.separateColumn = builder.getSeparateColumn();
-        this.disabled = builder.getDisabled();
+        this.disabled = builder.getDisabledSpec();
     }
 
     /**

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -293,7 +293,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         }
         String tabindex = modelFormField.getTabindex();
         String value = modelFormField.getEntry(context, textareaField.getDefaultValue(context));
-        boolean disabled = modelFormField.getDisabled();
+        boolean disabled = modelFormField.getDisabled(context);
         StringWriter sr = new StringWriter();
         sr.append("<@renderTextareaField ");
         sr.append("name=\"");
@@ -341,7 +341,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         ModelFormField modelFormField = dateTimeField.getModelFormField();
         String paramName = modelFormField.getParameterName(context);
         String defaultDateTimeString = dateTimeField.getDefaultDateTimeString(context);
-        boolean disabled = modelFormField.getDisabled();
+        boolean disabled = modelFormField.getDisabled(context);
         String className = "";
         String alert = "false";
         String name = "";
@@ -608,7 +608,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         ModelForm modelForm = modelFormField.getModelForm();
         String currentValue = modelFormField.getEntry(context);
         String conditionGroup = modelFormField.getConditionGroup();
-        boolean disabled = modelFormField.getDisabled();
+        boolean disabled = modelFormField.getDisabled(context);
         List<ModelFormField.OptionValue> allOptionValues = dropDownField.getAllOptionValues(context, WidgetWorker.getDelegator(context));
         ModelFormField.AutoComplete autoComplete = dropDownField.getAutoComplete();
         String event = modelFormField.getEvent();
@@ -860,7 +860,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         String currentValue = modelFormField.getEntry(context);
         String conditionGroup = modelFormField.getConditionGroup();
         Boolean allChecked = checkField.isAllChecked(context);
-        boolean disabled = modelFormField.getDisabled();
+        boolean disabled = modelFormField.getDisabled(context);
         String id = modelFormField.getCurrentContainerId(context);
         String className = "";
         String alert = "false";
@@ -941,7 +941,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         List<ModelFormField.OptionValue> allOptionValues = radioField.getAllOptionValues(context, WidgetWorker.getDelegator(context));
         String currentValue = modelFormField.getEntry(context);
         String conditionGroup = modelFormField.getConditionGroup();
-        boolean disabled = modelFormField.getDisabled();
+        boolean disabled = modelFormField.getDisabled(context);
         String className = "";
         String alert = "false";
         String name = modelFormField.getParameterName(context);
@@ -1044,6 +1044,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
             ajaxUrl = MacroCommonRenderer.createAjaxParamsFromUpdateAreas(updateAreas, null, modelForm, "", context);
         }
         String tabindex = modelFormField.getTabindex();
+        boolean disabled = modelFormField.getDisabled(context);
         StringWriter sr = new StringWriter();
         sr.append("<@renderSubmitField ");
         sr.append("buttonType=\"");
@@ -1082,7 +1083,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
         }
         sr.append("\" tabindex=\"");
         sr.append(tabindex);
-        sr.append("\" />");
+        sr.append("\" disabled=");
+        sr.append(Boolean.toString(disabled));
+        sr.append(" />");
         executeMacro(writer, sr.toString());
         this.appendTooltip(writer, context, modelFormField);
     }
@@ -1129,6 +1132,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         String conditionGroup = modelFormField.getConditionGroup();
         String event = modelFormField.getEvent();
         String id = modelFormField.getCurrentContainerId(context);
+        boolean disabled = modelFormField.getDisabled(context);
         StringWriter sr = new StringWriter();
         sr.append("<@renderHiddenField ");
         sr.append(" name=\"");
@@ -1147,7 +1151,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
         if (action != null) {
             sr.append(action);
         }
-        sr.append("\" />");
+        sr.append("\" disabled=");
+        sr.append(Boolean.toString(disabled));
+        sr.append(" />");
         executeMacro(writer, sr.toString());
     }
 
@@ -1774,6 +1780,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         boolean ignCase = textFindField.getIgnoreCase(context);
         boolean hideIgnoreCase = textFindField.getHideIgnoreCase();
         String tabindex = modelFormField.getTabindex();
+        boolean disabled = modelFormField.getDisabled(context);
         StringWriter sr = new StringWriter();
         sr.append("<@renderTextFindField ");
         sr.append(" name=\"");
@@ -1814,7 +1821,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
         sr.append(tabindex);
         sr.append("\" conditionGroup=\"");
         sr.append(conditionGroup);
-        sr.append("\" />");
+        sr.append("\" disabled=");
+        sr.append(Boolean.toString(disabled));
+        sr.append(" />");
         executeMacro(writer, sr.toString());
         this.appendTooltip(writer, context, modelFormField);
     }
@@ -1861,6 +1870,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         }
         String defaultOptionThru = rangeFindField.getDefaultOptionThru();
         String tabindex = modelFormField.getTabindex();
+        boolean disabled = modelFormField.getDisabled(context);
         StringWriter sr = new StringWriter();
         sr.append("<@renderRangeFindField ");
         sr.append(" className=\"");
@@ -1901,7 +1911,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
         sr.append(conditionGroup);
         sr.append("\" tabindex=\"");
         sr.append(tabindex);
-        sr.append("\" />");
+        sr.append("\" disabled=");
+        sr.append(Boolean.toString(disabled));
+        sr.append(" />");
         executeMacro(writer, sr.toString());
         this.appendTooltip(writer, context, modelFormField);
     }
@@ -1995,6 +2007,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         }
         String id = modelFormField.getCurrentContainerId(context);
         String tabindex = modelFormField.getTabindex();
+        boolean disabled = modelFormField.getDisabled(context);
         StringWriter sr = new StringWriter();
         sr.append("<@renderDateFindField ");
         sr.append(" className=\"");
@@ -2053,7 +2066,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
         sr.append(opIsEmpty);
         sr.append("\" tabindex=\"");
         sr.append(tabindex);
-        sr.append("\" />");
+        sr.append("\" disabled=");
+        sr.append(Boolean.toString(disabled));
+        sr.append(" />");
         executeMacro(writer, locale, sr.toString());
         this.appendTooltip(writer, context, modelFormField);
     }
@@ -2171,6 +2186,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         }
         lastViewName = UtilHttp.getEncodedParameter(lastViewName);
         String tabindex = modelFormField.getTabindex();
+        boolean disabled = modelFormField.getDisabled(context);
         StringWriter sr = new StringWriter();
         sr.append("<@renderLookupField ");
         sr.append(" className=\"");
@@ -2241,7 +2257,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
         sr.append(conditionGroup);
         sr.append("\" tabindex=\"");
         sr.append(tabindex);
-        sr.append("\" delegatorName=\"");
+        sr.append("\" disabled=");
+        sr.append(Boolean.toString(disabled));
+        sr.append(" delegatorName=\"");
         sr.append(((HttpSession) context.get("session")).getAttribute("delegatorName").toString());
         sr.append("\" />");
         executeMacro(writer, sr.toString());
@@ -2518,6 +2536,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
             autocomplete = "off";
         }
         String tabindex = modelFormField.getTabindex();
+        boolean disabled = modelFormField.getDisabled(context);
         StringWriter sr = new StringWriter();
         sr.append("<@renderFileField ");
         sr.append(" className=\"");
@@ -2536,7 +2555,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
         sr.append(autocomplete);
         sr.append("\" tabindex=\"");
         sr.append(tabindex);
-        sr.append("\" />");
+        sr.append("\" disabled=");
+        sr.append(Boolean.toString(disabled));
+        sr.append(" />");
         executeMacro(writer, sr.toString());
         this.makeHyperlinkString(writer, textField.getSubHyperlink(), context);
         this.appendTooltip(writer, context, modelFormField);
@@ -2551,6 +2572,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         String size = Integer.toString(passwordField.getSize());
         String maxlength = "";
         String id = modelFormField.getCurrentContainerId(context);
+        boolean disabled = modelFormField.getDisabled(context);
         String autocomplete = "";
         if (UtilValidate.isNotEmpty(modelFormField.getWidgetStyle())) {
             className = modelFormField.getWidgetStyle();
@@ -2606,7 +2628,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
         sr.append(autocomplete);
         sr.append("\" tabindex=\"");
         sr.append(tabindex);
-        sr.append("\" />");
+        sr.append("\" disabled=");
+        sr.append(Boolean.toString(disabled));
+        sr.append(" />");
         executeMacro(writer, sr.toString());
         this.addAsterisks(writer, context, modelFormField);
         this.makeHyperlinkString(writer, passwordField.getSubHyperlink(), context);

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
@@ -272,7 +272,7 @@ public final class RenderableFtlFormElementsBuilder {
             mask = textField.getMask();
         }
         String ajaxUrl = createAjaxParamsFromUpdateAreas(updateAreas, "", context);
-        boolean disabled = modelFormField.getDisabled();
+        boolean disabled = modelFormField.getDisabled(context);
         boolean readonly = textField.getReadonly();
         String tabindex = modelFormField.getTabindex();
 

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -43,7 +43,7 @@ under the License.
 </#macro>
 <#macro renderHyperlinkField></#macro>
 
-<#macro renderTextField name className alert value="" textSize="" maxlength="" id="" event="" action="" disabled="" clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" placeholder="" delegatorName="default">
+<#macro renderTextField name className alert value="" textSize="" maxlength="" id="" event="" action="" disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" placeholder="" delegatorName="default">
   <input type="text" name="${name?default("")?html}"<#t/>
   <#if ajaxEnabled?has_content && ajaxEnabled && ajaxUrl?has_content>
     <#local defaultMinLength = modelTheme.getAutocompleterDefaultMinLength()>
@@ -54,11 +54,10 @@ under the License.
      data-ajax-url="${ajaxUrl!}"<#rt/>
      data-default-delay="${defaultDelay!300}"<#rt/>
   </#if>
-    <@renderClass className alert />
+    <@renderClass className alert /> <@renderDisabled disabled />
     <#if value?has_content> value="${value}"</#if><#rt/>
     <#if textSize?has_content> size="${textSize}"</#if><#rt/>
     <#if maxlength?has_content> maxlength="${maxlength}"</#if><#rt/>
-    <#if disabled?has_content && disabled> disabled="disabled"</#if><#rt/>
     <#if readonly?has_content && readonly> readonly="readonly"</#if><#rt/>
     <#if mask?has_content> data-mask="${mask}"</#if><#rt/>
     <#if id?has_content> id="${id}"</#if><#rt/>
@@ -70,12 +69,12 @@ under the License.
   /><#t/>
 </#macro>
 
-<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled="">
+<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false>
   <#if visualEditorEnable?has_content>
     <#local className = className + " visual-editor">
   </#if>
   <textarea name="${name}"<#t/>
-    <@renderClass className alert />
+    <@renderClass className alert /> <@renderDisabled disabled />
     <#if cols?has_content> cols="${cols}"</#if><#rt/>
     <#if rows?has_content> rows="${rows}"</#if><#rt/>
     <#if id?has_content> id="${id}"</#if><#rt/>
@@ -84,33 +83,34 @@ under the License.
     <#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
     <#if visualEditorEnable?has_content> data-toolbar="${buttons?default("maxi")}"</#if><#rt/>
     <#if language?has_content> data-language="${language!"en"}"</#if><#rt/>
-    <#if disabled?has_content && disabled> disabled="disabled"</#if><#rt/>
     ><#t/>
     <#if value?has_content>${value}</#if><#t/>
   </textarea><#lt/>
 </#macro>
 
-<#macro renderDateTimeField name className alert dateType timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName minutes isTwelveHour ampmName amSelected pmSelected compositeType timeDropdown="" classString="" hour1="" hour2="" shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled="" isXMLHttpRequest="">
+<#macro renderDateTimeField name className alert dateType timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName minutes isTwelveHour ampmName amSelected pmSelected compositeType timeDropdown="" classString="" hour1="" hour2="" shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest="">
   <span class="view-calendar">
     <#local cultureInfo = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("datejs", .locale)/>
     <#local datePickerLang = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("jquery", .locale)/>
     <#local timePicker = "/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.min.js,/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.css"/>
     <#local timePickerLang = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("dateTime", .locale)/>
     <#if dateType!="time" >
-      <input type="text" <#if tabindex?has_content> tabindex="${tabindex}"</#if> name="${name}_i18n" <@renderClass className alert /><#rt/>
+      <input type="text" name="${name}_i18n" <@renderClass className alert /> <@renderDisabled disabled />
+        <#if tabindex?has_content> tabindex="${tabindex}"</#if>
         <#if title?has_content> title="${title}"</#if>
         <#if value?has_content> value="${value}"</#if>
         <#if size?has_content> size="${size}"</#if><#rt/>
         <#if maxlength?has_content>  maxlength="${maxlength}"</#if>
-        <#if disabled?has_content && disabled> disabled="disabled"</#if><#rt/>
         <#if id?has_content> id="${id}_i18n"</#if>/><#rt/>
         <#local className = className + " date-time-picker"/>
     </#if>
-    <input type="hidden" <#if tabindex?has_content> tabindex="${tabindex}"</#if> name="${name}" <#if event?has_content && action?has_content> ${event}="${action}"</#if> <@renderClass className alert /><#rt/>
+    <input type="hidden" name="${name}" <@renderClass className alert /> <@renderDisabled disabled />
+      <#if tabindex?has_content> tabindex="${tabindex}"</#if>
+      <#if event?has_content && action?has_content> ${event}="${action}"</#if><#rt/>
       <#if title?has_content> title="${title}"</#if>
       <#if value?has_content> value="${value}"</#if>
       <#if size?has_content> size="${size}"</#if><#rt/>
-      <#if maxlength?has_content>  maxlength="${maxlength}"</#if>
+      <#if maxlength?has_content> maxlength="${maxlength}"</#if>
       <#if mask?has_content> data-mask="${mask}"</#if><#rt/>
       <#if cultureInfo?has_content> data-cultureinfo="${cultureInfo}"</#if><#rt/>
       <#if datePickerLang?has_content> data-datepickerlang="${datePickerLang}"</#if><#rt/>
@@ -119,7 +119,7 @@ under the License.
       data-shortdate="${shortDateInput?string}"
       <#if id?has_content> id="${id}"</#if>/><#rt/>
     <#if timeDropdown?has_content && timeDropdown=="time-dropdown">
-      <select name="${timeHourName}" <#if classString?has_content>class="${classString}"</#if>><#rt/>
+      <select name="${timeHourName}" <@renderDisabled disabled /> <#if classString?has_content>class="${classString}"</#if>><#rt/>
         <#if isTwelveHour>
           <#local x=11>
           <#list 0..x as i>
@@ -131,7 +131,7 @@ under the License.
             <option value="${i}"<#if hour2?has_content><#if i=hour2> selected="selected"</#if></#if>>${i}</option><#rt/>
           </#list>
         </#if>
-        </select>:<select name="${timeMinutesName}" <#if classString?has_content>class="${classString}"</#if>><#rt/>
+        </select>:<select name="${timeMinutesName}" <@renderDisabled disabled /> <#if classString?has_content>class="${classString}"</#if>><#rt/>
           <#local values = Static["org.apache.ofbiz.base.util.StringUtil"].toList(timeValues)>
           <#list values as i>
             <option value="${i}"<#if minutes?has_content><#if i?number== minutes ||((i?number==(60 -step?number)) && (minutes &gt; 60 - (step?number/2))) || ((minutes &gt; i?number )&& (minutes &lt; i?number+(step?number/2))) || ((minutes &lt; i?number )&& (minutes &gt; i?number-(step?number/2)))> selected="selected"</#if></#if>>${i}</option><#rt/>
@@ -139,7 +139,7 @@ under the License.
         </select>
         <#rt/>
         <#if isTwelveHour>
-          <select name="${ampmName}" <#if classString?has_content>class="${classString}"</#if>><#rt/>
+          <select name="${ampmName}" <@renderDisabled disabled /> <#if classString?has_content>class="${classString}"</#if>><#rt/>
             <option value="AM" <#if "selected" == amSelected>selected="selected"</#if> >AM</option><#rt/>
             <option value="PM" <#if "selected" == pmSelected>selected="selected"</#if>>PM</option><#rt/>
           </select>
@@ -155,17 +155,24 @@ under the License.
   </span>
 </#macro>
 
-<#macro renderDropDownField name className alert id formName action explicitDescription options fieldName otherFieldName otherValue otherFieldSize ajaxEnabled ajaxOptions frequency minChars choices autoSelect partialSearch partialChars ignoreCase fullSearch conditionGroup="" tabindex="" multiple="" event="" size="" firstInList="" currentValue="" allowEmpty="" dDFCurrent="" noCurrentSelectedKey="" disabled="">
+<#macro renderDropDownField name className alert id formName action explicitDescription options fieldName otherFieldName otherValue otherFieldSize ajaxEnabled ajaxOptions frequency minChars choices autoSelect partialSearch partialChars ignoreCase fullSearch conditionGroup="" tabindex="" multiple="" event="" size="" firstInList="" currentValue="" allowEmpty="" dDFCurrent="" noCurrentSelectedKey="" disabled=false>
   <#if conditionGroup?has_content>
     <input type="hidden" name="${name}_grp" value="${conditionGroup}"/>
   </#if>
   <span class="ui-widget">
-    <select name="${name?default("")}<#rt/>" <@renderClass className alert /><#if id?has_content> id="${id}"</#if><#if multiple?has_content> multiple="multiple"</#if><#if ajaxEnabled> class="autoCompleteDropDown"</#if><#if event?has_content> ${event}="${action}"</#if><#if size?has_content> size="${size}"</#if><#if tabindex?has_content> tabindex="${tabindex}"</#if><#if disabled?has_content && disabled> disabled</#if><#rt/>
-    <#if otherFieldName?has_content>
-    data-other-field-name="${otherFieldName}"
-    data-other-field-value='${otherValue?js_string}'
-    data-other-field-size='${otherFieldSize}'
-    </#if>>
+    <select name="${name?default("")}<#rt/>"
+      <@renderClass className alert /> <@renderDisabled disabled />
+      <#if id?has_content> id="${id}"</#if>
+      <#if multiple?has_content> multiple="multiple"</#if>
+      <#if ajaxEnabled> class="autoCompleteDropDown"</#if>
+      <#if event?has_content> ${event}="${action}"</#if>
+      <#if size?has_content> size="${size}"</#if>
+      <#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
+      <#if otherFieldName?has_content>
+        data-other-field-name="${otherFieldName}"
+        data-other-field-value='${otherValue?js_string}'
+        data-other-field-size='${otherFieldSize}'
+      </#if>>
       <#if firstInList?has_content && currentValue?has_content && !multiple?has_content>
         <option selected="selected" value="${currentValue}">${explicitDescription?replace("&#x5c;&#x27;","&#x27;")}</option><#rt/><#-- replace("&#x5c;&#x27;","&#x27;") related to OFBIZ-6504 -->
       </#if>
@@ -188,61 +195,66 @@ under the License.
   </#if>
 </#macro>
 
-<#macro renderCheckField items className alert id name action conditionGroup="" allChecked="" currentValue=""  event="" tabindex="" disabled="">
+<#macro renderCheckField items className alert id name action conditionGroup="" allChecked="" currentValue=""  event="" tabindex="" disabled=false>
   <#if conditionGroup?has_content>
-    <input type="hidden" name="${name}_grp" value="${conditionGroup}"/>
+    <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
   <#list items as item>
     <span <@renderClass className alert />><#rt/>
-      <input type="checkbox"<#if (item_index == 0)> id="${id}"</#if><#rt/><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
-        <#if disabled?has_content && disabled> disabled="disabled"</#if><#rt/>
+      <input <@renderDisabled disabled /> type="checkbox"<#if (item_index == 0)> id="${id}"</#if><#rt/><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
         <#if allChecked?has_content && allChecked> checked="checked" <#elseif allChecked?has_content && !allChecked>
-          <#elseif item.checked?has_content && item.checked?boolean> checked="checked"</#if>
-          name="${name?default("")?html}" value="${item.value?default("")?html}"<#if event?has_content> ${event}="${action}"</#if>/><#rt/>
+        <#elseif item.checked?has_content && item.checked?boolean> checked="checked"</#if>
+        name="${name?default("")?html}" value="${item.value?default("")?html}"<#if event?has_content> ${event}="${action}"</#if>/><#rt/>
         ${item.description?default("")}
     </span>
   </#list>
 </#macro>
 
-<#macro renderRadioField items className alert name action conditionGroup="" currentValue="" noCurrentSelectedKey="" event="" tabindex="" disabled="">
+<#macro renderRadioField items className alert name action conditionGroup="" currentValue="" noCurrentSelectedKey="" event="" tabindex="" disabled=false>
   <#if conditionGroup?has_content>
-    <input type="hidden" name="${name}_grp" value="${conditionGroup}"/>
+    <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
   <#list items as item>
     <span <@renderClass className alert />><#rt/>
-      <input type="radio"<#if currentValue?has_content><#if currentValue==item.key> checked="checked"</#if><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
-        <#elseif noCurrentSelectedKey?has_content && noCurrentSelectedKey == item.key> checked="checked"</#if><#if disabled?has_content && disabled> disabled="disabled"</#if>
-        name="${name?default("")?html}" value="${item.key?default("")?html}"<#if event?has_content> ${event}="${action}"</#if>/><#rt/>
+      <input type="radio" <@renderDisabled disabled />
+        <#if currentValue?has_content>
+          <#if currentValue==item.key> checked="checked"</#if>
+          <#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
+        <#elseif noCurrentSelectedKey?has_content && noCurrentSelectedKey == item.key> checked="checked"</#if>
+        name="${name?default("")?html}" value="${item.key?default("")?html}"
+        <#if event?has_content> ${event}="${action}"</#if>/><#rt/>
       ${item.description}
     </span>
   </#list>
 </#macro>
 
-<#macro renderSubmitField buttonType className alert formName action imgSrc ajaxUrl id title="" name="" event="" confirmation="" containerId="" tabindex="">
+<#macro renderSubmitField buttonType className alert formName action imgSrc ajaxUrl id title="" name="" event="" confirmation="" containerId="" tabindex="" disabled=false>
   <#if buttonType=="text-link">
     <a <@renderClass className alert /> href="javascript:document.${formName}.submit()" <#if confirmation?has_content>onclick="return confirm('${confirmation?js_string}');"</#if>><#if title?has_content>${title}</#if> </a>
   <#elseif buttonType=="image">
-    <input type="image" src="${imgSrc}" <@renderClass className alert /><#if name?has_content> name="${name}"</#if>
+    <input type="image" src="${imgSrc}" <@renderClass className alert /> <@renderDisabled disabled /> <#if name?has_content> name="${name}"</#if>
     <#if title?has_content> alt="${title}"</#if><#if event?has_content> ${event}="${action}"</#if>
     <#if confirmation?has_content>onclick="return confirm('${confirmation?js_string}');"</#if>/>
   <#else>
-    <input type="<#if containerId?has_content>button<#else>submit</#if>" <@renderClass className alert />
-    <#if id?has_content> id="${id}"</#if><#rt/>
-    <#if name??> name="${name}"</#if><#if title?has_content> value="${title}"</#if><#if event?has_content> ${event}="${action}"</#if>
-    <#if containerId?has_content> onclick="<#if confirmation?has_content>if (confirm('${confirmation?js_string}')) </#if>ajaxSubmitFormUpdateAreas('${formName}', '${ajaxUrl}')"
-      <#else><#if confirmation?has_content> onclick="return confirm('${confirmation?js_string}');"</#if>
-    <#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
-    </#if>/>
-    <#if containerId?has_content>
-    <#-- the form will be submit by ajax, we inform that perss enter need to call  -->
-    <script>
-        $("form[name='${formName}']").keypress(function(e) {
-          if (e.which === 13 && ! $(e.target).is('textarea')) {
-            e.preventDefault();
-            $("#${id!}").click();
-          }});
-    </script>
-  </#if>
+    <input type="<#if containerId?has_content>button<#else>submit</#if>" <@renderClass className alert /> <@renderDisabled disabled />
+      <#if id?has_content> id="${id}"</#if><#rt/>
+      <#if name??> name="${name}"</#if>
+      <#if title?has_content> value="${title}"</#if>
+      <#if event?has_content> ${event}="${action}"</#if>
+      <#if containerId?has_content> onclick="<#if confirmation?has_content>if (confirm('${confirmation?js_string}')) </#if>ajaxSubmitFormUpdateAreas('${formName}', '${ajaxUrl}')"
+        <#else><#if confirmation?has_content> onclick="return confirm('${confirmation?js_string}');"</#if>
+      <#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
+      </#if>/>
+      <#if containerId?has_content>
+        <#-- the form will be submit by ajax, we inform that perss enter need to call  -->
+        <script>
+            $("form[name='${formName}']").keypress(function(e) {
+              if (e.which === 13 && ! $(e.target).is('textarea')) {
+                e.preventDefault();
+                $("#${id!}").click();
+              }});
+        </script>
+      </#if>
   </#if>
 </#macro>
 
@@ -250,11 +262,14 @@ under the License.
   <input type="reset" <@renderClass className alert /> name="${name}"<#if title?has_content> value="${title}"</#if>/>
 </#macro>
 
-<#macro renderHiddenField name conditionGroup="" value="" id="" event="" action="">
+<#macro renderHiddenField name conditionGroup="" value="" id="" event="" action="" disabled=false>
   <#if conditionGroup?has_content>
-    <input type="hidden" name="${name}_grp" value="${conditionGroup}"/>
+    <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
-  <input type="hidden" name="${name}"<#if value?has_content> value="${value}"</#if><#if id?has_content> id="${id}"</#if><#if event?has_content && action?has_content> ${event}="${action}"</#if>/>
+  <input type="hidden" name="${name}" <@renderDisabled disabled />
+    <#if value?has_content> value="${value}"</#if>
+    <#if id?has_content> id="${id}"</#if>
+    <#if event?has_content && action?has_content> ${event}="${action}"</#if>/>
 </#macro>
 
 <#macro renderIgnoredField></#macro>
@@ -396,12 +411,12 @@ under the License.
 
 <#macro renderFormatEmptySpace>&nbsp;</#macro>
 
-<#macro renderTextFindField name defaultOption opBeginsWith opContains opIsEmpty opNotEqual className alert hideIgnoreCase ignCase ignoreCase conditionGroup="" value="" opEquals="" size="" maxlength="" autocomplete="" titleStyle="" tabindex="">
+<#macro renderTextFindField name defaultOption opBeginsWith opContains opIsEmpty opNotEqual className alert hideIgnoreCase ignCase ignoreCase conditionGroup="" value="" opEquals="" size="" maxlength="" autocomplete="" titleStyle="" tabindex="" disabled=false>
   <#if conditionGroup?has_content>
-    <input type="hidden" name="${name}_grp" value="${conditionGroup}"/>
+    <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
   <#if opEquals?has_content>
-    <select <#if name?has_content>name="${name}_op"</#if>    class="selectBox"><#rt/>
+    <select <@renderDisabled disabled /> <#if name?has_content>name="${name}_op"</#if> class="selectBox"<#rt/>
       <option value="equals"<#if defaultOption=="equals"> selected="selected"</#if>>${opEquals}</option><#rt/>
       <option value="like"<#if defaultOption=="like"> selected="selected"</#if>>${opBeginsWith}</option><#rt/>
       <option value="contains"<#if defaultOption=="contains"> selected="selected"</#if>>${opContains}</option><#rt/>
@@ -411,20 +426,25 @@ under the License.
   <#else>
     <input type="hidden" name=<#if name?has_content> "${name}_op"</#if>    value="${defaultOption}"/><#rt/>
   </#if>
-    <input type="text" <@renderClass className alert /> name="${name}"<#if value?has_content> value="${value}"</#if><#if size?has_content> size="${size}"</#if><#if maxlength?has_content> maxlength="${maxlength}"</#if><#if autocomplete?has_content> autocomplete="off"</#if>/><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
+    <input type="text" <@renderClass className alert /> <@renderDisabled disabled /> name="${name}"
+      <#if value?has_content> value="${value}"</#if>
+      <#if size?has_content> size="${size}"</#if>
+      <#if maxlength?has_content> maxlength="${maxlength}"</#if>
+      <#if autocomplete?has_content> autocomplete="off"</#if>
+      <#if tabindex?has_content> tabindex="${tabindex}"</#if>/><#rt/>
     <#if titleStyle?has_content><span class="${titleStyle}" ><#rt/></#if>
     <#if hideIgnoreCase>
       <input type="hidden" name="${name}_ic" value=<#if ignCase>"Y"<#else> ""</#if>/><#rt/>
     <#else>
-      <input type="checkbox" name="${name}_ic" value="Y" <#if ignCase> checked="checked"</#if> /> ${ignoreCase}<#rt/>
+      <input type="checkbox" name="${name}_ic" value="Y" <#if ignCase> checked="checked"</#if> <@renderDisabled disabled />/> ${ignoreCase}<#rt/>
     </#if>
     <#if titleStyle?has_content></span>
   </#if>
 </#macro>
 
-<#macro renderDateFindField className alert id name dateType formName value defaultDateTimeString imgSrc localizedIconTitle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="">
+<#macro renderDateFindField className alert id name dateType formName value defaultDateTimeString imgSrc localizedIconTitle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false>
   <#if conditionGroup?has_content>
-    <input type="hidden" name="${name}_grp" value="${conditionGroup}"/>
+    <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
   <#if dateType != "time">
     <#local className = className + " date-time-picker"/>
@@ -435,7 +455,7 @@ under the License.
   <#local timePicker = "/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.min.js,/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.css"/>
   <#local timePickerLang = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("dateTime", .locale)/>
   <span class="view-calendar">
-    <input id="${id}_fld0_value" type="text" <@renderClass className alert />
+    <input id="${id}_fld0_value" type="text" <@renderClass className alert /> <@renderDisabled disabled />
         <#if name?has_content> name="${name?html}_fld0_value"</#if>
         <#if localizedInputTitle?has_content> title="${localizedInputTitle}"</#if>
         <#if value?has_content> value="${value}"</#if>
@@ -451,7 +471,7 @@ under the License.
     <#if titleStyle?has_content>
       <span class="${titleStyle}"><#rt/>
     </#if>
-    <select<#if name?has_content> name="${name}_fld0_op"</#if> class="selectBox"><#rt/>
+    <select <@renderDisabled disabled /> <#if name?has_content> name="${name}_fld0_op"</#if> class="selectBox"><#rt/>
       <option value="equals"<#if defaultOptionFrom=="equals"> selected="selected"</#if>>${opEquals}</option><#rt/>
       <option value="sameDay"<#if defaultOptionFrom=="sameDay"> selected="selected"</#if>>${opSameDay}</option><#rt/>
       <option value="greaterThanFromDayStart"<#if defaultOptionFrom=="greaterThanFromDayStart"> selected="selected"</#if>>${opGreaterThanFromDayStart}</option><#rt/>
@@ -461,7 +481,7 @@ under the License.
       </span><#rt/>
     </#if>
     <#rt/>
-    <input id="${id}_fld1_value" type="text" <@renderClass className alert />
+    <input id="${id}_fld1_value" type="text" <@renderClass className alert /> <@renderDisabled disabled />
         <#if name?has_content> name="${name}_fld1_value"</#if>
         <#if localizedInputTitle??> title="${localizedInputTitle?html}"</#if>
         <#if value2?has_content> value="${value2}"</#if>
@@ -471,12 +491,12 @@ under the License.
         <#if datePickerLang?has_content> data-datepickerlang="${datePickerLang}"</#if><#rt/>
         <#if timePicker?has_content> data-timePicker="${timePicker}"</#if><#rt/>
         <#if timePickerLang?has_content> data-timepickerlang="${timePickerLang}"</#if><#rt/>
-         data-shortdate="${shortDateInput?string}"
+        data-shortdate="${shortDateInput?string}"
     /><#rt/>
     <#if titleStyle?has_content>
       <span class="${titleStyle}"><#rt/>
     </#if>
-    <select name=<#if name?has_content>"${name}_fld1_op"</#if> class="selectBox"><#rt/>
+    <select name=<#if name?has_content>"${name}_fld1_op"</#if> class="selectBox" <@renderDisabled disabled />><#rt/>
       <option value="opLessThan"<#if defaultOptionThru=="opLessThan"> selected="selected"</#if>>${opLessThan}</option><#rt/>
       <option value="upToDay"<#if defaultOptionThru=="upToDay"> selected="selected"</#if>>${opUpToDay}</option><#rt/>
       <option value="upThruDay"<#if defaultOptionThru=="upThruDay"> selected="selected"</#if>>${opUpThruDay}</option><#rt/>
@@ -488,15 +508,21 @@ under the License.
   </span>
 </#macro>
 
-<#macro renderRangeFindField className alert value defaultOptionFrom opEquals opGreaterThan opGreaterThanEquals opLessThan opLessThanEquals defaultOptionThru conditionGroup="" name="" size="" maxlength="" autocomplete="" titleStyle="" value2="" tabindex="">
+<#macro renderRangeFindField className alert value defaultOptionFrom opEquals opGreaterThan opGreaterThanEquals opLessThan opLessThanEquals defaultOptionThru conditionGroup="" name="" size="" maxlength="" autocomplete="" titleStyle="" value2="" tabindex="" disabled=false>
   <#if conditionGroup?has_content>
-    <input type="hidden" name="${name}_grp" value="${conditionGroup}"/>
+    <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
-  <input type="text" <@renderClass className alert /> <#if name?has_content>name="${name}_fld0_value"</#if><#if value?has_content> value="${value}"</#if><#if size?has_content> size="${size}"</#if><#if maxlength?has_content> maxlength="${maxlength}"</#if><#if autocomplete?has_content> autocomplete="off"</#if>/><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
+  <input type="text" <@renderClass className alert /> <@renderDisabled disabled />
+    <#if name?has_content>name="${name}_fld0_value"</#if>
+    <#if value?has_content> value="${value}"</#if>
+    <#if size?has_content> size="${size}"</#if>
+    <#if maxlength?has_content> maxlength="${maxlength}"</#if>
+    <#if autocomplete?has_content> autocomplete="off"</#if>
+    <#if tabindex?has_content> tabindex="${tabindex}"</#if>/><#rt/>
   <#if titleStyle?has_content>
     <span class="${titleStyle}" ><#rt/>
   </#if>
-  <select <#if name?has_content>name="${name}_fld0_op"</#if> class="selectBox"><#rt/>
+  <select <@renderDisabled disabled /> <#if name?has_content>name="${name}_fld0_op"</#if> class="selectBox"><#rt/>
     <option value="equals"<#if defaultOptionFrom=="equals"> selected="selected"</#if>>${opEquals}</option><#rt/>
     <option value="greaterThan"<#if defaultOptionFrom=="greaterThan"> selected="selected"</#if>>${opGreaterThan}</option><#rt/>
     <option value="greaterThanEqualTo"<#if defaultOptionFrom=="greaterThanEqualTo"> selected="selected"</#if>>${opGreaterThanEquals}</option><#rt/>
@@ -505,11 +531,16 @@ under the License.
     </span><#rt/>
   </#if>
   <br /><#rt/>
-  <input type="text" <@renderClass className alert /><#if name?has_content> name="${name}_fld1_value"</#if><#if value2?has_content> value="${value2}"</#if><#if size?has_content> size="${size}"</#if><#if maxlength?has_content> maxlength="${maxlength}"</#if><#if autocomplete?has_content> autocomplete="off"</#if>/><#rt/>
+  <input type="text" <@renderClass className alert /> <@renderDisabled disabled />
+    <#if name?has_content> name="${name}_fld1_value"</#if>
+    <#if value2?has_content> value="${value2}"</#if>
+    <#if size?has_content> size="${size}"</#if>
+    <#if maxlength?has_content> maxlength="${maxlength}"</#if>
+    <#if autocomplete?has_content> autocomplete="off"</#if>/><#rt/>
   <#if titleStyle?has_content>
-    <span class="${titleStyle}" ><#rt/>
+    <span class="${titleStyle}"><#rt/>
   </#if>
-  <select name=<#if name?has_content>"${name}_fld1_op"</#if> class="selectBox"><#rt/>
+  <select <@renderDisabled disabled /> name=<#if name?has_content>"${name}_fld1_op"</#if> class="selectBox"><#rt/>
     <option value="lessThan"<#if defaultOptionThru=="lessThan"> selected="selected"</#if>>${opLessThan?html}</option><#rt/>
     <option value="lessThanEqualTo"<#if defaultOptionThru=="lessThanEqualTo"> selected="selected"</#if>>${opLessThanEquals?html}</option><#rt/>
   </select><#rt/>
@@ -553,7 +584,7 @@ Parameter: lastViewName, String, optional - If the ajaxEnabled parameter is true
 Parameter: tabindex, String, optional - HTML tabindex number.
 Parameter: delegatorName, String, optional - name of the delegator in context.
 -->
-<#macro renderLookupField name formName fieldFormName conditionGroup="" className="" alert="false" value="" size="" maxlength="" id="" event="" action="" readonly=false autocomplete="" descriptionFieldName="" targetParameterIter="" imgSrc="" ajaxUrl="" ajaxEnabled=javaScriptEnabled presentation="layer" width=modelTheme.getLookupWidth() height=modelTheme.getLookupHeight() position=modelTheme.getLookupPosition() fadeBackground="true" clearText="" showDescription="" initiallyCollapsed="" lastViewName="main" tabindex="" delegatorName="default">
+<#macro renderLookupField name formName fieldFormName conditionGroup="" className="" alert="false" value="" size="" maxlength="" id="" event="" action="" readonly=false autocomplete="" descriptionFieldName="" targetParameterIter="" imgSrc="" ajaxUrl="" ajaxEnabled=javaScriptEnabled presentation="layer" width=modelTheme.getLookupWidth() height=modelTheme.getLookupHeight() position=modelTheme.getLookupPosition() fadeBackground="true" clearText="" showDescription="" initiallyCollapsed="" lastViewName="main" tabindex="" delegatorName="default" disabled=false>
   <#if Static["org.apache.ofbiz.widget.model.ModelWidget"].widgetBoundaryCommentsEnabled(context)><#-- context is always null here, but this is handled in widgetBoundaryCommentsEnabled -->
   <!-- @renderLookupField -->
   </#if>
@@ -571,13 +602,16 @@ Parameter: delegatorName, String, optional - name of the delegator in context.
     <#local ajaxUrl = ajaxUrl + "&amp;_LAST_VIEW_NAME_=" + lastViewName />
   </#if>
   <#if conditionGroup?has_content>
-    <input type="hidden" name="${name}_grp" value="${conditionGroup}"/>
+    <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
   <span class="field-lookup">
     <#if size?has_content && size=="0">
-      <input type="hidden" <#if name?has_content> name="${name}"</#if><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
+      <input type="hidden" <@renderDisabled disabled />
+        <#if name?has_content> name="${name}"</#if>
+        <#if tabindex?has_content> tabindex="${tabindex}"</#if>
     <#else>
-      <input type="text" <@renderClass className alert /><#if name?has_content> name="${name}"</#if><#if value?has_content> value="${value}"</#if><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
+      <input type="text" <@renderClass className alert /> <@renderDisabled disabled />
+        <#if name?has_content> name="${name}"</#if><#if value?has_content> value="${value}"</#if><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
         <#if size?has_content> size="${size}"</#if><#if maxlength?has_content> maxlength="${maxlength}"</#if><#if id?has_content> id="${id}"</#if><#rt/>
         <#if readonly?has_content && readonly> readonly="readonly"</#if><#rt/><#if event?has_content && action?has_content> ${event}="${action}"</#if><#rt/>
         <#if autocomplete?has_content> autocomplete="off"</#if><#rt/>
@@ -659,12 +693,31 @@ Parameter: delegatorName, String, optional - name of the delegator in context.
   </#if>
 </#macro>
 
-<#macro renderFileField className alert name="" value="" size="" maxlength="" autocomplete="" tabindex="">
-  <input type="file" <@renderClass className alert /><#if name?has_content> name="${name}"</#if><#if value?has_content> value="${value}"</#if><#if size?has_content> size="${size}"</#if><#if maxlength?has_content> maxlength="${maxlength}"</#if><#if autocomplete?has_content> autocomplete="off"</#if>/><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
+<#macro renderFileField className alert name="" value="" size="" maxlength="" autocomplete="" tabindex="" disabled=false>
+  <input type="file"
+    <@renderClass className alert />
+    <@renderDisabled disabled />
+    <#if name?has_content> name="${name}"</#if>
+    <#if value?has_content> value="${value}"</#if>
+    <#if size?has_content> size="${size}"</#if>
+    <#if maxlength?has_content> maxlength="${maxlength}"</#if>
+    <#if autocomplete?has_content> autocomplete="off"</#if>
+    <#if tabindex?has_content> tabindex="${tabindex}"</#if>/><#rt/>
 </#macro>
-<#macro renderPasswordField className alert name="" value="" size="" maxlength="" id="" autocomplete="" tabindex="">
-  <input type="password" <@renderClass className alert /><#if name?has_content> name="${name}"</#if><#if value?has_content> value="${value}"</#if><#if size?has_content> size="${size}"</#if><#if maxlength?has_content> maxlength="${maxlength}"</#if><#if id?has_content> id="${id}"</#if><#if autocomplete?has_content> autocomplete="off"</#if><#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>/>
+
+<#macro renderPasswordField className alert name="" value="" size="" maxlength="" id="" autocomplete="" tabindex="" disabled=false>
+  <input type="password"
+    <@renderClass className alert />
+    <@renderDisabled disabled />
+    <#if name?has_content> name="${name}"</#if>
+    <#if value?has_content> value="${value}"</#if>
+    <#if size?has_content> size="${size}"</#if>
+    <#if maxlength?has_content> maxlength="${maxlength}"</#if>
+    <#if id?has_content> id="${id}"</#if>
+    <#if autocomplete?has_content> autocomplete="off"</#if>
+    <#if tabindex?has_content> tabindex="${tabindex}"</#if>/><#rt/>
 </#macro>
+
 <#macro renderImageField action value="" description="" alternate="" style="" event=""><img<#if value?has_content> src="${value}"</#if><#if description?has_content> title="${description}"</#if> alt="<#if alternate?has_content>${alternate}"</#if><#if style?has_content> class="${style}"</#if><#if event?has_content> ${event?html}="${action}" </#if>/></#macro>
 
 <#macro renderBanner style="" leftStyle="" rightStyle="" leftText="" text="" rightText="">
@@ -722,10 +775,14 @@ Parameter: delegatorName, String, optional - name of the delegator in context.
   <#if requiredField=="true"><#if !requiredStyle?has_content>*</#if></#if>
 </#macro>
 
-<#macro makeHiddenFormLinkForm actionUrl name parameters targetWindow="">
+<#macro renderDisabled disabled>
+  <#if disabled?has_content && disabled> disabled </#if>
+</#macro>
+
+<#macro makeHiddenFormLinkForm actionUrl name parameters targetWindow="" disabled=false>
   <form method="post" action="${actionUrl}" <#if targetWindow?has_content>target="${targetWindow}"</#if> onsubmit="javascript:submitFormDisableSubmits(this)" name="${name}">
     <#list parameters as parameter>
-      <input name="${parameter.name}" value="${parameter.value?html}" type="hidden"/>
+      <input name="${parameter.name}" value="${parameter.value?html}" type="hidden" <@renderDisabled disabled />/>
     </#list>
   </form>
 </#macro>


### PR DESCRIPTION
Add disabled support on all form field types

Switch to `FlexibleStringExpander` (instead of boolean) to support dynamic attribute values

[OFBIZ-12678](https://issues.apache.org/jira/browse/OFBIZ-12678)

Improved: Add `disabled` support on all form field types 
Fixed: bug in `tab-index` attribute implementation for some HTML macros

### Explanation

Before this PR, `disabled` attribute on form fields is a `boolean`, and its support is not implemented on all eligible widgets : 
```
<text disabled="false" />
<text disabled="true" />
```

Based on https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled, this PR implements dynamic `disabled` attribute for all relevant widgets : 
```
<date-range disabled="true" /> // disabled
<date-range disabled="${5==5}" /> // disabled
<date-range disabled="false" /> // not disabled
<date-range disabled="${5==6}" /> // not disabled
```

In addition, in HTML macros, the `disabled` attribute is rendered as a `boolean` instead of a string (see https://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-html.html#ID-642250288) : 
```
<text disabled="true" /> // renders as : 
<input disabled /> // instead of
<input disabled="true" />
```

Thanks: Néréide team
