### PR TITLE
Improved:Integrate Invoice Due Soon and Past Due into accounting main (OFBIZ-13011)

### DIFF
--- a/applications/accounting/config/AccountingUiLabels.xml
+++ b/applications/accounting/config/AccountingUiLabels.xml
@@ -130,6 +130,11 @@
         <value xml:lang="zh">缺少账户编号</value>
         <value xml:lang="zh-TW">沒有科目號碼</value>
     </property>
+    <property key="AccountingAccountsPayable">
+        <value xml:lang="en">Accounts Payable</value>
+        <value xml:lang="fr">Comptes créditeurs</value>
+        <value xml:lang="nl">Crediteuren</value>
+    </property>
     <property key="AccountingAccountsReceivable">
         <value xml:lang="en">Accounts Receivable</value>
         <value xml:lang="fr">Comptes débiteurs</value>

--- a/applications/accounting/data/AccountingPortletData.xml
+++ b/applications/accounting/data/AccountingPortletData.xml
@@ -37,7 +37,7 @@
     <PortalPageColumn portalPageId="FinAccountPortalPage" columnSeqId="00001"/>
     <PortalPagePortlet portalPageId="FinAccountPortalPage" portalPortletId="ListBankAccount" portletSeqId="00001" columnSeqId="00001" sequenceNum="0"/>
 
-    <!--Portlet data for AP -->
+    <!--Portlet data for AR -->
     <PortalPortlet portalPortletId="ArPastDueInvoices" portletName="AR Past Due Invoices" screenName="ArPastDueInvoices"
             screenLocation="component://accounting/widget/ar/CommonScreens.xml" description="List of Past Due Invoices in AR"/>
     <PortalPortlet portalPortletId="ArInvoicesDueSoon" portletName="AR Invoices Due Soon" screenName="ArInvoicesDueSoon"
@@ -83,7 +83,17 @@
     <PortletPortletCategory portalPortletId="ListPayments" portletCategoryId="ACCOUNTING"/>
     <PortalPortlet portalPortletId="InvoiceArPastDue" portletName="AR Invoices Past Due" screenName="InvoicesArPastDue"
             screenLocation="component://accounting/widget/InvoiceScreens.xml" description="Invoices Past Due in Accounts Receivable"/>
+    <PortalPortlet portalPortletId="InvoiceArDueSoon" portletName="AR Invoices Due Soon" screenName="InvoicesArDueSoon"
+            screenLocation="component://accounting/widget/InvoiceScreens.xml" description="Invoices Due Soon in Accounts Receivable"/>
+    <PortalPortlet portalPortletId="InvoiceApPastDue" portletName="AP Invoices Past Due" screenName="InvoicesApPastDue"
+            screenLocation="component://accounting/widget/InvoiceScreens.xml" description="Invoices Past Due in Accounts Payable"/>
+    <PortalPortlet portalPortletId="InvoiceApDueSoon" portletName="AP Invoices Due Soon" screenName="InvoicesApDueSoon"
+            screenLocation="component://accounting/widget/InvoiceScreens.xml" description="Invoices Due Soon in Accounts Payable"/>
     <PortalPage portalPageId="ACC_MAIN" portalPageName="Accounting Main Page" description="The main portal page of the Accounting application" ownerUserLoginId="_NA_" sequenceNum="1"/>
     <PortalPageColumn columnSeqId="00001" portalPageId="ACC_MAIN"/>
+    <PortalPageColumn columnSeqId="00002" portalPageId="ACC_MAIN"/>
     <PortalPagePortlet columnSeqId="00001" portalPageId="ACC_MAIN" portalPortletId="InvoiceArPastDue" portletSeqId="00001" sequenceNum="1"/>
+    <PortalPagePortlet columnSeqId="00001" portalPageId="ACC_MAIN" portalPortletId="InvoiceArDueSoon" portletSeqId="00002" sequenceNum="2"/>
+    <PortalPagePortlet columnSeqId="00002" portalPageId="ACC_MAIN" portalPortletId="InvoiceApPastDue" portletSeqId="00003" sequenceNum="1"/>
+    <PortalPagePortlet columnSeqId="00002" portalPageId="ACC_MAIN" portalPortletId="InvoiceApDueSoon" portletSeqId="00004" sequenceNum="2"/>
 </entity-engine-xml>

--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -745,11 +745,6 @@ under the License.
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" paginate="true" paginate-target="main">
         <row-actions>
             <set field="invoiceTypeId" from-field="invoiceTypeId"/>
-            <service service-name="getPartyNameForDate" result-map="partyNameResultFrom">
-                <field-map field-name="partyId" from-field="partyIdFrom"/>
-                <field-map field-name="compareDate" from-field="invoiceDate"/>
-                <field-map field-name="lastNameFirst" value="Y"/>
-            </service>
             <service service-name="getPartyNameForDate" result-map="partyNameResultTo">
                 <field-map field-name="partyId" from-field="partyId"/>
                 <field-map field-name="compareDate" from-field="invoiceDate"/>
@@ -785,11 +780,6 @@ under the License.
             <set field="invoiceTypeId" from-field="invoiceTypeId"/>
             <service service-name="getPartyNameForDate" result-map="partyNameResultFrom">
                 <field-map field-name="partyId" from-field="partyIdFrom"/>
-                <field-map field-name="compareDate" from-field="invoiceDate"/>
-                <field-map field-name="lastNameFirst" value="Y"/>
-            </service>
-            <service service-name="getPartyNameForDate" result-map="partyNameResultTo">
-                <field-map field-name="partyId" from-field="partyId"/>
                 <field-map field-name="compareDate" from-field="invoiceDate"/>
                 <field-map field-name="lastNameFirst" value="Y"/>
             </service>

--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -768,7 +768,45 @@ under the License.
             </hyperlink>
         </field>
         <field name="partyIdTo" title="${uiLabelMap.AccountingCustomer}">
-            <hyperlink description="${partyNameResultTo.fullName} [${partyId}]" target="/partymgr/control/viewprofile" target-type="inter-app">
+            <hyperlink description="${partyNameResultTo.fullName} [${partyId}]" target="/partymgr/control/PartyFinancialHistory" target-type="inter-app" target-window="_BLANK">
+                <parameter param-name="partyId"/>
+            </hyperlink>
+        </field>
+        <field name="invoiceTypeId" title="${uiLabelMap.CommonType}"><display-entity entity-name="InvoiceType"/></field>
+        <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
+        <field name="invoiceDate"><display type="date"/></field>
+        <field name="dueDate"><display type="date"/></field>
+        <field name="total" widget-area-style="align-text"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="amountToApply" widget-area-style="align-text"><display type="currency" currency="${currencyUomId}"/></field>
+    </grid>
+    <grid name="ListApReport" separate-columns="true" title="Invoice List" list-name="invoices" target=""
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar" paginate="true" paginate-target="main">
+        <row-actions>
+            <set field="invoiceTypeId" from-field="invoiceTypeId"/>
+            <service service-name="getPartyNameForDate" result-map="partyNameResultFrom">
+                <field-map field-name="partyId" from-field="partyIdFrom"/>
+                <field-map field-name="compareDate" from-field="invoiceDate"/>
+                <field-map field-name="lastNameFirst" value="Y"/>
+            </service>
+            <service service-name="getPartyNameForDate" result-map="partyNameResultTo">
+                <field-map field-name="partyId" from-field="partyId"/>
+                <field-map field-name="compareDate" from-field="invoiceDate"/>
+                <field-map field-name="lastNameFirst" value="Y"/>
+            </service>
+            <set field="amountToApply" value="${groovy:
+                import java.text.NumberFormat;
+                return(NumberFormat.getNumberInstance(context.get(&quot;locale&quot;)).format(org.apache.ofbiz.accounting.invoice.InvoiceWorker.getInvoiceNotApplied(delegator,invoiceId)));}"/>
+            <set field="total" value="${groovy:
+                import java.text.NumberFormat;
+                return(NumberFormat.getNumberInstance(context.get(&quot;locale&quot;)).format(org.apache.ofbiz.accounting.invoice.InvoiceWorker.getInvoiceTotal(delegator,invoiceId)));}"/>
+        </row-actions>
+        <field name="invoiceId"  title="${uiLabelMap.CommonInvoice}" widget-style="buttontext">
+            <hyperlink description="${invoiceId}" target="invoiceOverview">
+                <parameter param-name="invoiceId"/>
+            </hyperlink>
+        </field>
+        <field name="partyIdFrom" title="${uiLabelMap.PartySupplier}">
+            <hyperlink description="${partyNameResultFrom.fullName} [${partyId}]" target="/partymgr/control/PartyFinancialHistory" target-type="inter-app" target-window="_BLANK">
                 <parameter param-name="partyId"/>
             </hyperlink>
         </field>

--- a/applications/accounting/widget/InvoiceScreens.xml
+++ b/applications/accounting/widget/InvoiceScreens.xml
@@ -873,4 +873,52 @@ under the License.
             </widgets>
         </section>
     </screen>
+    <screen name="InvoicesArDueSoon">
+        <section>
+           <actions>
+                <property-map resource="AccountingUiLabels" map-name="uiLabelMap" global="true"/>
+                <set field="invoiceTypeId" value="SALES_INVOICE"/>
+                <set field="organizationPartyId" from-field="organizationPartyId" default-value="${defaultOrganizationPartyId}"/>
+                <script location="component://accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceReport.groovy"/>
+                <set field="invoices" from-field="InvoicesDueSoon"/>
+            </actions>
+            <widgets>
+                <screenlet title="${uiLabelMap.AccountingAccountsReceivable} ${uiLabelMap.AccountingInvoicesDueSoon}: ${InvoicesDueSoonTotalAmount}">
+                    <include-grid name="ListArReport" location="component://accounting/widget/InvoiceForms.xml"/>
+                </screenlet>
+            </widgets>
+        </section>
+    </screen>
+    <screen name="InvoicesApPastDue">
+        <section>
+           <actions>
+                <property-map resource="AccountingUiLabels" map-name="uiLabelMap" global="true"/>
+                <set field="invoiceTypeId" value="PURCHASE_INVOICE"/>
+                <set field="organizationPartyId" from-field="organizationPartyId" default-value="${defaultOrganizationPartyId}"/>
+                <script location="component://accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceReport.groovy"/>
+                <set field="invoices" from-field="PastDueInvoices"/>
+            </actions>
+            <widgets>
+                <screenlet title="${uiLabelMap.AccountingAccountsPayable} ${uiLabelMap.AccountingPastDueInvoices}: ${PastDueInvoicestotalAmount}">
+                    <include-grid name="ListApReport" location="component://accounting/widget/InvoiceForms.xml"/>
+                </screenlet>
+            </widgets>
+        </section>
+    </screen>
+    <screen name="InvoicesApDueSoon">
+        <section>
+           <actions>
+                <property-map resource="AccountingUiLabels" map-name="uiLabelMap" global="true"/>
+                <set field="invoiceTypeId" value="PURCHASE_INVOICE"/>
+                <set field="organizationPartyId" from-field="organizationPartyId" default-value="${defaultOrganizationPartyId}"/>
+                <script location="component://accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceReport.groovy"/>
+                <set field="invoices" from-field="InvoicesDueSoon"/>
+            </actions>
+            <widgets>
+                <screenlet title="${uiLabelMap.AccountingAccountsPayable} ${uiLabelMap.AccountingInvoicesDueSoon}: ${InvoicesDueSoonTotalAmount}">
+                    <include-grid name="ListApReport" location="component://accounting/widget/InvoiceForms.xml"/>
+                </screenlet>
+            </widgets>
+        </section>
+    </screen>
 </screens>


### PR DESCRIPTION
Further integrate overviews regarding Invoice Past Due and Due Soon into the main screen of the accounting application as portal pages.

modified:

- AccountingUiLabels.xmll - add label re Accounts Payable
- AccountingPortletData - add PortalPortlet records regarding AR Invoices Due Soon, AP Invoices Past Due and AP Invoices Due soon, as adding related PotralPageColumn and PortalPagePortlet records -I nvoiceScreens.xml - adding screens InvoiceArDueSoon, InvoicesApPastDue and InvoiceApDueSoon
- InvoiceForms.xml - improving grid  ListArReport, adding grid ListApReport
