### PR TITLE
Improved: Manufacturing-Main page (OFBIZ-13053)

### DIFF
--- a/applications/manufacturing/data/ManufacturingPortletData.xml
+++ b/applications/manufacturing/data/ManufacturingPortletData.xml
@@ -20,7 +20,7 @@
 <entity-engine-xml>
     <PortletCategory portletCategoryId="MFG" description="Manufacturing Management Portlets"/>
     <PortalPage portalPageId="manufacturing_MAIN" portalPageName="Manufacturing Main page"
-                description="The page to manage productStoreFacility data" 
+                description="The page to manage productStoreFacility data"
                 ownerUserLoginId="_NA_" sequenceNum="1"/>
     <PortalPortlet portalPortletId="ProdRun" portletName="List of Production Runs"
         description="List of best selling products of the day"

--- a/applications/manufacturing/data/ManufacturingPortletData.xml
+++ b/applications/manufacturing/data/ManufacturingPortletData.xml
@@ -20,10 +20,10 @@
 <entity-engine-xml>
     <PortletCategory portletCategoryId="MFG" description="Manufacturing Management Portlets"/>
     <PortalPage portalPageId="manufacturing_MAIN" portalPageName="Manufacturing Main page"
-                description="The page to manage productStoreFacility data"
+                description="The Manufacturing Main Portal Page"
                 ownerUserLoginId="_NA_" sequenceNum="1"/>
-    <PortalPortlet portalPortletId="ProdRun" portletName="List of Production Runs"
-        description="List of best selling products of the day"
+    <PortalPortlet portalPortletId="ProdRun" portletName="Active Production Runs"
+        description="Portlet to present active production runs"
         screenName="ProdRun" screenLocation="component://manufacturing/widget/manufacturing/JobshopScreens.xml"/>
     <PortletPortletCategory portletCategoryId="MFG" portalPortletId="ProdRun"/>
     <PortalPageColumn portalPageId="manufacturing_MAIN" columnSeqId="00001"/>

--- a/applications/manufacturing/data/ManufacturingPortletData.xml
+++ b/applications/manufacturing/data/ManufacturingPortletData.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<entity-engine-xml>
+    <PortletCategory portletCategoryId="MFG" description="Manufacturing Management Portlets"/>
+    <PortalPage portalPageId="manufacturing_MAIN" portalPageName="Manufacturing Main page"
+                description="The page to manage productStoreFacility data" 
+                ownerUserLoginId="_NA_" sequenceNum="1"/>
+    <PortalPortlet portalPortletId="ProdRun" portletName="List of Production Runs"
+        description="List of best selling products of the day"
+        screenName="ProdRun" screenLocation="component://manufacturing/widget/manufacturing/JobshopScreens.xml"/>
+    <PortletPortletCategory portletCategoryId="MFG" portalPortletId="ProdRun"/>
+    <PortalPageColumn portalPageId="manufacturing_MAIN" columnSeqId="00001"/>
+    <PortalPagePortlet portalPageId="manufacturing_MAIN" portalPortletId="ProdRun" columnSeqId="00001" portletSeqId="00001" sequenceNum="1"/>
+
+</entity-engine-xml>

--- a/applications/manufacturing/ofbiz-component.xml
+++ b/applications/manufacturing/ofbiz-component.xml
@@ -28,7 +28,7 @@ under the License.
 
     <!-- entity resources: model(s), eca(s) and group definitions -->
     <entity-resource type="data" reader-name="seed" loader="main" location="data/ManufacturingSecurityPermissionSeedData.xml"/>
-    <entity-resource type="data" reader-name="demo" loader="main" location="data/ManufacturingPortletData.xml"/>
+    <entity-resource type="data" reader-name="seed" loader="main" location="data/ManufacturingPortletData.xml"/>
     <!--<entity-resource type="data" reader-name="seed-initial" loader="main" location="data/ManufacturingScheduledServices.xml"/>-->
 
     <!-- service resources: model(s) [definitions], eca(s) and group definitions -->

--- a/applications/manufacturing/ofbiz-component.xml
+++ b/applications/manufacturing/ofbiz-component.xml
@@ -26,9 +26,9 @@ under the License.
     <!-- place the config directory on the classpath to access configuration files -->
     <classpath type="dir" location="config"/>
 
-
     <!-- entity resources: model(s), eca(s) and group definitions -->
     <entity-resource type="data" reader-name="seed" loader="main" location="data/ManufacturingSecurityPermissionSeedData.xml"/>
+    <entity-resource type="data" reader-name="demo" loader="main" location="data/ManufacturingPortletData.xml"/>
     <!--<entity-resource type="data" reader-name="seed-initial" loader="main" location="data/ManufacturingScheduledServices.xml"/>-->
 
     <!-- service resources: model(s) [definitions], eca(s) and group definitions -->

--- a/applications/manufacturing/webapp/manufacturing/WEB-INF/controller.xml
+++ b/applications/manufacturing/webapp/manufacturing/WEB-INF/controller.xml
@@ -825,7 +825,7 @@ under the License.
     <!-- end of request mappings -->
 
     <!-- View Mappings -->
-    <view-map name="main" type="screen" page="component://manufacturing/widget/manufacturing/JobshopScreens.xml#FindProductionRun"/>
+    <view-map name="main" type="screen" page="component://manufacturing/widget/manufacturing/CommonScreens.xml#Main"/>
 
     <!-- Routing view mappings -->
     <view-map name="FindCalendar" type="screen" page="component://manufacturing/widget/manufacturing/CalendarScreens.xml#FindCalendar"/>

--- a/applications/manufacturing/widget/manufacturing/CommonScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/CommonScreens.xml
@@ -91,5 +91,25 @@ under the License.
             </widgets>
         </section>
     </screen>
-</screens>
-
+    <screen name="Main">
+        <section>
+            <condition>
+            </condition>
+            <actions>
+                <set field="parameters.parentPortalPageId" from-field="parameters.parentPortalPageId" default-value="${parameters.localDispatcherName}_MAIN" global="true"/>
+                <script location="component://common/src/main/groovy/org/apache/ofbiz/common/GetParentPortalPageId.groovy"/>
+            </actions>
+            <widgets>
+                <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                         <include-menu location="${parameters.mainMenuLocation}" name="MainActionMenu"/>
+                     </decorator-section>
+                    <decorator-section name="body">
+                        <include-portal-page id="${parameters.portalPageId}"/>
+                    </decorator-section>
+                </decorator-screen>
+            </widgets>
+        </section>
+    </screen>
+</screens
+>

--- a/applications/manufacturing/widget/manufacturing/CommonScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/CommonScreens.xml
@@ -25,6 +25,7 @@ under the License.
             <actions>
                 <!-- base/top/specific map first, then more common map added for shared labels -->
                 <property-map resource="ManufacturingUiLabels" map-name="uiLabelMap" global="true"/>
+                <property-map resource="ManufacturingReportsUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="OrderUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="ProductUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="PartyUiLabels" map-name="uiLabelMap" global="true"/>

--- a/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
@@ -787,4 +787,27 @@ under the License.
             </widgets>
         </section>
     </screen>
+    <screen name="ProdRun">
+        <section>
+            <actions>
+                <entity-condition entity-name="WorkEffortAndProduct" list="productionRuns">
+                    <condition-list combine="and">
+                        <condition-list combine="or">
+                            <condition-expr field-name="workEffortTypeId" operator="equals" value="PROD_ORDER_HEADER"/>
+                        </condition-list>
+                        <condition-expr field-name="currentStatusId" operator="not-equals" value="PRUN_CANCELED"/>
+                        <condition-expr field-name="currentStatusId" operator="not-equals" value="PRUN_CLOSED"/>
+                    </condition-list>
+                    <order-by field-name="currentStatusId"/>
+                    <order-by field-name="actualStartDate"/>
+                    <order-by field-name="estimatedStartDate"/>
+                </entity-condition>
+            </actions>
+            <widgets>
+                <screenlet title="${uiLabelMap.FormFieldTitle_productionRuns}">
+                    <include-grid name="ProdRun" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
+                </screenlet>
+            </widgets>
+        </section>
+    </screen>
 </screens>

--- a/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
@@ -804,7 +804,7 @@ under the License.
                 </entity-condition>
             </actions>
             <widgets>
-                <screenlet title="${uiLabelMap.FormFieldTitle_productionRuns}">
+                <screenlet title="${uiLabelMap.ManufacturingProductionRuns}">
                     <include-grid name="ProdRun" location="component://manufacturing/widget/manufacturing/ProductionRunForms.xml"/>
                 </screenlet>
             </widgets>

--- a/applications/manufacturing/widget/manufacturing/ProductionRunForms.xml
+++ b/applications/manufacturing/widget/manufacturing/ProductionRunForms.xml
@@ -1008,5 +1008,27 @@ under the License.
         <field name="description"><text/></field>
         <field name="submitButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit/></field>
     </form>
+    <grid name="ProdRun" list-name="productionRuns"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <row-actions>
+            <entity-one entity-name="Product" value-field="product"/>
+            <entity-one entity-name="Uom" value-field="uom">
+                <field-map field-name="uomId" from-field="product.quantityUomId"/>
+            </entity-one>
+        </row-actions>
+        <field name="workEffortId" title="${uiLabelMap.CommonId}">
+            <hyperlink description="${workEffortId}" target="ShowProductionRun" also-hidden="false">
+                <parameter param-name="productionRunId" from-field="workEffortId"/>
+            </hyperlink>
+        </field>
+        <field name="workEffortName" title="${uiLabelMap.ManufacturingProductionRunName}"><display/></field>
+        <field name="productId" title="${uiLabelMap.CommonProduct}"><display description="${product.productId} - ${product.internalName}"/></field>
+        <field name="quantityToProduce" title="${uiLabelMap.ManufacturingQuantity}" widget-area-style="align-right" title-area-style="align-right"><display description="${quantityToProduce} ${uom.abbreviation}"/></field>
+        <field name="currentStatusId" title="${uiLabelMap.CommonStatus}">
+            <display-entity entity-name="StatusItem" key-field-name="statusId"/>
+        </field>
+        <field name="estimatedStartDate" title="${uiLabelMap.ManufacturingStartDate}"><display/></field>
+        <field name="description" title="${uiLabelMap.CommonDescription}"><display/></field>
+    </grid>
 </forms>
 


### PR DESCRIPTION
Currently the 'main' view-map points to the 'FindProductionRun' screen. In order to improve the user experience, the main request-map and view-map should show what is most pressing in manufacturing to address: the production runs in progress.

added:
- ManufacturingPortletData.xml, having record definitions for PortalPage, Portlet, etc

modified::
- ofbiz-component.xml: added data loader for ManufacturingPortletData.xml
- controller.xml: changed view-map 'main' to point to screen Main in CommonScreens.xml
- CommonScreens.xml: adding screen Main displaying a PortalPage
- JobShopScreens.xml: adding screen ProdRun for production runs to process
- ProductionRunForms.xml: adding grid ProdRun to list production runs to process