### PR TITLE
Fixed: Accounts Payable Past Due Invoices doesn't show outstanding amount (OFBIZ-13068)

### DIFF
--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -805,6 +805,6 @@ under the License.
         <field name="invoiceDate"><display type="date"/></field>
         <field name="dueDate"><display type="date"/></field>
         <field name="total" widget-area-style="align-right" title-area-style="align-right"><display type="currency" currency="${currencyUomId}"/></field>
-        <field name="amountToApply" widget-area-style="align-right" title-area-style="align-right"><display type="currency" currency="${currencyUomId}"/></field>
+        <field name="outstanding" widget-area-style="align-right" title-area-style="align-right"><display type="currency" currency="${currencyUomId}"/></field>
     </grid>
 </forms>


### PR DESCRIPTION
commit https://github.com/apache/ofbiz-framework/commit/c7230e1006ee18a8c55e8295e57725d78c355e13 broke visibility of the outstanding amount on Accounts Payable in the Main Screen of the accounting application

modified: InvoiceForms.xml
- replaced field in grid ListApReport