### PR TITLE
Fixed: Add missing CSS for tree select in Helveticus

### DIFF
--- a/themes/helveticus/webapp/helveticus/helveticus-main-theme.less
+++ b/themes/helveticus/webapp/helveticus/helveticus-main-theme.less
@@ -1505,3 +1505,30 @@ form .basic-table,
 .hidden{
   display: none;
 }
+
+// Tree select
+.basic-tree ul, .basic-tree li {
+  padding-right: 0;
+  padding-left: 1em;
+}
+
+.basic-tree li {
+  .expanded, .collapsed {
+    margin-right: 4px;
+    padding-right: 0;
+    padding-left: 1em;
+  }
+
+  .leafnode {
+    padding-right: 1em;
+    margin-right: 4px;
+  }
+
+  .expanded {
+    background: url(/images/collapse.gif) no-repeat right center;
+  }
+
+  .collapsed {
+    background: url(/images/expand.gif) no-repeat right center;
+  }
+}


### PR DESCRIPTION
Fixed: Add missing CSS, so tree select can be properly used. Make expand/collapse links visible

(OFBIZ-12725)

https://issues.apache.org/jira/browse/OFBIZ-12725
