### PR TITLE
Fixed: Support "text" attribute on hyperlinks in forms (OFBIZ-12940)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRenderer.java
@@ -216,6 +216,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
         this.request.setAttribute("title", hyperlinkField.getTitle());
         this.request.setAttribute("width", hyperlinkField.getWidth());
         this.request.setAttribute("height", hyperlinkField.getHeight());
+        this.request.setAttribute("text", hyperlinkField.getText(context));
         makeHyperlinkByType(writer, hyperlinkField.getLinkType(), modelFormField.getWidgetStyle(), hyperlinkField.getUrlMode(),
                 hyperlinkField.getTarget(context), hyperlinkField.getParameterMap(context, modelFormField.getEntityName(),
                 modelFormField.getServiceName()), hyperlinkField.getDescription(context), hyperlinkField.getTargetWindow(context),
@@ -2296,6 +2297,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
             String width = "";
             String height = "";
             String title = "";
+            String text = "";
             String hiddenFormName = WidgetWorker.makeLinkHiddenFormName(context, modelFormField);
             if (UtilValidate.isNotEmpty(modelFormField.getEvent()) && UtilValidate.isNotEmpty(modelFormField.getAction(context))) {
                 event = modelFormField.getEvent();
@@ -2323,6 +2325,9 @@ public final class MacroFormRenderer implements FormStringRenderer {
             }
             if (UtilValidate.isNotEmpty(request.getAttribute("id"))) {
                 id = request.getAttribute("id").toString();
+            }
+            if (UtilValidate.isNotEmpty(request.getAttribute("text"))) {
+                text = request.getAttribute("text").toString();
             }
             if (UtilValidate.isNotEmpty(request.getAttribute("uniqueItemName"))) {
                 uniqueItemName = request.getAttribute("uniqueItemName").toString();
@@ -2370,7 +2375,7 @@ public final class MacroFormRenderer implements FormStringRenderer {
             sr.append(targetWindow);
             sr.append("\" description=\"");
             sr.append(description);
-            sr.append("\" confirmation =\"");
+            sr.append("\" confirmation=\"");
             sr.append(confirmation);
             sr.append("\" uniqueItemName=\"");
             sr.append(uniqueItemName);
@@ -2380,6 +2385,8 @@ public final class MacroFormRenderer implements FormStringRenderer {
             sr.append(width);
             sr.append("\" id=\"");
             sr.append(id);
+            sr.append("\" text=\"");
+            sr.append(text);
             sr.append("\" />");
             executeMacro(writer, sr.toString());
         }

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -43,6 +43,7 @@ import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.template.FreeMarkerWorker;
 import org.apache.ofbiz.entity.Delegator;
+import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 import org.apache.ofbiz.webapp.control.RequestHandler;
 import org.apache.ofbiz.widget.model.FieldInfo;
 import org.apache.ofbiz.widget.model.ModelForm;
@@ -919,6 +920,54 @@ public class MacroFormRendererTest {
 
         macroFormRenderer.renderHyperlinkField(appendable, new HashMap<>(), hyperlinkField);
         assertAndGetMacroString("makeHyperlinkString", ImmutableMap.of("description", "DESCR…", "title", description));
+    }
+
+    @Test
+    public void hyperlinkFieldMacroRenderedModalParameters(@Mocked ModelFormField.HyperlinkField hyperlinkField) throws IOException {
+        final String title = "TitleValue";
+        final String text = "TextValue";
+        final String description = "DescriptionValue";
+        final String target = "Encoded Target";
+        final String id = "IdValue";
+        final String uniqueItemName = "UniqueItemName";
+        final String width = "650";
+        final String height = "150";
+        final String confirmation = "Are you sure ?";
+        final String targetWindow = "_blank";
+        final Map<String, ConfigXMLReader.RequestMap> requestMapMap = new HashMap<>();
+        final Map<String, String> parameterMap = new HashMap<>();
+        parameterMap.put("k1", "v1");
+        parameterMap.put("k2", "v2");
+
+        new Expectations() {
+            {
+                hyperlinkField.getDescription(withNotNull()); result = description;
+                hyperlinkField.getTarget(withNotNull()); result = target;
+                hyperlinkField.getParameterMap(withNotNull(), withNull(), withNull()); result = parameterMap;
+                hyperlinkField.getConfirmation(withNotNull()); result = confirmation;
+                hyperlinkField.getTargetWindow(withNotNull()); result = targetWindow;
+                request.getAttribute("title"); result = title;
+                request.getAttribute("text"); result = text;
+                request.getAttribute("requestMapMap"); result = requestMapMap;
+                request.getAttribute("id"); result = id;
+                request.getAttribute("uniqueItemName"); result = uniqueItemName;
+                request.getAttribute("width"); result = width;
+                request.getAttribute("height"); result = height;
+            }
+        };
+
+        macroFormRenderer.renderHyperlinkField(appendable, new HashMap<>(), hyperlinkField);
+        ImmutableMap<String, Object> result = ImmutableMap.<String, Object>builder()
+                .put("title", title)
+                .put("description", description)
+                .put("linkUrl", "Encoded%20Target")
+                .put("id", id)
+                .put("targetParameters", "{'k1':'v1','k2':'v2'}")
+                .put("width", width)
+                .put("confirmation", confirmation)
+                .put("targetWindow", targetWindow)
+                .build();
+        assertAndGetMacroString("makeHyperlinkString", result);
     }
 
     private String assertAndGetMacroString(final String expectedName) {

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -836,7 +836,7 @@ Parameter: delegatorName, String, optional - name of the delegator in context.
     <#if confirmation?has_content> onclick="return confirm('${confirmation?js_string}')"</#if>>
       <#if imgSrc?has_content><img src="${imgSrc}" alt=""/></#if>${description}</a>
 </#macro>
-<#macro makeHyperlinkString hiddenFormName imgSrc imgTitle title alternate linkUrl description linkStyle="" event="" action="" targetParameters="" targetWindow="" confirmation="" uniqueItemName="" height="" width="" id="">
+<#macro makeHyperlinkString hiddenFormName imgSrc imgTitle title alternate linkUrl description text="" linkStyle="" event="" action="" targetParameters="" targetWindow="" confirmation="" uniqueItemName="" height="" width="" id="">
     <#if uniqueItemName?has_content>
         <#local params = "{&quot;presentation&quot;: &quot;layer&quot;">
         <#if targetParameters?has_content && !targetParameters?is_hash>


### PR DESCRIPTION
Fixed: OFBIZ-12940

Explanation
"text" attribute on hyperlinks in forms should define the modal title when used in "layered-modal" mode. Code indicates this intention (OfbizUtil.js, HtmlFormMacroLibrary.ftl) but the makeHyperlinkString Freemarker macro and the form renderer don't process this parameter. This commit fixes the modal title behavior in this context.

Thanks:
Néréide team
