### PR TITLE
FIXED: Added mandatory seed data needed for Purchase Order creation (OFBIZ-12608)

### DIFF
--- a/applications/commonext/data/OfbizSetupShippingData.xml
+++ b/applications/commonext/data/OfbizSetupShippingData.xml
@@ -23,9 +23,7 @@
     <Party partyId="UPS" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <Party partyId="DHL" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
     <Party partyId="FEDEX" partyTypeId="PARTY_GROUP" statusId="PARTY_ENABLED"/>
-    <Party partyId="_NA_" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
 
-    <Person partyId="_NA_"/>
     <PartyGroup partyId="USPS" groupName="USPS"/>
     <PartyGroup partyId="UPS" groupName="UPS"/>
     <PartyGroup partyId="DHL" groupName="DHL"/>
@@ -34,7 +32,6 @@
     <PartyRole partyId="USPS" roleTypeId="CARRIER"/>
     <PartyRole partyId="UPS" roleTypeId="CARRIER"/>
     <PartyRole partyId="DHL" roleTypeId="CARRIER"/>
-    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
     <PartyRole partyId="FEDEX" roleTypeId="CARRIER"/>
 
     <PartyStatus partyId="USPS" statusId="PARTY_ENABLED" statusDate="2001-01-01 12:00:00.0"/>
@@ -76,7 +73,6 @@
     <ShipmentMethodType description="Fedex International Ground " shipmentMethodTypeId="FEDEX_INT_GROUND"/>
     <ShipmentMethodType description="Fedex Freight" shipmentMethodTypeId="FEDEX_FREIGHT"/>
 
-    <ShipmentMethodType description="Standard" shipmentMethodTypeId="STANDARD"/>
     <ShipmentMethodType description="Three-Day Select" shipmentMethodTypeId="THIRD_DAY_AIR_SEL"/>
     <ShipmentMethodType description="Second Day Air" shipmentMethodTypeId="SECOND_DAY_AIR"/>
     <ShipmentMethodType description="Second Day Air Early A.M.  " shipmentMethodTypeId="SECOND_DAY_AIR_AM"/>
@@ -102,7 +98,6 @@
     <ShipmentMethodType description="Express 10.30 AM" shipmentMethodTypeId="EXP_10_30_AM"/>
 
     <!-- Local options -->
-    <CarrierShipmentMethod partyId="_NA_" roleTypeId="CARRIER" shipmentMethodTypeId="STANDARD" sequenceNumber="5"/>
     <CarrierShipmentMethod partyId="_NA_" roleTypeId="CARRIER" shipmentMethodTypeId="NO_SHIPPING" sequenceNumber="5"/>
 
     <!-- Fedex shipping options -->

--- a/applications/datamodel/data/demo/OrderDemoData.xml
+++ b/applications/datamodel/data/demo/OrderDemoData.xml
@@ -1907,9 +1907,7 @@ under the License.
     <PartyRole partyId="USPS" roleTypeId="CARRIER"/>
     <PartyRole partyId="UPS" roleTypeId="CARRIER"/>
     <PartyRole partyId="Company" roleTypeId="CARRIER"/>
-    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
 
-    <ShipmentMethodType description="Standard" shipmentMethodTypeId="STANDARD"/>
     <ShipmentMethodType description="Express" shipmentMethodTypeId="EXPRESS"/>
     <ShipmentMethodType description="Ground" shipmentMethodTypeId="GROUND"/>
     <ShipmentMethodType description="Air" shipmentMethodTypeId="AIR"/>
@@ -1923,7 +1921,6 @@ under the License.
     <CarrierShipmentMethod partyId="UPS" roleTypeId="CARRIER" shipmentMethodTypeId="GROUND" sequenceNumber="3" carrierServiceCode="03"/>
     <CarrierShipmentMethod partyId="UPS" roleTypeId="CARRIER" shipmentMethodTypeId="AIR" sequenceNumber="2" carrierServiceCode="02"/>
     <CarrierShipmentMethod partyId="UPS" roleTypeId="CARRIER" shipmentMethodTypeId="NEXT_DAY" sequenceNumber="1" carrierServiceCode="01"/>
-    <CarrierShipmentMethod partyId="_NA_" roleTypeId="CARRIER" shipmentMethodTypeId="STANDARD" sequenceNumber="5"/>
     <CarrierShipmentMethod partyId="_NA_" roleTypeId="CARRIER" shipmentMethodTypeId="NO_SHIPPING" sequenceNumber="8"/>
 
     <ProductStoreShipmentMeth productStoreShipMethId="9017" productStoreId="RentalStore" partyId="_NA_" includeNoChargeItems="Y" allowUspsAddr="N" requireUspsAddr="N" roleTypeId="CARRIER" shipmentMethodTypeId="NO_SHIPPING" sequenceNumber="6"/>
@@ -1961,7 +1958,6 @@ under the License.
     <PartyRole partyId="FEDEX" roleTypeId="CARRIER"/>
 
     <PartyRole partyId="Company" roleTypeId="CARRIER"/>
-    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
 
     <ShipmentMethodType description="No Shipping" shipmentMethodTypeId="NO_SHIPPING"/>
     <ShipmentMethodType description="Local Delivery" shipmentMethodTypeId="LOCAL_DELIVERY"/>
@@ -1996,7 +1992,6 @@ under the License.
     <ShipmentMethodType description="Fedex International Ground " shipmentMethodTypeId="FEDEX_INT_GROUND"/>
     <ShipmentMethodType description="Fedex Freight" shipmentMethodTypeId="FEDEX_FREIGHT"/>
 
-    <ShipmentMethodType description="Standard" shipmentMethodTypeId="STANDARD"/>
     <ShipmentMethodType description="Three-Day Select" shipmentMethodTypeId="THIRD_DAY_AIR_SEL"/>
     <ShipmentMethodType description="Second Day Air" shipmentMethodTypeId="SECOND_DAY_AIR"/>
     <ShipmentMethodType description="Second Day Air Early A.M.  " shipmentMethodTypeId="SECOND_DAY_AIR_AM"/>
@@ -2023,7 +2018,6 @@ under the License.
 
     <!-- Local options -->
     <CarrierShipmentMethod partyId="Company" roleTypeId="CARRIER" shipmentMethodTypeId="LOCAL_DELIVERY" sequenceNumber="4"/>
-    <CarrierShipmentMethod partyId="_NA_" roleTypeId="CARRIER" shipmentMethodTypeId="STANDARD" sequenceNumber="5"/>
     <CarrierShipmentMethod partyId="_NA_" roleTypeId="CARRIER" shipmentMethodTypeId="NO_SHIPPING" sequenceNumber="5"/>
 
     <!-- Fedex shipping options -->

--- a/applications/datamodel/data/demo/SecurityExtDemoData.xml
+++ b/applications/datamodel/data/demo/SecurityExtDemoData.xml
@@ -20,9 +20,6 @@ under the License.
 
 <entity-engine-xml>
     <!-- OFBiz Core security -->
-    <Party partyId="_NA_" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
-    <Person partyId="_NA_"/>
-    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
     <PartyRole partyId="_NA_" roleTypeId="_NA_"/>
 
     <Party partyId="admin" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>

--- a/applications/order/data/PurchaseOrderShippingSeedData.xml
+++ b/applications/order/data/PurchaseOrderShippingSeedData.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!--
+    When creating a purchase order, reference is made to a standard shipment method. This file contains the
+    seed entities needed to support that shipment method.
+-->
+<entity-engine-xml>
+    <!-- Entities required to support creation of purchase orders. -->
+    <Party partyId="_NA_" partyTypeId="PERSON" statusId="PARTY_ENABLED"/>
+    <Person partyId="_NA_"/>
+    <PartyRole partyId="_NA_" roleTypeId="CARRIER"/>
+    <ShipmentMethodType description="Standard" shipmentMethodTypeId="STANDARD"/>
+    <CarrierShipmentMethod partyId="_NA_" roleTypeId="CARRIER" shipmentMethodTypeId="STANDARD" sequenceNumber="5"/>
+</entity-engine-xml>

--- a/applications/order/ofbiz-component.xml
+++ b/applications/order/ofbiz-component.xml
@@ -30,6 +30,7 @@ under the License.
     <entity-resource type="data" reader-name="seed" loader="main" location="data/OrderTypeData.xml"/>
     <entity-resource type="data" reader-name="seed" loader="main" location="data/OrderPortletData.xml"/>
     <entity-resource type="data" reader-name="seed" loader="main" location="data/OrderSecurityPermissionSeedData.xml"/>
+    <entity-resource type="data" reader-name="seed" loader="main" location="data/PurchaseOrderShippingSeedData.xml"/>
 
     <entity-resource type="data" reader-name="seed-initial" loader="main" location="data/OrderScheduledServices.xml"/>
     <entity-resource type="data" reader-name="seed-initial" loader="main" location="data/OrderSystemPropertyData.xml"/>


### PR DESCRIPTION
When creating an order it is necessary to specify shipping options and therefore ensure that entities representing those shipping options already exist in the OFBiz database. The ofbizsetup application imports some default shipping options when creating a Product Store.

In the case of purchase orders, shipping is handled by the supplier, but the OFBiz data model still requires that shipping information is recorded against the order. In this case OFBiz uses some hard-coded shipping options, but the corresponding entities for those shipping options were not included in seed data.

This fix moves the entities for the hard-coded purchase order shipping options to seed data.
