### PR TITLE
Implemented: Upgrade to node.js v20 (OFBIZ-12901)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.47.0' apply false
     id "com.github.ManifestClasspath" version "0.1.0-RELEASE"
     id "com.github.jakemarsden.git-hooks" version "0.0.2"
-    id "com.github.node-gradle.node" version '3.5.1' apply false
+    id "com.github.node-gradle.node" version '7.0.2' apply false
 }
 
 /* OWASP plugin

--- a/buildSrc/src/main/groovy/ofbiz-node-conventions.gradle
+++ b/buildSrc/src/main/groovy/ofbiz-node-conventions.gradle
@@ -42,7 +42,7 @@ plugins {
 
 node {
     download = true
-    version = "16.13.1"
+    version = "20.11.1"
 
     // If environment variable CI is set, use 'npm ci' instead of 'npm install' to populate node_modules.
     npmInstallCommand = System.getenv("CI") ? 'ci' : 'install'


### PR DESCRIPTION
Node.js and NPM are used during the OFBiz build to retrieve module dependencies and to build some example plugin React components.

Upgraded Node.js from v16 to v20 since v16 is end-of-life.