### PR TITLE
Improved: Facility-Main page (OFBIZ-13051)

### DIFF
--- a/applications/product/data/ProductPortletData.xml
+++ b/applications/product/data/ProductPortletData.xml
@@ -39,4 +39,23 @@
       <PortalPageColumn portalPageId="ProductStoreFacility" columnSeqId="00001"/>
         <PortalPagePortlet portalPageId="ProductStoreFacility" portalPortletId="PrdStoreFacilityMgmt" portletSeqId="00001" columnSeqId="00001" sequenceNum="0"/>
 
+
+<!-- facility main -->
+    <PortletCategory portletCategoryId="FACILITY" description="Facility Portlet"/>
+    <PortalPortlet portalPortletId="ShipmentIn" portletName="Shipment Incoming"
+        screenName="ShipmentIn" screenLocation="component://facility/widget/ShipmentScreens.xml"
+        description="Portlet to display incoming shipments"/>
+    <PortletPortletCategory portalPortletId="ShipmentIn" portletCategoryId="FACILITY"/>
+    <PortalPortlet portalPortletId="ShipmentOut" portletName="Shipment Outgoing"
+        screenName="ShipmentOut" screenLocation="component://facility/widget/ShipmentScreens.xml"
+        description="Portlet to display outgoinng shipments"/>
+    <PortletPortletCategory portalPortletId="ShipmentOut" portletCategoryId="FACILITY"/>
+
+    <PortalPage portalPageId="facility_MAIN" portalPageName="facility Main Page" 
+        description="The main portal page of the facility application" 
+        ownerUserLoginId="_NA_" sequenceNum="1"/>
+    <PortalPageColumn portalPageId="facility_MAIN" columnSeqId="00001"/>
+    <PortalPageColumn portalPageId="facility_MAIN" columnSeqId="00002"/>
+    <PortalPagePortlet portalPageId="facility_MAIN" portalPortletId="ShipmentIn" columnSeqId="00001" portletSeqId="00001" sequenceNum="1"/>
+    <PortalPagePortlet portalPageId="facility_MAIN" portalPortletId="ShipmentOut" columnSeqId="00002" portletSeqId="00001" sequenceNum="1"/>
 </entity-engine-xml>

--- a/applications/product/webapp/facility/WEB-INF/controller.xml
+++ b/applications/product/webapp/facility/WEB-INF/controller.xml
@@ -1364,7 +1364,7 @@ under the License.
     <!-- end of request mappings -->
 
     <!-- View Mappings -->
-    <view-map name="main" type="screen" page="component://product/widget/facility/FacilityScreens.xml#FindFacility"/>
+    <view-map name="main" type="screen" page="component://product/widget/facility/CommonScreens.xml#Main"/>
 
     <view-map name="FindFacility" type="screen" page="component://product/widget/facility/FacilityScreens.xml#FindFacility"/>
     <view-map name="FacilitySearchResults" type="screen" page="component://product/widget/facility/FacilityScreens.xml#FacilitySearchResults"/>

--- a/applications/product/widget/facility/CommonScreens.xml
+++ b/applications/product/widget/facility/CommonScreens.xml
@@ -186,7 +186,26 @@ under the License.
             </widgets>
         </section>
     </screen>
-
+    <screen name="Main">
+        <section>
+            <condition>
+                <if-service-permission service-name="acctgBasePermissionCheck" main-action="VIEW"/>
+            </condition>
+            <actions>
+                <set field="headerItem" value="main"/>
+                <set field="helpAnchor" value="_help_for_accounting_main_screen"/>
+                <set field="parameters.parentPortalPageId" from-field="parameters.parentPortalPageId" default-value="${parameters.localDispatcherName}_MAIN" global="true"/>
+                <script location="component://common/src/main/groovy/org/apache/ofbiz/common/GetParentPortalPageId.groovy"/>
+            </actions>
+            <widgets>
+                <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                    </decorator-section>
+                    <decorator-section name="body">
+                        <include-portal-page id="${parameters.portalPageId}"/>
+                    </decorator-section>
+                </decorator-screen>
+            </widgets>
+        </section>
+    </screen>
 </screens>
-
-

--- a/applications/product/widget/facility/CommonScreens.xml
+++ b/applications/product/widget/facility/CommonScreens.xml
@@ -189,11 +189,10 @@ under the License.
     <screen name="Main">
         <section>
             <condition>
-                <if-service-permission service-name="acctgBasePermissionCheck" main-action="VIEW"/>
             </condition>
             <actions>
                 <set field="headerItem" value="main"/>
-                <set field="helpAnchor" value="_help_for_accounting_main_screen"/>
+                <set field="helpAnchor" value="_help_for_facility_main_screen"/>
                 <set field="parameters.parentPortalPageId" from-field="parameters.parentPortalPageId" default-value="${parameters.localDispatcherName}_MAIN" global="true"/>
                 <script location="component://common/src/main/groovy/org/apache/ofbiz/common/GetParentPortalPageId.groovy"/>
             </actions>

--- a/applications/product/widget/facility/ShipmentForms.xml
+++ b/applications/product/widget/facility/ShipmentForms.xml
@@ -293,4 +293,32 @@ under the License.
             </hyperlink>
         </field>
     </grid>
+    <grid name="ShipmentIn" list-name="shipments"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <row-actions>
+        </row-actions>
+        <field name="shipmentId" title="${uiLabelMap.CommonShipment}">
+            <hyperlink description="${shipmentId}" target="ViewShipment" also-hidden="false">
+                <parameter param-name="shipmentId"/>
+            </hyperlink>
+        </field>
+        <field name="shipmentTypeId" title="${uiLabelMap.CommonType}"><display-entity entity-name="ShipmentType"/></field>
+        <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
+        <field name="createdDate" title="${uiLabelMap.CommonDate}"><display/></field>
+        <field name="destinationFacilityId" title="${uiLabelMap.CommonFacility}"><display-entity entity-name="Facility" key-field-name="facilityId" description="${facilityName}"/></field>
+    </grid>
+    <grid name="ShipmentOut" list-name="shipments"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <row-actions>
+        </row-actions>
+        <field name="shipmentId" title="${uiLabelMap.CommonShipment}">
+            <hyperlink description="${shipmentId}" target="ViewShipment" also-hidden="false">
+                <parameter param-name="shipmentId"/>
+            </hyperlink>
+        </field>
+        <field name="shipmentTypeId" title="${uiLabelMap.CommonType}"><display-entity entity-name="ShipmentType"/></field>
+        <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
+        <field name="createdDate" title="${uiLabelMap.CommonDate}"><display/></field>
+        <field name="originFacilityId" title="${uiLabelMap.CommonFacility}"><display-entity entity-name="Facility" key-field-name="facilityId" description="${facilityName}"/></field>
+    </grid>
 </forms>

--- a/applications/product/widget/facility/ShipmentScreens.xml
+++ b/applications/product/widget/facility/ShipmentScreens.xml
@@ -601,4 +601,55 @@ under the License.
             </widgets>
         </section>
     </screen>
+    <screen name="ShipmentIn">
+        <section>
+            <actions>
+                <set field="shipmentTypeId" value="INCOMING_SHIPMENT"/>
+                <entity-condition entity-name="ShipmentType" list="shipmentTypes">
+                    <condition-expr field-name="parentTypeId" from-field="shipmentTypeId"/>
+                    <order-by field-name="description"/>
+                </entity-condition>
+                <entity-condition entity-name="Shipment" list="shipments">
+                    <condition-list combine="and">
+                        <condition-list combine="or">
+                            <condition-expr field-name="shipmentTypeId" operator="equals" value="PURCHASE_SHIPMENT" ignore-if-empty="true"/>
+                            <condition-expr field-name="shipmentTypeId" operator="equals" value="SALES_RETURN" ignore-if-empty="true"/>
+                        </condition-list>
+                        <condition-expr field-name="statusId" operator="not-equals" value="SHIPMENT_CANCELLED"/>
+                        <condition-expr field-name="statusId" operator="not-equals" value="PURCH_SHIP_RECEIVED"/>
+                    </condition-list>
+                    <order-by field-name="createdDate"/>
+                    <order-by field-name="statusId"/>
+                </entity-condition>
+            </actions>
+            <widgets>
+                <screenlet title="${uiLabelMap.ProductIncomingShipments}">
+                    <include-grid name="ShipmentIn" location="component://product/widget/facility/ShipmentForms.xml"/>
+                </screenlet>
+            </widgets>
+        </section>
+    </screen>
+    <screen name="ShipmentOut">
+        <section>
+            <actions>
+                <entity-condition entity-name="Shipment" list="shipments">
+                    <condition-list combine="and">
+                        <condition-list combine="or">
+                            <condition-expr field-name="shipmentTypeId" operator="equals" value="SALES_SHIPMENT"/>
+                            <condition-expr field-name="shipmentTypeId" operator="equals" value="PURCHASE_RETURN"/>
+                        </condition-list>
+                        <condition-expr field-name="statusId" operator="not-equals" value="SHIPMENT_CANCELLED"/>
+                        <condition-expr field-name="statusId" operator="not-equals" value="SHIPMENT_DELIVERED"/>
+                    </condition-list>
+                    <order-by field-name="statusId"/>
+                    <order-by field-name="createdDate"/>
+                </entity-condition>
+            </actions>
+            <widgets>
+                <screenlet title="${uiLabelMap.ProductOutgoingShipments}">
+                    <include-grid name="ShipmentOut" location="component://product/widget/facility/ShipmentForms.xml"/>
+                </screenlet>
+            </widgets>
+        </section>
+    </screen>
 </screens>


### PR DESCRIPTION
Currently the 'main' view-map points to the 'FindFacility' screen. In order to improve the user experience the main request-map and view-map should show what is most pressing in warehousing to address: incoming and outgoing shipments to process.

modfified:
- controller.xml: changed view-map 'main' to point to screen Main in CommonScreens.xml
- CommonScreens.xml: adding screen Main displaying a PortalPage
- ProductPortletData.xml: adding PortalPage facility_MAIN, portlets for incoming and outgoing shipments, etc
- ShipmentScreens.xml: adding screens ShipmentIn and ShipmentOut for shipments to process
- ShipmentForms.xml: adding grids ShipmentIn and ShipmentOut to list shipments to process