### PR TITLE
Improved: MacroFormRenderer refactoring of datetime fields (OFBIZ-12126)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -88,7 +88,7 @@ import org.w3c.dom.Element;
 /**
  * Models the &lt;field&gt; element.
  *
- * @see <code>widget-form.xsd</code>
+ * @see <a href="https://ofbiz.apache.org/dtds/widget-form.xsd">widget-form.xsd</a>
  */
 public final class ModelFormField {
 
@@ -1276,7 +1276,7 @@ public final class ModelFormField {
         private final FlexibleStringExpander defaultValue;
         private final String inputMethod;
         private final String mask;
-        private final String step;
+        private final int step;
         private final String type;
 
         protected DateTimeField(DateTimeField original, ModelFormField modelFormField) {
@@ -1296,11 +1296,20 @@ public final class ModelFormField {
             this.inputMethod = element.getAttribute("input-method");
             this.clock = element.getAttribute("clock");
             this.mask = element.getAttribute("mask");
-            String step = element.getAttribute("step");
-            if (step.isEmpty()) {
-                step = "1";
+
+            final String stepAttribute = element.getAttribute("step");
+            if (stepAttribute.isEmpty()) {
+                this.step = 1;
+            } else {
+                try {
+                    this.step = Integer.parseInt(stepAttribute);
+                } catch (IllegalArgumentException e) {
+                    final String msg = "Could not read the step value of the datetime element: [" + stepAttribute
+                            + "]. Value must be an integer.";
+                    Debug.logError(msg, MODULE);
+                    throw new RuntimeException(msg, e);
+                }
             }
-            this.step = step;
         }
 
         public DateTimeField(int fieldSource, ModelFormField modelFormField) {
@@ -1310,7 +1319,7 @@ public final class ModelFormField {
             this.inputMethod = "";
             this.clock = "";
             this.mask = "";
-            this.step = "1";
+            this.step = 1;
         }
 
         public DateTimeField(int fieldSource, String type) {
@@ -1320,7 +1329,7 @@ public final class ModelFormField {
             this.inputMethod = "";
             this.clock = "";
             this.mask = "";
-            this.step = "1";
+            this.step = 1;
         }
 
         public DateTimeField(ModelFormField modelFormField) {
@@ -1330,7 +1339,7 @@ public final class ModelFormField {
             this.inputMethod = "";
             this.clock = "";
             this.mask = "";
-            this.step = "1";
+            this.step = 1;
         }
 
         @Override
@@ -1408,9 +1417,10 @@ public final class ModelFormField {
 
         /**
          * Gets step.
+         *
          * @return the step
          */
-        public String getStep() {
+        public int getStep() {
             return this.step;
         }
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -1272,7 +1272,7 @@ public final class ModelFormField {
      * @see <code>widget-form.xsd</code>
      */
     public static class DateTimeField extends FieldInfo {
-        private final String clock;
+        private final boolean isTwelveHour;
         private final FlexibleStringExpander defaultValue;
         private final String inputMethod;
         private final String mask;
@@ -1284,7 +1284,7 @@ public final class ModelFormField {
             this.defaultValue = original.defaultValue;
             this.type = original.type;
             this.inputMethod = original.inputMethod;
-            this.clock = original.clock;
+            this.isTwelveHour = original.isTwelveHour;
             this.mask = original.mask;
             this.step = original.step;
         }
@@ -1294,7 +1294,7 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance(element.getAttribute("default-value"));
             this.type = element.getAttribute("type");
             this.inputMethod = element.getAttribute("input-method");
-            this.clock = element.getAttribute("clock");
+            this.isTwelveHour = "12".equals(element.getAttribute("clock"));
             this.mask = element.getAttribute("mask");
 
             final String stepAttribute = element.getAttribute("step");
@@ -1317,7 +1317,7 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.type = "";
             this.inputMethod = "";
-            this.clock = "";
+            this.isTwelveHour = false;
             this.mask = "";
             this.step = 1;
         }
@@ -1327,7 +1327,7 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.type = type;
             this.inputMethod = "";
-            this.clock = "";
+            this.isTwelveHour = false;
             this.mask = "";
             this.step = 1;
         }
@@ -1337,7 +1337,7 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.type = "";
             this.inputMethod = "";
-            this.clock = "";
+            this.isTwelveHour = false;
             this.mask = "";
             this.step = 1;
         }
@@ -1353,11 +1353,10 @@ public final class ModelFormField {
         }
 
         /**
-         * Gets clock.
-         * @return the clock
+         * @return True if this field uses a 12-hour clock. If false then a 24-hour clock should be used.
          */
-        public String getClock() {
-            return this.clock;
+        public boolean isTwelveHour() {
+            return this.isTwelveHour;
         }
 
         /**

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -1423,12 +1423,16 @@ public final class ModelFormField {
             return this.step;
         }
 
-        /**
-         * Gets type.
-         * @return the type
-         */
-        public String getType() {
-            return type;
+        public final boolean isDateType() {
+            return "date".equals(type);
+        }
+
+        public final boolean isTimeType() {
+            return "time".equals(type);
+        }
+
+        public final boolean isTimestampType() {
+            return "timestamp".equals(type);
         }
 
         @Override

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -1275,7 +1275,7 @@ public final class ModelFormField {
         private final boolean isTwelveHour;
         private final FlexibleStringExpander defaultValue;
         private final String inputMethod;
-        private final String mask;
+        private final boolean useMask;
         private final int step;
         private final String type;
 
@@ -1285,7 +1285,7 @@ public final class ModelFormField {
             this.type = original.type;
             this.inputMethod = original.inputMethod;
             this.isTwelveHour = original.isTwelveHour;
-            this.mask = original.mask;
+            this.useMask = original.useMask;
             this.step = original.step;
         }
 
@@ -1295,7 +1295,7 @@ public final class ModelFormField {
             this.type = element.getAttribute("type");
             this.inputMethod = element.getAttribute("input-method");
             this.isTwelveHour = "12".equals(element.getAttribute("clock"));
-            this.mask = element.getAttribute("mask");
+            this.useMask = "Y".equals(element.getAttribute("mask"));
 
             final String stepAttribute = element.getAttribute("step");
             if (stepAttribute.isEmpty()) {
@@ -1318,7 +1318,7 @@ public final class ModelFormField {
             this.type = "";
             this.inputMethod = "";
             this.isTwelveHour = false;
-            this.mask = "";
+            this.useMask = false;
             this.step = 1;
         }
 
@@ -1328,7 +1328,7 @@ public final class ModelFormField {
             this.type = type;
             this.inputMethod = "";
             this.isTwelveHour = false;
-            this.mask = "";
+            this.useMask = false;
             this.step = 1;
         }
 
@@ -1338,7 +1338,7 @@ public final class ModelFormField {
             this.type = "";
             this.inputMethod = "";
             this.isTwelveHour = false;
-            this.mask = "";
+            this.useMask = false;
             this.step = 1;
         }
 
@@ -1408,10 +1408,11 @@ public final class ModelFormField {
 
         /**
          * Gets mask.
+         *
          * @return the mask
          */
-        public String getMask() {
-            return this.mask;
+        public boolean useMask() {
+            return this.useMask;
         }
 
         /**

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetFieldVisitor.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetFieldVisitor.java
@@ -363,7 +363,7 @@ public class XmlWidgetFieldVisitor extends XmlAbstractWidgetVisitor implements M
         visitAttribute("default-value", field.getDefaultValue());
         visitAttribute("type", field.getType());
         visitAttribute("input-method", field.getInputMethod());
-        visitAttribute("clock", field.getClock());
+        visitAttribute("isTwelveHour", field.isTwelveHour());
         visitAttribute("mask", field.getMask());
         visitAttribute("step", field.getStep());
     }

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetFieldVisitor.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetFieldVisitor.java
@@ -364,7 +364,7 @@ public class XmlWidgetFieldVisitor extends XmlAbstractWidgetVisitor implements M
         visitAttribute("type", field.isDateType() ? "date" : field.isTimeType() ? "time" : "timestamp");
         visitAttribute("input-method", field.getInputMethod());
         visitAttribute("isTwelveHour", field.isTwelveHour());
-        visitAttribute("mask", field.getMask());
+        visitAttribute("mask", field.useMask() ? "Y" : "N");
         visitAttribute("step", field.getStep());
     }
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetFieldVisitor.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetFieldVisitor.java
@@ -361,7 +361,7 @@ public class XmlWidgetFieldVisitor extends XmlAbstractWidgetVisitor implements M
 
     private void visitDateTimeFieldAttrs(DateTimeField field) throws Exception {
         visitAttribute("default-value", field.getDefaultValue());
-        visitAttribute("type", field.getType());
+        visitAttribute("type", field.isDateType() ? "date" : field.isTimeType() ? "time" : "timestamp");
         visitAttribute("input-method", field.getInputMethod());
         visitAttribute("isTwelveHour", field.isTwelveHour());
         visitAttribute("mask", field.getMask());

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -1609,14 +1609,13 @@ public final class MacroFormRenderer implements FormStringRenderer {
         // the default values for a timestamp
         int size = 25;
         int maxlength = 30;
-        String dateType = dateFindField.getType();
-        if ("date".equals(dateType)) {
+        if (dateFindField.isDateType()) {
             maxlength = 10;
             size = maxlength;
             if (uiLabelMap != null) {
                 localizedInputTitle = uiLabelMap.get("CommonFormatDate");
             }
-        } else if ("time".equals(dateFindField.getType())) {
+        } else if (dateFindField.isTimeType()) {
             maxlength = 8;
             size = maxlength;
             if (uiLabelMap != null) {
@@ -1639,7 +1638,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         String defaultDateTimeString = "";
         StringBuilder imgSrc = new StringBuilder();
         // add calendar pop-up button and seed data IF this is not a "time" type date-find
-        if (!"time".equals(dateFindField.getType())) {
+        if (!dateFindField.isTimeType()) {
             ModelForm modelForm = modelFormField.getModelForm();
             formName = FormRenderer.getCurrentFormName(modelForm, context);
             defaultDateTimeString = UtilHttp.encodeBlanks(modelFormField.getEntry(context, dateFindField.getDefaultDateTimeString(context)));
@@ -1688,9 +1687,11 @@ public final class MacroFormRenderer implements FormStringRenderer {
         sr.append(Integer.toString(size));
         sr.append("\" maxlength=\"");
         sr.append(Integer.toString(maxlength));
-        sr.append("\" dateType=\"");
-        sr.append(dateType);
-        sr.append("\" formName=\"");
+        sr.append("\" isDateType=");
+        sr.append(Boolean.toString(dateFindField.isDateType()));
+        sr.append("\" isTimeType=");
+        sr.append(Boolean.toString(dateFindField.isTimeType()));
+        sr.append(" formName=\"");
         sr.append(formName);
         sr.append("\" defaultDateTimeString=\"");
         sr.append(defaultDateTimeString);

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
@@ -49,7 +49,6 @@ import org.apache.ofbiz.widget.model.ModelForm;
 import org.apache.ofbiz.widget.model.ModelFormField;
 import org.apache.ofbiz.widget.model.ModelFormField.ContainerField;
 import org.apache.ofbiz.widget.model.ModelFormField.DisplayField;
-import org.apache.ofbiz.widget.model.ModelFormFieldBuilder;
 import org.apache.ofbiz.widget.model.ModelScreenWidget.Label;
 import org.apache.ofbiz.widget.model.ModelTheme;
 import org.apache.ofbiz.widget.renderer.FormRenderer;
@@ -433,21 +432,7 @@ public final class RenderableFtlFormElementsBuilder {
                 localizedInputTitle = uiLabelMap.get("CommonFormatDateTime");
             }
         }
-        /*
-         * FIXME: Using a builder here is a hack. Replace the builder with appropriate code.
-         */
-        ModelFormFieldBuilder fieldBuilder = new ModelFormFieldBuilder(modelFormField);
-        boolean memEncodeOutput = modelFormField.getEncodeOutput();
-        if (useTimeDropDown) {
-            // If time-dropdown deactivate encodingOutput for found hour and minutes
-            // FIXME: Encoding should be controlled by the renderer, not by the model.
-            fieldBuilder.setEncodeOutput(false);
-        }
-        // FIXME: modelFormField.getEntry ignores shortDateInput when converting Date objects to Strings.
-        if (useTimeDropDown) {
-            fieldBuilder.setEncodeOutput(memEncodeOutput);
-        }
-        modelFormField = fieldBuilder.build();
+
         String contextValue = modelFormField.getEntry(context, dateTimeField.getDefaultValue(context));
         String value = contextValue;
         if (UtilValidate.isNotEmpty(value)) {

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterMatcher.java
@@ -88,6 +88,14 @@ public final class MacroCallParameterMatcher extends TypeSafeMatcher<Map.Entry<S
         return new MacroCallParameterMatcher(name, new MacroCallParameterStringValueMatcher(value));
     }
 
+    public static MacroCallParameterMatcher hasNameAndStringValueStartsWith(final String name, final String startsWith) {
+        return new MacroCallParameterMatcher(name, new MacroCallParameterStringValueStartsWithMatcher(startsWith));
+    }
+
+    public static MacroCallParameterMatcher hasNameAndStringValueEndsWith(final String name, final String endsWith) {
+        return new MacroCallParameterMatcher(name, new MacroCallParameterStringValueEndsWithMatcher(endsWith));
+    }
+
     public static MacroCallParameterMatcher hasNameAndIntegerValue(final String name, final int value) {
         return new MacroCallParameterMatcher(name, new MacroCallParameterIntegerValueMatcher(value));
     }

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterStringValueEndsWithMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterStringValueEndsWithMatcher.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.ofbiz.widget.renderer.macro;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public final class MacroCallParameterStringValueEndsWithMatcher extends TypeSafeMatcher<Object> {
+    private final String endsWith;
+
+    public MacroCallParameterStringValueEndsWithMatcher(final String endsWith) {
+        this.endsWith = endsWith;
+    }
+
+    @Override
+    protected boolean matchesSafely(final Object item) {
+        return item != null && item instanceof String && ((String) item).endsWith(endsWith);
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("ends with '" + endsWith + "'");
+    }
+
+    @Override
+    protected void describeMismatchSafely(final Object item, final Description mismatchDescription) {
+        mismatchDescription.appendText("with value '" + item + "'");
+    }
+}

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterStringValueStartsWithMatcher.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroCallParameterStringValueStartsWithMatcher.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.ofbiz.widget.renderer.macro;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public final class MacroCallParameterStringValueStartsWithMatcher extends TypeSafeMatcher<Object> {
+    private final String startsWith;
+
+    public MacroCallParameterStringValueStartsWithMatcher(final String startsWith) {
+        this.startsWith = startsWith;
+    }
+
+    @Override
+    protected boolean matchesSafely(final Object item) {
+        return item != null && item instanceof String && ((String) item).startsWith(startsWith);
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("starts with '" + startsWith + "'");
+    }
+
+    @Override
+    protected void describeMismatchSafely(final Object item, final Description mismatchDescription) {
+        mismatchDescription.appendText("with value '" + item + "'");
+    }
+}

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -222,7 +222,7 @@ public class MacroFormRendererTest {
     }
 
     @Test
-    public void textAreaMacroRendered(@Mocked ModelFormField.TextareaField textareaField) throws IOException {
+    public void textAreaMacroRendered(@Mocked ModelFormField.TextareaField textareaField) {
         new Expectations() {
             {
                 renderableFtlFormElementsBuilder.textArea(withNotNull(), textareaField);
@@ -239,19 +239,20 @@ public class MacroFormRendererTest {
     }
 
     @Test
-    public void dateTimeMacroRendered(@Mocked ModelFormField.DateTimeField dateTimeField) throws IOException {
+    public void dateTimeMacroRendered(@Mocked ModelFormField.DateTimeField dateTimeField) {
         new Expectations() {
             {
-                modelFormField.getEntry(withNotNull(), anyString);
-                result = "2020-01-02";
-
-                dateTimeField.getInputMethod();
-                result = "date";
+                renderableFtlFormElementsBuilder.dateTime(withNotNull(), dateTimeField);
+                result = genericMacroCall;
             }
         };
 
+        genericTooltipRenderedExpectation(dateTimeField);
+
         macroFormRenderer.renderDateTimeField(appendable, ImmutableMap.of(), dateTimeField);
-        assertAndGetMacroString("renderDateTimeField", ImmutableMap.of("value", "2020-01-02"));
+
+        genericSingleMacroRenderedVerification();
+        genericTooltipRenderedVerification();
     }
 
     @Test

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
@@ -215,8 +215,8 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
                 datetimeField.getInputMethod();
                 result = "time-dropdown";
 
-                datetimeField.getClock();
-                result = "12";
+                datetimeField.isTwelveHour();
+                result = true;
 
                 modelFormField.getEntry(withNotNull(), anyString);
                 result = "2022-05-18 16:44:57";
@@ -230,6 +230,6 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
                 MacroCallParameterMatcher.hasNameAndIntegerValue("hour1", 4),
                 MacroCallParameterMatcher.hasNameAndIntegerValue("hour2", 16),
                 MacroCallParameterMatcher.hasNameAndBooleanValue("isTwelveHour", true),
-                MacroCallParameterMatcher.hasNameAndStringValue("pmSelected", "selected")));
+                MacroCallParameterMatcher.hasNameAndBooleanValue("pmSelected", true)));
     }
 }

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
@@ -91,8 +91,8 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
     public void datetimeFieldSetsLengthAndMaskForDateType(@Mocked final ModelFormField.DateTimeField datetimeField) {
         new Expectations() {
             {
-                datetimeField.getType();
-                result = "date";
+                datetimeField.isDateType();
+                result = true;
 
                 datetimeField.getMask();
                 result = "Y";
@@ -115,8 +115,8 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
     public void datetimeFieldSetsLengthForTimeType(@Mocked final ModelFormField.DateTimeField datetimeField) {
         new Expectations() {
             {
-                datetimeField.getType();
-                result = "time";
+                datetimeField.isTimeType();
+                result = true;
 
                 datetimeField.getMask();
                 result = "Y";
@@ -139,8 +139,8 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
     public void datetimeFieldSetsLengthForTimestampType(@Mocked final ModelFormField.DateTimeField datetimeField) {
         new Expectations() {
             {
-                datetimeField.getType();
-                result = "timestamp";
+                datetimeField.isTimestampType();
+                result = true;
 
                 datetimeField.getMask();
                 result = "Y";

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
@@ -1,0 +1,229 @@
+package org.apache.ofbiz.widget.renderer.macro;
+
+import mockit.Expectations;
+import mockit.Injectable;
+import mockit.Mocked;
+import mockit.Tested;
+import org.apache.ofbiz.webapp.control.RequestHandler;
+import org.apache.ofbiz.widget.model.ModelFormField;
+import org.apache.ofbiz.widget.model.ModelTheme;
+import org.apache.ofbiz.widget.renderer.VisualTheme;
+import org.apache.ofbiz.widget.renderer.macro.renderable.RenderableFtl;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.util.HashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RenderableFtlFormElementsBuilderDatetimeTest {
+
+    @Injectable
+    private VisualTheme visualTheme;
+
+    @Injectable
+    private RequestHandler requestHandler;
+
+    @Injectable
+    private HttpServletRequest request;
+
+    @Injectable
+    private HttpServletResponse response;
+
+    @Mocked
+    private HttpSession httpSession;
+
+    @Mocked
+    private ModelTheme modelTheme;
+
+    @Mocked
+    private ModelFormField.ContainerField containerField;
+
+    @Mocked
+    private ModelFormField modelFormField;
+
+    @Tested
+    private RenderableFtlFormElementsBuilder renderableFtlFormElementsBuilder;
+
+    @Test
+    public void datetimeFieldSetsIdAndValue(@Mocked final ModelFormField.DateTimeField datetimeField) {
+        final int maxLength = 22;
+        new Expectations() {
+            {
+                modelFormField.getCurrentContainerId(withNotNull());
+                result = "CurrentDatetimeId";
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "DATETIMEVALUE";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.dateTime(context, datetimeField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderDateTimeField",
+                MacroCallParameterMatcher.hasNameAndStringValue("id", "CurrentDatetimeId"),
+                MacroCallParameterMatcher.hasNameAndStringValue("value", "DATETIMEVALUE")));
+    }
+
+    @Test
+    public void datetimeFieldSetsDisabledParameters(@Mocked final ModelFormField.DateTimeField datetimeField) {
+        new Expectations() {
+            {
+                modelFormField.getDisabled(withNotNull());
+                result = true;
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "DATETIMEVALUE";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.dateTime(context, datetimeField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderDateTimeField",
+                MacroCallParameterMatcher.hasNameAndBooleanValue("disabled", true)));
+    }
+
+    @Test
+    public void datetimeFieldSetsLengthAndMaskForDateType(@Mocked final ModelFormField.DateTimeField datetimeField) {
+        new Expectations() {
+            {
+                datetimeField.getType();
+                result = "date";
+
+                datetimeField.getMask();
+                result = "Y";
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "DATETIMEVALUE";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.dateTime(context, datetimeField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderDateTimeField",
+                MacroCallParameterMatcher.hasNameAndStringValue("mask", "9999-99-99"),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("size", 10),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("maxlength", 10)));
+    }
+
+    @Test
+    public void datetimeFieldSetsLengthForTimeType(@Mocked final ModelFormField.DateTimeField datetimeField) {
+        new Expectations() {
+            {
+                datetimeField.getType();
+                result = "time";
+
+                datetimeField.getMask();
+                result = "Y";
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "DATETIMEVALUE";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.dateTime(context, datetimeField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderDateTimeField",
+                MacroCallParameterMatcher.hasNameAndStringValue("mask", "99:99:99"),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("size", 8),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("maxlength", 8)));
+    }
+
+    @Test
+    public void datetimeFieldSetsLengthForTimestampType(@Mocked final ModelFormField.DateTimeField datetimeField) {
+        new Expectations() {
+            {
+                datetimeField.getType();
+                result = "timestamp";
+
+                datetimeField.getMask();
+                result = "Y";
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "DATETIMEVALUE";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.dateTime(context, datetimeField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderDateTimeField",
+                MacroCallParameterMatcher.hasNameAndStringValue("mask", "9999-99-99 99:99:99"),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("size", 25),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("maxlength", 30)));
+    }
+
+    @Test
+    public void datetimeFieldSetsTimeValuesForDefaultStep(@Mocked final ModelFormField.DateTimeField datetimeField) {
+        new Expectations() {
+            {
+                datetimeField.getInputMethod();
+                result = "time-dropdown";
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "DATETIMEVALUE";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.dateTime(context, datetimeField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderDateTimeField",
+                MacroCallParameterMatcher.hasNameAndStringValueStartsWith("timeValues", "[0, 1, 2, 3,"),
+                MacroCallParameterMatcher.hasNameAndStringValueEndsWith("timeValues", "56, 57, 58, 59]")));
+    }
+
+    @Test
+    public void datetimeFieldSetsTimeValuesForStepSize3(@Mocked final ModelFormField.DateTimeField datetimeField) {
+        new Expectations() {
+            {
+                datetimeField.getInputMethod();
+                result = "time-dropdown";
+
+                datetimeField.getStep();
+                result = "3";
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "DATETIMEVALUE";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.dateTime(context, datetimeField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderDateTimeField",
+                MacroCallParameterMatcher.hasNameAndStringValueStartsWith("timeValues", "[0, 3, 6, 9,"),
+                MacroCallParameterMatcher.hasNameAndStringValueEndsWith("timeValues", "48, 51, 54, 57]")));
+    }
+
+    @Test
+    public void datetimeFieldSetsValuesFor12HourClock(@Mocked final ModelFormField.DateTimeField datetimeField) {
+        new Expectations() {
+            {
+                datetimeField.getInputMethod();
+                result = "time-dropdown";
+
+                datetimeField.getClock();
+                result = "12";
+
+                modelFormField.getEntry(withNotNull(), anyString);
+                result = "2022-05-18 16:44:57";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.dateTime(context, datetimeField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderDateTimeField",
+                MacroCallParameterMatcher.hasNameAndIntegerValue("hour1", 4),
+                MacroCallParameterMatcher.hasNameAndIntegerValue("hour2", 16),
+                MacroCallParameterMatcher.hasNameAndBooleanValue("isTwelveHour", true),
+                MacroCallParameterMatcher.hasNameAndStringValue("pmSelected", "selected")));
+    }
+}

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
@@ -94,8 +94,8 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
                 datetimeField.isDateType();
                 result = true;
 
-                datetimeField.getMask();
-                result = "Y";
+                datetimeField.useMask();
+                result = true;
 
                 modelFormField.getEntry(withNotNull(), anyString);
                 result = "DATETIMEVALUE";
@@ -118,8 +118,8 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
                 datetimeField.isTimeType();
                 result = true;
 
-                datetimeField.getMask();
-                result = "Y";
+                datetimeField.useMask();
+                result = true;
 
                 modelFormField.getEntry(withNotNull(), anyString);
                 result = "DATETIMEVALUE";
@@ -141,9 +141,10 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
             {
                 datetimeField.isTimestampType();
                 result = true;
+                minTimes = 0;
 
-                datetimeField.getMask();
-                result = "Y";
+                datetimeField.useMask();
+                result = true;
 
                 modelFormField.getEntry(withNotNull(), anyString);
                 result = "DATETIMEVALUE";

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
@@ -160,9 +160,12 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
     }
 
     @Test
-    public void datetimeFieldSetsTimeValuesForDefaultStep(@Mocked final ModelFormField.DateTimeField datetimeField) {
+    public void datetimeFieldSetsTimeValuesForStepSize1(@Mocked final ModelFormField.DateTimeField datetimeField) {
         new Expectations() {
             {
+                datetimeField.getStep();
+                result = 1;
+
                 datetimeField.getInputMethod();
                 result = "time-dropdown";
 
@@ -183,11 +186,11 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
     public void datetimeFieldSetsTimeValuesForStepSize3(@Mocked final ModelFormField.DateTimeField datetimeField) {
         new Expectations() {
             {
+                datetimeField.getStep();
+                result = 3;
+
                 datetimeField.getInputMethod();
                 result = "time-dropdown";
-
-                datetimeField.getStep();
-                result = "3";
 
                 modelFormField.getEntry(withNotNull(), anyString);
                 result = "DATETIMEVALUE";
@@ -206,6 +209,9 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
     public void datetimeFieldSetsValuesFor12HourClock(@Mocked final ModelFormField.DateTimeField datetimeField) {
         new Expectations() {
             {
+                datetimeField.getStep();
+                result = 1;
+
                 datetimeField.getInputMethod();
                 result = "time-dropdown";
 

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -88,13 +88,13 @@ under the License.
   </textarea><#lt/>
 </#macro>
 
-<#macro renderDateTimeField name className alert dateType timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName minutes isTwelveHour ampmName amSelected pmSelected compositeType timeDropdown="" classString="" hour1="" hour2="" shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest="">
+<#macro renderDateTimeField name className alert timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName minutes isTwelveHour ampmName compositeType isTimeType=false isDateType=false amSelected=false pmSelected=false timeDropdown="" classString="" hour1="" hour2="" shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest="">
   <span class="view-calendar">
     <#local cultureInfo = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("datejs", .locale)/>
     <#local datePickerLang = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("jquery", .locale)/>
     <#local timePicker = "/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.min.js,/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.css"/>
     <#local timePickerLang = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("dateTime", .locale)/>
-    <#if dateType!="time" >
+    <#if !isTimeType >
       <input type="text" name="${name}_i18n" <@renderClass className alert /> <@renderDisabled disabled />
         <#if tabindex?has_content> tabindex="${tabindex}"</#if>
         <#if title?has_content> title="${title}"</#if>
@@ -442,14 +442,14 @@ under the License.
   </#if>
 </#macro>
 
-<#macro renderDateFindField className alert id name dateType formName value defaultDateTimeString imgSrc localizedIconTitle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false>
+<#macro renderDateFindField className alert id name formName value defaultDateTimeString imgSrc localizedIconTitle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty isTimeType=false isDateType=false conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false>
   <#if conditionGroup?has_content>
     <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
-  <#if dateType != "time">
+  <#if !isTimeType>
     <#local className = className + " date-time-picker"/>
   </#if>
-  <#local shortDateInput = "date" == dateType/>
+  <#local shortDateInput = isDateType/>
   <#local cultureInfo = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("datejs", .locale)/>
   <#local datePickerLang = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("jquery", .locale)/>
   <#local timePicker = "/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.min.js,/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.css"/>

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -140,8 +140,8 @@ under the License.
         <#rt/>
         <#if isTwelveHour>
           <select name="${ampmName}" <@renderDisabled disabled /> <#if classString?has_content>class="${classString}"</#if>><#rt/>
-            <option value="AM" <#if "selected" == amSelected>selected="selected"</#if> >AM</option><#rt/>
-            <option value="PM" <#if "selected" == pmSelected>selected="selected"</#if>>PM</option><#rt/>
+            <option value="AM" <#if amSelected>selected="selected"</#if>>AM</option><#rt/>
+            <option value="PM" <#if pmSelected>selected="selected"</#if>>PM</option><#rt/>
           </select>
         <#rt/>
       </#if>

--- a/themes/common-theme/template/macro/XlsFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XlsFormMacroLibrary.ftl
@@ -34,9 +34,9 @@ under the License.
 
 <#macro renderTextareaField name className alert cols rows maxlength id readonly value visualEditorEnable buttons tabindex language="" disabled=""></#macro>
 
-<#macro renderDateTimeField name className alert title value size maxlength id dateType shortDateInput timeDropdownParamName defaultDateTimeString localizedIconTitle timeDropdown timeHourName classString hour1 hour2 timeMinutesName minutes isTwelveHour ampmName amSelected pmSelected compositeType formName mask="" event="" action="" step="" timeValues="" tabindex="" disabled="" isXMLHttpRequest=""> 
-<#if dateType=="time" ><@renderItemField value "tf" className/>
-<#elseif dateType=="date"><@renderItemField value "dt" className/>
+<#macro renderDateTimeField name className alert title value size maxlength id isTimeType isDateType shortDateInput timeDropdownParamName defaultDateTimeString localizedIconTitle timeDropdown timeHourName classString hour1 hour2 timeMinutesName minutes isTwelveHour ampmName amSelected pmSelected compositeType formName mask="" event="" action="" step="" timeValues="" tabindex="" disabled="" isXMLHttpRequest="">
+<#if isTimeType ><@renderItemField value "tf" className/>
+<#elseif isDateType><@renderItemField value "dt" className/>
 <#else><@renderItemField value "dtf" className/></#if>
 </#macro>
 


### PR DESCRIPTION
Part of the OFBIZ-11456 MacroFormRenderer refactoring effort.

Rather than MacroFormRenderer producing and evaulating FTL strings, it now uses RenderableFtlElementsBuilder to create RenderableFtlMacroCall objects for datetime fields which are then passed to an FtlWriter for evaluation.

Added tests to document how rendering parameters are generated for datetime fields.

Ready for review: First commit was a straight migration of code from MacroFormRenderer to RenderableFtlElementsBuilder, with tests added and only required compatibility changes made. Subsequent changes rearrange and cleanup code.

It is recommended that reviewers review the commits in order.