### PR TITLE
Improved: Marketing-Main page (OFBIZ-13054)

### DIFF
--- a/applications/marketing/data/MarketingPortletData.xml
+++ b/applications/marketing/data/MarketingPortletData.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<entity-engine-xml>
+
+    <!-- marketing_MAIN -->
+    <PortletCategory portletCategoryId="MARKETING" description="Marketing Portlet"/>
+    <PortalPortlet portalPortletId="Campaigns" portletName="Active Campaigns"
+        description="Portlet to display active campaigns "
+        screenName="Campaigns" screenLocation="component://marketing/widget/MarketingCampaignScreens.xml"/>
+    <PortletPortletCategory portalPortletId="Campaigns" portletCategoryId="MARKETING"/>
+    <PortalPortlet portalPortletId="CommEvents" portletName="Communication Event"
+        description="Portlet to display active communication events"
+        screenName="CommEvents" screenLocation="component://marketing/widget/ContactListScreens.xml"/>
+    <PortletPortletCategory portalPortletId="CommEvents" portletCategoryId="MARKETING"/>
+
+    <PortalPage portalPageId="marketing_MAIN" portalPageName="Marketing Main Page" 
+        description="The main portal page of the marketing application" 
+        ownerUserLoginId="_NA_" sequenceNum="1"/>
+    <PortalPageColumn portalPageId="marketing_MAIN" columnSeqId="00001"/>
+    <PortalPageColumn portalPageId="marketing_MAIN" columnSeqId="00002"/>
+    <PortalPagePortlet portalPageId="marketing_MAIN" portalPortletId="Campaigns" columnSeqId="00001" portletSeqId="00001" sequenceNum="1"/>
+    <PortalPagePortlet portalPageId="marketing_MAIN" portalPortletId="CommEvents" columnSeqId="00002" portletSeqId="00001" sequenceNum="1"/>
+
+</entity-engine-xml>

--- a/applications/marketing/data/MarketingPortletData.xml
+++ b/applications/marketing/data/MarketingPortletData.xml
@@ -22,7 +22,7 @@
     <!-- marketing_MAIN -->
     <PortletCategory portletCategoryId="MARKETING" description="Marketing Portlet"/>
     <PortalPortlet portalPortletId="Campaigns" portletName="Active Campaigns"
-        description="Portlet to display active campaigns "
+        description="Portlet to display active campaigns"
         screenName="Campaigns" screenLocation="component://marketing/widget/MarketingCampaignScreens.xml"/>
     <PortletPortletCategory portalPortletId="Campaigns" portletCategoryId="MARKETING"/>
     <PortalPortlet portalPortletId="CommEvents" portletName="Communication Event"
@@ -30,8 +30,8 @@
         screenName="CommEvents" screenLocation="component://marketing/widget/ContactListScreens.xml"/>
     <PortletPortletCategory portalPortletId="CommEvents" portletCategoryId="MARKETING"/>
 
-    <PortalPage portalPageId="marketing_MAIN" portalPageName="Marketing Main Page" 
-        description="The main portal page of the marketing application" 
+    <PortalPage portalPageId="marketing_MAIN" portalPageName="Marketing Main Page"
+        description="The main portal page of the marketing application"
         ownerUserLoginId="_NA_" sequenceNum="1"/>
     <PortalPageColumn portalPageId="marketing_MAIN" columnSeqId="00001"/>
     <PortalPageColumn portalPageId="marketing_MAIN" columnSeqId="00002"/>

--- a/applications/marketing/ofbiz-component.xml
+++ b/applications/marketing/ofbiz-component.xml
@@ -25,6 +25,7 @@ under the License.
     <classpath type="dir" location="config"/>
 
     <entity-resource type="data" reader-name="seed" loader="main" location="data/MarketingSecurityPermissionSeedData.xml"/>
+    <entity-resource type="data" reader-name="seed" loader="main" location="data/NarketingPortletData.xml"/>
     <entity-resource type="data" reader-name="seed" loader="main" location="data/SfaPortletData.xml"/>
 
     <service-resource type="model" loader="main" location="servicedef/services.xml"/>

--- a/applications/marketing/ofbiz-component.xml
+++ b/applications/marketing/ofbiz-component.xml
@@ -25,7 +25,7 @@ under the License.
     <classpath type="dir" location="config"/>
 
     <entity-resource type="data" reader-name="seed" loader="main" location="data/MarketingSecurityPermissionSeedData.xml"/>
-    <entity-resource type="data" reader-name="seed" loader="main" location="data/NarketingPortletData.xml"/>
+    <entity-resource type="data" reader-name="seed" loader="main" location="data/MarketingPortletData.xml"/>
     <entity-resource type="data" reader-name="seed" loader="main" location="data/SfaPortletData.xml"/>
 
     <service-resource type="model" loader="main" location="servicedef/services.xml"/>

--- a/applications/marketing/webapp/marketing/WEB-INF/controller.xml
+++ b/applications/marketing/webapp/marketing/WEB-INF/controller.xml
@@ -406,7 +406,7 @@ under the License.
     <!-- end of request mappings -->
 
     <!-- View Mappings -->
-    <view-map name="main" type="screen" page="component://marketing/widget/CommonScreens.xml#main"/>
+    <view-map name="main" type="screen" page="component://marketing/widget/CommonScreens.xml#Main"/>
     <view-map name="MarketingReport" type="screen" page="component://marketing/widget/MarketingReportScreens.xml#MarketingReportList"/>
 
     <view-map name="FindDataSource"  type="screen" page="component://marketing/widget/DataSourceScreens.xml#ListDataSource"/>

--- a/applications/marketing/widget/CommonScreens.xml
+++ b/applications/marketing/widget/CommonScreens.xml
@@ -111,7 +111,6 @@ under the License.
                         <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
-                    <label>${parameters.parentPortalPageId}</label>
                         <include-portal-page id="${parameters.portalPageId}"/>
                     </decorator-section>
                 </decorator-screen>

--- a/applications/marketing/widget/CommonScreens.xml
+++ b/applications/marketing/widget/CommonScreens.xml
@@ -98,10 +98,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-    <screen name="main">
+    <screen name="Main">
         <section>
             <actions>
                 <set field="headerItem" value="main"/>
+                <set field="parameters.parentPortalPageId" from-field="parameters.parentPortalPageId" default-value="${parameters.localDispatcherName}_MAIN" global="true"/>
+                <script location="component://common/src/main/groovy/org/apache/ofbiz/common/GetParentPortalPageId.groovy"/>
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
@@ -109,9 +111,8 @@ under the License.
                         <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
                     </decorator-section>
                     <decorator-section name="body">
-                        <screenlet title="${uiLabelMap.MarketingManagerApplication}">
-                            <container><label style="label" text="${uiLabelMap.MarketingManagerWelcome}"/></container>
-                        </screenlet>
+                    <label>${parameters.parentPortalPageId}</label>
+                        <include-portal-page id="${parameters.portalPageId}"/>
                     </decorator-section>
                 </decorator-screen>
             </widgets>

--- a/applications/marketing/widget/ContactListForms.xml
+++ b/applications/marketing/widget/ContactListForms.xml
@@ -665,4 +665,25 @@ under the License.
             </hyperlink>
         </field>
     </form>
+    <grid name="CommEvents" list-name="commEvents"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <row-actions>
+            <set field="contactListId" from-field="contactListId"/>
+            <entity-one entity-name="ContactList" value-field="contactList"/>
+            <set field="marketingCampaignId" from-field="contactList.marketingCampaignId"/>
+            <entity-one entity-name="MarketingCampaign" value-field="campaign"/>
+        </row-actions>
+        <field name="communicationEventId" title="${uiLabelMap.CommonEvent}">
+            <hyperlink description="${communicationEventId} - ${subject}" target="EditContactListCommEvent" also-hidden="false">
+                <parameter param-name="communicationEventId"/>
+                <parameter param-name="contactListId"/>
+            </hyperlink>
+        </field>
+        <field name="communicationEventTypeId" title="${uiLabelMap.CommonType}"><display-entity entity-name="CommunicationEventType"/></field>
+        <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
+        <field name="entryDate" title="${uiLabelMap.CommonDate}"><display type="date"/></field>
+        <field name="datetimeStarted" title="${uiLabelMap.CommonStartDate}"><display type="date"/></field>
+        <field name="datetimeEnded" title="${uiLabelMap.CommonEndDate}"><display type="date"/></field>
+        <field name="contactListId"><display description="${contactListId} - ${contactList.contactListName}"/></field>
+    </grid>
 </forms>

--- a/applications/marketing/widget/ContactListScreens.xml
+++ b/applications/marketing/widget/ContactListScreens.xml
@@ -496,4 +496,23 @@ under the License.
             </widgets>
         </section>
     </screen>
+    <screen name="CommEvents">
+        <section>
+            <actions>
+                <entity-condition entity-name="CommunicationEvent" list="commEvents">
+                    <condition-list combine="and">
+                        <condition-expr field-name="contactListId" operator="not-equals" from-field="null"/>
+                    </condition-list>
+                <!--
+                    <order-by field-name="statusId"/>
+                -->
+                </entity-condition>
+            </actions>
+            <widgets>
+                <screenlet title="${uiLabelMap.PartyListCommunicationEvents}">
+                    <include-grid name="CommEvents" location="component://marketing/widget/ContactListForms.xml"/>
+                </screenlet>
+            </widgets>
+        </section>
+    </screen>
 </screens>

--- a/applications/marketing/widget/ContactListScreens.xml
+++ b/applications/marketing/widget/ContactListScreens.xml
@@ -503,9 +503,6 @@ under the License.
                     <condition-list combine="and">
                         <condition-expr field-name="contactListId" operator="not-equals" from-field="null"/>
                     </condition-list>
-                <!--
-                    <order-by field-name="statusId"/>
-                -->
                 </entity-condition>
             </actions>
             <widgets>

--- a/applications/marketing/widget/MarketingCampaignForms.xml
+++ b/applications/marketing/widget/MarketingCampaignForms.xml
@@ -144,4 +144,21 @@ under the License.
             </hyperlink>
         </field>
     </form>
+    <grid name="Campaigns" list-name="campaigns"
+        odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <row-actions>
+        </row-actions>
+        <field name="marketingCampaignId" title="${uiLabelMap.MarketingCampaign}">
+            <hyperlink description="${marketingCampaignId} - ${campaignName}" target="EditMarketingCampaign" also-hidden="false">
+                <parameter param-name="marketingCampaignId"/>
+            </hyperlink>
+        </field>
+        <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
+        <field name="budgetedCost" widget-area-style="align-right" title-area-style="align-right">><display/></field>
+        <field name="fromDate" title-="${uiLabelMap.CommonFrom}"><display type="date"/></field>
+        <field name="thruDate" title-="${uiLabelMap.CommonThru}"><display type="date"/></field>
+        <field name="parentCampaignId" title="${uiLabelMap.CommonParent}">
+            <display-entity entity-name="MarketingCampaign" key-field-name="marketingCampaignId" description="${parentGlAccountId}"/>
+        </field>
+    </grid>
 </forms>

--- a/applications/marketing/widget/MarketingCampaignForms.xml
+++ b/applications/marketing/widget/MarketingCampaignForms.xml
@@ -147,6 +147,8 @@ under the License.
     <grid name="Campaigns" list-name="campaigns"
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
         <row-actions>
+            <set field="uomId" from-field="currencyUomId"/>
+            <entity-one entity-name="Uom" value-field="currency"/>
         </row-actions>
         <field name="marketingCampaignId" title="${uiLabelMap.MarketingCampaign}">
             <hyperlink description="${marketingCampaignId} - ${campaignName}" target="EditMarketingCampaign" also-hidden="false">
@@ -154,11 +156,11 @@ under the License.
             </hyperlink>
         </field>
         <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
-        <field name="budgetedCost" widget-area-style="align-right" title-area-style="align-right">><display/></field>
+        <field name="budgetedCost" widget-area-style="align-right" title-area-style="align-right">><display description="${budgetedCost} ${currency.abbreviation}"/></field>
         <field name="fromDate" title-="${uiLabelMap.CommonFrom}"><display type="date"/></field>
         <field name="thruDate" title-="${uiLabelMap.CommonThru}"><display type="date"/></field>
         <field name="parentCampaignId" title="${uiLabelMap.CommonParent}">
-            <display-entity entity-name="MarketingCampaign" key-field-name="marketingCampaignId" description="${parentGlAccountId}"/>
+            <display-entity entity-name="MarketingCampaign" key-field-name="marketingCampaignId" description="${marketingCampaignId} - ${campaignName}"/>
         </field>
     </grid>
 </forms>

--- a/applications/marketing/widget/MarketingCampaignScreens.xml
+++ b/applications/marketing/widget/MarketingCampaignScreens.xml
@@ -182,5 +182,22 @@ under the License.
             </widgets>
         </section>
     </screen>
-
+    <screen name="Campaigns">
+        <section>
+            <actions>
+                <entity-condition entity-name="MarketingCampaign" list="campaigns">
+                    <condition-list combine="and">
+                        <condition-expr field-name="statusId" operator="not-equals" value="MKTG_CAMP_COMPLETED"/>
+                        <condition-expr field-name="statusId" operator="not-equals" value="MKTG_CAMP_CANCELLED"/>
+                    </condition-list>
+                    <order-by field-name="statusId"/>
+                </entity-condition>
+            </actions>
+            <widgets>
+                <screenlet title="${uiLabelMap.MarketingCampaign}">
+                    <include-grid name="Campaigns" location="component://marketing/widget/MarketingCampaignForms.xml"/>
+                </screenlet>
+            </widgets>
+        </section>
+    </screen>
 </screens>


### PR DESCRIPTION
Currently the 'main' view-map points to a screen showing a label
In order to improve the user experience the main request-map and view-map should show what is most pressing in marketing to address: active campaigns and contact list communication events.

added:
- MarketingPortletData.xml, having record definitions for PortalPage, Portlet, etc

modified::
- ofbiz-component.xml: added data loader for MarketingPortletData.xml
- controller.xml: changed view-map 'main' to point to screen Main in CommonScreens.xml
- CommonScreens.xml: screen Main displaying a PortalPage
- MarketingCampaignScreens.xml: adding screen Campaigns for active campaigns
- MarketingCampaignForms.xml: adding grid Campaigns to list active campaigns
- ContactListScreens.xml: adding screen CommEvents for active communication events
- ContactListForms.xml: adding grid Campaigns to list active communication events
