### PR TITLE
Improved: Have library dependencies moved to a dependencies.gradle file (OFBIZ-10924)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ if (project.hasProperty('enableDependencyUpdates')) {
 }
 
 apply from: 'common.gradle'
+apply from: 'dependencies.gradle'
 
 // global properties
 ext.os = System.getProperty('os.name').toLowerCase()

--- a/build.gradle
+++ b/build.gradle
@@ -205,91 +205,6 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
-    implementation 'com.google.zxing:core:3.5.3'
-    implementation 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2'
-    implementation 'com.googlecode.ez-vcard:ez-vcard:0.11.3' // 0.12.1 does not compile
-    implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1'
-    implementation 'com.googlecode.libphonenumber:libphonenumber:8.13.31'
-    implementation 'com.ibm.icu:icu4j:74.2'
-    implementation ('com.lowagie:itext:2.1.7') { // Don't update due to license change in newer versions, see OFBIZ-10455
-        exclude  group: 'bouncycastle', module: 'bcmail-jdk14'
-        exclude  group: 'bouncycastle', module: 'bcprov-jdk14'
-        exclude  group: 'bouncycastle', module: 'bctsp-jdk14'
-    }
-    implementation 'com.sun.mail:javax.mail:1.6.2'
-    implementation 'com.rometools:rome:2.1.0'
-    implementation 'com.thoughtworks.xstream:xstream:1.4.20'
-    implementation 'commons-cli:commons-cli:1.5.0' // with 1.6.0, 2 tests of OfbizStartupUnitTests don't pass
-    implementation 'commons-fileupload:commons-fileupload:1.5'
-    implementation 'commons-net:commons-net:3.10.0'
-    implementation 'commons-validator:commons-validator:1.8.0'
-    implementation 'de.odysseus.juel:juel-impl:2.2.7'
-    implementation 'javax.transaction:javax.transaction-api:1.3'
-    implementation 'net.fortuna.ical4j:ical4j:1.0-rc4-atlassian-12'
-    implementation 'net.lingala.zip4j:zip4j:2.11.5'
-    implementation 'org.apache.ant:ant-junit:1.10.14'
-    implementation 'org.apache.commons:commons-collections4:4.4'
-    implementation 'org.apache.commons:commons-csv:1.10.0'
-    implementation 'org.apache.commons:commons-dbcp2:2.10.0'// 2.11.0 does not compile.
-    implementation 'org.apache.commons:commons-imaging:1.0-alpha3' // Alpha but OK, "Imaging was working and was used by a number of projects in production even before reaching its initial release as an Apache Commons component."
-    implementation 'org.apache.commons:commons-text:1.11.0'
-    implementation 'org.apache.geronimo.components:geronimo-transaction:3.1.5' // 4.0.0 does not compile
-    implementation 'org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1'
-    implementation 'org.apache.httpcomponents:httpclient-cache:4.5.14'
-    implementation 'org.apache.logging.log4j:log4j-api:2.20.0' // the API of log4j 2
-    implementation 'org.apache.logging.log4j:log4j-core:2.20.0' // Somehow needed by Buildbot to compile OFBizDynamicThresholdFilter.java
-    implementation 'org.apache.poi:poi:4.1.2' // poi-ooxml-schemas-5.0.0.pom'. Received status code 401 from server
-    implementation 'org.apache.pdfbox:pdfbox:2.0.29' // 3.0.1 does not compile
-    implementation 'org.apache.shiro:shiro-core:1.13.0'
-    implementation 'org.apache.sshd:sshd-core:2.10.0'
-    implementation 'org.apache.sshd:sshd-sftp:2.10.0'
-    implementation 'org.apache.tika:tika-core:2.5.0'
-    implementation 'org.apache.tika:tika-parsers:2.5.0'
-    implementation 'org.apache.tika:tika-parser-pdf-module:2.5.0'
-    implementation 'org.apache.cxf:cxf-rt-frontend-jaxrs:3.5.6' // 4.0.3 does not compile
-    implementation 'org.apache.tomcat:tomcat-catalina-ha:9.0.82' // Remember to change the version number (9 now) in javadoc block if needed.
-    implementation 'org.apache.tomcat:tomcat-jasper:9.0.82'
-    implementation 'org.apache.axis2:axis2-kernel:1.8.2'
-    implementation 'org.apache.xmlgraphics:batik-anim:1.17'
-    implementation 'org.apache.xmlgraphics:batik-util:1.17'
-    implementation 'org.apache.xmlgraphics:batik-bridge:1.17'
-    implementation 'org.apache.xmlgraphics:fop:2.3' // NOTE: since 2.4 dependencies are messed up. See https://github.com/moqui/moqui-fop/blob/master/build.gradle
-    implementation 'org.clojure:clojure:1.11.1'
-    implementation 'org.codehaus.groovy:groovy-all:3.0.20'
-    implementation 'org.freemarker:freemarker:2.3.32' // Remember to change the version number in FreeMarkerWorker class when upgrading. See OFBIZ-10019 if >= 2.4
-    implementation 'org.owasp.esapi:esapi:2.5.3.1'
-    implementation 'org.cyberneko:html:1.9.8'
-    implementation 'org.springframework:spring-test:5.3.29' //  6.1.4 does not compile
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-    implementation 'oro:oro:2.0.8'
-    implementation 'wsdl4j:wsdl4j:1.6.3'
-    implementation 'com.auth0:java-jwt:4.4.0'
-    implementation 'org.jdom:jdom:1.1.3' // don't upgrade above 1.1.3, makes a lot of not obvious and useless complications, see last commits of OFBIZ-12092 for more
-    implementation 'com.google.re2j:re2j:1.7'
-    implementation 'xerces:xercesImpl:2.12.2'
-    implementation 'org.mustangproject:library:2.8.0' // 2.10.0 did not work, cf. OFBIZ-12920 (https://github.com/apache/ofbiz-framework/pull/712#issuecomment-1968960963)
-
-
-    testImplementation 'org.hamcrest:hamcrest-library:2.2' // Enable junit4 to not depend on hamcrest-1.3
-    testImplementation 'org.mockito:mockito-core:5.10.0'
-    testImplementation 'org.jmockit:jmockit:1.49'
-    testImplementation 'com.pholser:junit-quickcheck-generators:1.0'
-
-    runtimeOnly 'javax.xml.soap:javax.xml.soap-api:1.4.0'
-    runtimeOnly 'de.odysseus.juel:juel-spi:2.2.7'
-    runtimeOnly 'net.sf.barcode4j:barcode4j-fop-ext:2.1'
-    runtimeOnly 'net.sf.barcode4j:barcode4j:2.1'
-    runtimeOnly 'org.apache.axis2:axis2-transport-http:1.8.2'
-    runtimeOnly 'org.apache.axis2:axis2-transport-local:1.8.2'
-    runtimeOnly 'org.apache.derby:derby:10.14.2.0' // 10.17.1.0 does not compile
-    runtimeOnly 'org.apache.geronimo.specs:geronimo-jaxrpc_1.1_spec:2.1'
-    runtimeOnly 'org.apache.logging.log4j:log4j-1.2-api:2.20.0' // for external jars using the old log4j1.2: routes logging to log4j 2
-    runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.20.0' // for external jars using the java.util.logging: routes logging to log4j 2
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0' // for external jars using slf4j: routes logging to log4j 2
-    runtimeOnly 'org.apache.logging.log4j:log4j-web:2.20.0' //???
-    runtimeOnly 'org.apache.logging.log4j:log4j-jcl:2.20.0' // need to constrain to version to avoid classpath conflict (ReflectionUtil)
-
     // Dependencies defined by the plugins
     subprojects.each { subProject ->
         implementation project(path: subProject.path, configuration: 'pluginLibsCompile')
@@ -305,8 +220,6 @@ dependencies {
     getDirectoryInActiveComponentsIfExists('lib').each { libDir ->
         implementation fileTree(dir: libDir, include: '**/*.jar')
     }
-    // specify last codenarc version for java 17 compliance
-    codenarc('org.codenarc:CodeNarc:3.4.0')
 }
 
 def excludedJavaSources = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+dependencies {
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    implementation 'com.google.zxing:core:3.5.3'
+    implementation 'com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2'
+    implementation 'com.googlecode.ez-vcard:ez-vcard:0.11.3' // 0.12.1 does not compile
+    implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.13.31'
+    implementation 'com.ibm.icu:icu4j:74.2'
+    implementation ('com.lowagie:itext:2.1.7') { // Don't update due to license change in newer versions, see OFBIZ-10455
+        exclude  group: 'bouncycastle', module: 'bcmail-jdk14'
+        exclude  group: 'bouncycastle', module: 'bcprov-jdk14'
+        exclude  group: 'bouncycastle', module: 'bctsp-jdk14'
+    }
+    implementation 'com.sun.mail:javax.mail:1.6.2'
+    implementation 'com.rometools:rome:2.1.0'
+    implementation 'com.thoughtworks.xstream:xstream:1.4.20'
+    implementation 'commons-cli:commons-cli:1.5.0' // with 1.6.0, 2 tests of OfbizStartupUnitTests don't pass
+    implementation 'commons-fileupload:commons-fileupload:1.5'
+    implementation 'commons-net:commons-net:3.10.0'
+    implementation 'commons-validator:commons-validator:1.8.0'
+    implementation 'de.odysseus.juel:juel-impl:2.2.7'
+    implementation 'javax.transaction:javax.transaction-api:1.3'
+    implementation 'net.fortuna.ical4j:ical4j:1.0-rc4-atlassian-12'
+    implementation 'net.lingala.zip4j:zip4j:2.11.5'
+    implementation 'org.apache.ant:ant-junit:1.10.14'
+    implementation 'org.apache.commons:commons-collections4:4.4'
+    implementation 'org.apache.commons:commons-csv:1.10.0'
+    implementation 'org.apache.commons:commons-dbcp2:2.10.0'// 2.11.0 does not compile.
+    implementation 'org.apache.commons:commons-imaging:1.0-alpha3' // Alpha but OK, "Imaging was working and was used by a number of projects in production even before reaching its initial release as an Apache Commons component."
+    implementation 'org.apache.commons:commons-text:1.11.0'
+    implementation 'org.apache.geronimo.components:geronimo-transaction:3.1.5' // 4.0.0 does not compile
+    implementation 'org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1'
+    implementation 'org.apache.httpcomponents:httpclient-cache:4.5.14'
+    implementation 'org.apache.logging.log4j:log4j-api:2.20.0' // the API of log4j 2
+    implementation 'org.apache.logging.log4j:log4j-core:2.20.0' // Somehow needed by Buildbot to compile OFBizDynamicThresholdFilter.java
+    implementation 'org.apache.poi:poi:4.1.2' // poi-ooxml-schemas-5.0.0.pom'. Received status code 401 from server
+    implementation 'org.apache.pdfbox:pdfbox:2.0.29' // 3.0.1 does not compile
+    implementation 'org.apache.shiro:shiro-core:1.13.0'
+    implementation 'org.apache.sshd:sshd-core:2.10.0'
+    implementation 'org.apache.sshd:sshd-sftp:2.10.0'
+    implementation 'org.apache.tika:tika-core:2.5.0'
+    implementation 'org.apache.tika:tika-parsers:2.5.0'
+    implementation 'org.apache.tika:tika-parser-pdf-module:2.5.0'
+    implementation 'org.apache.cxf:cxf-rt-frontend-jaxrs:3.5.6' // 4.0.3 does not compile
+    implementation 'org.apache.tomcat:tomcat-catalina-ha:9.0.82' // Remember to change the version number (9 now) in javadoc block if needed.
+    implementation 'org.apache.tomcat:tomcat-jasper:9.0.82'
+    implementation 'org.apache.axis2:axis2-kernel:1.8.2'
+    implementation 'org.apache.xmlgraphics:batik-anim:1.17'
+    implementation 'org.apache.xmlgraphics:batik-util:1.17'
+    implementation 'org.apache.xmlgraphics:batik-bridge:1.17'
+    implementation 'org.apache.xmlgraphics:fop:2.3' // NOTE: since 2.4 dependencies are messed up. See https://github.com/moqui/moqui-fop/blob/master/build.gradle
+    implementation 'org.clojure:clojure:1.11.1'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.20'
+    implementation 'org.freemarker:freemarker:2.3.32' // Remember to change the version number in FreeMarkerWorker class when upgrading. See OFBIZ-10019 if >= 2.4
+    implementation 'org.owasp.esapi:esapi:2.5.3.1'
+    implementation 'org.cyberneko:html:1.9.8'
+    implementation 'org.springframework:spring-test:5.3.29' //  6.1.4 does not compile
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'oro:oro:2.0.8'
+    implementation 'wsdl4j:wsdl4j:1.6.3'
+    implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'org.jdom:jdom:1.1.3' // don't upgrade above 1.1.3, makes a lot of not obvious and useless complications, see last commits of OFBIZ-12092 for more
+    implementation 'com.google.re2j:re2j:1.7'
+    implementation 'xerces:xercesImpl:2.12.2'
+    implementation 'org.mustangproject:library:2.8.0' // 2.10.0 did not work, cf. OFBIZ-12920 (https://github.com/apache/ofbiz-framework/pull/712#issuecomment-1968960963)
+
+
+    testImplementation 'org.hamcrest:hamcrest-library:2.2' // Enable junit4 to not depend on hamcrest-1.3
+    testImplementation 'org.mockito:mockito-core:5.10.0'
+    testImplementation 'org.jmockit:jmockit:1.49'
+    testImplementation 'com.pholser:junit-quickcheck-generators:1.0'
+
+    runtimeOnly 'javax.xml.soap:javax.xml.soap-api:1.4.0'
+    runtimeOnly 'de.odysseus.juel:juel-spi:2.2.7'
+    runtimeOnly 'net.sf.barcode4j:barcode4j-fop-ext:2.1'
+    runtimeOnly 'net.sf.barcode4j:barcode4j:2.1'
+    runtimeOnly 'org.apache.axis2:axis2-transport-http:1.8.2'
+    runtimeOnly 'org.apache.axis2:axis2-transport-local:1.8.2'
+    runtimeOnly 'org.apache.derby:derby:10.14.2.0' // 10.17.1.0 does not compile
+    runtimeOnly 'org.apache.geronimo.specs:geronimo-jaxrpc_1.1_spec:2.1'
+    runtimeOnly 'org.apache.logging.log4j:log4j-1.2-api:2.20.0' // for external jars using the old log4j1.2: routes logging to log4j 2
+    runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.20.0' // for external jars using the java.util.logging: routes logging to log4j 2
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0' // for external jars using slf4j: routes logging to log4j 2
+    runtimeOnly 'org.apache.logging.log4j:log4j-web:2.20.0' //???
+    runtimeOnly 'org.apache.logging.log4j:log4j-jcl:2.20.0' // need to constrain to version to avoid classpath conflict (ReflectionUtil)
+
+    // specify last codenarc version for java 17 compliance
+    codenarc('org.codenarc:CodeNarc:3.4.0')
+}


### PR DESCRIPTION
Currently the libraries needed by ofbiz are defined in the build.gradle file. These should reside in a separate dependencies.gradle file that is referenced in the build.gradle file, like the common.gradle. As is common practice in other projects/solutions that work with dependencies on external libraries.

modified:

build.gradle: removed implementation, testImplementation and runtimeOnly library dependencies added: dependencies.gradle, having the implementation, testImplementation and runtimeOnly library dependencies