### PR TITLE
Fixed: Accounts Payable Past Due Invoices doesn't show outstanding amount (OFBIZ-13068)

### DIFF
--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -771,8 +771,8 @@ under the License.
         <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
         <field name="invoiceDate"><display type="date"/></field>
         <field name="dueDate"><display type="date"/></field>
-        <field name="total" widget-area-style="align-text"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="outstanding" widget-area-style="align-text"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="total" widget-area-style="align-right" title-area-style="align-right"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="outstanding" widget-area-style="align-right" title-area-style="align-right"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
     <grid name="ListApReport" separate-columns="true" title="Invoice List" list-name="invoices" target=""
         odd-row-style="alternate-row" default-table-style="basic-table hover-bar" paginate="true" paginate-target="main">
@@ -804,7 +804,7 @@ under the License.
         <field name="statusId" title="${uiLabelMap.CommonStatus}"><display-entity entity-name="StatusItem"/></field>
         <field name="invoiceDate"><display type="date"/></field>
         <field name="dueDate"><display type="date"/></field>
-        <field name="total" widget-area-style="align-text"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="amountToApply" widget-area-style="align-text"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="total" widget-area-style="align-right" title-area-style="align-right"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="outstanding" widget-area-style="align-right" title-area-style="align-right"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
 </forms>


### PR DESCRIPTION
With recent changes via commit ec0adc02f102d75be15e1ee04062b75621219f0d [ec0adc02f1] the field outstanding got replaced with amountToApply in grid ListApReport.

modified: InvoiceForms.xml
- replaced field amountToApply with outstanding in grid ListApReport
- corrected style of fields total and outstanding in grid ListArReport
- corrected style of fields total and outstanding in grid ListApReport