### PR TITLE
Improved: Move from hard-code menu location to parameterized (OFBIZ-12918)

### DIFF
--- a/applications/accounting/webapp/accounting/WEB-INF/web.xml
+++ b/applications/accounting/webapp/accounting/WEB-INF/web.xml
@@ -43,6 +43,11 @@ under the License.
         <param-name>partyDecoratorLocation</param-name>
         <param-value>component://accounting/widget/CommonScreens.xml</param-value>
     </context-param>
+    <context-param>
+        <description>The location of the main *Menus XML file to be used in this webapp; referred to as a context variable in screen def XML files.</description>
+        <param-name>mainMenuLocation</param-name>
+        <param-value>component://accounting/widget/AccountingMenus.xml</param-value>
+    </context-param>
 
     <filter>
         <display-name>ControlFilter</display-name>

--- a/applications/accounting/widget/AgreementScreens.xml
+++ b/applications/accounting/widget/AgreementScreens.xml
@@ -34,7 +34,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <and>
@@ -44,7 +44,7 @@ under the License.
                             </condition>
                             <widgets>
                                 <label style="h1">${uiLabelMap.AccountingAgreement}: ${agreementId}</label>
-                                <include-menu name="AgreementTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="AgreementTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                         </section>
                     </decorator-section>
@@ -64,7 +64,7 @@ under the License.
                                                 <not><if-empty field="agreementItem"/></not>
                                             </condition>
                                             <widgets>
-                                                <include-menu name="AgreementItemTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                                <include-menu name="AgreementItemTabBar" location="${parameters.mainMenuLocation}"/>
                                             </widgets>
                                         </section>
                                     </widgets>

--- a/applications/accounting/widget/BillingAccountScreens.xml
+++ b/applications/accounting/widget/BillingAccountScreens.xml
@@ -26,7 +26,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <!-- do check for ACCOUNTING, _VIEW permission -->
                             <condition>
@@ -39,7 +39,7 @@ under the License.
                                     </condition>
                                     <widgets>
                                         <label style="h1">${uiLabelMap.AccountingBillingAccount}: ${billingAccount.billingAccountId}</label>
-                                        <include-menu name="BillingAccountTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                        <include-menu name="BillingAccountTabBar" location="${parameters.mainMenuLocation}"/>
                                     </widgets>
                                 </section>
                             </widgets>

--- a/applications/accounting/widget/BudgetScreens.xml
+++ b/applications/accounting/widget/BudgetScreens.xml
@@ -90,7 +90,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="${parameters.mainMenuLocation}" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <not><if-empty field="budgetId"/></not>

--- a/applications/accounting/widget/BudgetScreens.xml
+++ b/applications/accounting/widget/BudgetScreens.xml
@@ -31,7 +31,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
@@ -90,13 +90,13 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu location="${parameters.mainMenuLocation}" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <not><if-empty field="budgetId"/></not>
                             </condition>
                             <widgets>
-                                <include-menu name="BudgetTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="BudgetTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                         </section>
                         <decorator-section-include name="pre-body"/>
@@ -109,7 +109,7 @@ under the License.
                                         <not><if-empty field="budgetId"/></not>
                                     </condition>
                                     <widgets>
-                                        <include-menu name="BudgetSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                        <include-menu name="BudgetSubTabBar" location="${parameters.mainMenuLocation}"/>
                                         <label style="h1" text="Budget : [${budgetId}]"/>
                                     </widgets>
                                 </section>

--- a/applications/accounting/widget/CommonScreens.xml
+++ b/applications/accounting/widget/CommonScreens.xml
@@ -37,7 +37,7 @@ under the License.
                 <!--<set field="layoutSettings.headerImageUrl" value="/images/ofbiz_logo.png" global="true"/>-->
                 <set field="activeApp" value="accounting" global="true"/>
                 <set field="applicationMenuName" value="AccountingAppBar" global="true"/>
-                <set field="applicationMenuLocation" value="component://accounting/widget/AccountingMenus.xml" global="true"/>
+                <set field="applicationMenuLocation" value="${parameters.mainMenuLocation}" global="true"/>
                 <set field="applicationTitle" from-field="uiLabelMap.AccountingManagerApplication" global="true"/>
                 <set field="helpAnchor" from-field="helpAnchor" default-value="_accounting"/>
             </actions>
@@ -55,7 +55,7 @@ under the License.
             <widgets>
                 <decorator-screen name="ShortcutDecorator" location="component://common/widget/CommonScreens.xml">
                     <decorator-section name="body">
-                        <include-menu name="AccountingShortcutAppBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="AccountingShortcutAppBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                 </decorator-screen>
             </widgets>
@@ -70,7 +70,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainDecoratorLocation}"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="acctgFinAcctPermissionCheck" main-action="VIEW"/>
@@ -79,10 +79,10 @@ under the License.
                                 <section>
                                     <condition><not><if-empty field="finAccountId"/></not></condition>
                                     <widgets>
-                                        <include-menu name="FinAccountTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                        <include-menu name="FinAccountTabBar" location="${parameters.mainMenuLocation}"/>
                                     </widgets>
                                     <fail-widgets>
-                                        <include-menu name="FinAccountMainTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                        <include-menu name="FinAccountMainTabBar" location="${parameters.mainMenuLocation}"/>
                                     </fail-widgets>
                                 </section>
                             </widgets>
@@ -111,14 +111,14 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="acctgBasePermissionCheck" main-action="VIEW"/>
                             </condition>
                             <widgets>
-                                <include-menu name="PaymentTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
-                                <include-menu name="PaymentSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="PaymentTabBar" location="${parameters.mainMenuLocation}"/>
+                                <include-menu name="PaymentSubTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                         </section>
                     </decorator-section>
@@ -134,7 +134,7 @@ under the License.
                                             <not><if-empty field="paymentId"/></not>
                                         </condition>
                                         <widgets>
-                                            <include-menu name="PaymentSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                            <include-menu name="PaymentSubTabBar" location="${parameters.mainMenuLocation}"/>
                                             <label style="h1" text="${uiLabelMap[labelTitleProperty]} ${uiLabelMap.CommonId}:[${paymentId}]  ${${extraFunctionName}}"/>
                                         </widgets>
                                     </section>
@@ -163,7 +163,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <and>
@@ -173,8 +173,8 @@ under the License.
                             </condition>
                             <widgets>
                                 <label style="h1">${uiLabelMap.AccountingPaymentGroup}: ${paymentGroupId}</label>
-                                <include-menu name="PaymentGroupTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
-                                <include-menu name="PaymentGroupSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="PaymentGroupTabBar" location="${parameters.mainMenuLocation}"/>
+                                <include-menu name="PaymentGroupSubTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                             <fail-widgets>
                                 <label style="h1">${uiLabelMap.AccountingNewPaymentGroup}</label>
@@ -206,14 +206,14 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <not><if-empty field="organizationPartyId"/></not>
                             </condition>
                             <widgets>
                                 <label style="h1">${uiLabelMap[labelTitleProperty]} ${uiLabelMap.CommonFor}: ${currentOrganization.groupName} [${organizationPartyId}]</label>
-                                <include-menu name="PartyTopTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="PartyTopTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                         </section>
                     </decorator-section>
@@ -242,8 +242,8 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonPartyDecorator" location="${parameters.partyDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="OrganizationAccountingTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
-                        <include-menu name="OrganizationAccountingReportsTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="OrganizationAccountingTabBar" location="${parameters.mainMenuLocation}"/>
+                        <include-menu name="OrganizationAccountingReportsTabBar" location="${parameters.mainMenuLocation}"/>
                         <decorator-section-include name="body"/>
                     </decorator-section>
                 </decorator-screen>
@@ -261,8 +261,8 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonPartyDecorator" location="${parameters.partyDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="OrganizationAccountingTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
-                        <include-menu name="PartyAccountingChecksTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="OrganizationAccountingTabBar" location="${parameters.mainMenuLocation}"/>
+                        <include-menu name="PartyAccountingChecksTabBar" location="${parameters.mainMenuLocation}"/>
                         <label style="h1">${uiLabelMap.CommonFor}: ${currentOrganization.groupName} [${organizationPartyId}]</label>
                         <decorator-section-include name="checks-body"/>
                     </decorator-section>
@@ -299,7 +299,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingMainPage}">
@@ -325,8 +325,8 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
-                        <include-menu name="GlobalGLSettingMenus" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
+                        <include-menu name="GlobalGLSettingMenus" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <decorator-section-include name="body"/>

--- a/applications/accounting/widget/FinAccountScreens.xml
+++ b/applications/accounting/widget/FinAccountScreens.xml
@@ -32,7 +32,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="acctgFinAcctPermissionCheck" main-action="VIEW"/>
@@ -41,10 +41,10 @@ under the License.
                                 <section>
                                     <condition><not><if-empty field="finAccountId"/></not></condition>
                                     <widgets>
-                                        <include-menu name="FinAccountTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                        <include-menu name="FinAccountTabBar" location="${parameters.mainMenuLocation}"/>
                                     </widgets>
                                     <fail-widgets>
-                                        <include-menu name="FinAccountMainTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                        <include-menu name="FinAccountMainTabBar" location="${parameters.mainMenuLocation}"/>
                                     </fail-widgets>
                                 </section>
                             </widgets>
@@ -85,7 +85,7 @@ under the License.
                                 <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                                     <decorator-section name="menu-bar">
                                         <container style="button-bar">
-                                            <include-menu name="FinAccountSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                            <include-menu name="FinAccountSubTabBar" location="${parameters.mainMenuLocation}"/>
                                         </container>
                                     </decorator-section>
                                     <decorator-section name="search-options">
@@ -690,7 +690,7 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonFinAccountDecorator" location="${parameters.finAccountDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="FinAccountReconciliationsTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="FinAccountReconciliationsTabBar" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <if-empty field="glReconciliationId"/>
@@ -792,7 +792,7 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonFinAccountDecorator" location="${parameters.finAccountDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="FinAccountReconciliationsTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="FinAccountReconciliationsTabBar" location="${parameters.mainMenuLocation}"/>
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                             <decorator-section name="search-options">
                                 <include-form name="FindBankReconciliation" location="component://accounting/widget/FinAccountForms.xml"/>

--- a/applications/accounting/widget/FixedAssetScreens.xml
+++ b/applications/accounting/widget/FixedAssetScreens.xml
@@ -86,7 +86,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="${parameters.mainMenuLocation}" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <not><if-empty field="fixedAssetId"/></not>

--- a/applications/accounting/widget/FixedAssetScreens.xml
+++ b/applications/accounting/widget/FixedAssetScreens.xml
@@ -32,7 +32,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
@@ -86,13 +86,13 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu location="${parameters.mainMenuLocation}" name="MainActionMenu"/>
                         <section>
                             <condition>
                                 <not><if-empty field="fixedAssetId"/></not>
                             </condition>
                             <widgets>
-                                <include-menu name="FixedAssetTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="FixedAssetTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                         </section>
                         <decorator-section-include name="pre-body"/>
@@ -332,7 +332,7 @@ under the License.
                         <section>
                             <condition><not><if-empty field="maintHistSeqId"/></not></condition>
                             <widgets>
-                                <include-menu name="FixedAssetMaintTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="FixedAssetMaintTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                         </section>
                     </decorator-section>

--- a/applications/accounting/widget/GlScreens.xml
+++ b/applications/accounting/widget/GlScreens.xml
@@ -32,10 +32,10 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonPartyDecorator" location="${parameters.partyDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
-                        <include-menu name="OrganizationAccountingTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="OrganizationAccountingTabBar" location="${parameters.mainMenuLocation}"/>
                         <decorator-section-include name="body"/>
                     </decorator-section>
                 </decorator-screen>
@@ -59,7 +59,7 @@ under the License.
                         <section>
                             <widgets>
                                 <screenlet title="${uiLabelMap.AccountingPartyAccountsSummary}">
-                                <include-menu name="PartyGlShortCuts" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="PartyGlShortCuts" location="${parameters.mainMenuLocation}"/>
                                 </screenlet>
                             </widgets>
                         </section>
@@ -310,7 +310,7 @@ under the License.
                                 <not><if-empty field="acctgTransId"/></not>
                             </condition>
                             <widgets>
-                                <include-menu name="EditGlAcctgTransSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="EditGlAcctgTransSubTabBar" location="${parameters.mainMenuLocation}"/>
                                 <section>
                                     <condition>
                                         <if-compare field="acctgTrans.isPosted" operator="equals"  value="Y"/>

--- a/applications/accounting/widget/GlSetupScreens.xml
+++ b/applications/accounting/widget/GlSetupScreens.xml
@@ -33,13 +33,13 @@ under the License.
             <widgets>
                 <decorator-screen name="CommonPartyDecorator" location="${parameters.partyDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="PartyAdminTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="PartyAdminTabBar" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <if-compare field="tabButtonItem" operator="equals" value="GlAccountAssignment"/>
                             </condition>
                             <widgets>
-                                <include-menu name="PartyAdminAssignTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="PartyAdminAssignTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                         </section>
                         <decorator-section-include name="body"/>
@@ -68,11 +68,11 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu name="MainActionMenu" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingAvailableInternalOrganizations}" navigation-menu-name="NewAccountOrganization">
-                            <include-menu name="NewAccountOrganization" location="component://accounting/widget/AccountingMenus.xml"/>
+                            <include-menu name="NewAccountOrganization" location="${parameters.mainMenuLocation}"/>
                             <include-form name="ListCompanies" location="component://accounting/widget/GlSetupForms.xml"/>
                         </screenlet>
                     </decorator-section>
@@ -88,7 +88,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu name="MainActionMenu" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingNewCompany}">
@@ -110,7 +110,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu name="MainActionMenu" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.AccountingInvoice} ${uiLabelMap.CommonImportExport} ${uiLabelMap.CommonFor}: ${partyGroup.groupName} [${organizationPartyId}]">
@@ -687,7 +687,7 @@ under the License.
                             </condition>
                             <widgets>
                                 <container style="h1"><label>${uiLabelMap.FormFieldTitle_editGlAccountCategory}</label></container>
-                                <include-menu name="GlAccountCategoryTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="GlAccountCategoryTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                             <fail-widgets>
                                 <container style="h1"><label>${uiLabelMap.FormFieldTitle_newGlAccountCategory}</label></container>
@@ -712,7 +712,7 @@ under the License.
                     <decorator-section name="body">
                         <screenlet>
                             <container style="h1"><label>${uiLabelMap.FormFieldTitle_editGlAccountCategoryMember}</label></container>
-                            <include-menu name="GlAccountCategoryTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                            <include-menu name="GlAccountCategoryTabBar" location="${parameters.mainMenuLocation}"/>
                             <include-form  name="ListGlAccountCategoryMember" location="component://accounting/widget/GlSetupForms.xml"/>
                             <include-form name="AddGlAccountCategoryMember" location="component://accounting/widget/GlSetupForms.xml"/>
                         </screenlet>

--- a/applications/accounting/widget/GlobalGlAccountsScreens.xml
+++ b/applications/accounting/widget/GlobalGlAccountsScreens.xml
@@ -33,7 +33,7 @@ under the License.
                     <decorator-section name="body">
                         <section>
                             <widgets>
-                                <include-menu name="GlAccountTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="GlAccountTabBar" location="${parameters.mainMenuLocation}"/>
 
                                     <!-- label style="h1">List Accounts</label -->
                                     <label style="h1">${uiLabelMap[labelTitleProperty]}</label>
@@ -68,7 +68,7 @@ under the License.
                                 <if-has-permission permission="CATALOG" action="_VIEW"/>
                             </condition -->
                             <widgets>
-                                <include-menu name="GlAccountTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="GlAccountTabBar" location="${parameters.mainMenuLocation}"/>
                                 <label style="h1">${uiLabelMap[labelTitleProperty]} ${product.internalName} [${uiLabelMap.CommonId}:${productId}]</label>
                                 <decorator-section-include name="body"/>
                             </widgets>
@@ -98,7 +98,7 @@ under the License.
             <widgets>
                 <decorator-screen name="GlobalGLSettingsDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="GlSettingTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="GlSettingTabBar" location="${parameters.mainMenuLocation}"/>
                         <screenlet title="${uiLabelMap.AcctgAssignGlAccount}">
                             <include-form name="AssignGlAccount" location="component://accounting/widget/GlobalGlAccountsForms.xml"/>
                         </screenlet>
@@ -126,7 +126,7 @@ under the License.
             <widgets>
                 <decorator-screen name="GlobalGLSettingsDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="GlSettingTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="GlSettingTabBar" location="${parameters.mainMenuLocation}"/>
                         <screenlet title="${uiLabelMap.AcctgNavigateAccts}">
                             <include-tree name="GlAccountTree" location="component://accounting/widget/AccountingTrees.xml"/>
                         </screenlet>
@@ -178,7 +178,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="GlAccountTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="GlAccountTabBar" location="${parameters.mainMenuLocation}"/>
                         <screenlet title="${uiLabelMap.PageTitleViewAccountingTransaction}">
                             <include-tree name="ListGlAccountTree" location="component://accounting/widget/AccountingTrees.xml"/>
                         </screenlet>
@@ -233,7 +233,7 @@ under the License.
             <widgets>
                 <decorator-screen name="GlobalGLSettingsDecorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="body">
-                        <include-menu name="GlSettingTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="GlSettingTabBar" location="${parameters.mainMenuLocation}"/>
                         <screenlet title="${uiLabelMap[labelTitleProperty]}">
                             <container style="button-bar">
                                 <link target="ListGlAccountsReport" target-window="_blank" text="${uiLabelMap.CommonPrint}" style="buttontext"/>

--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -33,7 +33,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <condition>
                                 <if-service-permission service-name="acctgInvoicePermissionCheck" main-action="VIEW"/>
@@ -43,8 +43,8 @@ under the License.
                                     <condition><not><if-empty field="parameters.invoiceId"/></not></condition>
                                     <widgets>
                                         <label style="h1">${uiLabelMap.CommonInvoice}: ${invoiceId}</label>
-                                        <include-menu name="InvoiceTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
-                                        <include-menu name="InvoiceSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                        <include-menu name="InvoiceTabBar" location="${parameters.mainMenuLocation}"/>
+                                        <include-menu name="InvoiceSubTabBar" location="${parameters.mainMenuLocation}"/>
                                     </widgets>
                                 </section>
                             </widgets>
@@ -87,7 +87,7 @@ under the License.
                             <widgets>
                                 <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
                                     <decorator-section name="menu-bar">
-                                        <include-menu name="InvoiceSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                        <include-menu name="InvoiceSubTabBar" location="${parameters.mainMenuLocation}"/>
                                         <container style="clear"/>
                                     </decorator-section>
                                     <decorator-section name="search-options">

--- a/applications/accounting/widget/PaymentGatewayConfigScreens.xml
+++ b/applications/accounting/widget/PaymentGatewayConfigScreens.xml
@@ -30,8 +30,8 @@ under the License.
                 <!-- main defines the regions of the HTML page -->
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
-                        <include-menu name="PaymentGatewayConfigTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
+                        <include-menu name="PaymentGatewayConfigTabBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <section>

--- a/applications/accounting/widget/PaymentGroupScreens.xml
+++ b/applications/accounting/widget/PaymentGroupScreens.xml
@@ -34,7 +34,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <section>

--- a/applications/accounting/widget/PaymentScreens.xml
+++ b/applications/accounting/widget/PaymentScreens.xml
@@ -29,14 +29,14 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                         <section>
                             <widgets>
                                 <container style="leftclear">
                                     <label style="h1" text="${uiLabelMap.CommonPayment}: ${paymentId}"/>
                                 </container>
-                                <include-menu name="PaymentTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
-                                <include-menu name="PaymentSubTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                                <include-menu name="PaymentTabBar" location="${parameters.mainMenuLocation}"/>
+                                <include-menu name="PaymentSubTabBar" location="${parameters.mainMenuLocation}"/>
                             </widgets>
                         </section>
                     </decorator-section>

--- a/applications/accounting/widget/TaxAuthorityScreens.xml
+++ b/applications/accounting/widget/TaxAuthorityScreens.xml
@@ -34,7 +34,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
                         <section>

--- a/applications/accounting/widget/TransactionScreens.xml
+++ b/applications/accounting/widget/TransactionScreens.xml
@@ -31,8 +31,8 @@ under the License.
                 <!-- main defines the regions of the HTML page -->
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
-                        <include-menu location="component://accounting/widget/AccountingMenus.xml" name="MainActionMenu"/>
-                        <include-menu name="TransactionsTabBar" location="component://accounting/widget/AccountingMenus.xml"/>
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
+                        <include-menu name="TransactionsTabBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
 
                     <!-- body is the primary display for this page and is called recursively -->


### PR DESCRIPTION
Customization is a key aspect of the OFBiz (Open For Business) platform, providing businesses with a robust and adaptable base to customize their enterprise software solutions according to their unique operational requirements. The *Menus.xml file of a component, essential for designing user interfaces that are both intuitive and tailored to the specific roles and tasks of its users, plays a significant role in this context, as referenced within screen widgets and Freemarker templates. However, as customizations and the project's source code evolve over time, the likelihood of encountering merge conflicts increases significantly, especially when attempting to incorporate customizations alongside ongoing bug fixes and enhancements from the project. To improve the appeal of OFbiz and the developer experience, it is recommended to shift from fixed menu locations to a parameterized approach in our components and plugins. This change would enable developers to more seamlessly incorporate a 'custom' menu, facilitating the integration of project updates.

modified:
- accounting/WEB-INF/web.xml: added parameter for mainMenuLocation 
- various *Screens.xml files: changing location of 'include-menu' elements from location="component://accounting/widget/AccountingMenus.xml to location="${parameters.mainMenuLocation}"
