### PR TITLE
Fixed loading of the Employee training and leave screens (OFBIZ-12710)

### DIFF
--- a/applications/humanres/widget/EmployeeScreens.xml
+++ b/applications/humanres/widget/EmployeeScreens.xml
@@ -222,7 +222,7 @@ under the License.
                 <decorator-screen name="EmployeeDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet id="TrainingStatus" title="${uiLabelMap.HumanResTrainingStatus}" collapsible="true">
-                            <include-form name="ListTrainingStatus" location="component://humanres/widget/forms/PersonTrainingForms.xml"/>
+                            <include-grid name="ListTrainingStatus" location="component://humanres/widget/forms/PersonTrainingForms.xml"/>
                         </screenlet>
                     </decorator-section>
                 </decorator-screen>
@@ -303,7 +303,7 @@ under the License.
                 <decorator-screen name="EmployeeDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
                         <screenlet>
-                            <include-form name="ListEmplLeaves" location="component://humanres/widget/forms/EmployeeForms.xml"/>
+                            <include-grid name="ListEmplLeaves" location="component://humanres/widget/forms/EmployeeForms.xml"/>
                         </screenlet>
                         <screenlet id="AddEmplLeavePanel" title="${uiLabelMap.HumanResAddEmplLeave}" collapsible="true">
                             <include-form name="AddEmplLeave" location="component://humanres/widget/forms/EmployeeForms.xml"/>


### PR DESCRIPTION
Two screens in EmployeeScreens.xml needed their `include-form` elements replaced with `include-grid`.