### PR TITLE
Improved: MFG-Move from hard-code menu location to parameterized (OFBIZ-12928)

### DIFF
--- a/applications/manufacturing/webapp/manufacturing/WEB-INF/web.xml
+++ b/applications/manufacturing/webapp/manufacturing/WEB-INF/web.xml
@@ -43,6 +43,11 @@ under the License.
         <param-name>commonManufacturingDecoratorLocation</param-name>
         <param-value>component://manufacturing/widget/manufacturing/CommonScreens.xml</param-value>
     </context-param>
+    <context-param>
+        <description>The location of the menus file to be used in this webapp; referred to as a context variable in screen def XML files.</description>
+        <param-name>mainMenuLocation</param-name>
+        <param-value>component://manufacturing/widget/manufacturing/ManufacturingMenus.xml</param-value>
+    </context-param>
 
     <filter>
         <display-name>ControlFilter</display-name>

--- a/applications/manufacturing/widget/manufacturing/BomScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/BomScreens.xml
@@ -31,7 +31,7 @@ under the License.
                                 <if-has-permission permission="MANUFACTURING" action="_VIEW"/>
                             </condition>
                             <widgets>
-                                <include-menu name="BomTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                                <include-menu name="BomTabBar" location="${parameters.mainMenuLocation}"/>
                                 <container style="button-bar"><link target="EditProductBom" text="${uiLabelMap.ManufacturingCreateBom}" style="buttontext"/></container>
                                 <decorator-section-include name="body"/>
                             </widgets>

--- a/applications/manufacturing/widget/manufacturing/CalendarScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/CalendarScreens.xml
@@ -27,7 +27,7 @@ under the License.
                     <decorator-section name="body">
                         <section>
                             <widgets>
-                                <include-menu name="CalendarTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                                <include-menu name="CalendarTabBar" location="${parameters.mainMenuLocation}"/>
                                 <container style="button-bar">
                                     <link style="buttontext" target="EditCalendar" text="${uiLabelMap.ManufacturingNewCalendar}"/>
                                     <link style="buttontext" target="EditCalendarWeek" text="${uiLabelMap.ManufacturingNewCalendarWeek}"/>

--- a/applications/manufacturing/widget/manufacturing/CommonScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/CommonScreens.xml
@@ -41,7 +41,7 @@ under the License.
                 <!-- <set field="layoutSettings.headerRightBackgroundUrl" value="" global="true"/> -->
                 <set field="activeApp" value="manufacturing" global="true"/>
                 <set field="applicationMenuName" value="ManufacturingAppBar" global="true"/>
-                <set field="applicationMenuLocation" value="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml" global="true"/>
+                <set field="applicationMenuLocation" value="${parameters.mainMenuLocation}" global="true"/>
                 <set field="applicationTitle" from-field="uiLabelMap.ManufacturingManagerApplication" global="true"/>
                 <set field="helpAnchor" from-field="helpAnchor" default-value="_manufacturing"/>
             </actions>
@@ -56,7 +56,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
-                         <include-menu location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml" name="MainActionMenu"/>
+                         <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                      </decorator-section>
                     <decorator-section name="body">
                         <section>
@@ -85,7 +85,7 @@ under the License.
             <widgets>
                 <decorator-screen name="ShortcutDecorator" location="component://common/widget/CommonScreens.xml">
                     <decorator-section name="body">
-                        <include-menu name="ManufacturingShortcutAppBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                        <include-menu name="ManufacturingShortcutAppBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                 </decorator-screen>
             </widgets>

--- a/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
@@ -32,7 +32,7 @@ under the License.
                                         <not><if-empty field="productionRun"/></not>
                                     </condition>
                                     <widgets>
-                                        <include-menu name="ProductionRunTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                                        <include-menu name="ProductionRunTabBar" location="${parameters.mainMenuLocation}"/>
                                     </widgets>
                                 </section>
                                 <container>
@@ -114,7 +114,7 @@ under the License.
                 <decorator-screen name="CommonJobshopDecorator" location="${parameters.commonJobshopDecorator}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.ManufacturingProductionRunId} ${productionRunId}"  navigation-menu-name="ProductionRunStatusAction">
-                            <include-menu name="ProductionRunStatusTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                            <include-menu name="ProductionRunStatusTabBar" location="${parameters.mainMenuLocation}"/>
                             <include-form name="UpdateProductionRun" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
                         </screenlet>
                         <section>
@@ -194,7 +194,7 @@ under the License.
                 <decorator-screen name="CommonJobshopDecorator" location="${parameters.commonJobshopDecorator}">
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.ManufacturingProductionRunId} ${productionRunId}" navigation-menu-name="ProductionRunStatusAction">
-                            <include-menu name="ProductionRunStatusTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                            <include-menu name="ProductionRunStatusTabBar" location="${parameters.mainMenuLocation}"/>
                             <include-form name="ShowProductionRun" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
                         </screenlet>
                         <section>

--- a/applications/manufacturing/widget/manufacturing/MrpScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/MrpScreens.xml
@@ -27,7 +27,7 @@ under the License.
                     <decorator-section name="body">
                         <section>
                             <widgets>
-                                <include-menu name="MrpTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                                <include-menu name="MrpTabBar" location="${parameters.mainMenuLocation}"/>
                                 <decorator-section-include name="body"/>
                             </widgets>
                         </section>

--- a/applications/manufacturing/widget/manufacturing/RoutingScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/RoutingScreens.xml
@@ -37,7 +37,7 @@ under the License.
                                     </condition>
                                     <widgets>
                                         <label style="h1">${uiLabelMap.CommonRouting}: ${routing.workEffortId}</label>
-                                        <include-menu name="RoutingTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                                        <include-menu name="RoutingTabBar" location="${parameters.mainMenuLocation}"/>
                                     </widgets>
                                 </section>
                                 <decorator-section-include name="body"/>
@@ -65,7 +65,7 @@ under the License.
                                     </condition>
                                     <widgets>
                                         <label style="h1">${uiLabelMap.WorkEffortTask}: ${routingTask.workEffortId}</label>
-                                        <include-menu name="RoutingTaskTabBar" location="component://manufacturing/widget/manufacturing/ManufacturingMenus.xml"/>
+                                        <include-menu name="RoutingTaskTabBar" location="${parameters.mainMenuLocation}"/>
                                     </widgets>
                                 </section>
                                 <decorator-section-include name="body"/>


### PR DESCRIPTION
Customization is a key aspect of the OFBiz (Open For Business) platform, providing businesses with a robust and adaptable base to customize their enterprise software solutions according to their unique operational requirements. The *Menus.xml file of a component, essential for designing user interfaces that are both intuitive and tailored to the specific roles and tasks of its users, plays a significant role in this context, as referenced within screen widgets and Freemarker templates. However, as customizations and the project's source code evolve over time, the likelihood of encountering merge conflicts increases significantly, especially when attempting to incorporate customizations alongside ongoing bug fixes and enhancements from the project. To improve the appeal of OFbiz and the developer experience, it is recommended to shift from fixed menu locations to a parameterized approach in our components and plugins. This change would enable developers to more seamlessly incorporate a 'custom' menu, facilitating the integration of project updates.

modified:
- manufacturing/WEB-INF/web.xml: added parameter for mainMenuLocation 
- various *Screens.xml files: changing location of 'include-menu' elements from location="component://manufacturing/widget/ManufacturingMenus.xml to location="${parameters.mainMenuLocation}"
