### PR TITLE
Improved: Removed unused oldQOH and oldATP fields from InventoryItem (OFBIZ-12723)

### DIFF
--- a/applications/datamodel/entitydef/product-entitymodel.xml
+++ b/applications/datamodel/entitydef/product-entitymodel.xml
@@ -1973,8 +1973,6 @@ under the License.
       <field name="quantityOnHandTotal" type="fixed-point"></field>
       <field name="availableToPromiseTotal" type="fixed-point"></field>
       <field name="accountingQuantityTotal" type="fixed-point"></field>
-      <field name="oldQuantityOnHand" col-name="QUANTITY_ON_HAND" type="fixed-point"></field>
-      <field name="oldAvailableToPromise" col-name="AVAILABLE_TO_PROMISE" type="fixed-point"></field>
       <field name="serialNumber" type="value"></field>
       <field name="softIdentifier" type="value"></field>
       <field name="activationNumber" type="value"></field>
@@ -2115,8 +2113,6 @@ under the License.
         <alias entity-alias="II" name="quantityOnHandTotal"/>
         <alias entity-alias="II" name="availableToPromiseTotal"/>
         <alias entity-alias="II" name="accountingQuantityTotal"/>
-        <alias entity-alias="II" name="oldQuantityOnHand"/>
-        <alias entity-alias="II" name="oldAvailableToPromise"/>
         <alias entity-alias="II" name="serialNumber"/>
         <alias entity-alias="II" name="softIdentifier"/>
         <alias entity-alias="II" name="activationNumber"/>

--- a/applications/datamodel/entitydef/shipment-entitymodel.xml
+++ b/applications/datamodel/entitydef/shipment-entitymodel.xml
@@ -112,8 +112,6 @@ under the License.
         <alias entity-alias="IITM" name="quantityOnHandTotal"/>
         <alias entity-alias="IITM" name="availableToPromiseTotal"/>
         <alias entity-alias="IITM" name="accountingQuantityTotal"/>
-        <alias entity-alias="IITM" name="oldQuantityOnHand"/>
-        <alias entity-alias="IITM" name="oldAvailableToPromise"/>
         <alias entity-alias="IITM" name="serialNumber"/>
         <alias entity-alias="IITM" name="softIdentifier"/>
         <alias entity-alias="IITM" name="activationNumber"/>

--- a/applications/product/minilang/product/inventory/InventoryServices.xml
+++ b/applications/product/minilang/product/inventory/InventoryServices.xml
@@ -452,32 +452,6 @@ under the License.
         </if-compare>
     </simple-method>
 
-    <simple-method method-name="updateOldInventoryToDetailAll" short-description="Update Old Inventory To Detail All">
-        <!-- find all InventoryItem records where oldQuantityOnHand or oldAvailableToPromise are not null -->
-        <entity-condition entity-name="InventoryItem" list="inventoryItemList">
-            <condition-list combine="or">
-                <condition-expr field-name="oldQuantityOnHand" operator="not-equals" value=""/>
-                <condition-expr field-name="oldAvailableToPromise" operator="not-equals" value=""/>
-            </condition-list>
-        </entity-condition>
-        <iterate list="inventoryItemList" entry="inventoryItem">
-            <set from-field="inventoryItem" field="callServiceMap.inventoryItem"/>
-            <call-service service-name="updateOldInventoryToDetailSingle" in-map-name="callServiceMap"/>
-            <clear-field field="callServiceMap.inventoryItem"/>
-        </iterate>
-    </simple-method>
-    <simple-method method-name="updateOldInventoryToDetailSingle" short-description="Update Old Inventory To Detail Single">
-        <!-- for each create an InventoryItemDetail representing the old QOH or ATP value, then null those fields -->
-        <set from-field="parameters.inventoryItem.inventoryItemId" field="createDetailMap.inventoryItemId"/>
-        <set from-field="parameters.inventoryItem.oldAvailableToPromise" field="createDetailMap.availableToPromiseDiff"/>
-        <set from-field="parameters.inventoryItem.oldQuantityOnHand" field="createDetailMap.quantityOnHandDiff"/>
-        <call-service service-name="createInventoryItemDetail" in-map-name="createDetailMap"/>
-
-        <clear-field field="parameters.inventoryItem.oldAvailableToPromise"/>
-        <clear-field field="parameters.inventoryItem.oldQuantityOnHand"/>
-        <store-value value-field="parameters.inventoryItem"/>
-    </simple-method>
-
     <simple-method method-name="checkProductInventoryDiscontinuation" short-description="Check Product Inventory Discontinuation" login-required="false">
         <set from-field="parameters.productId" field="productIdMap.productId"/>
         <find-by-primary-key entity-name="Product" map="productIdMap" value-field="product"/>

--- a/applications/product/servicedef/services_maint.xml
+++ b/applications/product/servicedef/services_maint.xml
@@ -201,20 +201,4 @@ under the License.
         <attribute name="productStoreId" type="String" mode="IN" optional="true"/>
     </service>
 
-    <!-- ============================== -->
-    <!-- Inventory Maintenance Services -->
-    <!-- ============================== -->
-    <service name="updateOldInventoryToDetailAll" engine="simple"
-            location="component://product/minilang/product/inventory/InventoryServices.xml" invoke="updateOldInventoryToDetailAll" auth="true">
-        <description>Update Old Inventory To Detail</description>
-    </service>
-    <service name="updateOldInventoryToDetailSingle" engine="simple" require-new-transaction="true"
-            location="component://product/minilang/product/inventory/InventoryServices.xml" invoke="updateOldInventoryToDetailSingle" auth="true">
-        <description>Update Old Inventory To Detail</description>
-        <attribute name="inventoryItem" type="org.apache.ofbiz.entity.GenericValue" mode="IN" optional="false">
-	     <type-validate>
-	         <fail-property resource="ProductErrorUiLabels" property="ProductRequiredFieldMissingInventoryItem"/>
-	     </type-validate>
-        </attribute>
-    </service>
 </services>

--- a/applications/product/widget/facility/InventoryForms.xml
+++ b/applications/product/widget/facility/InventoryForms.xml
@@ -36,10 +36,6 @@ under the License.
         <alt-target use-when="inventoryItemId==null" target="CreateInventoryItem"/>
         <auto-fields-service service-name="updateInventoryItem" map-name="inventoryItem"/>        
 
-        <!-- ignored fields -->
-        <field name="oldAvailableToPromise"><ignored/></field>
-        <field name="oldQuantityOnHand"><ignored/></field>
-        
         <!-- custom formatted fields -->
         <field name="inventoryItemId" tooltip="${uiLabelMap.ProductNotModificationRecrationInventoryItem}"><display/></field>
         <field name="inventoryItemTypeId" title="${uiLabelMap.ProductInventoryItemTypeId}">


### PR DESCRIPTION
Fields were used to migrate QOH and ATP inventory values to InventoryItemDetails entities following data model changes prior to June 2006 are are no longer needed. Similarly, services which performed the migration have also been removed.
