### PR TITLE
Fixed: isPosted set to No for new Accounting Transactions (OFBIZ-12774)

### DIFF
--- a/applications/accounting/groovyScripts/ledger/GeneralLedgerServices.groovy
+++ b/applications/accounting/groovyScripts/ledger/GeneralLedgerServices.groovy
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import org.apache.ofbiz.base.util.UtilProperties
+import org.apache.ofbiz.base.util.UtilValidate
+import org.apache.ofbiz.entity.GenericValue
+
+/**
+ * Create a new Accounting Transaction (AcctgTrans) with isPosted set to 'N'.
+ *
+ * @param parameters Contains all attributes for service interface, interfaceAcctgTrans.
+ * @return Success response containing the AcctgTrans primary key, error response otherwise.
+ */
+def createAcctgTrans() {
+    GenericValue newAcctgTrans = makeValue('AcctgTrans', [*:parameters, isPosted: 'N'])
+    newAcctgTrans.acctgTransId = delegator.getNextSeqId('AcctgTrans')
+    newAcctgTrans.create()
+
+    return success([acctgTransId: newAcctgTrans.acctgTransId])
+}

--- a/applications/accounting/servicedef/services_ledger.xml
+++ b/applications/accounting/servicedef/services_ledger.xml
@@ -193,12 +193,12 @@ under the License.
         <override name="glFiscalTypeId" optional="false"/>
     </service>
     <!-- AcctgTrans services -->
-    <service name="createAcctgTrans" default-entity-name="AcctgTrans" engine="entity-auto" invoke="create" auth="true">
-        <description>Create a AcctgTrans record.  isPosted is forced to "N"</description>
+    <service name="createAcctgTrans" default-entity-name="AcctgTrans" engine="groovy" auth="true"
+             location="component://accounting/groovyScripts/ledger/GeneralLedgerServices.groovy" invoke="createAcctgTrans" >
+        <description>Create a AcctgTrans record with isPosted set to "N"</description>
         <permission-service service-name="acctgTransactionPermissionCheck" main-action="CREATE"/>
         <implements service="interfaceAcctgTrans"/>
         <auto-attributes include="pk" mode="OUT" optional="false"/>
-        <override name="isPosted" default-value="N"/>
     </service>
     <service name="updateAcctgTrans" default-entity-name="AcctgTrans" engine="entity-auto" invoke="update" auth="true">
         <description>Update a AcctgTrans record</description>

--- a/applications/accounting/widget/GlForms.xml
+++ b/applications/accounting/widget/GlForms.xml
@@ -730,15 +730,8 @@ under the License.
                 </entity-options>
             </drop-down>
         </field>
-        <field name="transactionDate"  position="1"></field>
+        <field name="transactionDate"  position="1" required-field="true" />
         <field name="scheduledPostingDate"  position="2"></field>
-        <field name="isPosted"  position="1">
-            <drop-down allow-empty="true">
-                <option key="N" description="${uiLabelMap.CommonNo}"/>
-                <option key="Y" description="${uiLabelMap.CommonYes}"/>
-            </drop-down>
-        </field>
-        <field name="postedDate" position="2"><date-time/></field>
         <field name="receiptId"  position="1"></field>
         <field name="theirAcctgTransId"  position="2"></field>
         <field name="voucherRef" position="1"></field>


### PR DESCRIPTION
isPosted is set to No for all new transactions created through the createAcctgTrans service.

Removed the isPosted and postedDate fields from the Create Transaction form since they have no effect during the creation stage of a transaction.

Marked the transactionDate field as mandatory on the Create Transaction form.