### PR TITLE
improved: Duplicate action trigger in Manufacturing (OFBIZ-13101)

### DIFF
--- a/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/JobshopScreens.xml
@@ -702,11 +702,6 @@ under the License.
                         <section>
                             <widgets>
                                 <decorator-screen name="FindScreenDecorator" location="component://common/widget/CommonScreens.xml">
-                                    <decorator-section name="menu-bar">
-                                        <container style="button-bar">
-                                            <link target="CreateProductionRun" text="${uiLabelMap.CommonCreate}" style="buttontext create"/>
-                                        </container>
-                                    </decorator-section>
                                     <decorator-section name="search-options">
                                         <platform-specific>
                                             <html><html-template multi-block="true" location="component://common-theme/template/includes/SetMultipleSelectJsList.ftl"/></html>


### PR DESCRIPTION
On the 'FndProductionRun' an action trigger to create something is shown. This links to CreateProductionRun. This action trigger is already available via the MainActionMenu.

Removing this duplicate also improves the experience for users with only VIEW permissions, like auditor in the demo site.

modified: JopshopScreens.xml
- removed decorator-section having action trigger