### PR TITLE
improved: have profileMenuLocation (OFBIZ-12981)

### DIFF
--- a/applications/order/webapp/ordermgr/WEB-INF/web.xml
+++ b/applications/order/webapp/ordermgr/WEB-INF/web.xml
@@ -43,6 +43,11 @@ under the License.
         <param-name>mainMenuLocation</param-name>
         <param-value>component://order/widget/ordermgr/OrderMenus.xml</param-value>
     </context-param>
+    <context-param>
+        <description>The location of the request menus file to be used in this webapp; referred to as a context variable in screen def XML files.</description>
+        <param-name>requestMenuLocation</param-name>
+        <param-value>component://order/widget/ordermgr/OrderMenus.xml</param-value>
+    </context-param>
 
     <filter>
         <display-name>ControlFilter</display-name>

--- a/applications/order/widget/ordermgr/CommonScreens.xml
+++ b/applications/order/widget/ordermgr/CommonScreens.xml
@@ -69,12 +69,12 @@ under the License.
                                 <not><if-empty field="custRequest"/></not>
                             </condition>
                             <widgets>
-                                <include-menu name="RequestTabBar" location="${parameters.mainMenuLocation}"/>
+                                <include-menu name="RequestTabBar" location="${parameters.requestMenuLocation}"/>
                             </widgets>
                         </section>
                     </decorator-section>
                     <decorator-section name="body">
-                        <include-menu name="RequestSubTabBar" location="${parameters.mainMenuLocation}"/>
+                        <include-menu name="RequestSubTabBar" location="${parameters.requestMenuLocation}"/>
                         <container>
                             <section>
                                 <condition>

--- a/applications/order/widget/ordermgr/CustRequestScreens.xml
+++ b/applications/order/widget/ordermgr/CustRequestScreens.xml
@@ -570,7 +570,7 @@ under the License.
                     </condition>
                     <widgets>
                         <screenlet title="${uiLabelMap.OrderIncomingCustRequests}" navigation-menu-name="RequestScreenletMenu">
-                            <include-menu name="RequestScreenletMenu" location="${parameters.mainMenuLocation}"/>
+                            <include-menu name="RequestScreenletMenu" location="${parameters.requestMenuLocation}"/>
                             <include-form name="ListRequestList" location="component://order/widget/ordermgr/CustRequestForms.xml"/>
                         </screenlet>
                     </widgets>

--- a/applications/party/webapp/partymgr/WEB-INF/web.xml
+++ b/applications/party/webapp/partymgr/WEB-INF/web.xml
@@ -48,6 +48,11 @@ under the License.
         <param-name>communicationMenuLocation</param-name>
         <param-value>component://party/widget/partymgr/PartyMenus.xml</param-value>
     </context-param>
+    <context-param>
+        <description>The location of the profile screen menus file to be used in this webapp; referred to as a context variable in screen def XML files.</description>
+        <param-name>profileMenuLocation</param-name>
+        <param-value>component://party/widget/partymgr/PartyMenus.xml</param-value>
+    </context-param>
 
   <filter>
       <display-name>ControlFilter</display-name>

--- a/applications/party/widget/partymgr/ProfileScreens.xml
+++ b/applications/party/widget/partymgr/ProfileScreens.xml
@@ -63,7 +63,7 @@
                             </condition>
                             <widgets>
                                 <screenlet title="${uiLabelMap.PartyPersonalInformation}" navigation-menu-name="PersonUpdate" id="PartyPersonalInformationPanel">
-                                           <include-menu name="PersonUpdate" location="${parameters.mainMenuLocation}"/>
+                                           <include-menu name="PersonUpdate" location="${parameters.profileMenuLocation}"/>
                                     <include-form name="ViewPartyPerson" location="component://party/widget/partymgr/PartyForms.xml"/>
                                     <section>
                                         <condition>
@@ -102,7 +102,7 @@
                                </condition>
                             <widgets>
                                 <screenlet title="${uiLabelMap.PartyPartyGroupInformation}" navigation-menu-name="GroupUpdate" id="PartyGroupInformationPanel">
-                                    <include-menu name="GroupUpdate" location="${parameters.mainMenuLocation}"/>
+                                    <include-menu name="GroupUpdate" location="${parameters.profileMenuLocation}"/>
                                     <include-form name="ViewPartyGroup" location="component://party/widget/partymgr/PartyForms.xml"/>
                                     <section>
                                         <condition>
@@ -160,7 +160,7 @@
             </actions>
             <widgets>
                 <screenlet title="${uiLabelMap.PartyPartyIdentifications}" navigation-menu-name="NewPartyIdentification" id="PartyIdentificationPanel">
-                    <include-menu name="NewPartyIdentification" location="${parameters.mainMenuLocation}"/>
+                    <include-menu name="NewPartyIdentification" location="${parameters.profileMenuLocation}"/>
                     <include-form name="ListPartyIdentification" location="component://party/widget/partymgr/PartyForms.xml"/>
                 </screenlet>
             </widgets>
@@ -493,7 +493,7 @@
             </actions>
             <widgets>
                 <screenlet title="${uiLabelMap.PartyShipperAccount}" navigation-menu-name="AddShipper">
-                    <include-menu name="AddShipper" location="${parameters.mainMenuLocation}"/>
+                    <include-menu name="AddShipper" location="${parameters.profileMenuLocation}"/>
                     <include-form name="ListCarrierAccounts" location="component://party/widget/partymgr/PartyForms.xml"/>
                 </screenlet>
             </widgets>
@@ -528,7 +528,7 @@
                     </condition>
                     <widgets>
                         <screenlet title="${uiLabelMap.PartyListRelatedContacts}" navigation-menu-name="AddRelAccountContacts">
-                            <include-menu name="AddRelAccountContacts" location="${parameters.mainMenuLocation}"/>
+                            <include-menu name="AddRelAccountContacts" location="${parameters.profileMenuLocation}"/>
                             <section>
                                 <condition>
                                     <not><if-empty field="parameters.editPartyRel"/></not>
@@ -563,7 +563,7 @@
                     </condition>
                     <widgets>                        
                         <screenlet title="${uiLabelMap.PartyListRelatedAccounts}" navigation-menu-name="AddRelContactAccounts">  
-                            <include-menu name="AddRelContactAccounts" location="${parameters.mainMenuLocation}"/>
+                            <include-menu name="AddRelContactAccounts" location="${parameters.profileMenuLocation}"/>
                             <section>
                                 <condition>
                                     <not><if-empty field="parameters.editPartyRel"/></not>


### PR DESCRIPTION
Profile screens are used in various components as portalpageportlets, and have references to various party menus. As menus in the various profile screens are parameterized to use ${parameters.mainMenuLocation} this generates errors in the components/applications where these screens are used as portal page elements.

Having a context-param profileMenuLocation resolves this issue.

modified:
partty - web.xml: have context-param profileMenuLocation
party - ProfileScreens.xml:  change location profile menus various screens