### PR TITLE
Improved: Corrected the condition to fetch currency UOM id from shipment instead of shipment route segment

### DIFF
--- a/applications/product/src/main/java/org/apache/ofbiz/shipment/thirdparty/fedex/FedexServices.java
+++ b/applications/product/src/main/java/org/apache/ofbiz/shipment/thirdparty/fedex/FedexServices.java
@@ -538,7 +538,7 @@ public class FedexServices {
             String currencyCode = null;
             if (UtilValidate.isNotEmpty(shipmentRouteSegment.getString("currencyUomId"))) {
                 currencyCode = shipmentRouteSegment.getString("currencyUomId");
-            } else if (UtilValidate.isNotEmpty(shipmentRouteSegment.getString("currencyUomId"))) {
+            } else if (UtilValidate.isNotEmpty(shipment.getString("currencyUomId"))) {
                 currencyCode = shipment.getString("currencyUomId");
             } else {
                 currencyCode = EntityUtilProperties.getPropertyValue("general", "currency.uom.id.default", "USD", delegator);


### PR DESCRIPTION
There is a typo in the condition while fetching a currency UOM id from the shipment route segment entity instead of shipment at the time of creating a shipment on the FedEx carrier.

Improved:Corrected the condition to fetch currency UOM id from shipment instead of shipment route segment
(OFBIZ-13013)

Explanation

Thanks:
