### PR TITLE
Improved: Reduce logo size BlueLight theme (OFBIZ-12997)

### DIFF
--- a/themes/bluelight/template/Header.ftl
+++ b/themes/bluelight/template/Header.ftl
@@ -151,7 +151,7 @@ under the License.
           </#if>
           <#if headerImageUrl??>
                 <#if organizationLogoLinkURL?has_content>
-                    <li><a href="<@ofbizUrl>${logoLinkURL}</@ofbizUrl>"><img alt="${layoutSettings.companyName}" src="<@ofbizContentUrl>${StringUtil.wrapString(organizationLogoLinkURL)}</@ofbizContentUrl>"></a></li>
+                    <li><a href="<@ofbizUrl>${logoLinkURL}</@ofbizUrl>"><img alt="${layoutSettings.companyName}" src="<@ofbizContentUrl>${StringUtil.wrapString(organizationLogoLinkURL)}</@ofbizContentUrl>" height="60"></a></li>
                     <#else>
                     <li class="logo-area"><a href="<@ofbizUrl>${logoLinkURL}</@ofbizUrl>"><img alt="${layoutSettings.companyName}" src="<@ofbizContentUrl>${StringUtil.wrapString(headerImageUrl)}</@ofbizContentUrl>"/></a></li>
                 </#if>


### PR DESCRIPTION
When using the Bluelight theme the size of the default logo is greater than the visible 'system notes' lines. Reducing the height of the logo displayed, increases the visibility of the pages useful to user and thus enhance the user experience (less vertical scrolling).

modified: header.ftl - added height value