### PR TITLE
Fixed: Set tenant db password for docker deployments (OFBIZ-12791)

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -339,7 +339,7 @@ configure_database() {
         --expression="s/@OLAP_PASSWORD@/$OFBIZ_POSTGRES_OLAP_PASSWORD/;" \
         --expression="s/@TENANT_DB@/$OFBIZ_POSTGRES_TENANT_DB/;" \
         --expression="s/@TENANT_USERNAME@/$OFBIZ_POSTGRES_TENANT_USER/;" \
-        --expression="s/@TENAN_PASSWORD@/$OFBIZ_POSTGRES_TENANT_PASSWORD/;" \
+        --expression="s/@TENANT_PASSWORD@/$OFBIZ_POSTGRES_TENANT_PASSWORD/;" \
         templates/postgres-entityengine.xml > config/entityengine.xml
 
       if [ -z "$OFBIZ_SKIP_DB_DRIVER_DOWNLOAD" ]; then


### PR DESCRIPTION
When deploying OFBiz as a docker container connecting to a Postgres DB, ensure the password for the tenant database connection is set.
