### PR TITLE
Improved: Have screen ImportExport show Party MainActionMenu (OFBIZ-12903)

### DIFF
--- a/applications/party/widget/partymgr/PartyScreens.xml
+++ b/applications/party/widget/partymgr/PartyScreens.xml
@@ -1394,6 +1394,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://party/widget/partymgr/PartyMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PartyParty} ${uiLabelMap.CommonImportExport} ID Name, single role (employee, customer, supplier) and contactmechs">
                             <container style="lefthalf">


### PR DESCRIPTION
Currently the ImportExport  screen in PartyScreens.xml does not show the MainActionMenu of the party component. For a consistent user experience this should be.

modified: PartyScreens.xml
- added decorator-section 'pre-body' having include-menu for MainActionMenu
