### PR TITLE
Fixed: Added accounting main action menu to Organization GL Settings screens (OFBIZ-12771)

### DIFF
--- a/applications/accounting/widget/CommonScreens.xml
+++ b/applications/accounting/widget/CommonScreens.xml
@@ -206,6 +206,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <not><if-empty field="organizationPartyId"/></not>

--- a/applications/accounting/widget/GlScreens.xml
+++ b/applications/accounting/widget/GlScreens.xml
@@ -31,6 +31,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="CommonPartyDecorator" location="${parameters.partyDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <include-menu name="OrganizationAccountingTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
                         <decorator-section-include name="body"/>


### PR DESCRIPTION
Clicking on the Create a Gl Transactions button navigates to a screen within the Organisation GL Settings group of screens. Within this context the main actions menu - which included the Create button - is not visible, meaning it is cumbersome for the user to add another transaction.

This commit adds the main actions menu to the Organization GL Settings screens, matching the way the actions are displayed in all other Accountancy screens.