### PR TITLE
Improved: Make theme variants visible in demo sites (OFBIZ-13024)

### DIFF
--- a/applications/datamodel/data/demo/PartyDemoData.xml
+++ b/applications/datamodel/data/demo/PartyDemoData.xml
@@ -132,7 +132,6 @@ under the License.
     <UserPreference userLoginId="bizadmin" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="HELVETICUS_SAPHIR"/>
     <UserPreference userLoginId="accountingadmin" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="HELVETICUS_RUBY"/>
     <UserPreference userLoginId="DemoBuyer" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="HELVETICUS_EMERALD"/>
-    <UserPreference userLoginId="bizadmin" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="HELVETICUS_AMBER"/>
     <UserPreference userLoginId="DemoSupplier" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="RAINBOWSTONE_SAPHIR"/>
     <UserPreference userLoginId="DemoCustomer" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="RAINBOWSTONE_RUBY"/>
     <UserPreference userLoginId="DemoEmployee" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="RAINBOWSTONE_EMERALD"/>

--- a/applications/datamodel/data/demo/PartyDemoData.xml
+++ b/applications/datamodel/data/demo/PartyDemoData.xml
@@ -126,4 +126,16 @@ under the License.
     <!-- PartyClassification data -->
     <PartyClassificationGroup partyClassificationGroupId="EMEA" description="Europe and Middle East" partyClassificationTypeId="REGION"/>
     <PartyClassificationGroup partyClassificationGroupId="APAC" description="Asia and Pacific" partyClassificationTypeId="REGION"/>
+
+    <UserPreference userLoginId="auditor" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="BLUELIGHT"/>
+    <UserPreference userLoginId="FrenchCustomer" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="FLAT_GREY"/>
+    <UserPreference userLoginId="bizadmin" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="HELVETICUS_SAPHIR"/>
+    <UserPreference userLoginId="accountingadmin" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="HELVETICUS_RUBY"/>
+    <UserPreference userLoginId="DemoBuyer" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="HELVETICUS_EMERALD"/>
+    <UserPreference userLoginId="bizadmin" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="HELVETICUS_AMBER"/>
+    <UserPreference userLoginId="DemoSupplier" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="RAINBOWSTONE_SAPHIR"/>
+    <UserPreference userLoginId="DemoCustomer" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="RAINBOWSTONE_RUBY"/>
+    <UserPreference userLoginId="DemoEmployee" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="RAINBOWSTONE_EMERALD"/>
+    <UserPreference userLoginId="productowner" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="RAINBOWSTONE_AMBER"/>
+    <UserPreference userLoginId="scrummaster" userPrefGroupTypeId="GLOBAL_PREFERENCES" userPrefTypeId="VISUAL_THEME" userPrefValue="TOMAHAWK"/>
 </entity-engine-xml>


### PR DESCRIPTION
Currently we have 58 UserLogin records in demo data, and 12 back-office VisualTheme records in our demo data sets. In order to have more visibilities of the various themes, we should set for various UserLogins the theme as a preference.

modified: PartyDemoData.xml
- added UserPreference records relating to themes