### PR TITLE
Improved: Move create new BillingAccount trigger to MainActionMenu (OFBIZ-12907)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -87,6 +87,14 @@ under the License.
             </condition>
             <link target="EditPaymentGroup"/>
         </menu-item>
+        <menu-item name="NewBillingAccount" title="${uiLabelMap.CommonCreate} ${uiLabelMap.AccountingNewBillingAccount}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditBillingAccount"/>
+        </menu-item>
     </menu>
 
     <menu name="AccountingShortcutAppBar" title="${uiLabelMap.AccountingManager}">

--- a/applications/accounting/widget/BillingAccountScreens.xml
+++ b/applications/accounting/widget/BillingAccountScreens.xml
@@ -52,9 +52,6 @@ under the License.
                                 <if-service-permission service-name="acctgBasePermissionCheck" main-action="VIEW"/>
                             </condition>
                             <widgets>
-                                <container style="button-bar">
-                                    <link target="EditBillingAccount" text="${uiLabelMap.CommonCreate}" style="buttontext create"/>
-                                </container>
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>


### PR DESCRIPTION
On CommonBillingAccountDecorator there is a action trigger to create a new Billing Account that is visible to users with only VIEW permissions. Moving the action trigger to the MainActionMenu with a permission condition ensures that is only visible to the appropriate users.

modified:
- BillingAccountScreens.xml: removed container with action trigger to create a new billing account
- AccountingMenus.xml: added menu-item for creating a new billing account
