### PR TITLE
Improved: MacroFormRenderer refactoring of datefind fields (OFBIZ-12712)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/content/StaticContentUrlProvider.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/content/StaticContentUrlProvider.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.ofbiz.widget.content;
+
+import org.apache.ofbiz.webapp.taglib.ContentUrlTag;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Generates URL strings for addressing static content based properties configured on an HttpRequest's website or
+ * configured properties in url.properties.
+ *
+ * @See ContentUrlTag
+ */
+public class StaticContentUrlProvider {
+    // HttpServletRequest used to find the URL of the current website.
+    private final HttpServletRequest request;
+
+    // Cached copy of the URL prefix to use for static content.
+    private String prefix;
+
+    /**
+     * Create a new URL provider for given HttpServletRequest's website.
+     *
+     * @param request The HttpServletRequest request to look up the website for.
+     */
+    public StaticContentUrlProvider(final HttpServletRequest request) {
+        this.request = request;
+    }
+
+    /**
+     * Given a path to a static content resource, return the URL string that a client can use to retrieve that resource.
+     *
+     * @param resourcePath Path to static resource
+     * @return String representation of the URL which can be used to retrieve the static resource.
+     */
+    public String pathAsContentUrlString(final String resourcePath) {
+        return getPrefix() + resourcePath;
+    }
+
+    private String getPrefix() {
+        if (prefix == null) {
+            this.prefix = ContentUrlTag.getContentPrefix(this.request);
+        }
+        return prefix;
+    }
+}

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/content/StaticContentUrlProvider.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/content/StaticContentUrlProvider.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletRequest;
  * Generates URL strings for addressing static content based properties configured on an HttpRequest's website or
  * configured properties in url.properties.
  *
- * @See ContentUrlTag
+ * @see ContentUrlTag
  */
 public class StaticContentUrlProvider {
     // HttpServletRequest used to find the URL of the current website.

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -592,29 +592,6 @@ public class MacroFormRendererTest {
     }
 
     @Test
-    public void dateFindFieldMacroRendered(@Mocked ModelFormField modelFormField,
-                                           @Mocked ModelFormField.DateFindField dateFindField) throws IOException {
-        new Expectations() {
-            {
-                dateFindField.getModelFormField();
-                result = modelFormField;
-
-                modelFormField.getEntry(withNotNull(), withNull());
-                result = "2020-01-01";
-
-                modelFormField.getParameterName(withNotNull());
-                result = "FIELDNAME";
-            }
-        };
-
-        ImmutableMap<String, Object> context = ImmutableMap.of();
-        macroFormRenderer.renderDateFindField(appendable, context, dateFindField);
-        assertAndGetMacroString("renderDateFindField", ImmutableMap.of(
-                "name", "FIELDNAME",
-                "value", "2020-01-01"));
-    }
-
-    @Test
     public void lookupFieldMacroRendered(@Mocked ModelFormField modelFormField,
                                          @Mocked ModelFormField.LookupField lookupField) throws IOException {
         new Expectations() {

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
@@ -5,6 +5,7 @@ import mockit.Injectable;
 import mockit.Mocked;
 import mockit.Tested;
 import org.apache.ofbiz.webapp.control.RequestHandler;
+import org.apache.ofbiz.widget.content.StaticContentUrlProvider;
 import org.apache.ofbiz.widget.model.ModelFormField;
 import org.apache.ofbiz.widget.model.ModelTheme;
 import org.apache.ofbiz.widget.renderer.VisualTheme;
@@ -31,6 +32,9 @@ public class RenderableFtlFormElementsBuilderDatetimeTest {
 
     @Injectable
     private HttpServletResponse response;
+
+    @Injectable
+    private StaticContentUrlProvider staticContentUrlProvider;
 
     @Mocked
     private HttpSession httpSession;

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
@@ -26,6 +26,7 @@ import mockit.Mocked;
 import mockit.Tested;
 import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 import org.apache.ofbiz.webapp.control.RequestHandler;
+import org.apache.ofbiz.widget.content.StaticContentUrlProvider;
 import org.apache.ofbiz.widget.model.ModelForm;
 import org.apache.ofbiz.widget.model.ModelFormField;
 import org.apache.ofbiz.widget.model.ModelScreenWidget;
@@ -59,6 +60,9 @@ public class RenderableFtlFormElementsBuilderTest {
 
     @Injectable
     private HttpServletResponse response;
+
+    @Injectable
+    private StaticContentUrlProvider staticContentUrlProvider;
 
     @Mocked
     private HttpSession httpSession;

--- a/themes/common-theme/template/macro/CsvFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/CsvFormMacroLibrary.ftl
@@ -100,7 +100,7 @@ under the License.
 
 <#macro renderTextFindField name value defaultOption opEquals opBeginsWith opContains opIsEmpty opNotEqual className alert size maxlength autocomplete titleStyle hideIgnoreCase ignCase ignoreCase conditionGroup tabindex><@renderField value /></#macro>
 
-<#macro renderDateFindField className alert id name localizedInputTitle value value2 size maxlength dateType formName defaultDateTimeString imgSrc localizedIconTitle titleStyle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty conditionGroup tabindex><@renderField value /></#macro>
+<#macro renderDateFindField id name formName defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty className="" alert=false imgSrc="" value="" isTimeType=false isDateType=false conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false><@renderField value /></#macro>
 
 <#macro renderRangeFindField className alert name value size maxlength autocomplete titleStyle defaultOptionFrom opEquals opGreaterThan opGreaterThanEquals opLessThan opLessThanEquals value2 defaultOptionThru conditionGroup tabindex>
 <@renderField value />

--- a/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
@@ -124,7 +124,7 @@ under the License.
 
 <#macro renderTextFindField name value defaultOption opEquals opBeginsWith opContains opIsEmpty opNotEqual className alert size maxlength autocomplete titleStyle hideIgnoreCase ignCase ignoreCase conditionGroup tabindex><@makeBlock className value/></#macro>
 
-<#macro renderDateFindField className alert id name localizedInputTitle value value2 size maxlength dateType formName defaultDateTimeString imgSrc localizedIconTitle titleStyle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty conditionGroup tabindex>
+<#macro renderDateFindField id name formName defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty className="" alert=false imgSrc="" value="" isTimeType=false isDateType=false conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false>
 <@makeBlock className value />
 </#macro>
 <#macro renderRangeFindField className alert name value size maxlength autocomplete titleStyle defaultOptionFrom opEquals opGreaterThan opGreaterThanEquals opLessThan opLessThanEquals value2 defaultOptionThru conditionGroup tabindex>

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -442,7 +442,7 @@ under the License.
   </#if>
 </#macro>
 
-<#macro renderDateFindField className alert id name formName value defaultDateTimeString imgSrc localizedIconTitle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty isTimeType=false isDateType=false conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false>
+<#macro renderDateFindField id name formName defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty className="" alert=false imgSrc="" value="" isTimeType=false isDateType=false conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false>
   <#if conditionGroup?has_content>
     <input type="hidden" name="${name}_grp" value="${conditionGroup}" <@renderDisabled disabled />/>
   </#if>
@@ -455,7 +455,7 @@ under the License.
   <#local timePicker = "/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.min.js,/common/js/node_modules/@chinchilla-software/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.css"/>
   <#local timePickerLang = Static["org.apache.ofbiz.common.JsLanguageFilesMappingUtil"].getFile("dateTime", .locale)/>
   <span class="view-calendar">
-    <input id="${id}_fld0_value" type="text" <@renderClass className alert /> <@renderDisabled disabled />
+    <input id="${id}_fld0_value" type="text" <@renderClass className alert?c /> <@renderDisabled disabled />
         <#if name?has_content> name="${name?html}_fld0_value"</#if>
         <#if localizedInputTitle?has_content> title="${localizedInputTitle}"</#if>
         <#if value?has_content> value="${value}"</#if>
@@ -481,7 +481,7 @@ under the License.
       </span><#rt/>
     </#if>
     <#rt/>
-    <input id="${id}_fld1_value" type="text" <@renderClass className alert /> <@renderDisabled disabled />
+    <input id="${id}_fld1_value" type="text" <@renderClass className alert?c /> <@renderDisabled disabled />
         <#if name?has_content> name="${name}_fld1_value"</#if>
         <#if localizedInputTitle??> title="${localizedInputTitle?html}"</#if>
         <#if value2?has_content> value="${value2}"</#if>

--- a/themes/common-theme/template/macro/TextFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/TextFormMacroLibrary.ftl
@@ -100,7 +100,7 @@ under the License.
 
 <#macro renderTextFindField name value defaultOption opEquals opBeginsWith opContains opIsEmpty opNotEqual className alert size maxlength autocomplete titleStyle hideIgnoreCase ignCase ignoreCase conditionGroup tabindex><@renderField value /></#macro>
 
-<#macro renderDateFindField className alert id name localizedInputTitle value value2 size maxlength dateType formName defaultDateTimeString imgSrc localizedIconTitle titleStyle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty conditionGroup tabindex><@renderField value /></#macro>
+<#macro renderDateFindField id name formName defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty className="" alert=false imgSrc="" value="" isTimeType=false isDateType=false conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false><@renderField value /></#macro>
 
 <#macro renderRangeFindField className alert name value size maxlength autocomplete titleStyle defaultOptionFrom opEquals opGreaterThan opGreaterThanEquals opLessThan opLessThanEquals value2 defaultOptionThru conditionGroup tabindex>
 <@renderField value />

--- a/themes/common-theme/template/macro/XlsFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XlsFormMacroLibrary.ftl
@@ -115,7 +115,7 @@ under the License.
 
 <#macro renderTextFindField name value defaultOption opEquals opBeginsWith opContains opIsEmpty opNotEqual className alert size maxlength autocomplete titleStyle hideIgnoreCase ignCase ignoreCase conditionGroup tabindex></#macro>
 
-<#macro renderDateFindField className alert id name localizedInputTitle value value2 size maxlength dateType formName defaultDateTimeString imgSrc localizedIconTitle titleStyle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty conditionGroup tabindex></#macro>
+<#macro renderDateFindField id name formName defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty className="" alert=false imgSrc="" value="" isTimeType=false isDateType=false conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false></#macro>
 
 <#macro renderRangeFindField className alert name value size maxlength autocomplete titleStyle defaultOptionFrom opEquals opGreaterThan opGreaterThanEquals opLessThan opLessThanEquals value2 defaultOptionThru conditionGroup tabindex></#macro>
 

--- a/themes/common-theme/template/macro/XmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XmlFormMacroLibrary.ftl
@@ -93,7 +93,7 @@ under the License.
 
 <#macro renderTextFindField name value defaultOption opEquals opBeginsWith opContains opIsEmpty opNotEqual className alert size maxlength autocomplete titleStyle hideIgnoreCase ignCase ignoreCase tabindex><@renderField value/></#macro>
 
-<#macro renderDateFindField className alert id name localizedInputTitle value value2 size maxlength dateType formName defaultDateTimeString imgSrc localizedIconTitle titleStyle defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty conditionGroup tabindex></#macro>
+<#macro renderDateFindField id name formName defaultOptionFrom defaultOptionThru opEquals opSameDay opGreaterThanFromDayStart opGreaterThan opGreaterThan opLessThan opUpToDay opUpThruDay opIsEmpty className="" alert=false imgSrc="" value="" isTimeType=false isDateType=false conditionGroup="" localizedInputTitle="" value2="" size="" maxlength="" titleStyle="" tabindex="" disabled=false></#macro>
 
 <#macro renderRangeFindField className alert name value size maxlength autocomplete titleStyle defaultOptionFrom opEquals opGreaterThan opGreaterThanEquals opLessThan opLessThanEquals value2 defaultOptionThru conditionGroup tabindex>
 </#macro>


### PR DESCRIPTION
Part of the OFBIZ-11456 MacroFormRenderer refactoring effort.

Rather than MacroFormRenderer producing and evaulating FTL strings, it now uses RenderableFtlElementsBuilder to create RenderableFtlMacroCall objects for datefind fields which are then passed to an FtlWriter for evaluation.

Removed unused parameters from the renderDateFindField FTL macro definition. Set defaults for several parameters, simplifying generation of macro calls.

Synchronised the parameter list of rendateDateFindField macros across all output types - i.e. html, xml, text, etc.