### PR TITLE
Fixed: Permission check when creating a Product Facility (OFBIZ-12739)

### DIFF
--- a/applications/product/groovyScripts/product/product/ProductServices.groovy
+++ b/applications/product/groovyScripts/product/product/ProductServices.groovy
@@ -552,7 +552,7 @@ def checkProductRelatedPermission(String callingMethodName, String checkAction) 
     if (!(security.hasEntityPermission("CATALOG", "_${checkAction}", parameters.userLogin)
             || (roleCategories && security.hasEntityPermission("CATALOG_ROLE", "_${checkAction}", parameters.userLogin))
             || (parameters.alternatePermissionRoot &&
-            security.hasEntityPermission(parameters.alternatePermissionRoot, checkAction, parameters.userLogin)))) {
+            security.hasEntityPermission(parameters.alternatePermissionRoot, "_${checkAction}", parameters.userLogin)))) {
         String checkActionLabel = "ProductCatalog${checkAction.charAt(0)}${checkAction.substring(1).toLowerCase()}PermissionError"
         return error(UtilProperties.getMessage("ProductUiLabels", checkActionLabel,
                 [resourceDescription: callingMethodName, mainAction: checkAction], parameters.locale))


### PR DESCRIPTION
Typo in the action being checked when creating a product facility prevented users with the FACILITY_CREATE permission, but not the CATALOG_CREATE permission, from creating Product Facilities.