### PR TITLE
Fixed: PaymentGroup Cancell button is shown to viewer (OFBIZ-12820)

### DIFF
--- a/applications/accounting/widget/PaymentGroupForms.xml
+++ b/applications/accounting/widget/PaymentGroupForms.xml
@@ -61,11 +61,6 @@ under the License.
                 <parameter param-name="paymentGroupId"/>
             </hyperlink>
         </field>
-        <field name="deleteLink" title=" " widget-style="buttontext" use-when="${paymentGroupTypeId == 'CHECK_RUN'} @and ${paymentGroupMemberAndTransList[0].finAccountTransStatusId != 'FINACT_TRNS_APPROVED'} @and ${groovy:org.apache.ofbiz.base.util.UtilValidate.isNotEmpty(paymentGroupMembers)}">
-            <hyperlink description="${uiLabelMap.CommonCancel}" target="cancelCheckRunPayments" also-hidden="false">
-                <parameter param-name="paymentGroupId"/>
-            </hyperlink>
-        </field>
     </form>
     
     <form name="EditPaymentGroup" type="single" target="updatePaymentGroup" title="" default-map-name="paymentGroup">


### PR DESCRIPTION
Currently when a user with only view permissions accesses the PaymentGroup overview, as demonstrated in demo-trunk with userid=auditor, the action trigger to cancel a PaymentGroup is shown. See attached image.

modified: PaymentGroupForms.xml
- removed action trigger field regarding cancelCheckRunPayments
