### PR TITLE
Improved: getPathInfoOnlyParameterMap should be public (OFBIZ-12842)

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
@@ -380,7 +380,7 @@ public final class UtilHttp {
      * @param pred the predicate filtering parameter names
      * @return a canonicalized parameter map.
      */
-    static Map<String, Object> getPathInfoOnlyParameterMap(String path, Predicate<String> pred) {
+    public static Map<String, Object> getPathInfoOnlyParameterMap(String path, Predicate<String> pred) {
         String path1 = Optional.ofNullable(path).orElse("");
         Map<String, List<String>> allParams = Arrays.stream(path1.split("/"))
                 .filter(segment -> segment.startsWith("~") && segment.contains("="))


### PR DESCRIPTION
Improved: getPathInfoOnlyParameterMap should be public (OFBIZ-12842)