### PR TITLE
Improved: InvoiceReport.groovy should return list with DueDate ASC (OFBIZ-13012)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceReport.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceReport.groovy
@@ -34,7 +34,7 @@ if (invoiceTypeId) {
     }
     expr = exprBldr.AND([expr, invoiceStatusesCondition])
 
-    PastDueInvoices = from('Invoice').where(expr).orderBy('dueDate DESC').queryList()
+    PastDueInvoices = from('Invoice').where(expr).orderBy('dueDate ASC').queryList()
     if (PastDueInvoices) {
         invoiceIds = PastDueInvoices.invoiceId
         totalAmount = runService('getInvoiceRunningTotal', [invoiceIds: invoiceIds, organizationPartyId: organizationPartyId])


### PR DESCRIPTION
Currently the InvoiceReport.groovy function returns the result sorted on DueDate ascending. This means that newer invoices are shown before older ones. This is undesirable, as the oldest invoices are more important to take action on.
