### PR TITLE
Improved: Fix cross-app menu location issues (OFBIZ-13035)

### DIFF
--- a/applications/workeffort/widget/WorkEffortMenus.xml
+++ b/applications/workeffort/widget/WorkEffortMenus.xml
@@ -407,4 +407,15 @@ under the License.
             </link>
         </menu-item>
     </menu>
+    <menu name="TimesheetActionMenu">
+        <menu-item name="setToComplete" title="${uiLabelMap.CommonStatustoComplete}">
+            <condition>
+                <if-compare field="timesheet.statusId" operator="equals" value="TIMESHEET_IN_PROCESS"/>
+            </condition>
+            <link target="${my}StatusToComplete">
+                <parameter param-name="timesheetId" from-field="timesheet.timesheetId"/>
+                <parameter param-name="statusId" value="TIMESHEET_COMPLETED"/>
+            </link>
+        </menu-item>
+    </menu>
 </menus>


### PR DESCRIPTION
address cross application menu-location issues.

Plugins use the timesheet functionality from the workeffort component. Given that base approval should be in the worrkeffort component, duplicate menus in plugins should reside in workeffort

modified: WorkEffortMenus.xml
- added: TimesheetActionMenu