### PR TITLE
Fixed: Error when exporting Comparative Income Statement report (OFBIZ-12915)

### DIFF
--- a/applications/accounting/widget/ReportFinancialSummaryScreens.xml
+++ b/applications/accounting/widget/ReportFinancialSummaryScreens.xml
@@ -974,7 +974,7 @@ under the License.
                             <label style="h3" text="${uiLabelMap.AccountingIncome}"/>
                             <include-grid name="ComparativeIncomeStatementIncomePdf" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
                             <label style="h3" text="${uiLabelMap.CommonTotal}"/>
-                            <include-form name="ComparativeBalanceTotals" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
+                            <include-grid name="ComparativeBalanceTotals" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
                         </container>
                     </decorator-section>
                 </decorator-screen>
@@ -1050,7 +1050,7 @@ under the License.
                 <label style="h3" text="${uiLabelMap.AccountingIncome}"/>
                 <include-grid name="ComparativeIncomeStatementIncome" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
                 <label style="h3" text="${uiLabelMap.CommonTotal}"/>
-                <include-form name="ComparativeBalanceTotals" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
+                <include-grid name="ComparativeBalanceTotals" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
             </widgets>
         </section>
     </screen>


### PR DESCRIPTION
Screen definitions for the PDF and CSV variants of the Accounting application's Comparative Income Statement report where incorrectly using the include-form rather then the include-grid directive when referencing grid, ComparativeBalanceTotals.
