### PR TITLE
Improved: show MainActionMenu in Party - LoggedInUser screen (OFBIZ-12895)

### DIFF
--- a/applications/party/widget/partymgr/VisitScreens.xml
+++ b/applications/party/widget/partymgr/VisitScreens.xml
@@ -67,6 +67,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <include-screen name="LoggedInUsersScreen" />
                     </decorator-section>


### PR DESCRIPTION
Currently the ListLoggedInUsers screen in VisitScreens.xml does not show the MainActionMenu of the party component. For a consistent user experience this should be.

Modified: VisitScreens.xml
- added decorator-section 'pre-body'  having MainActionMenu to screen ListLoggedInUser