### PR TITLE
Improved: Have 'Tax Authority' menu item in GlobalGLSettingMenus (OFBIZ-13026)

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -45,7 +45,6 @@ under the License.
         </menu-item>
         <menu-item name="billingaccount" title="${uiLabelMap.AccountingBillingMenu}"><link target="FindBillingAccount"/></menu-item>
         <menu-item name="FindFinAccount" title="${uiLabelMap.AccountingFinAccount}"><link target="FinAccountMain"/></menu-item>
-        <menu-item name="TaxAuthorities" title="${uiLabelMap.AccountingTaxAuthorities}"><link target="FindTaxAuthority"/></menu-item>
         <menu-item name="agreements" title="${uiLabelMap.AccountingAgreements}"><link target="FindAgreement"/></menu-item>
         <menu-item name="ListFixedAssets" title="${uiLabelMap.AccountingFixedAssets}"><link target="ListFixedAssets"/></menu-item>
         <menu-item name="ListBudgets" title="${uiLabelMap.AccountingBudgets}"><link target="ListBudgets"/></menu-item>
@@ -1383,6 +1382,7 @@ under the License.
         <menu-item name="CostCenters" title="${uiLabelMap.FormFieldTitle_costCenters}">
             <link target="CostCenters"/>
         </menu-item>
+        <menu-item name="TaxAuthorities" title="${uiLabelMap.AccountingTaxAuthorities}"><link target="FindTaxAuthority"/></menu-item>
     </menu>
 
     <menu name="AgreementTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">


### PR DESCRIPTION
In order to enhance the UX of users of the accounting application, the TaxAuthorities should move into the GlobalGLSettingMenus. The motivation for this are that:
TaxAuthority functionality is applicable to all internal organisations with accounting set up, for which we have the GlobalGLSettingMenus; It reduces distractions for users that do day-to-day accounting activities regarding: search/finding gl transactions, invoices and payments creating, reviewing, updating gl transactions, invoices and payments

modiified: AccountingMenus.xml
- move menu-item 'TaxAuthorities' from menu AccountingAppBar to menu GlobalGLSettingMenus
