### PR TITLE
Improved: MacroFormRenderer refactoring of textarea fields (OFBIZ-12124

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -245,88 +245,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
 
     @Override
     public void renderTextareaField(Appendable writer, Map<String, Object> context, TextareaField textareaField) {
-        ModelFormField modelFormField = textareaField.getModelFormField();
-        String name = modelFormField.getParameterName(context);
-        String cols = Integer.toString(textareaField.getCols());
-        String rows = Integer.toString(textareaField.getRows());
-        String id = modelFormField.getCurrentContainerId(context);
-        String className = "";
-        String alert = "false";
-        if (UtilValidate.isNotEmpty(modelFormField.getWidgetStyle())) {
-            className = modelFormField.getWidgetStyle();
-            if (modelFormField.shouldBeRed(context)) {
-                alert = "true";
-            }
-        }
-        //check for required field style on single forms
-        if (shouldApplyRequiredField(modelFormField)) {
-            String requiredStyle = modelFormField.getRequiredFieldStyle();
-            if (UtilValidate.isEmpty(requiredStyle)) {
-                requiredStyle = "required";
-            }
-            if (UtilValidate.isEmpty(className)) {
-                className = requiredStyle;
-            } else {
-                className = requiredStyle + " " + className;
-            }
-        }
-        String visualEditorEnable = "";
-        String buttons = "";
-        if (textareaField.getVisualEditorEnable()) {
-            visualEditorEnable = "true";
-            buttons = textareaField.getVisualEditorButtons(context);
-            if (UtilValidate.isEmpty(buttons)) {
-                buttons = "maxi";
-            }
-        }
-        String readonly = "";
-        if (textareaField.isReadOnly()) {
-            readonly = "readonly";
-        }
-        Map<String, Object> userLogin = UtilGenerics.cast(context.get("userLogin"));
-        String language = "en";
-        if (userLogin != null) {
-            language = UtilValidate.isEmpty((String) userLogin.get("lastLocale")) ? "en" : (String) userLogin.get("lastLocale");
-        }
-        String maxlength = "";
-        if (textareaField.getMaxlength() != null) {
-            maxlength = Integer.toString(textareaField.getMaxlength());
-        }
-        String tabindex = modelFormField.getTabindex();
-        String value = modelFormField.getEntry(context, textareaField.getDefaultValue(context));
-        boolean disabled = modelFormField.getDisabled(context);
-        StringWriter sr = new StringWriter();
-        sr.append("<@renderTextareaField ");
-        sr.append("name=\"");
-        sr.append(name);
-        sr.append("\" className=\"");
-        sr.append(className);
-        sr.append("\" alert=\"");
-        sr.append(alert);
-        sr.append("\" value=\"");
-        sr.append(value);
-        sr.append("\" cols=\"");
-        sr.append(cols);
-        sr.append("\" rows=\"");
-        sr.append(rows);
-        sr.append("\" maxlength=\"");
-        sr.append(maxlength);
-        sr.append("\" id=\"");
-        sr.append(id);
-        sr.append("\" readonly=\"");
-        sr.append(readonly);
-        sr.append("\" visualEditorEnable=\"");
-        sr.append(visualEditorEnable);
-        sr.append("\" language=\"");
-        sr.append(language);
-        sr.append("\" buttons=\"");
-        sr.append(buttons);
-        sr.append("\" tabindex=\"");
-        sr.append(tabindex);
-        sr.append("\" disabled=");
-        sr.append(Boolean.toString(disabled));
-        sr.append(" />");
-        executeMacro(writer, sr.toString());
+        writeFtlElement(writer, renderableFtlFormElementsBuilder.textArea(context, textareaField));
+
+        final ModelFormField modelFormField = textareaField.getModelFormField();
         this.addAsterisks(writer, context, modelFormField);
         this.appendTooltip(writer, context, modelFormField);
     }

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/renderable/RenderableFtlMacroCall.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/renderable/RenderableFtlMacroCall.java
@@ -69,6 +69,10 @@ public final class RenderableFtlMacroCall implements RenderableFtl {
             return parameter(parameterName, parameterValue);
         }
 
+        public RenderableFtlMacroCallBuilder intParameter(final String parameterName, final int parameterValue) {
+            return parameter(parameterName, parameterValue);
+        }
+
         public RenderableFtlMacroCallBuilder booleanParameter(final String parameterName, final boolean parameterValue) {
             return parameter(parameterName, parameterValue);
         }

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallMatcher.java
@@ -25,11 +25,14 @@ import org.hamcrest.TypeSafeMatcher;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public final class MacroCallMatcher extends TypeSafeMatcher<RenderableFtl> {
     private final String macroName;
     private final MacroCallParameterMatcher[] parameterMatchers;
 
+    private boolean nameMatched;
     private final List<MacroCallParameterMatcher> failedParameterMatchers = new ArrayList<>();
 
     public MacroCallMatcher(final String macroName, final MacroCallParameterMatcher... parameterMatchers) {
@@ -42,7 +45,7 @@ public final class MacroCallMatcher extends TypeSafeMatcher<RenderableFtl> {
     @Override
     protected boolean matchesSafely(final RenderableFtl item) {
         final RenderableFtlMacroCall macroCall = (RenderableFtlMacroCall) item;
-        boolean nameMatched = (macroName == null) || macroName.equals(macroCall.getName());
+        nameMatched = (macroName == null) || macroName.equals(macroCall.getName());
 
         for (final MacroCallParameterMatcher parameterMatcher : parameterMatchers) {
             boolean matchForParameterMatcher = macroCall.getParameters()
@@ -59,7 +62,7 @@ public final class MacroCallMatcher extends TypeSafeMatcher<RenderableFtl> {
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText("MacroCall has name '" + macroName + "' ");
+        description.appendText("MacroCall named '" + macroName + "' ");
         description.appendText("with Parameters[");
         for (final MacroCallParameterMatcher parameterMatcher : parameterMatchers) {
             parameterMatcher.describeTo(description);
@@ -71,17 +74,27 @@ public final class MacroCallMatcher extends TypeSafeMatcher<RenderableFtl> {
     protected void describeMismatchSafely(final RenderableFtl item, final Description mismatchDescription) {
         final RenderableFtlMacroCall macroCall = (RenderableFtlMacroCall) item;
 
-        mismatchDescription.appendText("MacroCall has name '" + macroCall.getName() + "' ");
+        if (!nameMatched) {
+            mismatchDescription.appendText("MacroCall has name '" + macroCall.getName() + "' but expected was '" + macroName + "'");
+        }
 
         if (!failedParameterMatchers.isEmpty()) {
-            mismatchDescription.appendText("with Parameters[");
             for (final MacroCallParameterMatcher failedParameterMatcher : failedParameterMatchers) {
-                macroCall.getParameters()
+
+                final String failedParameterName = failedParameterMatcher.getName();
+                final Optional<Map.Entry<String, Object>> matchedParameterByName = macroCall.getParameters()
                         .entrySet()
-                        .forEach(entry ->
-                                failedParameterMatcher.describeMismatch(entry, mismatchDescription));
+                        .stream()
+                        .filter(entry -> failedParameterName.equals(entry.getKey()))
+                        .findFirst();
+
+                matchedParameterByName.ifPresent(parameterEntry ->
+                        failedParameterMatcher.describeMismatchSafely(parameterEntry, mismatchDescription));
+
+                if (!matchedParameterByName.isPresent()) {
+                    mismatchDescription.appendText("Parameter '" + failedParameterName + "' was missing, ");
+                }
             }
-            mismatchDescription.appendText("]");
         }
     }
 

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterBooleanValueMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterBooleanValueMatcher.java
@@ -35,7 +35,7 @@ public final class MacroCallParameterBooleanValueMatcher extends TypeSafeMatcher
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText("with boolean value '" + value + "'");
+        description.appendText("boolean value '" + value + "'");
     }
 
     @Override

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterIntegerValueMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterIntegerValueMatcher.java
@@ -21,25 +21,25 @@ package org.apache.ofbiz.widget.renderer.macro;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
-public final class MacroCallParameterStringValueMatcher extends TypeSafeMatcher<Object> {
-    private final String value;
+public final class MacroCallParameterIntegerValueMatcher extends TypeSafeMatcher<Object> {
+    private final int value;
 
-    public MacroCallParameterStringValueMatcher(final String value) {
+    public MacroCallParameterIntegerValueMatcher(final int value) {
         this.value = value;
     }
 
     @Override
     protected boolean matchesSafely(final Object item) {
-        return value.equals(item);
+        return item.equals(value);
     }
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText("string value '" + value + "'");
+        description.appendText("integer value '" + value + "'");
     }
 
     @Override
     protected void describeMismatchSafely(final Object item, final Description mismatchDescription) {
-        mismatchDescription.appendText("with value '" + item + "'");
+        mismatchDescription.appendText("with integer value '" + item + "'");
     }
 }

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterMapValueMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterMapValueMatcher.java
@@ -38,7 +38,7 @@ public final class MacroCallParameterMapValueMatcher extends TypeSafeMatcher<Obj
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText("with map value '");
+        description.appendText("map value '");
         matcher.describeTo(description);
         description.appendText("' ");
     }

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterMatcher.java
@@ -36,6 +36,10 @@ public final class MacroCallParameterMatcher extends TypeSafeMatcher<Map.Entry<S
         this.valueMatcher = valueMatcher;
     }
 
+    public String getName() {
+        return name;
+    }
+
     @Override
     protected boolean matchesSafely(final Map.Entry<String, Object> item) {
         if (name != null) {
@@ -52,19 +56,21 @@ public final class MacroCallParameterMatcher extends TypeSafeMatcher<Map.Entry<S
     @Override
     public void describeTo(final Description description) {
         if (name != null) {
-            description.appendText("has name '" + name + "' ");
+            description.appendText("'" + name + "' ");
         }
 
         if (valueMatcher != null) {
             valueMatcher.describeTo(description);
         }
+
+        description.appendText(", ");
     }
 
     @Override
     protected void describeMismatchSafely(final Map.Entry<String, Object> item,
                                           final Description mismatchDescription) {
         if (name != null) {
-            mismatchDescription.appendText("has name '" + item.getKey() + "' ");
+            mismatchDescription.appendText("Parameter '" + item.getKey() + "' ");
         }
 
         if (valueMatcher != null) {
@@ -80,6 +86,10 @@ public final class MacroCallParameterMatcher extends TypeSafeMatcher<Map.Entry<S
 
     public static MacroCallParameterMatcher hasNameAndStringValue(final String name, final String value) {
         return new MacroCallParameterMatcher(name, new MacroCallParameterStringValueMatcher(value));
+    }
+
+    public static MacroCallParameterMatcher hasNameAndIntegerValue(final String name, final int value) {
+        return new MacroCallParameterMatcher(name, new MacroCallParameterIntegerValueMatcher(value));
     }
 
     public static MacroCallParameterMatcher hasNameAndBooleanValue(final String name, final boolean value) {

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -225,23 +225,17 @@ public class MacroFormRendererTest {
     public void textAreaMacroRendered(@Mocked ModelFormField.TextareaField textareaField) throws IOException {
         new Expectations() {
             {
-                modelFormField.getEntry(withNotNull(), anyString);
-                result = "TEXTAREAVALUE";
-
-                textareaField.getCols();
-                result = 11;
-
-                textareaField.getRows();
-                result = 22;
+                renderableFtlFormElementsBuilder.textArea(withNotNull(), textareaField);
+                result = genericMacroCall;
             }
         };
 
+        genericTooltipRenderedExpectation(textareaField);
+
         macroFormRenderer.renderTextareaField(appendable, ImmutableMap.of(), textareaField);
 
-        assertAndGetMacroString("renderTextareaField", ImmutableMap.of(
-                "value", "TEXTAREAVALUE",
-                "cols", "11",
-                "rows", "22"));
+        genericSingleMacroRenderedVerification();
+        genericTooltipRenderedVerification();
     }
 
     @Test

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
@@ -237,6 +237,57 @@ public class RenderableFtlFormElementsBuilderTest {
     }
 
     @Test
+    public void textareaFieldSetsIdValueLengthAndSize(@Mocked final ModelFormField.TextareaField textareaField) {
+        final int maxLength = 142;
+        final int cols = 80;
+        final int rows = 5;
+        new Expectations() {
+            {
+                modelFormField.getCurrentContainerId(withNotNull());
+                result = "CurrentTextareaId";
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "TEXTAREAVALUE";
+
+                textareaField.getMaxlength();
+                result = maxLength;
+
+                textareaField.getCols();
+                result = cols;
+
+                textareaField.getRows();
+                result = rows;
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textArea(context, textareaField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderTextareaField",
+                MacroCallParameterMatcher.hasNameAndStringValue("id", "CurrentTextareaId"),
+                MacroCallParameterMatcher.hasNameAndStringValue("value", "TEXTAREAVALUE"),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("cols", cols),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("rows", rows),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("maxlength", maxLength)));
+    }
+
+    @Test
+    public void textareaFieldSetsDisabledParameters(@Mocked final ModelFormField.TextareaField textareaField) {
+        new Expectations() {
+            {
+                modelFormField.getDisabled(withNotNull());
+                result = true;
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textArea(context, textareaField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderTextareaField",
+                MacroCallParameterMatcher.hasNameAndBooleanValue("disabled", true)));
+    }
+
+    @Test
     public void fieldGroupOpenRendersCollapsibleAreaId(@Mocked final ModelForm.FieldGroup fieldGroup) {
         new Expectations() {
             {


### PR DESCRIPTION
Part of the OFBIZ-11456 MacroFormRenderer refactoring effort.

Rather than MacroFormRenderer producing and evaulating FTL strings when rendering textareas, it now uses RenderableFtlElementsBuilder to create RenderableFtlMacroCall objects which are then passed to an FtlWriter for evaluation.
