### PR TITLE
Fixed: Jump to page with AJAX decrease page number by one

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -1912,7 +1912,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         if (listSize > 0 && this.javaScriptEnabled) {
             if (ajaxEnabled) {
                 ajaxSelectUrl = MacroCommonRenderer.createAjaxParamsFromUpdateAreas(updateAreas, null, modelForm,
-                        prepLinkText + "' + this.value + '", context);
+                        prepLinkText + "' + (this.value - 1) + '", context);
             } else {
                 linkText = prepLinkText;
                 if (linkText.startsWith("/")) {


### PR DESCRIPTION
Fixed: Jump to page with AJAX enabled fetches the wrong page, we need to decrement the value entered by the user by one (page numbers are zero-indexed)

[OFBIZ-12817](https://issues.apache.org/jira/browse/OFBIZ-12817)

Thanks: Néréide Team :)
