### PR TITLE
Improved: Wrong partyId Accounts Payable (OFBIZ-13063)

### DIFF
--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -796,7 +796,7 @@ under the License.
             </hyperlink>
         </field>
         <field name="partyIdFrom" title="${uiLabelMap.PartySupplier}">
-            <hyperlink description="${partyNameResultFrom.fullName} [${partyId}]" target="/partymgr/control/PartyFinancialHistory" target-type="inter-app" target-window="_BLANK">
+            <hyperlink description="${partyNameResultFrom.fullName} [${partyIdFrom}]" target="/partymgr/control/PartyFinancialHistory" target-type="inter-app" target-window="_BLANK">
                 <parameter param-name="partyId"/>
             </hyperlink>
         </field>


### PR DESCRIPTION
The Accounts Payable Past Due and Due Soon overviews in the Main page shows the wrong partyId of the creditor.

modified: InvoiceForms.xml
- adjusted grid ListArReport