### PR TITLE
Improved: Move Create Agreement action trigger to MainActionsMenu (OFBIZ-12917)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -95,6 +95,14 @@ under the License.
             </condition>
             <link target="EditBillingAccount"/>
         </menu-item>
+        <menu-item name="NewAgreement" title="${uiLabelMap.CommonNew} ${uiLabelMap.AccountingAgreement}">
+            <condition>
+                <or>
+                    <if-has-permission permission="ACCOUNTING" action="_CREATE"/>
+                </or>
+            </condition>
+            <link target="EditBillingAccount"/>
+        </menu-item>
     </menu>
 
     <menu name="AccountingShortcutAppBar" title="${uiLabelMap.AccountingManager}">

--- a/applications/accounting/widget/AgreementScreens.xml
+++ b/applications/accounting/widget/AgreementScreens.xml
@@ -96,7 +96,7 @@ under the License.
                                 <if-service-permission service-name="acctgAgreementPermissionCheck" main-action="VIEW"/>
                             </condition>
                             <widgets>
-                                <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml"
+                                <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                                     <decorator-section name="search-options">
                                         <include-form name="FindAgreements" location="component://accounting/widget/AgreementForms.xml"/>
                                     </decorator-section>

--- a/applications/accounting/widget/AgreementScreens.xml
+++ b/applications/accounting/widget/AgreementScreens.xml
@@ -67,9 +67,6 @@ under the License.
                                                 <include-menu name="AgreementItemTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
                                             </widgets>
                                         </section>
-                                        <container style="button-bar">
-                                            <link target="EditAgreement" text="${uiLabelMap.CommonCreate}" style="buttontext create"/>
-                                        </container>
                                     </widgets>
                                 </section>
                                 <decorator-section-include name="body"/>
@@ -99,12 +96,7 @@ under the License.
                                 <if-service-permission service-name="acctgAgreementPermissionCheck" main-action="VIEW"/>
                             </condition>
                             <widgets>
-                                <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                                    <decorator-section name="menu-bar">
-                                        <container style="button-bar">
-                                            <link target="EditAgreement" text="${uiLabelMap.CommonCreate}" style="buttontext create"/>
-                                        </container>
-                                    </decorator-section>
+                                <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml"
                                     <decorator-section name="search-options">
                                         <include-form name="FindAgreements" location="component://accounting/widget/AgreementForms.xml"/>
                                     </decorator-section>


### PR DESCRIPTION
On the agreements search/find page and the agreement pages a create trigger exists. This should move too the MainActionMenu for a unified User Experience.

modified:
- AccountingMenus.xml: added menu-item with permission condition regarding the start of a new agreement
- AgreementScreens.xml: removed container with link target from CommonAgreementDecorator, and removed decorator-section menu-bar with container and link target from FindAgreement screen.
