### PR TITLE
Improved: FinAccount Screen shows create trigger to user with VIEW permission (OFBIZ-12567)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -95,6 +95,14 @@ under the License.
             </condition>
             <link target="EditBillingAccount"/>
         </menu-item>
+        <menu-item name="NewFinAccount" title="${uiLabelMap.CommonCreate} ${uiLabelMap.AccountingFinAccount}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditFinAccount"/>
+        </menu-item>
     </menu>
 
     <menu name="AccountingShortcutAppBar" title="${uiLabelMap.AccountingManager}">

--- a/applications/accounting/widget/FinAccountScreens.xml
+++ b/applications/accounting/widget/FinAccountScreens.xml
@@ -59,9 +59,6 @@ under the License.
                                 <label style="h3" text="${uiLabelMap.AccountingViewPermissionError}"/>
                             </widgets>
                         </section>
-                        <container style="button-bar">
-                            <link target="EditFinAccount" text="${uiLabelMap.CommonCreate}" style="buttontext create"/>
-                        </container>
                         <decorator-section-include name="body"/>
                     </decorator-section>
                 </decorator-screen>


### PR DESCRIPTION
When accessing https://localhost:8443/accounting/control/EditFinAccount?finAccountId=ABN_CHECKING as a user with only VIEW permissions (e.g. userid=auditor) the screen shows a action trigger to create something. This should not be visible to such a user as it leads to a undesired effect and diminished user experience.

modified:
- FinAccountScreens.xml - removed container having link target to create a new financial account
- AccountMenus.xml - added menu-iitem to MainActionMenu for creating a new financial account
