### PR TITLE
Implemented: Use node/npm during gradle build from multiple sub-projects (OFBIZ-12789)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,4 +27,5 @@ Dockerfile
 /plugins/.svn
 /plugins/.github
 /plugins/.git
-
+/buildSrc/.gradle
+/buildSrc/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN --mount=type=cache,id=gradle-cache,sharing=locked,target=/root/.gradle \
     ["./gradlew", "--console", "plain"]
 
 # Copy all OFBiz sources.
+COPY buildSrc/ buildSrc/
 COPY applications/ applications/
 COPY config/ config/
 COPY framework/ framework/

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.42.0' apply false
     id "com.github.ManifestClasspath" version "0.1.0-RELEASE"
     id "com.github.jakemarsden.git-hooks" version "0.0.2"
-    id "com.github.node-gradle.node" version "3.5.0"
+    id "com.github.node-gradle.node" version '3.5.1' apply false
 }
 
 /* OWASP plugin
@@ -113,27 +113,6 @@ javadoc {
     }
 }
 
-node {
-    download = true
-    version = '16.13.1'
-    // npmVersion will be the one that comes default with node
-
-    // https://github.com/node-gradle/gradle-node-plugin/blob/2.2.4/README.md
-    // Set the work directory where node_modules should be located
-    nodeModulesDir = file("${project.projectDir}/themes/common-theme/webapp/common-theme/js")
-    // If you set a "CI" env var then ci only will be used:
-    // https://github.com/node-gradle/gradle-node-plugin/blob/master/docs/faq.md#how-do-i-use-npm-ci-instead-of-npm-install
-    npmInstallCommand = System.getenv('CI') ? 'ci' : 'install'
-}
-
-tasks.getByName("distTar") {
-    dependsOn "npmInstall"
-}
-
-tasks.getByName("distZip") {
-    dependsOn "npmInstall"
-}
-
 java {
     sourceCompatibility(JavaVersion.VERSION_17)
     targetCompatibility(JavaVersion.VERSION_17)
@@ -147,8 +126,6 @@ tasks.withType(JavaCompile) {
         // Exclude varargs warnings which are not silenced by @SafeVarargs.
         options.compilerArgs << '-Xlint:-varargs'
     }
-    // Executes on each compilation so that if dependencies are not downloaded yet or some new dependencies are added they get automatically downloaded
-    if (!project.hasProperty('skipNpmInstall')) finalizedBy 'npmInstall'
 }
 
 // Only used for release branches
@@ -1083,11 +1060,6 @@ task cleanXtra(group: cleanupGroup, description: 'Clean extra generated files li
 task cleanFooterFiles(group: cleanupGroup, description: 'clean generated footer files') {
     doLast {
         delete gitFooterFile
-    }
-}
-task cleanNpm(group: cleanupGroup, description: 'clean node modules') {
-    doLast {
-        delete "${project.projectDir}/themes/common-theme/webapp/common-theme/js/node_modules"
     }
 }
 /*

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'groovy-gradle-plugin'
+}

--- a/buildSrc/src/main/groovy/ofbiz-node-conventions.gradle
+++ b/buildSrc/src/main/groovy/ofbiz-node-conventions.gradle
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This plugin defines usage of the node-gradle plugin for OFBiz sub-projects.
+ *
+ * NPM Install (or ci) will be run as a dependency of the classes task. The output from NPM Install will be cleaned
+ * up as part of the parent project's cleanAll task.
+ *
+ * Sub projects should apply this plugin and then configure the node block with the path to the directory containing
+ * the package.json file. Example:
+ *
+ *  plugins {
+ *      id 'ofbiz-node-conventions'
+ *  }
+ *
+ *  node {
+ *      nodeProjectDir = file('webapp/common-theme/js')
+ *  }
+ */
+
+plugins {
+    id 'base'  // Provides the clean<TaskName> rule for the cleanNpmInstall task.
+    id 'com.github.node-gradle.node'
+}
+
+node {
+    download = true
+    version = "16.13.1"
+
+    // If environment variable CI is set, use 'npm ci' instead of 'npm install' to populate node_modules.
+    npmInstallCommand = System.getenv("CI") ? 'ci' : 'install'
+}
+
+// Pull NPM dependencies when the classes task is run.
+// Hooking into classes ensures that dependencies are available if OFBiz is
+// started via the Gradle Application Plugin's run task, or if a distribution
+// is being built (distTar, distZip, etc.).
+if (!project.rootProject.hasProperty('skipNpmInstall')) {
+    project.rootProject.tasks.getByName('classes').dependsOn npmInstall
+}
+
+// Task to clean up the output from npmInstall.
+task cleanNpm(group: 'Cleaning', description: 'Clean installed node modules') {
+    dependsOn cleanNpmInstall
+}
+
+// Hook into the root project's cleanAll task to clean up the output from the
+// npmInstall task.
+project.rootProject.tasks.whenTaskAdded { task ->
+    if (task.name == 'cleanAll') {
+        task.dependsOn cleanNpmInstall
+    }
+}

--- a/themes/common-theme/build.gradle
+++ b/themes/common-theme/build.gradle
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'ofbiz-node-conventions'
+}
+
+node {
+    nodeProjectDir = file('webapp/common-theme/js')
+}

--- a/themes/common-theme/webapp/common-theme/js/package-lock.json
+++ b/themes/common-theme/webapp/common-theme/js/package-lock.json
@@ -81,7 +81,7 @@
         "node_modules/jquery.browser": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/jquery.browser/-/jquery.browser-0.1.0.tgz",
-            "integrity": "sha1-nHKmCV/SgUtER26o9xZne3Kmors=",
+            "integrity": "sha512-5GjtLzzEBzxs/nwSVpCbSdk0acssfKsP7Upp43zmdHVV1Vb6E9VayyqPAQlfLrTeZL3YSWocCbkOvKdAc2CN4g==",
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -160,7 +160,7 @@
         "jquery.browser": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/jquery.browser/-/jquery.browser-0.1.0.tgz",
-            "integrity": "sha1-nHKmCV/SgUtER26o9xZne3Kmors="
+            "integrity": "sha512-5GjtLzzEBzxs/nwSVpCbSdk0acssfKsP7Upp43zmdHVV1Vb6E9VayyqPAQlfLrTeZL3YSWocCbkOvKdAc2CN4g=="
         },
         "trumbowyg": {
             "version": "2.27.3",


### PR DESCRIPTION
Added gradle plugin, ofbiz-node-conventions, to set conventional use of the gradle node plugin across OFBiz sub-projects (i.e. components).

Modified common-theme to install and cleanup NPM modules at appropriate points in the gradle task lifecycle.

This change will allow multiple components, including plugsin, to leverage the gradle node plugin in their build process without needing updates to the parent build.gradle script.
