### PR TITLE
Improved: Menu-items of EditGlAcctgTransSubTabBar are visible to user with only VIIEW PERMISSIONS (OFBIZ-12916)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -1038,6 +1038,11 @@ under the License.
     </menu>
     <menu name="EditGlAcctgTransSubTabBar" menu-container-style="button-bar button-style-2" default-selected-style="selected">
         <menu-item name="DuplicateAccountingTransaction">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
             <link text="${uiLabelMap.AccountingDuplicateAccountingTransaction}" style="buttontext" target="copyAcctgTransAndEntries">
                 <parameter param-name="revert" value="N"/>
                 <parameter param-name="fromAcctgTransId" from-field="acctgTransId"/>
@@ -1045,6 +1050,11 @@ under the License.
             </link>
         </menu-item>
         <menu-item name="RevertAccountingTransaction">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
             <link text="${uiLabelMap.AccountingRevertAccountingTransaction}" style="buttontext" target="copyAcctgTransAndEntries">
                 <parameter param-name="revert" value="Y"/>
                 <parameter param-name="fromAcctgTransId" from-field="acctgTransId"/>


### PR DESCRIPTION
The menu-items of the EditGlAcctgTransSubTabBar with en-US translated labels Duplicate Accounting Transaction
Revert Accounting Transaction
are visible to a user with only VIEW permissions, like 'auditor' This should not be.

modifiied: AccountingMenus.xml
- added permission conditions to menu-items DuplicateAccountiingTransaction, RevertAccountingTransactiion
