### PR TITLE
Improved: Manufacturing - VIEW permissions (OFBIZ-13090)

### DIFF
--- a/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
@@ -38,9 +38,6 @@ under the License.
                                 <container>
                                     <label style="h1">[${uiLabelMap.CommonId} ${productionRunId}]</label>
                                 </container>
-                                <container style="button-bar">
-                                    <link target="CreateProductionRun" text="${uiLabelMap.CommonCreate}" style="buttontext"/>
-                                </container>
                                 <decorator-section-include name="body"/>
                             </widgets>
                         </section>
@@ -702,11 +699,6 @@ under the License.
                         <section>
                             <widgets>
                                 <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                                    <decorator-section name="menu-bar">
-                                        <container style="button-bar">
-                                            <link target="CreateProductionRun" text="${uiLabelMap.CommonCreate}" style="buttontext create"/>
-                                        </container>
-                                    </decorator-section>
                                     <decorator-section name="search-options">
                                         <platform-specific>
                                             <html><html-template multi-block="true" location="component://common-theme/template/includes/SetMultipleSelectJsList.ftl"/></html>


### PR DESCRIPTION
Currently, a user with only 'VIEW' permissions, as demonstrated in trunk demo with userId = auditor, accessing a ProductionRun related screen, sees triggers (to requests) reserved for users with 'CREATE' or 'UPDATE' permissions. To see/test: https://localhost:8443/manufacturing/control/ShowProductionRun

modified: JobshopScreens.xml
- removed links to create a production run, as such functionality is provided through the MainActionMenu