### PR TITLE
Improved: Exclude jquery sources, used by common-theme, from sonarcloud analysis.

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,3 @@
 
+# Exclude jquery files stored to the ofbiz-framework repository. These appear to cause warning around code duplication.
+sonar.exclusions=themes/common-theme/webapp/common-theme/js/jquery/**/*


### PR DESCRIPTION
Sonarcloud appears to be erroneously detecting duplicates on PR #549. This PR doesn't make any changes to the code flagged as duplicated so it is strange that that PR seems to be one of the few which are flagged with this warning.

The `.sonarcloud.properties` file allows the scope of SonarClouds analysis to be changed through exclusions. This PR excludes the jquery code from the analysis which should remove the false reporting of duplicated code.

Removing jquery code from analysis seems reasonable since it was not authored and is not maintained by the ofbiz project.
