### PR TITLE
Improved: Have a Menu in SFA featuring actions to create the main objects (OFBIZ-12527)

### DIFF
--- a/applications/marketing/widget/sfa/AccountScreens.xml
+++ b/applications/marketing/widget/sfa/AccountScreens.xml
@@ -33,6 +33,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <widgets>

--- a/applications/marketing/widget/sfa/CommonScreens.xml
+++ b/applications/marketing/widget/sfa/CommonScreens.xml
@@ -61,6 +61,10 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                        <decorator-section-include name="pre-body"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar"/>
                     </decorator-section>
@@ -110,6 +114,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="OpportunityTabBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="left-column">
@@ -750,6 +755,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="AccountTabBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="left-column">
@@ -768,6 +774,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="ContactTabBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="left-column">
@@ -794,6 +801,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="LeadTabBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
@@ -812,6 +820,7 @@ under the License.
             <widgets>
                 <decorator-screen name="main-decorator">
                     <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
                         <include-menu name="EventTabBar" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="left-column">

--- a/applications/marketing/widget/sfa/ContactScreens.xml
+++ b/applications/marketing/widget/sfa/ContactScreens.xml
@@ -33,6 +33,10 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                        <decorator-section-include name="pre-body"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
                     </decorator-section>

--- a/applications/marketing/widget/sfa/ForecastScreens.xml
+++ b/applications/marketing/widget/sfa/ForecastScreens.xml
@@ -28,6 +28,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
                     </decorator-section>                    
@@ -59,6 +62,10 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                        <decorator-section-include name="pre-body"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
                     </decorator-section>                    

--- a/applications/marketing/widget/sfa/LeadScreens.xml
+++ b/applications/marketing/widget/sfa/LeadScreens.xml
@@ -33,6 +33,10 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="component://marketing/widget/sfa/SfaMenus.xml"/>
+                        <decorator-section-include name="pre-body"/>
+                    </decorator-section>
                     <decorator-section name="left-column">
                         <include-screen name="leftbar" location="component://marketing/widget/sfa/CommonScreens.xml"/>
                     </decorator-section>

--- a/applications/marketing/widget/sfa/SfaMenus.xml
+++ b/applications/marketing/widget/sfa/SfaMenus.xml
@@ -31,7 +31,32 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
+    <menu name="MainActionMenu" menu-container-style="button-bar button-style-2" default-selected-style="selected">
+        <menu-item name="NewAccount" title="${uiLabelMap.CommonNew} ${uiLabelMap.PartyAccount}">
+            <condition>
+                <if-has-permission permission="SFA" action="CREATE"/>
+            </condition>
+            <link target="NewAccount"/>
+        </menu-item>
+        <menu-item name="NewContact" title="${uiLabelMap.CommonNew} ${uiLabelMap.SfaContact}">
+            <condition>
+                <if-has-permission permission="SFA" action="CREATE"/>
+            </condition>
+            <link target="NewContact"/>
+        </menu-item>
+        <menu-item name="NewOpportunity" title="${uiLabelMap.CommonNew} ${uiLabelMap.SfaOpportunity}">
+            <condition>
+                <if-has-permission permission="SFA" action="CREATE"/>
+            </condition>
+            <link target="EditSalesOpportunity"/>
+        </menu-item>
+        <menu-item name="NewForeCast" title="${uiLabelMap.CommonNew} ${uiLabelMap.SfaForecast}">
+            <condition>
+                <if-has-permission permission="SFA" action="CREATE"/>
+            </condition>
+            <link target="EditSalesForecast"/>
+        </menu-item>
+    </menu>
     <menu name="SfaShortcutAppBar" title="${uiLabelMap.SfaManager}">
         <menu-item name="Accounts" title="${uiLabelMap.SfaAcccounts}"><link target="/sfa/control/FindAccounts" url-mode="inter-app"/></menu-item>
         <menu-item name="Contacts" title="${uiLabelMap.SfaContacts}"><link target="/sfa/control/FindContacts" url-mode="inter-app"/></menu-item>
@@ -45,7 +70,7 @@ under the License.
             </link>
         </menu-item>
     </menu>
-
+    
     <menu name="OpportunityTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
         <menu-item name="ViewSalesOpportunity" title="${uiLabelMap.SfaOpportunitySummary}">
             <link target="ViewSalesOpportunity">


### PR DESCRIPTION
Currently the create buttons for the main objects of the SFA application are located within find and profile widgets/templates of those objects. In order to improve the usability of this application, OFBiz and thus the appeal of it for adopters and users, these create buttons/links/etc. should be in a main action menu visible at all times when a user with CREATE permissions is working within the application

modified:
- SfaMenus.xml - Added menu MainActionMenu
- included MainActionMenu in various screens to ensure that it is visible to user with CREATE permissions
