### PR TITLE
Improved: allow uploading ZUGFeRD compliant pdf files (OFBIZ-12920)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,6 +268,7 @@ dependencies {
     implementation 'org.jdom:jdom:1.1.3' // don't upgrade above 1.1.3, makes a lot of not obvious and useless complications, see last commits of OFBIZ-12092 for more
     implementation 'com.google.re2j:re2j:1.7'
     implementation 'xerces:xercesImpl:2.12.2'
+    implementation 'org.mustangproject:library:2.8.0'
 
 
     testImplementation 'org.hamcrest:hamcrest-library:2.2' // Enable junit4 to not depend on hamcrest-1.3

--- a/framework/security/config/security.properties
+++ b/framework/security/config/security.properties
@@ -283,7 +283,7 @@ allowStringConcatenationInUploadedFiles=false
 maxLineLength=
 
 # Allow uploading non-empty pdf files as long as they are ZUGFeRD compliant
-#allowZUGFeRDCompliantUpload=false
+allowZUGFeRDCompliantUpload=true
 
 #-- Popup last-visited time from database after user has logged in.
 #-- So users can know of any unauthorised access to their accounts.

--- a/framework/security/config/security.properties
+++ b/framework/security/config/security.properties
@@ -282,6 +282,9 @@ allowStringConcatenationInUploadedFiles=false
 #-- Max line length for uploaded files, by default 10000
 maxLineLength=
 
+# Allow uploading non-empty pdf files as long as they are ZUGFeRD compliant
+#allowZUGFeRDCompliantUpload=false
+
 #-- Popup last-visited time from database after user has logged in.
 #-- So users can know of any unauthorised access to their accounts.
 #-- Default is false.

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -87,6 +88,7 @@ import org.apache.tika.parser.RecursiveParserWrapper;
 import org.apache.tika.sax.BasicContentHandlerFactory;
 import org.apache.tika.sax.ContentHandlerFactory;
 import org.apache.tika.sax.RecursiveParserWrapperHandler;
+import org.mustangproject.ZUGFeRD.ZUGFeRDImporter;
 import org.xml.sax.SAXException;
 
 import com.lowagie.text.pdf.PdfReader;
@@ -470,6 +472,7 @@ public class SecuredUpload {
     private static boolean isValidPdfFile(String fileName) throws IOException {
         File file = new File(fileName);
         boolean safeState = false;
+        boolean canParse = false;
         try {
             if ((file != null) && file.exists()) {
                 // Load stream in PDF parser
@@ -484,7 +487,11 @@ public class SecuredUpload {
                         PDDocumentNameDictionary names = new PDDocumentNameDictionary(pdDocument.getDocumentCatalog());
                         efTree = names.getEmbeddedFiles();
                     }
-                    safeState = efTree == null;
+                    if (UtilProperties.getPropertyAsBoolean("security", "allowZUGFeRDCompliantUpload", false)) {
+                        ZUGFeRDImporter importer = new ZUGFeRDImporter(file.getAbsolutePath());
+                        canParse = importer.canParse();
+                    }
+                    safeState = Objects.isNull(efTree) || canParse;
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Improved: Allow uploading non-empty pdf files.

Use ZUGFeRD parser to validate those files. Can be configured in security.properties.
See https://github.com/ZUGFeRD/mustangproject for more information.