### PR TITLE
Fixed: Keep needed classpath entries in the Eclipse .classpath file (OFBIZ-12880)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -411,14 +411,12 @@ eclipse.classpath.file.whenMerged { classpath ->
 
         classpath.entries.removeAll { entry ->
             // remove any "src" entries in .classpath of the form /componentName
-            entry.kind == 'src' && !(entry.path ==~ 'framework/base/config' || entry.path ==~ 'framework/base/dtd') && (
+            entry.kind == 'src' && (
             entry.path ==~ '.*/+(' + componentName.tokenize(fileSep).last() + ')$' ||
             entry.path ==~ /(\/+framework)$/ ||
             entry.path ==~ /(\/+applications)$/ ||
             entry.path ==~ /(\/+plugins)$/ ||
-            entry.path ==~ /(\/+themes)$/ ||
-            entry.path ==~ eclipseEntry + '/config' ||
-            entry.path ==~ eclipseEntry + '/dtd')
+            entry.path ==~ /(\/+themes)$/ )
         }
     }
 }


### PR DESCRIPTION
Keeps classpath entries for config folders and dtds which are removed from the .classpath file after it is generated by the Eclipse Gradle task.