### PR TITLE
Fixed: Duplicate main menu button after plugin creation (OFBIZ-13080)

### DIFF
--- a/framework/resources/templates/Menus.xml
+++ b/framework/resources/templates/Menus.xml
@@ -20,6 +20,5 @@ under the License.
 
 <menus xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://ofbiz.apache.org/Widget-Menu" xsi:schemaLocation="http://ofbiz.apache.org/Widget-Menu http://ofbiz.apache.org/dtds/widget-menu.xsd">
     <menu name="MainAppBar" title="${uiLabelMap.@component-resource-name@Application}" extends="CommonAppBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
-        <menu-item name="main" title="${uiLabelMap.CommonMain}"><link target="main"/></menu-item>
     </menu>
 </menus>


### PR DESCRIPTION
The 'main' menu-item is no longer necessary as there is a default main menu button for every plugin.