### PR TITLE
fixed: Link to supplier in Accounting Main does not show PartyFinancialHistory (OFBIZ-13100)

### DIFF
--- a/applications/accounting/widget/InvoiceForms.xml
+++ b/applications/accounting/widget/InvoiceForms.xml
@@ -797,7 +797,7 @@ under the License.
         </field>
         <field name="partyIdFrom" title="${uiLabelMap.PartySupplier}">
             <hyperlink description="${partyNameResultFrom.fullName} [${partyIdFrom}]" target="/partymgr/control/PartyFinancialHistory" target-type="inter-app" target-window="_BLANK">
-                <parameter param-name="partyIdFrom"/>
+                <parameter param-name="partyId" from-field="partyIdFrom"/>
             </hyperlink>
         </field>
         <field name="description" sort-field="true"><display size="100"/></field>


### PR DESCRIPTION
When accessing the link to the PartyFinancialHistory screen of the supplier in [https://demo-trunk.ofbiz.apache.org/accounting/control/main|https://demo-trunk.ofbiz.apache.org/accounting/control/main,] the resulting PartyFinancialHistory in partymgr shows no data.

modified: InvoiceForms.xml
- improved parameter in grid ListApReport
