### PR TITLE
OFBIZ-12728 updateProductAverageCostOnReceiveInventory

### DIFF
--- a/applications/product/groovyScripts/product/cost/CostServices.groovy
+++ b/applications/product/groovyScripts/product/cost/CostServices.groovy
@@ -448,7 +448,7 @@ def updateProductAverageCostOnReceiveInventory() {
     } else {
         // Expire existing one and calculate average cost
         updateProductAverageCostMap << productAverageCost
-        updateProductAverageCostMap.thurDate = UtilDateTime.nowTimestamp()
+        updateProductAverageCostMap.thruDate = UtilDateTime.nowTimestamp()
         run service: "updateProductAverageCost", with: updateProductAverageCostMap
 
         Map serviceInMap = [productId: parameters.productId, facilityId: parameters.facilityId]


### PR DESCRIPTION
Fixed: updateProductAverageCostOnReceiveInventory (OFBIZ-12728)

Due to a typo the updateProductAverageCostOnReceiveInventory function can't expire an old ProductAverageCost record of a product on new inventory receipt.

Modified: CostServices.groovy
fixed typo in function updateProductAverageCostOnReceiveInventory

Thanks: Pierre Smits
