### PR TITLE
Improved: Use a version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,14 +29,15 @@ plugins {
     id 'checkstyle'
     id 'codenarc'
     id 'maven-publish'
-    id 'org.asciidoctor.jvm.convert' version '3.3.2' // 4.0.2 does not compile
-    id 'org.asciidoctor.jvm.pdf' version '3.3.2'     // 4.0.2 does not compile
-    id 'org.owasp.dependencycheck' version '9.0.9' apply false //Not tested after 7.4.4
-    id 'se.patrikerdes.use-latest-versions' version '0.2.18' apply false
-    id 'com.github.ben-manes.versions' version '0.51.0' apply false
-    id "com.github.ManifestClasspath" version "0.1.0-RELEASE"
-    id "com.github.jakemarsden.git-hooks" version "0.0.2"
-    id "com.github.node-gradle.node" version '7.0.2' apply false
+
+    alias(libs.plugins.asciidoctorJvmConvert)
+    alias(libs.plugins.asciidoctorJvmPdf)
+    alias(libs.plugins.dependencycheck) apply false
+    alias(libs.plugins.gitHooks)
+    alias(libs.plugins.manifestClasspath)
+    alias(libs.plugins.node) apply false
+    alias(libs.plugins.useLatestVersions) apply false
+    alias(libs.plugins.versions) apply false
 }
 
 /* OWASP plugin
@@ -48,7 +49,7 @@ plugins {
  * Syntax: gradlew -PenableOwasp dependencyCheckAnalyze
  */
 if (project.hasProperty('enableOwasp')) {
-    apply plugin: 'org.owasp.dependencycheck'
+    apply plugin: libs.plugins.dependencycheck.get().pluginId
 }
 
 /* DependencyUpdates plugin
@@ -67,8 +68,8 @@ if (project.hasProperty('enableOwasp')) {
  *  If you use it without check you will need to check things by yourself (can be as tedious as not using this plugin)
  */
 if (project.hasProperty('enableDependencyUpdates')) {
-    apply plugin: 'com.github.ben-manes.versions'
-    apply plugin: 'se.patrikerdes.use-latest-versions'
+    apply plugin: libs.plugins.useLatestVersions.get().pluginId
+    apply plugin: libs.plugins.versions.get().pluginId
 }
 
 apply from: 'common.gradle'
@@ -213,8 +214,8 @@ dependencies {
         compileOnly project(path: subProject.path, configuration: 'pluginLibsCompileOnly')
     }
 
-    junitReport 'junit:junit:4.13.2'
-    junitReport 'org.apache.ant:ant-junit:1.10.14'
+    junitReport libs.antJunit
+    junitReport libs.junit
 
     // Libraries downloaded manually
     implementation fileTree(dir: file("${rootDir}/lib"), include: '**/*.jar')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,91 +17,67 @@
  * under the License.
  */
 dependencies {
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
-    implementation 'com.google.zxing:core:3.5.3'
-    implementation 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2'
-    implementation 'com.googlecode.ez-vcard:ez-vcard:0.11.3' // 0.12.1 does not compile
-    implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1'
-    implementation 'com.googlecode.libphonenumber:libphonenumber:8.13.31'
-    implementation 'com.ibm.icu:icu4j:74.2'
-    implementation ('com.lowagie:itext:2.1.7') { // Don't update due to license change in newer versions, see OFBIZ-10455
+    codenarc libs.codeNarc
+
+    implementation libs.bundles.batik
+    implementation libs.bundles.commons
+    implementation libs.bundles.geronimo
+    implementation libs.bundles.log4j
+    implementation libs.bundles.sshd
+    implementation libs.bundles.tika
+    implementation libs.bundles.tomcat
+    implementation libs.antJunit
+    implementation libs.axis2Kernel
+    implementation libs.caffeine
+    implementation libs.clojure
+    implementation libs.concurrentlinkedhashmapLru
+    implementation libs.cxfRtFrontendJaxrs
+    implementation libs.esapi
+    implementation libs.ezVcard
+    implementation libs.fop
+    implementation libs.freemarker
+    implementation libs.groovyAll
+    implementation libs.httpclientCache
+    implementation libs.ical4j
+    implementation libs.icu4j
+    implementation (libs.itext) {
         exclude  group: 'bouncycastle', module: 'bcmail-jdk14'
         exclude  group: 'bouncycastle', module: 'bcprov-jdk14'
         exclude  group: 'bouncycastle', module: 'bctsp-jdk14'
     }
-    implementation 'com.sun.mail:javax.mail:1.6.2'
-    implementation 'com.rometools:rome:2.1.0'
-    implementation 'com.thoughtworks.xstream:xstream:1.4.20'
-    implementation 'commons-cli:commons-cli:1.5.0' // with 1.6.0, 2 tests of OfbizStartupUnitTests don't pass
-    implementation 'commons-fileupload:commons-fileupload:1.5'
-    implementation 'commons-net:commons-net:3.10.0'
-    implementation 'commons-validator:commons-validator:1.8.0'
-    implementation 'de.odysseus.juel:juel-impl:2.2.7'
-    implementation 'javax.transaction:javax.transaction-api:1.3'
-    implementation 'net.fortuna.ical4j:ical4j:1.0-rc4-atlassian-12'
-    implementation 'net.lingala.zip4j:zip4j:2.11.5'
-    implementation 'org.apache.ant:ant-junit:1.10.14'
-    implementation 'org.apache.commons:commons-collections4:4.4'
-    implementation 'org.apache.commons:commons-csv:1.10.0'
-    implementation 'org.apache.commons:commons-dbcp2:2.10.0'// 2.11.0 does not compile.
-    implementation 'org.apache.commons:commons-imaging:1.0-alpha3' // Alpha but OK, "Imaging was working and was used by a number of projects in production even before reaching its initial release as an Apache Commons component."
-    implementation 'org.apache.commons:commons-text:1.11.0'
-    implementation 'org.apache.geronimo.components:geronimo-transaction:3.1.5' // 4.0.0 does not compile
-    implementation 'org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1'
-    implementation 'org.apache.httpcomponents:httpclient-cache:4.5.14'
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0' // the API of log4j 2
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0' // Somehow needed by Buildbot to compile OFBizDynamicThresholdFilter.java
-    implementation 'org.apache.poi:poi:4.1.2' // poi-ooxml-schemas-5.0.0.pom'. Received status code 401 from server
-    implementation 'org.apache.pdfbox:pdfbox:2.0.29' // 3.0.1 does not compile
-    implementation 'org.apache.shiro:shiro-core:1.13.0'
-    implementation 'org.apache.sshd:sshd-core:2.10.0'
-    implementation 'org.apache.sshd:sshd-sftp:2.10.0'
-    implementation 'org.apache.tika:tika-core:2.5.0'
-    implementation 'org.apache.tika:tika-parsers:2.5.0'
-    implementation 'org.apache.tika:tika-parser-pdf-module:2.5.0'
-    implementation 'org.apache.cxf:cxf-rt-frontend-jaxrs:3.5.6' // 4.0.3 does not compile
-    implementation 'org.apache.tomcat:tomcat-catalina-ha:9.0.82' // Remember to change the version number (9 now) in javadoc block if needed.
-    implementation 'org.apache.tomcat:tomcat-jasper:9.0.82'
-    implementation 'org.apache.axis2:axis2-kernel:1.8.2'
-    implementation 'org.apache.xmlgraphics:batik-anim:1.17'
-    implementation 'org.apache.xmlgraphics:batik-util:1.17'
-    implementation 'org.apache.xmlgraphics:batik-bridge:1.17'
-    implementation 'org.apache.xmlgraphics:fop:2.3' // NOTE: since 2.4 dependencies are messed up. See https://github.com/moqui/moqui-fop/blob/master/build.gradle
-    implementation 'org.clojure:clojure:1.11.1'
-    implementation 'org.codehaus.groovy:groovy-all:3.0.21'
-    implementation 'org.freemarker:freemarker:2.3.32' // Remember to change the version number in FreeMarkerWorker class when upgrading. See OFBIZ-10019 if >= 2.4
-    implementation 'org.owasp.esapi:esapi:2.5.3.1'
-    implementation 'org.cyberneko:html:1.9.8'
-    implementation 'org.springframework:spring-test:5.3.29' //  6.1.4 does not compile
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    implementation 'oro:oro:2.0.8'
-    implementation 'wsdl4j:wsdl4j:1.6.3'
-    implementation 'com.auth0:java-jwt:4.4.0'
-    implementation 'org.jdom:jdom:1.1.3' // don't upgrade above 1.1.3, makes a lot of not obvious and useless complications, see last commits of OFBIZ-12092 for more
-    implementation 'com.google.re2j:re2j:1.7'
-    implementation 'xerces:xercesImpl:2.12.2'
-    implementation 'org.mustangproject:library:2.8.0' // 2.10.0 did not work, cf. OFBIZ-12920 (https://github.com/apache/ofbiz-framework/pull/712#issuecomment-1968960963)
+    implementation libs.jacksonDatabind
+    implementation libs.javaJwt
+    implementation libs.jdom
+    implementation libs.juelImpl
+    implementation libs.libphonenumber
+    implementation libs.mail
+    implementation libs.mustangLibrary
+    implementation libs.nekoHtml
+    implementation libs.oro
+    implementation libs.owaspJavaHtmlSanitizer
+    implementation libs.pdfbox
+    implementation libs.poi
+    implementation libs.re2j
+    implementation libs.rome
+    implementation libs.shiroCore
+    implementation libs.springTest
+    implementation libs.transactionApi
+    implementation libs.wsdl4j
+    implementation libs.xercesImpl
+    implementation libs.xstream
+    implementation libs.zip4j
+    implementation libs.zxing
 
+    runtimeOnly libs.bundles.axis2Runtime
+    runtimeOnly libs.bundles.barcode4jRuntime
+    runtimeOnly libs.bundles.log4jRuntime
+    runtimeOnly libs.derby
+    runtimeOnly libs.geronimoJaxrpc11Spec
+    runtimeOnly libs.juelSpi
+    runtimeOnly libs.soapApi
 
-    testImplementation 'org.hamcrest:hamcrest-library:2.2' // Enable junit4 to not depend on hamcrest-1.3
-    testImplementation 'org.mockito:mockito-core:5.10.0'
-    testImplementation 'org.jmockit:jmockit:1.49'
-    testImplementation 'com.pholser:junit-quickcheck-generators:1.0'
-
-    runtimeOnly 'javax.xml.soap:javax.xml.soap-api:1.4.0'
-    runtimeOnly 'de.odysseus.juel:juel-spi:2.2.7'
-    runtimeOnly 'net.sf.barcode4j:barcode4j-fop-ext:2.1'
-    runtimeOnly 'net.sf.barcode4j:barcode4j:2.1'
-    runtimeOnly 'org.apache.axis2:axis2-transport-http:1.8.2'
-    runtimeOnly 'org.apache.axis2:axis2-transport-local:1.8.2'
-    runtimeOnly 'org.apache.derby:derby:10.14.2.0' // 10.17.1.0 does not compile
-    runtimeOnly 'org.apache.geronimo.specs:geronimo-jaxrpc_1.1_spec:2.1'
-    runtimeOnly 'org.apache.logging.log4j:log4j-1.2-api:2.20.0' // for external jars using the old log4j1.2: routes logging to log4j 2
-    runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.20.0' // for external jars using the java.util.logging: routes logging to log4j 2
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0' // for external jars using slf4j: routes logging to log4j 2
-    runtimeOnly 'org.apache.logging.log4j:log4j-web:2.20.0' //???
-    runtimeOnly 'org.apache.logging.log4j:log4j-jcl:2.20.0' // need to constrain to version to avoid classpath conflict (ReflectionUtil)
-
-    // specify last codenarc version for java 17 compliance
-    codenarc('org.codenarc:CodeNarc:3.4.0')
+    testImplementation libs.hamcrestLibrary
+    testImplementation libs.jmockit
+    testImplementation libs.junitQuickcheckGenerators
+    testImplementation libs.mockitoCore
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,176 @@
+[bundles]
+axis2Runtime = ['axis2TransportHttp', 'axis2TransportLocal']
+barcode4jRuntime = ['barcode4jFopExt', 'barcode4j']
+batik = ['batikAnim', 'batikBridge', 'batikUtil']
+commons = ['commonsCli', 'commonsCollections4', 'commonsCsv', 'commonsDbcp2', 'commonsFileupload', 'commonsImaging', 'commonsNet', 'commonsText', 'commonsValidator']
+geronimo = ['geronimoJms11Spec', 'geronimoTransaction']
+log4j = ['log4jApi', 'log4jCore']
+log4jRuntime = ['log4j12Api', 'log4jJcl', 'log4jJul', 'log4jSlf4jImpl', 'log4jWeb']
+sshd = ['sshdCore', 'sshdSftp']
+tika = ['tikaCore', 'tikaParsers', 'tikaParsersPdfModule']
+tomcat = ['tomcatCatalinaHa', 'tomcatJasper']
+
+[libraries]
+antJunit = { module = 'org.apache.ant:ant-junit', version.ref = 'antJunit' }
+axis2Kernel = { module = 'org.apache.axis2:axis2-kernel', version.ref = 'axis2' }
+axis2TransportHttp = { module = 'org.apache.axis2:axis2-transport-http', version.ref = 'axis2' }
+axis2TransportLocal = { module = 'org.apache.axis2:axis2-transport-local', version.ref = 'axis2' }
+barcode4jFopExt = { module = 'net.sf.barcode4j:barcode4j-fop-ext', version.ref = 'barcode4j' }
+barcode4j = { module = 'net.sf.barcode4j:barcode4j', version.ref = 'barcode4j' }
+batikAnim = { module = 'org.apache.xmlgraphics:batik-anim', version.ref = 'batik' }
+batikBridge = { module = 'org.apache.xmlgraphics:batik-bridge', version.ref = 'batik' }
+batikUtil = { module = 'org.apache.xmlgraphics:batik-util', version.ref = 'batik' }
+caffeine = { module = 'com.github.ben-manes.caffeine:caffeine', version.ref = 'caffeine' }
+clojure = { module = 'org.clojure:clojure', version.ref = 'clojure' }
+codeNarc = { module = 'org.codenarc:CodeNarc', version.ref = 'codeNarc' }
+commonsCli = { module = 'commons-cli:commons-cli', version.ref = 'commonsCli' }
+commonsCollections4 = { module = 'org.apache.commons:commons-collections4', version.ref = 'commonsCollections4' }
+commonsCsv = { module = 'org.apache.commons:commons-csv', version.ref = 'commonsCsv' }
+commonsDbcp2 = { module = 'org.apache.commons:commons-dbcp2', version.ref = 'commonsDbcp2' }
+commonsFileupload = { module = 'commons-fileupload:commons-fileupload', version.ref = 'commonsFileupload' }
+commonsImaging = { module = 'org.apache.commons:commons-imaging', version.ref = 'commonsImaging' }
+commonsNet = { module = 'commons-net:commons-net', version.ref = 'commonsNet' }
+commonsText = { module = 'org.apache.commons:commons-text', version.ref = 'commonsText' }
+commonsValidator = { module = 'commons-validator:commons-validator', version.ref = 'commonsValidator' }
+concurrentlinkedhashmapLru = { module = 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru', version.ref = 'concurrentlinkedhashmapLru' }
+cxfRtFrontendJaxrs = { module = 'org.apache.cxf:cxf-rt-frontend-jaxrs', version.ref = 'cxf' }
+derby = { module = 'org.apache.derby:derby', version.ref = 'derby' }
+esapi = { module = 'org.owasp.esapi:esapi', version.ref = 'esapi' }
+ezVcard = { module = 'com.googlecode.ez-vcard:ez-vcard', version.ref = 'ezVcard' }
+fop = { module = 'org.apache.xmlgraphics:fop', version.ref = 'fop' }
+freemarker = { module = 'org.freemarker:freemarker', version.ref = 'freemarker' }
+geronimoJaxrpc11Spec = { module = 'org.apache.geronimo.specs:geronimo-jaxrpc_1.1_spec', version.ref = 'geronimoJaxrpc11Spec' }
+geronimoJms11Spec = { module = 'org.apache.geronimo.specs:geronimo-jms_1.1_spec', version.ref = 'geronimoJms11Spec' }
+geronimoTransaction = { module = 'org.apache.geronimo.components:geronimo-transaction', version.ref = 'geronimoTransaction' }
+groovyAll = { module = 'org.codehaus.groovy:groovy-all', version.ref = 'groovy' }
+hamcrestLibrary = { module = 'org.hamcrest:hamcrest-library', version.ref = 'hamcrest' } # Enable junit4 to not depend on hamcrest-1.3
+httpclientCache = { module = 'org.apache.httpcomponents:httpclient-cache', version.ref = 'httpclient' }
+ical4j = { module = 'net.fortuna.ical4j:ical4j', version.ref = 'ical4j' }
+icu4j = { module = 'com.ibm.icu:icu4j', version.ref = 'icu4j' }
+itext = { module = 'com.lowagie:itext', version.ref = 'itext' }
+jacksonDatabind = { module = 'com.fasterxml.jackson.core:jackson-databind', version.ref = 'jackson' }
+javaJwt = { module = 'com.auth0:java-jwt', version.ref = 'javaJwt' }
+jdom = { module = 'org.jdom:jdom', version.ref = 'jdom' }
+jmockit = { module = 'org.jmockit:jmockit', version.ref = 'jmockit' }
+juelImpl = { module = 'de.odysseus.juel:juel-impl', version.ref = 'juel' }
+juelSpi = { module = 'de.odysseus.juel:juel-spi', version.ref = 'juel' }
+junit = { module = 'junit:junit', version.ref = 'junit' }
+junitQuickcheckGenerators = { module = 'com.pholser:junit-quickcheck-generators', version.ref = 'junitQuickcheckGenerators' }
+libphonenumber = { module = 'com.googlecode.libphonenumber:libphonenumber', version.ref = 'libphonenumber' }
+log4j12Api = { module = 'org.apache.logging.log4j:log4j-1.2-api', version.ref = 'log4j' } # for external jars using the old log4j1.2: routes logging to log4j 2
+log4jApi = { module = 'org.apache.logging.log4j:log4j-api', version.ref = 'log4j' } # the API of log4j 2
+log4jCore = { module = 'org.apache.logging.log4j:log4j-core', version.ref = 'log4j' } # Somehow needed by Buildbot to compile OFBizDynamicThresholdFilter.java
+log4jJcl = { module = 'org.apache.logging.log4j:log4j-jcl', version.ref = 'log4j' } # need to constrain to version to avoid classpath conflict (ReflectionUtil)
+log4jJul = { module = 'org.apache.logging.log4j:log4j-jul', version.ref = 'log4j' } # for external jars using the java.util.logging: routes logging to log4j 2
+log4jSlf4jImpl = { module = 'org.apache.logging.log4j:log4j-slf4j-impl', version.ref = 'log4j' } # for external jars using slf4j: routes logging to log4j 2
+log4jWeb = { module = 'org.apache.logging.log4j:log4j-web', version.ref = 'log4j' } # ???
+mail = { module = 'com.sun.mail:javax.mail', version.ref = 'mail' }
+mockitoCore = { module = 'org.mockito:mockito-core', version.ref = 'mockito' }
+mustangLibrary = { module = 'org.mustangproject:library', version.ref = 'mustangLibrary' }
+nekoHtml = { module = 'org.cyberneko:html', version.ref = 'nekoHtml' }
+oro = { module = 'oro:oro', version.ref = 'oro' }
+owaspJavaHtmlSanitizer = { module = 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer', version.ref = 'owaspJavaHtmlSanitizer' }
+pdfbox = { module = 'org.apache.pdfbox:pdfbox', version.ref = 'pdfbox' }
+poi = { module = 'org.apache.poi:poi', version.ref = 'poi' }
+re2j = { module = 'com.google.re2j:re2j', version.ref = 're2j' }
+rome = { module = 'com.rometools:rome', version.ref = 'rome' }
+shiroCore = { module = 'org.apache.shiro:shiro-core', version.ref = 'shiro' }
+soapApi = { module = 'javax.xml.soap:javax.xml.soap-api', version.ref = 'soapApi' }
+springTest = { module = 'org.springframework:spring-test', version.ref = 'spring' }
+sshdCore = { module = 'org.apache.sshd:sshd-core', version.ref = 'sshd' }
+sshdSftp = { module = 'org.apache.sshd:sshd-sftp', version.ref = 'sshd' }
+tikaCore = { module = 'org.apache.tika:tika-core', version.ref = 'tika' }
+tikaParsers = { module = 'org.apache.tika:tika-parsers', version.ref = 'tika' }
+tikaParsersPdfModule = { module = 'org.apache.tika:tika-parser-pdf-module', version.ref = 'tika' }
+tomcatCatalinaHa = { module = 'org.apache.tomcat:tomcat-catalina-ha', version.ref = 'tomcat' }
+tomcatJasper = { module = 'org.apache.tomcat:tomcat-jasper', version.ref = 'tomcat' }
+transactionApi = { module = 'javax.transaction:javax.transaction-api', version.ref = 'transactionApi' }
+wsdl4j = { module = 'wsdl4j:wsdl4j', version.ref = 'wsdl4j' }
+xercesImpl = { module = 'xerces:xercesImpl', version.ref = 'xercesImpl' }
+xstream = { module = 'com.thoughtworks.xstream:xstream', version.ref = 'xstream' }
+zip4j = { module = 'net.lingala.zip4j:zip4j', version.ref = 'zip4j' }
+zxing = { module = 'com.google.zxing:core', version.ref = 'zxing' }
+
+[plugins]
+asciidoctorJvmConvert = { id = 'org.asciidoctor.jvm.convert', version.ref = 'asciidoctorPlugin' }
+asciidoctorJvmPdf = { id = 'org.asciidoctor.jvm.pdf', version.ref = 'asciidoctorPlugin' }
+dependencycheck = { id = 'org.owasp.dependencycheck', version.ref = 'dependencycheckPlugin' }
+gitHooks = { id = 'com.github.jakemarsden.git-hooks', version.ref = 'gitHooksPlugin' }
+manifestClasspath = { id = 'com.github.ManifestClasspath', version.ref = 'manifestClasspathPlugin' }
+node = { id = 'com.github.node-gradle.node', version.ref = 'nodePlugin' }
+useLatestVersions = { id = 'se.patrikerdes.use-latest-versions', version.ref = 'useLatestVersionsPlugin' }
+versions = { id = 'com.github.ben-manes.versions', version.ref = 'versionsPlugin' }
+
+[versions]
+# plugins
+asciidoctorPlugin = '3.3.2' # 4.0.2 does not compile
+dependencycheckPlugin = '9.0.9' # Not tested after 7.4.4
+gitHooksPlugin = '0.0.2'
+manifestClasspathPlugin = '0.1.0-RELEASE'
+nodePlugin = '7.0.2'
+useLatestVersionsPlugin = '0.2.18'
+versionsPlugin = '0.51.0'
+# libraries
+antJunit = '1.10.14'
+axis2 = '1.8.2'
+barcode4j = '2.1'
+batik = '1.17'
+caffeine = '3.1.8'
+clojure = '1.11.1'
+codeNarc = '3.4.0' # specify last codenarc version for java 17 compliance
+commonsCli = '1.5.0' # with 1.6.0, 2 tests of OfbizStartupUnitTests don't pass
+commonsCollections4 = '4.4'
+commonsCsv = '1.10.0'
+commonsDbcp2 = '2.10.0' # 2.11.0 does not compile.
+commonsFileupload = '1.5'
+commonsImaging = '1.0-alpha3' # Alpha but OK, "Imaging was working and was used by a number of projects in production even before reaching its initial release as an Apache Commons component."
+commonsNet = '3.10.0'
+commonsText = '1.11.0'
+commonsValidator = '1.8.0'
+concurrentlinkedhashmapLru = '1.4.2'
+cxf = '3.5.6' # 4.0.3 does not compile
+derby = '10.14.2.0' # 10.17.1.0 does not compile
+esapi = '2.5.3.1'
+ezVcard = '0.11.3' # 0.12.1 does not compile
+fop = '2.3' # NOTE: since 2.4 dependencies are messed up. See https://github.com/moqui/moqui-fop/blob/master/build.gradle
+freemarker = '2.3.32' # Remember to change the version number in FreeMarkerWorker class when upgrading. See OFBIZ-10019 if >= 2.4
+geronimoJaxrpc11Spec = '2.1'
+geronimoJms11Spec = '1.1.1'
+geronimoTransaction = '3.1.5' # 4.0.0 does not compile
+groovy = '3.0.21'
+hamcrest = '2.2'
+httpclient = '4.5.14'
+ical4j = '1.0-rc4-atlassian-12'
+icu4j = '74.2'
+itext = '2.1.7' # Don't update due to license change in newer versions, see OFBIZ-10455
+jackson = '2.15.2'
+javaJwt = '4.4.0'
+jdom = '1.1.3' # don't upgrade above 1.1.3, makes a lot of not obvious and useless complications, see last commits of OFBIZ-12092 for more
+jmockit = '1.49'
+juel = '2.2.7'
+junit = '4.13.2'
+junitQuickcheckGenerators = '1.0'
+libphonenumber = '8.13.31'
+log4j = '2.20.0'
+mail = '1.6.2'
+mockito = '5.10.0'
+mustangLibrary = '2.8.0' # 2.10.0 did not work, cf. OFBIZ-12920 (https://github.com/apache/ofbiz-framework/pull/712#issuecomment-1968960963)
+nekoHtml = '1.9.8'
+oro = '2.0.8'
+owaspJavaHtmlSanitizer = '20220608.1'
+pdfbox = '2.0.29' # 3.0.1 does not compile
+poi = '4.1.2' # poi-ooxml-schemas-5.0.0.pom'. Received status code 401 from server
+re2j = '1.7'
+rome = '2.1.0'
+shiro = '1.13.0'
+soapApi = '1.4.0'
+spring = '5.3.29' # 6.1.4 does not compile
+sshd = '2.10.0'
+tika = '2.5.0'
+tomcat = '9.0.82' # Remember to change the version number (9 now) in javadoc block if needed.
+transactionApi = '1.3'
+wsdl4j = '1.6.3'
+xercesImpl = '2.12.2'
+xstream = '1.4.20'
+zip4j = '2.11.5'
+zxing = '3.5.3'


### PR DESCRIPTION
Using a version catalog makes things easier:
- You can update a single version for multiple artifacts (e.g. Tomcat)
- You have all the artifacts and their versions at a single place separated from other stuff

See also https://docs.gradle.org/current/userguide/platforms.html