### PR TITLE
Fixed: PDF Trial Balance header row styling (OFBIZ-12776)

### DIFF
--- a/applications/accounting/widget/ReportFinancialSummaryForms.xml
+++ b/applications/accounting/widget/ReportFinancialSummaryForms.xml
@@ -579,7 +579,7 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
         <field name="openingBalance" title="${uiLabelMap.AccountingOpeningBalance}" widget-style="tabletextright"><display description="${openingBalance}" type="currency" currency="${currencyUomId}"/></field>
         <field name="postedDebits" title="${uiLabelMap.AccountingDebitFlag}" widget-style="tabletextright"><display description="${postedDebits}" type="currency" currency="${currencyUomId}"/></field>
         <field name="postedCredits" title="${uiLabelMap.AccountingCreditFlag}" widget-style="tabletextright"><display description="${postedCredits}" type="currency" currency="${currencyUomId}"/></field>

--- a/applications/accounting/widget/ReportFinancialSummaryScreens.xml
+++ b/applications/accounting/widget/ReportFinancialSummaryScreens.xml
@@ -304,18 +304,21 @@ under the License.
                     <condition-expr field-name="partyId" operator="in" from-field="partyIds"/>
                 </entity-condition>
                 <set field="partyIds[]" value="${groovy:parameters.get('ApplicationDecorator|organizationPartyId')}"/>
+                <entity-one entity-name="CustomTimePeriod" value-field="customTimePeriod" auto-field-map="true" use-cache="true"/>
                 <script location="component://accounting/groovyScripts/reports/TrialBalance.groovy"/>
             </actions>
             <widgets>
                 <decorator-screen name="SimpleDecorator" location="component://common/widget/CommonScreens.xml">
                     <decorator-section name="body">
-                        <container style="h3">
+                        <container style="h1">
                             <label text="${uiLabelMap.AccountingTrialBalance}"/>
+                        </container>
+                        <container style="h2">
+                            <label text="${uiLabelMap.AccountingTimePeriod}: ${customTimePeriod.periodName}: ${customTimePeriod.fromDate} - ${customTimePeriod.thruDate}"/>
                         </container>
                         <container style="h3">
                             <label text="${uiLabelMap.AccountingConsolidatedDataFromDivisions}"/>
                         </container>
-                        <include-form name="TrialBalanceFinancialTimePeriodSelection" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
                         <include-grid name="TrialBalanceReport" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
                         <container style="h3">
                             <label text="${uiLabelMap.AccountingDebitFlag}: ${postedDebitsTotal}"/>

--- a/themes/common-theme/template/macro/CsvFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/CsvFormMacroLibrary.ftl
@@ -30,7 +30,7 @@ under the License.
 
 <#macro renderDateTimeField name className timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName ampmName compositeType alert=false isTimeType=false isDateType=false amSelected=false pmSelected=false timeDropdown="" classString="" isTwelveHour=false hour1="" hour2="" minutes=0 shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest=false><@renderField value /></#macro>
 
-<#macro renderDropDownField name className alert id multiple formName otherFieldName event action size firstInList currentValue explicitDescription allowEmpty options fieldName otherFieldName otherValue otherFieldSize dDFCurrent ajaxEnabled noCurrentSelectedKey ajaxOptions frequency minChars choices autoSelect partialSearch partialChars ignoreCase fullSearch conditionGroup tabindex disabled>
+<#macro renderDropDownField name className alert id formName action explicitDescription options fieldName otherFieldName otherValue otherFieldSize ajaxEnabled ajaxOptions frequency minChars choices autoSelect partialSearch partialChars ignoreCase fullSearch conditionGroup="" tabindex="" multiple="" event="" size="" firstInList="" currentValue="" allowEmpty="" dDFCurrent="" noCurrentSelectedKey="" disabled=false>
 <#if currentValue?has_content && firstInList?has_content>
 <@renderField explicitDescription />
 <#else>

--- a/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
@@ -57,7 +57,7 @@ under the License.
 
 <#macro renderDateTimeField name className timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName ampmName compositeType alert=false isTimeType=false isDateType=false amSelected=false pmSelected=false timeDropdown="" classString="" isTwelveHour=false hour1="" hour2="" minutes=0 shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest=false></#macro>
 
-<#macro renderDropDownField name className alert id multiple formName otherFieldName event action size explicitDescription allowEmpty options fieldName otherFieldName otherValue otherFieldSize dDFCurrent ajaxEnabled noCurrentSelectedKey ajaxOptions frequency minChars choices autoSelect partialSearch partialChars ignoreCase fullSearch conditionGroup tabindex firstInList="" currentValue="" disabled="">
+<#macro renderDropDownField name className alert id formName action explicitDescription options fieldName otherFieldName otherValue otherFieldSize ajaxEnabled ajaxOptions frequency minChars choices autoSelect partialSearch partialChars ignoreCase fullSearch conditionGroup="" tabindex="" multiple="" event="" size="" firstInList="" currentValue="" allowEmpty="" dDFCurrent="" noCurrentSelectedKey="" disabled=false>
 <#if currentValue?has_content && firstInList?has_content>
 <@makeBlock "" explicitDescription />
 <#else>


### PR DESCRIPTION
Trial Balance PDF rendering shows the selected time period rather than
listing all selectable time periods from the Trial Balance form.

The renderDropDown macros for PDF and CSV form renderers have been
updated to match the same macro for the HTML renderer, ensuring that all
expected macros are defined.

Added cell outline for Account Name column header.