### PR TITLE
Fixed: MainActionMenu not shown on findreturn screen (OFBIZ-13107)

### DIFF
--- a/applications/order/widget/ordermgr/OrderReturnScreens.xml
+++ b/applications/order/widget/ordermgr/OrderReturnScreens.xml
@@ -25,6 +25,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <section>
                             <widgets>
@@ -58,6 +61,9 @@ under the License.
             </actions>
             <widgets>
                 <decorator-screen name="main-decorator" location="${parameters.mainDecoratorLocation}">
+                    <decorator-section name="pre-body">
+                        <include-menu name="MainActionMenu" location="${parameters.mainMenuLocation}"/>
+                    </decorator-section>
                     <decorator-section name="body">
                         <screenlet title="${uiLabelMap.PageTitleFindReturn}">
                             <container style="basic-nav">


### PR DESCRIPTION
The MainActionMenu of the order component is shown on various screens, but not on the findreturn screen.

modified: OrderReturnScreens,xml
- added pre-body decorator section having MainActionMenu to screen CommonOrderReturnDecorator and screen OrderFindReturn