### PR TITLE
fixed: PartyFinancialHistory throws an error (OFBIZ-13099)

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyFinancialHistory.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyFinancialHistory.groovy
@@ -54,7 +54,8 @@ invExprs =
 
 invIterator = from('InvoiceAndType').where(invExprs).cursorScrollInsensitive().distinct().queryIterator()
 
-while (invoice = invIterator.next()) {
+while (invIterator.next()) {
+    invoice = nvIterator.next()
     Boolean isPurchaseInvoice = EntityTypeUtil.hasParentType(delegator, 'InvoiceType', 'invoiceTypeId',
             invoice.getString('invoiceTypeId'), 'parentTypeId', 'PURCHASE_INVOICE')
     Boolean isSalesInvoice = EntityTypeUtil.hasParentType(delegator, 'InvoiceType', 'invoiceTypeId', (String) invoice.getString('invoiceTypeId'),
@@ -97,7 +98,8 @@ payExprs =
 
 payIterator = from('PaymentAndType').where(payExprs).cursorScrollInsensitive().distinct().queryIterator()
 
-while (payment = payIterator.next()) {
+while (payIterator.next()) {
+    payment = payIterator.next()
     if (payment.parentTypeId == 'DISBURSEMENT' || payment.parentTypeId == 'TAX_PAYMENT') {
         totalPayOutApplied += PaymentWorker.getPaymentApplied(payment, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
         totalPayOutNotApplied += PaymentWorker.getPaymentNotApplied(payment, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
@@ -111,6 +113,7 @@ while (payment = payIterator.next()) {
                 + ' !!!! Should be either DISBURSEMENT, TAX_PAYMENT or RECEIPT')
     }
 }
+payIterator.close()
 
 context.finanSummary = [:]
 context.finanSummary.totalSalesInvoice = totalSalesInvoice = totalInvSaApplied.add(totalInvSaNotApplied)

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyFinancialHistory.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyFinancialHistory.groovy
@@ -54,8 +54,7 @@ invExprs =
 
 invIterator = from('InvoiceAndType').where(invExprs).cursorScrollInsensitive().distinct().queryIterator()
 
-while (invIterator.hasNext()) {
-    invoice = invIterator.next()
+while (invoice = invIterator.next()) {
     Boolean isPurchaseInvoice = EntityTypeUtil.hasParentType(delegator, 'InvoiceType', 'invoiceTypeId',
             invoice.getString('invoiceTypeId'), 'parentTypeId', 'PURCHASE_INVOICE')
     Boolean isSalesInvoice = EntityTypeUtil.hasParentType(delegator, 'InvoiceType', 'invoiceTypeId', (String) invoice.getString('invoiceTypeId'),
@@ -73,8 +72,6 @@ while (invIterator.hasNext()) {
                 + ' !!!! Should be either PURCHASE_INVOICE or SALES_INVOICE')
     }
 }
-
-invIterator.close()
 
 //get total/unapplied/applied payment in/out total amount:
 totalPayInApplied = BigDecimal.ZERO
@@ -100,8 +97,7 @@ payExprs =
 
 payIterator = from('PaymentAndType').where(payExprs).cursorScrollInsensitive().distinct().queryIterator()
 
-while (payIterator.hasNext()) {
-    payment = payIterator.next()
+while (payment = payIterator.next()) {
     if (payment.parentTypeId == 'DISBURSEMENT' || payment.parentTypeId == 'TAX_PAYMENT') {
         totalPayOutApplied += PaymentWorker.getPaymentApplied(payment, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
         totalPayOutNotApplied += PaymentWorker.getPaymentNotApplied(payment, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
@@ -115,7 +111,6 @@ while (payIterator.hasNext()) {
                 + ' !!!! Should be either DISBURSEMENT, TAX_PAYMENT or RECEIPT')
     }
 }
-payIterator.close()
 
 context.finanSummary = [:]
 context.finanSummary.totalSalesInvoice = totalSalesInvoice = totalInvSaApplied.add(totalInvSaNotApplied)

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyFinancialHistory.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyFinancialHistory.groovy
@@ -113,7 +113,6 @@ while (payIterator.next()) {
                 + ' !!!! Should be either DISBURSEMENT, TAX_PAYMENT or RECEIPT')
     }
 }
-payIterator.close()
 
 context.finanSummary = [:]
 context.finanSummary.totalSalesInvoice = totalSalesInvoice = totalInvSaApplied.add(totalInvSaNotApplied)

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedInvoicesForParty.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedInvoicesForParty.groovy
@@ -47,7 +47,6 @@ invExprs =
 invIterator = from('InvoiceAndType').where(invExprs).cursorScrollInsensitive().distinct().queryIterator()
 invoiceList = []
 while (invoice = invIterator.next()) {
-    
     unAppliedAmount = InvoiceWorker.getInvoiceNotApplied(invoice, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
     if (unAppliedAmount.signum() == 1) {
         if (actualCurrency == true) {

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedInvoicesForParty.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedInvoicesForParty.groovy
@@ -46,8 +46,8 @@ invExprs =
 
 invIterator = from('InvoiceAndType').where(invExprs).cursorScrollInsensitive().distinct().queryIterator()
 invoiceList = []
-while (invIterator.hasNext()) {
-    invoice = invIterator.next()
+while (invoice = invIterator.next()) {
+    
     unAppliedAmount = InvoiceWorker.getInvoiceNotApplied(invoice, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
     if (unAppliedAmount.signum() == 1) {
         if (actualCurrency == true) {
@@ -64,6 +64,5 @@ while (invIterator.hasNext()) {
                          invoiceParentTypeId: invoice.parentTypeId])
     }
 }
-invIterator.close()
 
 context.ListUnAppliedInvoices = invoiceList

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedInvoicesForParty.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedInvoicesForParty.groovy
@@ -46,7 +46,8 @@ invExprs =
 
 invIterator = from('InvoiceAndType').where(invExprs).cursorScrollInsensitive().distinct().queryIterator()
 invoiceList = []
-while (invoice = invIterator.next()) {
+while (invIterator.next()) {
+    invoice = invIterator.next()
     unAppliedAmount = InvoiceWorker.getInvoiceNotApplied(invoice, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
     if (unAppliedAmount.signum() == 1) {
         if (actualCurrency == true) {
@@ -63,5 +64,6 @@ while (invoice = invIterator.next()) {
                          invoiceParentTypeId: invoice.parentTypeId])
     }
 }
+invIterator.close()
 
 context.ListUnAppliedInvoices = invoiceList

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedInvoicesForParty.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedInvoicesForParty.groovy
@@ -64,6 +64,5 @@ while (invIterator.next()) {
                          invoiceParentTypeId: invoice.parentTypeId])
     }
 }
-invIterator.close()
 
 context.ListUnAppliedInvoices = invoiceList

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedPaymentsForParty.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedPaymentsForParty.groovy
@@ -48,8 +48,7 @@ payExprs =
 paymentList = []
 payIterator = from('PaymentAndType').where(payExprs).cursorScrollInsensitive().distinct().queryIterator()
 
-while (payIterator.hasNext()) {
-    payment = payIterator.next()
+while (payment = payIterator.next()) {
     unAppliedAmount = PaymentWorker.getPaymentNotApplied(payment, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
     if (unAppliedAmount.signum() == 1) {
         if (actualCurrency == true && payment.actualCurrencyAmount && payment.actualCurrencyUomId) {
@@ -68,6 +67,5 @@ while (payIterator.hasNext()) {
                          paymentParentTypeId: payment.parentTypeId])
     }
 }
-payIterator.close()
 
 context.paymentList = paymentList

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedPaymentsForParty.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedPaymentsForParty.groovy
@@ -48,7 +48,8 @@ payExprs =
 paymentList = []
 payIterator = from('PaymentAndType').where(payExprs).cursorScrollInsensitive().distinct().queryIterator()
 
-while (payment = payIterator.next()) {
+while (payIterator.next()) {
+    payment = payIterator.next()
     unAppliedAmount = PaymentWorker.getPaymentNotApplied(payment, actualCurrency).setScale(2, BigDecimal.ROUND_HALF_UP)
     if (unAppliedAmount.signum() == 1) {
         if (actualCurrency == true && payment.actualCurrencyAmount && payment.actualCurrencyUomId) {
@@ -67,5 +68,6 @@ while (payment = payIterator.next()) {
                          paymentParentTypeId: payment.parentTypeId])
     }
 }
+payIterator.close()
 
 context.paymentList = paymentList

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedPaymentsForParty.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/UnAppliedPaymentsForParty.groovy
@@ -68,6 +68,5 @@ while (payIterator.next()) {
                          paymentParentTypeId: payment.parentTypeId])
     }
 }
-payIterator.close()
 
 context.paymentList = paymentList


### PR DESCRIPTION
When accessing the financial history screen in the partymgr application (e.g. via [https://localhost:8443/partymgr/control/PartyFinancialHistory?partyId=EuroSupplier] following error multiple times are thrown.

modified:
- replaced .hasNext() in PartyFinancialHistory.groovy, UnAppliedInvoicesForParty.groovy, UnAppliedPaymentsForParty.groovy
