### PR TITLE
Fixed: Eclipse build problems and proper dependency setup (OFBIZ-12808)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,17 @@ configurations {
     }
 }
 
+configurations.all {
+    exclude group: 'log4j', module: 'log4j'
+    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    exclude group: 'xml-apis', module: 'xml-apis'
+    exclude group: 'jaxen', module: 'jaxen'
+    exclude group: 'javax.xml.stream', module: 'stax-api'
+    exclude group: 'org.apache.geronimo.specs', module: 'geronimo-stax-api_1.0_spec'
+    exclude group: 'org.apache.geronimo.specs', module: 'geronimo-jta_1.1_spec'
+    exclude group: 'javax.transaction', module: 'jta'
+}
+
 dependencies {
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.1'
     implementation 'com.google.zxing:core:3.5.1'
@@ -216,6 +227,7 @@ dependencies {
     implementation 'commons-net:commons-net:3.8.0'
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'de.odysseus.juel:juel-impl:2.2.7'
+    implementation 'javax.transaction:javax.transaction-api:1.3'
     implementation 'net.fortuna.ical4j:ical4j:1.0-rc4-atlassian-12'
     implementation 'net.lingala.zip4j:zip4j:2.11.2'
     implementation 'org.apache.ant:ant-junit:1.10.12'
@@ -241,7 +253,9 @@ dependencies {
     implementation 'org.apache.tomcat:tomcat-catalina-ha:9.0.74' // Remember to change the version number (9 now) in javadoc block if needed.
     implementation 'org.apache.tomcat:tomcat-jasper:9.0.74'
     implementation 'org.apache.axis2:axis2-kernel:1.8.2'
-    implementation 'batik:batik-svg-dom:1.6-1'
+    implementation 'org.apache.xmlgraphics:batik-anim:1.14'
+    implementation 'org.apache.xmlgraphics:batik-util:1.14'
+    implementation 'org.apache.xmlgraphics:batik-bridge:1.14'
     implementation 'org.apache.xmlgraphics:fop:2.3' // NOTE: since 2.4 dependencies are messed up. See https://github.com/moqui/moqui-fop/blob/master/build.gradle
     implementation 'org.apache.xmlrpc:xmlrpc-client:3.1.3'
     implementation 'org.apache.xmlrpc:xmlrpc-server:3.1.3'
@@ -278,7 +292,6 @@ dependencies {
     runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.19.0' // for external jars using slf4j: routes logging to log4j 2
     runtimeOnly 'org.apache.logging.log4j:log4j-web:2.19.0' //???
     runtimeOnly 'org.apache.logging.log4j:log4j-jcl:2.19.0' // need to constrain to version to avoid classpath conflict (ReflectionUtil)
-    runtimeOnly 'org.codeartisans.thirdparties.swing:batik-all:1.8pre-r1084380'
 
     // Dependencies defined by the plugins
     subprojects.each { subProject ->

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -49,7 +49,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
-import org.apache.batik.dom.svg.SAXSVGDocumentFactory;
+import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.util.XMLResourceDescriptor;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;


### PR DESCRIPTION
Due to improper dependency configurations and the JPMS (Java Plattform Module System) which was introduced to Java since version 9, the Eclipse build and running/debugging is not working with JDK 17 (trunk and release22.01).

The reason is that there are dependencies to libraries which are also shipped with the JDK which causes a conflict leading to ignore those packages/classes in the build.

This commit fixes the problems for trunk without plugins, they have to be modified separately.