### PR TITLE
Improved: Remove Agreements menu-item from AR and AP menus (OFBIZ-13010)

### DIFF
--- a/applications/accounting/widget/ap/ApMenus.xml
+++ b/applications/accounting/widget/ap/ApMenus.xml
@@ -19,7 +19,6 @@ under the License.
 -->
 <menus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://ofbiz.apache.org/Widget-Menu" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Menu http://ofbiz.apache.org/dtds/widget-menu.xsd">
     <menu name="ApAppBar" title="${uiLabelMap.AccountingApManager}" extends="CommonAppBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
-        <menu-item name="agreements" title="${uiLabelMap.AccountingAgreements}"><link target="FindAgreement"/></menu-item>
         <menu-item name="invoices" title="${uiLabelMap.AccountingInvoicesMenu}"><link target="FindApInvoices"/></menu-item>
         <menu-item name="payments" title="${uiLabelMap.AccountingPaymentsMenu}"><link target="findPayments"/></menu-item>
         <menu-item name="apPaymentGroups" title="${uiLabelMap.AccountingApPaymentGroupMenu}"><link target="FindApPaymentGroups"/></menu-item>

--- a/applications/accounting/widget/ar/ArMenus.xml
+++ b/applications/accounting/widget/ar/ArMenus.xml
@@ -20,7 +20,6 @@ under the License.
 
 <menus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://ofbiz.apache.org/Widget-Menu" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Menu http://ofbiz.apache.org/dtds/widget-menu.xsd">
     <menu name="ArAppBar" title="${uiLabelMap.AccountingArManager}" extends="CommonAppBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
-        <menu-item name="agreements" title="${uiLabelMap.AccountingAgreements}"><link target="FindAgreement"/></menu-item>
         <menu-item name="invoices" title="${uiLabelMap.AccountingInvoicesMenu}"><link target="findInvoices"/></menu-item>
         <menu-item name="payments" title="${uiLabelMap.AccountingPaymentsMenu}"><link target="findPayments"/></menu-item>
         <menu-item name="paymentGroups" title="${uiLabelMap.AccountingArPaymentGroupMenu}"><link target="FindArPaymentGroups"/></menu-item>


### PR DESCRIPTION
The Agreements menu-item serves no specific purpose in both the AR and the AP application of the accounting component. As a user I would expect that in the AR application it would present the search/find functionality related to contracts with customers and the same in the AP application but then related to contracts with suppliers. However, this is not the case. The functionality just presents the OOTB functionality of the accounting application without any uniqueness related to resp AR or AP.

modified:
- ApMenus.xml - remove menu-item agreements
- ArMenus.xml - remove menu-item agreements