### PR TITLE
Fixed: sendCommEventAsEmail requires communicationEventId

### DIFF
--- a/applications/party/groovyScripts/communication/CommunicationEventServices.groovy
+++ b/applications/party/groovyScripts/communication/CommunicationEventServices.groovy
@@ -483,7 +483,7 @@ def sendEmailDated() {
     List<GenericValue> communicationEvents = from("CommunicationEvent").where(conditions).queryList()
     communicationEvents.each { communicationEvent ->
         // run service don't cover the new transaction need
-        serviceContext.communicationEvent = communicationEvent
+        serviceContext.communicationEventId = communicationEvent.communicationEventId
         dispatcher.runSync("sendCommEventAsEmail", serviceContext, 7200, true)
     }
 


### PR DESCRIPTION
In the new groovy file, `component://party/groovyScripts/communication/CommunicationEventServices.groovy` The parameter was set as the whole object  `communicationEvent` instead of the ID only `communicationEventId` which is the one required. It gave this error : 

`Error running Groovy method [sendEmailDated] in Groovy file [component://party/groovyScripts/communication/CommunicationEventServices.groovy]:  (org.apache.ofbiz.service.ServiceValidationException: The following required parameter is missing: [IN] [sendCommEventAsEmail.communicationEventId])`

I did the line change and it worked and sent the email.

Thanks:
