### PR TITLE
Improved: Display version information in container builds (OFBIZ-12785)

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -68,6 +68,24 @@ jobs:
             # Build container tag based on branch name and string '-snapshot'
             type=ref,event=branch,suffix=-snapshot,priority=650
 
+      - name: Update VERSION file
+        run: |
+          # Populate the VERSION file based on the outputs of the metadata-action above.
+          # The same VERSION file will be used for all container images built in this workflow.
+
+          # Set the version label for this build.
+          echo "${{fromJSON(steps.runtimemeta.outputs.json).labels['org.opencontainers.image.version']}}. " > VERSION
+
+          # Append the git commit SHA.
+          echo '${uiLabelMap.CommonRevision}:' "${{fromJSON(steps.runtimemeta.outputs.json).labels['org.opencontainers.image.revision']}}. " >> VERSION
+
+          # Append the timestamp.
+          echo '${uiLabelMap.CommonBuiltOn}:' "${{fromJSON(steps.runtimemeta.outputs.json).labels['org.opencontainers.image.created']}}. " >> VERSION
+
+          echo "Version file contents:"
+          cat VERSION
+
+
       - name: Build and push runtime docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -13,6 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#############################################################################
+# Local testing of this workflow can be carried out using
+# act (https://github.com/nektos/act).
+#
+# Act will set an environment variable, ACT, to indicate that it is running the workflow.
+# This environment variable is used to skip some build steps, such as logging in to
+# a container registry or pushing container images.
+#
+# On first run, act will prompt you to select a micro, medium or large runner image. This
+# workflow can be run using the medium image.
+#
+# Some actions, such as docker/metadata-action, require a GITHUB_TOKEN. To meet this
+# requirement when using act you will need to create a Personal Access Token on GitHub.
+# You can then run act using a command similar to:
+#   act --job docker_build --secret GITHUB_TOKEN
+# Act will then prompt you to enter your token.
+
+
 name: Build and push docker images
 
 on:
@@ -30,6 +48,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the Container registry
+        if: ${{ !env.ACT }}
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: ghcr.io
@@ -54,7 +73,7 @@ jobs:
         with:
           context: .
           target: runtime
-          push: true
+          push: ${{ !env.ACT }}
           tags: ${{ steps.runtimemeta.outputs.tags }}
           labels: ${{ steps.runtimemeta.outputs.labels }}
 
@@ -74,7 +93,7 @@ jobs:
         with:
           context: .
           target: demo
-          push: true
+          push: ${{ !env.ACT }}
           tags: ${{ steps.demometa.outputs.tags }}
           labels: ${{ steps.demometa.outputs.labels }}
 
@@ -109,6 +128,6 @@ jobs:
         with:
           context: .
           target: runtime
-          push: true
+          push: ${{ !env.ACT }}
           tags: ${{ steps.pluginsmeta.outputs.tags }}
           labels: ${{ steps.pluginsmeta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,13 @@ RUN --mount=type=bind,from=builder,source=/builder/build/distributions/ofbiz.tar
 # Create directories for OFBiz volume mountpoints.
 RUN ["mkdir", "/ofbiz/runtime", "/ofbiz/config", "/ofbiz/lib-extra"]
 
-COPY docker/docker-entrypoint.sh .
+# Append the java runtime version to the OFBiz VERSION file.
+COPY VERSION .
+RUN echo '${uiLabelMap.CommonJavaVersion}:' "$(java --version | grep Runtime | sed 's/.*Runtime Environment //; s/ (build.*//;')" >> /ofbiz/VERSION
+
+COPY --chmod=755 docker/docker-entrypoint.sh .
 COPY docker/disable-component.xslt .
-COPY docker/send_ofbiz_stop_signal.sh .
+COPY --chmod=755 docker/send_ofbiz_stop_signal.sh .
 COPY docker/templates templates
 
 EXPOSE 8443

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update \
 WORKDIR /builder
 
 # Add and run the gradle wrapper to trigger a download if needed.
-COPY gradle/init-gradle-wrapper.sh gradle/
-COPY gradlew .
+COPY --chmod=755 gradle/init-gradle-wrapper.sh gradle/
+COPY --chmod=755 gradlew .
 RUN ["sed", "-i", "s/shasum/sha1sum/g", "gradle/init-gradle-wrapper.sh"]
 RUN ["gradle/init-gradle-wrapper.sh"]
 


### PR DESCRIPTION
The GitHub Actions workflow prepares the first part of the VERSION file 
based on the current the current git reference.

During the container build step, the java runtime environment version string
is appended to the VERSION file.

The contents of the VERSION file are displayed in the footer of the
various OFBiz themes.
