### PR TITLE
OFBIZ-12900 Have screen FindPartyClassificationGroups show Party MainActionMenu

### DIFF
--- a/applications/party/widget/partymgr/PartyClassificationScreens.xml
+++ b/applications/party/widget/partymgr/PartyClassificationScreens.xml
@@ -104,6 +104,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PartyClassificationGroups}">
                             <container style="button-bar"><link target="EditPartyClassificationGroup" style="buttontext create" text="${uiLabelMap.PartyCreateNewPartyClassificationGroup}"/></container>


### PR DESCRIPTION
Currently the FindPartyClassificationGroups screen in PartyClassificationScreens.xml does not show the MainActionMenu of the party component. For a consistent user experience this should be.

modified: PartyClassificationsScreens.xml
- added decorator-section 'pre-body', having MainActionMenu
