### PR TITLE
Improved: Support HTML textarea placeholder attribute

### DIFF
--- a/framework/widget/dtd/widget-form.xsd
+++ b/framework/widget/dtd/widget-form.xsd
@@ -1512,6 +1512,13 @@ under the License.
                         table clean html spellcheck |(separator) Default is that all buttons are shown</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute type="xs:string" name="placeholder">
+                <xs:annotation>
+                    <xs:documentation>
+                        Content of the HTML placeholder attribute (https://developer.mozilla.org/fr/docs/Web/HTML/Element/textarea#placeholder), text to be displayed to the user when textarea is empty. Similar to text input placeholder.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     <xs:element name="text-find" substitutionGroup="AllFields">

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -5074,6 +5074,7 @@ public final class ModelFormField {
         private final FlexibleStringExpander visualEditorButtons;
         private final boolean visualEditorEnable;
         private final Integer maxlength;
+        private final FlexibleStringExpander placeholder;
 
         public TextareaField(Element element, ModelFormField modelFormField) {
             super(element, modelFormField);
@@ -5114,6 +5115,7 @@ public final class ModelFormField {
             this.maxlength = maxlength;
             this.visualEditorButtons = FlexibleStringExpander.getInstance(element.getAttribute("visual-editor-buttons"));
             this.visualEditorEnable = "true".equals(element.getAttribute("visual-editor-enable"));
+            this.placeholder = FlexibleStringExpander.getInstance(element.getAttribute("placeholder"));
         }
 
         public TextareaField(int fieldSource, ModelFormField modelFormField) {
@@ -5125,6 +5127,7 @@ public final class ModelFormField {
             this.maxlength = null;
             this.visualEditorButtons = FlexibleStringExpander.getInstance("");
             this.visualEditorEnable = false;
+            this.placeholder = FlexibleStringExpander.getInstance("");
         }
 
         public TextareaField(ModelFormField modelFormField) {
@@ -5140,6 +5143,7 @@ public final class ModelFormField {
             this.cols = original.cols;
             this.rows = original.rows;
             this.maxlength = original.maxlength;
+            this.placeholder = original.placeholder;
         }
 
         @Override
@@ -5227,6 +5231,22 @@ public final class ModelFormField {
          */
         public boolean isReadOnly() {
             return readOnly;
+        }
+
+        /**
+         * Returns the placeholder
+         * @return the placeholder
+         */
+        public FlexibleStringExpander getPlaceholder() {
+            return this.placeholder;
+        }
+
+        /**
+         * Returns the placeholder
+         * @return the placeholder
+         */
+        public String getPlaceholder(Map<String, Object> context) {
+            return this.placeholder.expandString(context);
         }
 
         @Override

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetFieldVisitor.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetFieldVisitor.java
@@ -312,6 +312,7 @@ public class XmlWidgetFieldVisitor extends XmlAbstractWidgetVisitor implements M
         visitAttribute("rows", textareaField.getRows());
         visitAttribute("visual-editor-buttons", textareaField.getVisualEditorButtons());
         visitAttribute("visual-editor-enable", textareaField.getVisualEditorEnable());
+        visitAttribute("placeholder", textareaField.getPlaceholder());
         writer.append("/></field>");
     }
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
@@ -367,6 +367,8 @@ public final class RenderableFtlFormElementsBuilder {
             builder.intParameter("maxlength", textareaField.getMaxlength());
         }
 
+        builder.stringParameter("placeholder", textareaField.getPlaceholder(context));
+
         builder.stringParameter("tabindex", modelFormField.getTabindex());
 
         builder.stringParameter("value", modelFormField.getEntry(context, textareaField.getDefaultValue(context)));

--- a/themes/common-theme/template/macro/CsvFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/CsvFormMacroLibrary.ftl
@@ -26,7 +26,7 @@ under the License.
 
 <#macro renderTextField name className alert value textSize maxlength id event action disabled clientAutocomplete ajaxUrl ajaxEnabled mask tabindex readonly placeholder="" delegatorName="default"><@renderField value /></#macro>
 
-<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false></#macro>
+<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false placeholder=""></#macro>
 
 <#macro renderDateTimeField name className timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName ampmName compositeType alert=false isTimeType=false isDateType=false amSelected=false pmSelected=false timeDropdown="" classString="" isTwelveHour=false hour1="" hour2="" minutes=0 shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest=false><@renderField value /></#macro>
 

--- a/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
@@ -53,7 +53,7 @@ under the License.
 
 <#macro renderTextField name className alert value textSize maxlength id event action disabled clientAutocomplete ajaxUrl ajaxEnabled mask tabindex readonly placeholder="" delegatorName="default"><@makeBlock className value /></#macro>
 
-<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false><@makeBlock className value /></#macro>
+<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false placeholder=""><@makeBlock className value /></#macro>
 
 <#macro renderDateTimeField name className timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName ampmName compositeType alert=false isTimeType=false isDateType=false amSelected=false pmSelected=false timeDropdown="" classString="" isTwelveHour=false hour1="" hour2="" minutes=0 shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest=false><@makeBlock className value /></#macro>
 

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -69,7 +69,7 @@ under the License.
   /><#t/>
 </#macro>
 
-<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false>
+<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false placeholder="">
   <#if visualEditorEnable?has_content>
     <#local className = className + " visual-editor">
   </#if>
@@ -83,6 +83,7 @@ under the License.
     <#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
     <#if visualEditorEnable?has_content> data-toolbar="${buttons?default("maxi")}"</#if><#rt/>
     <#if language?has_content> data-language="${language!"en"}"</#if><#rt/>
+    <#if placeholder?has_content> placeholder="${placeholder}"</#if><#rt/>
     ><#t/>
     <#if value?has_content>${value}</#if><#t/>
   </textarea><#lt/>

--- a/themes/common-theme/template/macro/TextFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/TextFormMacroLibrary.ftl
@@ -26,7 +26,7 @@ under the License.
 
 <#macro renderTextField name className alert value textSize maxlength id event action disabled clientAutocomplete ajaxUrl ajaxEnabled mask tabindex readonly placeholder="" delegatorName="default"><@renderField value /></#macro>
 
-<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false><@renderField value /></#macro>
+<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false placeholder=""><@renderField value /></#macro>
 
 <#macro renderDateTimeField name className alert title value size maxlength id dateType shortDateInput timeDropdownParamName defaultDateTimeString localizedIconTitle timeDropdown timeHourName classString hour1 hour2 timeMinutesName minutes isTwelveHour ampmName amSelected pmSelected compositeType formName mask="" event="" action="" step="" timeValues="" tabindex="" disabled="" isXMLHttpRequest=""><@renderField value /></#macro>
 

--- a/themes/common-theme/template/macro/XlsFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XlsFormMacroLibrary.ftl
@@ -32,7 +32,7 @@ under the License.
 
 <#macro renderTextField name className alert value textSize maxlength id event action disabled clientAutocomplete ajaxUrl ajaxEnabled mask tabindex readonly placeholder="" delegatorName="default"><@renderItemField value "txf" className/></#macro>
 
-<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false></#macro>
+<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false placeholder=""></#macro>
 
 <#macro renderDateTimeField name className timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName ampmName compositeType alert=false isTimeType=false isDateType=false amSelected=false pmSelected=false timeDropdown="" classString="" isTwelveHour=false hour1="" hour2="" minutes=0 shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest=false>
 <#if isTimeType ><@renderItemField value "tf" className/>

--- a/themes/common-theme/template/macro/XmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XmlFormMacroLibrary.ftl
@@ -42,7 +42,7 @@ under the License.
 
 <#macro renderTextField name className alert value textSize maxlength id event action disabled clientAutocomplete ajaxUrl ajaxEnabled mask tabindex readonly placeholder="" delegatorName="default"><@renderField value/></#macro>
 
-<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false><@renderField value/></#macro>
+<#macro renderTextareaField name className alert cols="" rows="" maxlength="" id="" readonly="" value="" visualEditorEnable="" buttons="" tabindex="" language="" disabled=false placeholder=""><@renderField value/></#macro>
 
 <#macro renderDateTimeField name className timeDropdownParamName defaultDateTimeString localizedIconTitle timeHourName timeMinutesName ampmName compositeType alert=false isTimeType=false isDateType=false amSelected=false pmSelected=false timeDropdown="" classString="" isTwelveHour=false hour1="" hour2="" minutes=0 shortDateInput="" title="" value="" size="" maxlength="" id="" formName="" mask="" event="" action="" step="" timeValues="" tabindex="" disabled=false isXMLHttpRequest=false><@renderField value/></#macro>
 


### PR DESCRIPTION
Improved: Adds support for textarea placeholder attribute, using a FlexibleStringExpander

([OFBIZ-12859](https://issues.apache.org/jira/browse/OFBIZ-12859))

With this PR we can add a "placeholder" attribute on "textarea" field widget. This attribute can be dynamic (FlexibleStringExpander). Its content is added in a "placeholder" attribute on the HTML textarea (https://developer.mozilla.org/fr/docs/Web/HTML/Element/textarea#placeholder).

Thanks: Néréide team
