### PR TITLE
Improved: Screen Classifications in Party should not show create trigger to user with only VIEW permission (OFBIZ-12892)

### DIFF
--- a/applications/party/widget/partymgr/PartyClassificationScreens.xml
+++ b/applications/party/widget/partymgr/PartyClassificationScreens.xml
@@ -109,7 +109,6 @@ under the License.
                     </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PartyClassificationGroups}">
-                            <container style="button-bar"><link target="EditPartyClassificationGroup" style="buttontext create" text="${uiLabelMap.PartyCreateNewPartyClassificationGroup}"/></container>
                             <container style="screenlet-body">
                                 <include-form name="ListPartyClassificationGroups" location="component://party/widget/partymgr/PartyClassificationForms.xml"/>
                             </container>

--- a/applications/party/widget/partymgr/PartyMenus.xml
+++ b/applications/party/widget/partymgr/PartyMenus.xml
@@ -58,6 +58,16 @@
                 <parameter param-name="create_new" value="Y"/>
              </link>
          </menu-item>
+        <menu-item name="newPartyClassificationGroup" title="${uiLabelMap.PartyCreateNewPartyClassificationGroup}">
+            <condition>
+                <or>
+                    <if-has-permission permission="PARTYMGR" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditPartyClassificationGroup">
+                <parameter param-name="create_new" value="Y"/>
+            </link>
+        </menu-item>
     </menu>
     <menu name="PartyShortcutAppBar" title="${uiLabelMap.PartyManager}">
         <menu-item name="find" title="${uiLabelMap.PartyParties}"><link target="/partymgr/control/findparty" url-mode="inter-app"/></menu-item>


### PR DESCRIPTION
When accessing https://demo-trunk.ofbiz.apache.org/partymgr/control/showclassgroups as a user with only VIEW permissions (e.g. userId = auditor) the action trigger to create a new Party Classification Group is shown.

This should not be visible to such a user as it leads to an undesired effect and diminished user experience.

modified:
PartyClassificationScreens.xml - removed container having action trigger PartyMenus.xml - added menu-item newPartyClassificationGroup having permission condition