### PR TITLE
Improved: Screen Communications in Party should not show create trigger to user with VIEW permissions (OFBIZ-12891)

### DIFF
--- a/applications/party/widget/partymgr/PartyMenus.xml
+++ b/applications/party/widget/partymgr/PartyMenus.xml
@@ -685,6 +685,11 @@
 
     <menu name="CommSubTabBar" extends="CommonButtonBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="new" title="${uiLabelMap.PartyNewCommunication}" widget-style="buttontext create">
+            <condition>
+                <or>
+                    <if-has-permission permission="PARTYMGR" action="_CREATE"/>
+                </or>
+            </condition>
             <link target="EditCommunicationEvent"/>
         </menu-item>
         <menu-item name="reply" title="${uiLabelMap.PartyReply}">


### PR DESCRIPTION
When accessing https://demo-trunk.ofbiz.apache.org/partymgr/control/FindCommunicationEvents as a user with only VIEW permissions (.e.g. userId = auditor) the action trigger to create a new communication is shown.

This should not be visible to such a user as it leads to an undesired effect and diminished user experience.

modified:
- PartyMenus.xml - added permission condition to menu-item 'new' in CommSubTabBar