### PR TITLE
Implemented: Extending calculateProductPrice (custom) Service and ShoppingCart / OrderItem to deliver/hold an individual discountRate value (OFBIZ-12802)

### DIFF
--- a/applications/datamodel/entitydef/order-entitymodel.xml
+++ b/applications/datamodel/entitydef/order-entitymodel.xml
@@ -549,6 +549,7 @@ under the License.
       <field name="unitListPrice" type="currency-precise"></field>
       <field name="unitAverageCost" type="currency-amount"></field>
       <field name="unitRecurringPrice" type="currency-amount"></field>
+      <field name="discountRate" type="fixed-point"></field>
       <field name="isModifiedPrice" type="indicator"></field>
       <field name="recurringFreqUomId" type="id"></field>
       <field name="itemDescription" type="description"></field>

--- a/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/ShoppingCart.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/ShoppingCart.java
@@ -4382,6 +4382,7 @@ public class ShoppingCart implements Iterable<ShoppingCartItem>, Serializable {
                 orderItem.set("selectedAmount", item.getSelectedAmount());
                 orderItem.set("unitPrice", item.getBasePrice());
                 orderItem.set("unitListPrice", item.getListPrice());
+                orderItem.set("discountRate", item.getDiscountRate());
                 orderItem.set("isModifiedPrice", item.getIsModifiedPrice() ? "Y" : "N");
                 orderItem.set("isPromo", item.getIsPromo() ? "Y" : "N");
 

--- a/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/ShoppingCartItem.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/ShoppingCartItem.java
@@ -134,6 +134,7 @@ public class ShoppingCartItem implements java.io.Serializable {
      */
     private BigDecimal reservNthPPPerc = BigDecimal.ZERO;
     private BigDecimal listPrice = BigDecimal.ZERO;
+    private BigDecimal discountRate = null;
     /**
      * flag to know if the price have been modified
      */
@@ -1355,6 +1356,7 @@ public class ShoppingCartItem implements java.io.Serializable {
                         }
 
                         this.setSpecialPromoPrice((BigDecimal) priceResult.get("specialPromoPrice"));
+                        this.discountRate = (BigDecimal) priceResult.get("discountRate");
                     }
 
                     this.orderItemPriceInfos = UtilGenerics.cast(priceResult.get("orderItemPriceInfos"));
@@ -2443,6 +2445,14 @@ public class ShoppingCartItem implements java.io.Serializable {
      */
     public void setListPrice(BigDecimal listPrice) {
         this.listPrice = listPrice;
+    }
+
+    /**
+     * Returns the DiscountRate
+     * @return discountRate
+     */
+    public BigDecimal getDiscountRate() {
+        return discountRate;
     }
 
     /**

--- a/applications/product/servicedef/services_pricepromo.xml
+++ b/applications/product/servicedef/services_pricepromo.xml
@@ -49,6 +49,7 @@ under the License.
         <attribute name="basePrice" type="BigDecimal" mode="OUT" optional="false"><!-- will only be different from price if there is a display price adjustment, for example: checkIncludeVat=Y and a VAT amount was found --></attribute>
         <attribute name="price" type="BigDecimal" mode="OUT" optional="false"/>
         <attribute name="listPrice" type="BigDecimal" mode="OUT" optional="true"/>
+        <attribute name="discountRate" type="BigDecimal" mode="OUT" optional="true" />
         <attribute name="defaultPrice" type="BigDecimal" mode="OUT" optional="true"/>
         <attribute name="competitivePrice" type="BigDecimal" mode="OUT" optional="true"/>
         <attribute name="averageCost" type="BigDecimal" mode="OUT" optional="true"/>


### PR DESCRIPTION
Implemented: Extending calculateProductPrice (custom) Service and ShoppingCart / OrderItem to deliver/hold an individual discountRate value (OFBIZ-12802)

+ Addition of additional context information "productStoreGroupId" and "partyId" to the call parameters of a "customMethodName" price-calc-service
+ Obtaining the fields discountRate and listPrice from calling a "customMethodName" price-calc-service

+ discountRate as Result Field
+ Transport original discount rate from custom price calculation over cart to order to have the correct rate instead of back-calculating it from unitPrice and unitListPrice