### PR TITLE
Improved: PaymentGroup Create Button shown to viewer (OFBIZ-12819)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -79,6 +79,14 @@ under the License.
             </condition>
             <link target="newPayment"/>
         </menu-item>
+        <menu-item name="NewPaymentGroup" title="${uiLabelMap.CommonCreate} ${uiLabelMap.AccountingNewPaymentGroup}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditPaymentGroup"/>
+        </menu-item>
     </menu>
 
     <menu name="AccountingShortcutAppBar" title="${uiLabelMap.AccountingManager}">

--- a/applications/accounting/widget/PaymentGroupScreens.xml
+++ b/applications/accounting/widget/PaymentGroupScreens.xml
@@ -40,11 +40,6 @@ under the License.
                         <section>
                             <widgets>
                                 <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                                    <decorator-section name="menu-bar">
-                                        <container style="button-bar">
-                                            <link target="EditPaymentGroup" text="${uiLabelMap.CommonCreate}" style="buttontext create"/>
-                                        </container>
-                                    </decorator-section>
                                     <decorator-section name="search-options">
                                         <include-form name="FindPaymentGroup" location="component://accounting/widget/PaymentGroupForms.xml"/>
                                     </decorator-section>


### PR DESCRIPTION
Currently when a user with only view permissions accesses the PaymentGroup overview, as shown in demo-trunk with userid=auditor, the action trigger to create a new PaymentGroup is shown.

Modified:
- PaymentGroupScreens.xml - removed decorator-section "menu-bar"
- AccountingMenus.xml - added menu-item "NewPaymentGroup" to MainActionMenu