### PR TITLE
Fixed: Duplicate create trigger for PaymentGroup (OFBIZ-12904)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -711,17 +711,6 @@ under the License.
     </menu>
     <menu name="PaymentGroupSubTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml"
             menu-container-style="button-bar button-style-2">
-        <menu-item name="createNew" title="${uiLabelMap.CommonCreate}" widget-style="buttontext create">
-            <condition>
-                <and>
-                    <or>
-                        <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
-                    </or>
-                    <not><if-empty field="paymentGroup"/></not>
-                </and>
-            </condition>
-            <link target="EditPaymentGroup"/>
-        </menu-item>
         <menu-item name="EditPaymentGroup" title="${uiLabelMap.CommonEdit}">
             <condition>
                 <and>


### PR DESCRIPTION
The action trigger for creating a new PaymentGroup record is included in the MainActionMenu of the component and in the action menu related to Payment group. The second one is superfluous.

modified: AccountingMenus.xml
- removed menu-item regarding creating a new PaymentGroup
