### PR TITLE
Fixed: Styling updates to accounting PDF reports (OFBIZ-12778)

### DIFF
--- a/applications/accounting/widget/ReportFinancialSummaryForms.xml
+++ b/applications/accounting/widget/ReportFinancialSummaryForms.xml
@@ -105,8 +105,8 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="IncomeStatementExpenses" list-name="expenseAccountBalanceList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
@@ -116,8 +116,8 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="IncomeStatementIncome" list-name="incomeAccountBalanceList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
@@ -127,8 +127,8 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <form name="ComparativeIncomeStatementParameters" type="single" target="ComparativeIncomeStatement" header-row-style="header-row" default-table-style="basic-table">
         <field name="organizationPartyId"><hidden/></field>
@@ -183,9 +183,9 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeIncomeStatementRevenuesPdf" extends="ComparativeIncomeStatementRevenues">
         <field name="accountCode"><display/></field>
@@ -198,9 +198,9 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeIncomeStatementExpensesPdf" extends="ComparativeIncomeStatementExpenses">
         <field name="accountCode"><display/></field>
@@ -213,9 +213,9 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeIncomeStatementIncomePdf" extends="ComparativeIncomeStatementIncome">
         <field name="accountCode"><display/></field>
@@ -326,9 +326,9 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeBalanceSheetAssetsPdf" extends="ComparativeBalanceSheetAssets">
         <field name="accountCode"><display/></field>
@@ -341,9 +341,9 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeBalanceSheetLiabilitiesPdf" extends="ComparativeBalanceSheetLiabilities">
         <field name="accountCode"><display/></field>
@@ -356,9 +356,9 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeBalanceSheetEquitiesPdf" extends="ComparativeBalanceSheetEquities">
         <field name="accountCode"><display/></field>
@@ -368,9 +368,9 @@ under the License.
         <row-actions>
             <set field="totalName" value="${groovy: uiLabelMap.get(totalName)}"/>
         </row-actions>
-        <field name="totalName" title-area-style="tableheadwide"><display description="${totalName}"/></field>
-        <field name="balance1" title="Period1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" title="Period2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="totalName" title-area-style="tableheadwide listtitlestyle"><display description="${totalName}"/></field>
+        <field name="balance1" title="Period1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" title="Period2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
 
     <form name="SelectAcctReportPeriod" type="single" title="Select period for report">
@@ -412,13 +412,13 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="openingD" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="openingC" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="D" title="${uiLabelMap.AccountingDebitFlag}" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="C" title="${uiLabelMap.AccountingCreditFlag}" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="closingD" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="closingC" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="openingD" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="openingC" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="D" title="${uiLabelMap.AccountingDebitFlag}" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="C" title="${uiLabelMap.AccountingCreditFlag}" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="closingD" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="closingC" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="PostedTransactionTotalListPdf" extends="PostedTransactionTotalList">
         <field name="accountCode"><display/></field>
@@ -551,9 +551,9 @@ under the License.
             <set field="quantityUom" from-field="uom.abbreviation" default-value="${uom.uomId}"/>
         </row-actions>
         <field name="productId"><display/></field>
-        <field name="unitCost" widget-style="tabletextright"><display currency="${currencyUomId}" type="currency"/></field>
-        <field name="accountingQuantitySum" widget-style="tabletextright"><display description="${accountingQuantitySum} ${quantityUom}"/></field>
-        <field name="value" widget-style="tabletextright"><display description="${accountingQuantitySum * unitCost}" currency="${currencyUomId}" type="currency"/></field>
+        <field name="unitCost" widget-area-style="tabletextright"><display currency="${currencyUomId}" type="currency"/></field>
+        <field name="accountingQuantitySum" widget-area-style="tabletextright"><display description="${accountingQuantitySum} ${quantityUom}"/></field>
+        <field name="value" widget-area-style="tabletextright"><display description="${accountingQuantitySum * unitCost}" currency="${currencyUomId}" type="currency"/></field>
     </grid>
 
     <form name="TrialBalanceFinancialTimePeriodSelection" type="single" header-row-style="header-row" target="TrialBalance" default-table-style="basic-table">
@@ -580,10 +580,10 @@ under the License.
             </hyperlink>
         </field>
         <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
-        <field name="openingBalance" title="${uiLabelMap.AccountingOpeningBalance}" widget-style="tabletextright"><display description="${openingBalance}" type="currency" currency="${currencyUomId}"/></field>
-        <field name="postedDebits" title="${uiLabelMap.AccountingDebitFlag}" widget-style="tabletextright"><display description="${postedDebits}" type="currency" currency="${currencyUomId}"/></field>
-        <field name="postedCredits" title="${uiLabelMap.AccountingCreditFlag}" widget-style="tabletextright"><display description="${postedCredits}" type="currency" currency="${currencyUomId}"/></field>
-        <field name="endingBalance" title="${uiLabelMap.AccountingEndingBalance}" widget-style="tabletextright"><display description="${endingBalance}" type="currency" currency="${currencyUomId}"/></field>
+        <field name="openingBalance" title="${uiLabelMap.AccountingOpeningBalance}" widget-area-style="tabletextright"><display description="${openingBalance}" type="currency" currency="${currencyUomId}"/></field>
+        <field name="postedDebits" title="${uiLabelMap.AccountingDebitFlag}" widget-area-style="tabletextright"><display description="${postedDebits}" type="currency" currency="${currencyUomId}"/></field>
+        <field name="postedCredits" title="${uiLabelMap.AccountingCreditFlag}" widget-area-style="tabletextright"><display description="${postedCredits}" type="currency" currency="${currencyUomId}"/></field>
+        <field name="endingBalance" title="${uiLabelMap.AccountingEndingBalance}" widget-area-style="tabletextright"><display description="${endingBalance}" type="currency" currency="${currencyUomId}"/></field>
     </grid>
 
     <form name="CashFlowStatementParameters" type="single" header-row-style="header-row" default-table-style="basic-table">
@@ -613,8 +613,8 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="CashFlowStatementOpeningCashBalancePdf" extends="CashFlowStatementOpeningCashBalance">
         <field name="accountCode"><display/></field>
@@ -627,10 +627,10 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="D" widget-style="tabletextright" title="${uiLabelMap.AccountingTotalDebit_Receipts}"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="C" widget-style="tabletextright" title="${uiLabelMap.AccountingTotalCredit_Disbursement}"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="D" widget-area-style="tabletextright" title="${uiLabelMap.AccountingTotalDebit_Receipts}"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="C" widget-area-style="tabletextright" title="${uiLabelMap.AccountingTotalCredit_Disbursement}"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="CashFlowStatementPeriodCashBalancePdf" extends="CashFlowStatementPeriodCashBalance">
         <field name="accountCode"><display/></field>
@@ -643,8 +643,8 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="CashFlowStatementClosingCashBalancePdf" extends="CashFlowStatementClosingCashBalance">
         <field name="accountCode"><display/></field>
@@ -654,8 +654,8 @@ under the License.
         <row-actions>
             <set field="totalName" value="${groovy: uiLabelMap.get(totalName)}"/>
         </row-actions>
-        <field name="totalName" title="${uiLabelMap.CommonTotal}" title-area-style="tableheadhuge"><display description="${totalName}"/></field>
-        <field name="balance" title="_" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="totalName" title="${uiLabelMap.CommonTotal}" title-area-style="tableheadhuge listtitlestyle"><display description="${totalName}"/></field>
+        <field name="balance" title="_" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <form name="FindCashFlowTotals" type="single" target="TransactionTotals" title="Find list of cash flow totals"
         header-row-style="header-row" default-table-style="basic-table">
@@ -701,9 +701,9 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeCashFlowStatementOpeningCashBalancePdf" extends="ComparativeCashFlowStatementOpeningCashBalance">
         <field name="accountCode"><display/></field>
@@ -716,13 +716,13 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="D1" widget-style="tabletextright" title="${uiLabelMap.AccountingPeriod1Debit_Receipts}"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="C1" widget-style="tabletextright" title="${uiLabelMap.AccountingPeriod1Credit_Disbursement}"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="D2" widget-style="tabletextright" title="${uiLabelMap.AccountingPeriod2Debit_Receipts}"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="C2" widget-style="tabletextright" title="${uiLabelMap.AccountingPeriod2Credit_Disbursement}"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="D1" widget-area-style="tabletextright" title="${uiLabelMap.AccountingPeriod1Debit_Receipts}"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="C1" widget-area-style="tabletextright" title="${uiLabelMap.AccountingPeriod1Credit_Disbursement}"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="D2" widget-area-style="tabletextright" title="${uiLabelMap.AccountingPeriod2Debit_Receipts}"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="C2" widget-area-style="tabletextright" title="${uiLabelMap.AccountingPeriod2Credit_Disbursement}"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeCashFlowStatementPeriodCashBalancePdf" extends="ComparativeCashFlowStatementPeriodCashBalance">
         <field name="accountCode"><display/></field>
@@ -735,9 +735,9 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ComparativeCashFlowStatementClosingCashBalancePdf" extends="ComparativeCashFlowStatementClosingCashBalance">
         <field name="accountCode"><display/></field>
@@ -747,9 +747,9 @@ under the License.
         <row-actions>
             <set field="totalName" value="${groovy: uiLabelMap.get(totalName)}"/>
         </row-actions>
-        <field name="totalName" title-area-style="tableheadwide"><display description="${totalName}"/></field>
-        <field name="balance1" title="Period1" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="balance2" title="Period2" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="totalName" title-area-style="tableheadwide listtitlestyle"><display description="${totalName}"/></field>
+        <field name="balance1" title="Period1" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="balance2" title="Period2" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <!-- This is required to render the date range in the PDF: the two columns layout is not supported -->
     <form name="ComparativeCashFlowStatementParametersOneColumn" type="single" target="" header-row-style="header-row" default-table-style="basic-table">

--- a/applications/accounting/widget/ReportFinancialSummaryForms.xml
+++ b/applications/accounting/widget/ReportFinancialSummaryForms.xml
@@ -242,8 +242,8 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="BalanceSheetLiabilities" list-name="liabilityAccountBalanceList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
@@ -253,8 +253,8 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="BalanceSheetEquities" list-name="equityAccountBalanceList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
@@ -264,16 +264,16 @@ under the License.
                 <parameter param-name="organizationPartyId"/>
             </hyperlink>
         </field>
-        <field name="accountName" title-area-style="tableheadwide"><display description="${accountName}"/></field>
-        <field name="balance" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="accountName" title-area-style="tableheadwide listtitlestyle"><display description="${accountName}"/></field>
+        <field name="balance" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="BalanceTotals" list-name="balanceTotalList"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <row-actions>
             <set field="totalName" value="${groovy: uiLabelMap.get(totalName)}"/>
         </row-actions>
-        <field name="totalName" title="${uiLabelMap.CommonTotal}" title-area-style="tableheadhuge"><display description="${totalName}"/></field>
-        <field name="balance" title="_" widget-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="totalName" title="${uiLabelMap.CommonTotal}" title-area-style="tableheadhuge listtitlestyle"><display description="${totalName}"/></field>
+        <field name="balance" title="_" widget-area-style="tabletextright"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <form name="ComparativeBalanceSheetParameters" type="single" target="ComparativeBalanceSheet"
         header-row-style="header-row" default-table-style="basic-table">

--- a/applications/accounting/widget/ReportFinancialSummaryScreens.xml
+++ b/applications/accounting/widget/ReportFinancialSummaryScreens.xml
@@ -286,13 +286,13 @@ under the License.
                         <container>
                             <label style="h1" text="${uiLabelMap.AccountingBalanceSheet}"/>
                             <include-form name="BalanceSheetParameters" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
-                            <label style="h3" text="${uiLabelMap.AccountingAssets}"/>
+                            <label style="h2" text="${uiLabelMap.AccountingAssets}"/>
                             <include-grid name="BalanceSheetAssets" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
-                            <label style="h3" text="${uiLabelMap.AccountingLiabilities}"/>
+                            <label style="h2" text="${uiLabelMap.AccountingLiabilities}"/>
                             <include-grid name="BalanceSheetLiabilities" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
-                            <label style="h3" text="${uiLabelMap.AccountingEquities}"/>
+                            <label style="h2" text="${uiLabelMap.AccountingEquities}"/>
                             <include-grid name="BalanceSheetEquities" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
-                            <label style="h3" text="${uiLabelMap.CommonTotal}"/>
+                            <label style="h2" text="${uiLabelMap.CommonTotal}"/>
                             <include-grid name="BalanceTotals" location="component://accounting/widget/ReportFinancialSummaryForms.xml"/>
                         </container>
                     </decorator-section>

--- a/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
@@ -64,7 +64,7 @@ under the License.
 <#macro renderCheckField items className alert id currentValue name event action conditionGroup tabindex disabled allChecked=""><@makeBlock "" "" /></#macro>
 <#macro renderRadioField items className alert currentValue noCurrentSelectedKey name event action conditionGroup tabindex disabled><@makeBlock "" "" /></#macro>
 
-<#macro renderSubmitField buttonType className alert formName action imgSrc ajaxUrl id title="" name="" event="" confirmation="" containerId="" tabindex="" disabled=false><@makeBlock "" "" /></#macro>
+<#macro renderSubmitField buttonType className alert formName action imgSrc ajaxUrl id title="" name="" event="" confirmation="" containerId="" tabindex="" disabled=false closeOnSubmit="true"><@makeBlock "" "" /></#macro>
 <#macro renderResetField className alert name title><@makeBlock "" "" /></#macro>
 
 <#macro renderHiddenField name conditionGroup="" value="" id="" event="" action="" disabled=false><!--hidden--></#macro>

--- a/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
@@ -20,7 +20,7 @@ under the License.
     <#local foStyles = {
         "listtitlestyle":"font-weight=\"bold\" text-align=\"center\" border=\"solid black\" padding=\"2pt\"",
         "tabletext":"border-left=\"solid black\" border-right=\"solid black\" padding-left=\"2pt\" padding-top=\"2pt\"",
-        "tabletextright":"border-left=\"solid black\" border-right=\"solid black\" padding-left=\"2pt\" padding-top=\"2pt\" text-align=\"right\"",
+        "tabletextright":"border-left=\"solid black\" border-right=\"solid black\" padding-left=\"2pt\" padding-top=\"2pt\" padding-right=\"2pt\" text-align=\"right\"",
         "tableheadverysmall":"column-width=\"0.3in\"",
         "tableheadsmall":"column-width=\"0.5in\"",
         "tableheadmedium":"column-width=\"1.5in\"",

--- a/themes/common-theme/template/macro/FoScreenMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/FoScreenMacroLibrary.ftl
@@ -28,8 +28,8 @@ under the License.
         "head2":"font-weight=\"bold\"",
         "head3":"font-weight=\"bold\" font-style=\"italic\"",
         "h1":"font-size=\"12\" font-weight=\"bold\"",
-        "h2":"font-weight=\"bold\"",
-        "h3":"font-weight=\"bold\" font-style=\"italic\"",
+        "h2":"font-size=\"10\" font-weight=\"bold\" padding-top=\"10pt\" padding-bottom=\"4pt\"",
+        "h3":"font-weight=\"bold\" font-style=\"italic\" padding-top=\"10pt\" padding-bottom=\"4pt\"",
         "error":"color=\"red\""}/>
     <#list style?split(' ') as styleItem>
         <#local foStyle = foStyles[styleItem]?default("")/>


### PR DESCRIPTION
Fixed parameter list of renderSubmitField FTL macro used when producing Formatting Objects (XSL) used to create a PDF. Parameter list was missing parameter, closeOnSubmit.

Adjusted styling of widgets used in the screens and forms used for PDF rendering. Changes ensure consistent header styling and application of padding to aid readability of right-aligned columns.