### PR TITLE
Fixed: Update version of GitHub Action setup-java (OFBIZ-12714)

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -33,9 +33,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3.6.0
       with:
         java-version: 11
+        distribution: zulu
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
Resolves deprecation warning regarding version of Node.js used by the action, updating to Node.js v16, and also resolves the deprecation warning about the set-output workflow command.

Settings chosen to match the defaults used by v1 of the setup-java action - i.e. choice of the Azul Zulu JDK distribution.