### PR TITLE
Fixed: Gradle eclipse target produces duplicate build path entries in .classpath (OFBIZ-12888)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -352,20 +352,6 @@ sourceSets {
             srcDirs = getDirectoryInActiveComponentsIfExists('src/test/resources')
         }
     }
-
-    groovyScripts {
-        groovy {
-            srcDirs += getDirectoryInActiveComponentsIfExists('src/main/groovy')
-            compileClasspath += sourceSets.main.compileClasspath
-            compileClasspath += sourceSets.main.output
-        }
-    }
-}
-
-tasks.named('compileGroovyScriptsGroovy') {
-    // We don't want to build groovyScripts as they should be considered as standalone elements executed in
-    // isolation by ofbiz. Building them will result in numerous error due to duplicated classes.
-    enabled = false
 }
 
 jar.manifest.attributes(
@@ -386,7 +372,7 @@ checkstyle {
     showViolations = true
 }
 gitHooks {
-    hooks = ['pre-push': 'checkstyleMain codenarcGroovyScripts']
+    hooks = ['pre-push': 'checkstyleMain codenarcMain codenarcTest']
 }
 
 // Checks OFBiz Groovy coding conventions.


### PR DESCRIPTION
Removes the groovyScripts source set, the compileGroovyScriptsGroovy task configuration and changes the pre-push hook to "checkstyleMain codenarcMain codenarcTest" instead of "checkstyleMain codenarcGroovyScripts".
