### PR TITLE
Improved: Extend standard view OrderItemAndShipGroupAssoc with missing relation to OrderItemAttribute (OFBIZ-12752)

### DIFF
--- a/applications/order/entitydef/entitymodel_view.xml
+++ b/applications/order/entitydef/entitymodel_view.xml
@@ -764,6 +764,10 @@ under the License.
         <key-map field-name="orderId"/>
         <key-map field-name="orderItemSeqId"/>
       </relation>
+      <relation type="many" rel-entity-name="OrderItemAttribute">
+        <key-map field-name="orderId"/>
+        <key-map field-name="orderItemSeqId"/>
+      </relation>
     </view-entity>
     <view-entity entity-name="OrderItemAndShipGrpInvResAndItem"
             package-name="org.apache.ofbiz.order.order"


### PR DESCRIPTION
Improved: Extend standard view OrderItemAndShipGroupAssoc with missing relation to OrderItemAttribute (OFBIZ-12752) #582
