### PR TITLE
Improved: Added support to allow direct view rendering in override vi…

### DIFF
--- a/applications/content/webapp/content/WEB-INF/controller.xml
+++ b/applications/content/webapp/content/WEB-INF/controller.xml
@@ -1851,7 +1851,7 @@ under the License.
     <view-map name="EditWebSitePathAlias" type="screen" page="component://content/widget/WebSiteScreens.xml#EditWebSitePathAlias"/>
     <view-map name="WebSiteContent" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteContent"/>
     <view-map name="WebSiteCMS" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMS"/>
-    <view-map name="WebSiteCMSContent" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSContent"/>
+    <view-map name="WebSiteCMSContent" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSContent" allow-direct-view-rendering="true"/>
     <view-map name="WebSiteCMSEditor" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSEditor"/>
     <view-map name="WebSiteCMSMetaInfo" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSMetaInfo"/>
     <view-map name="WebSiteCMSPathAlias" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSPathAlias"/>

--- a/framework/webapp/dtd/site-conf.xsd
+++ b/framework/webapp/dtd/site-conf.xsd
@@ -776,6 +776,17 @@ under the License.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute type="xs:boolean" name="allow-direct-view-rendering" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    This attribute determines whether direct rendering of the view is allowed when using the override view functionality.
+                    If set to true,
+                    the system permits the view to be rendered directly using the override view functionality.
+                    If false or not specified,
+                    direct rendering is not allowed, and system throws Unknown request exception.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="x-frame-options" default="sameorigin">
             <xs:annotation>
                 <xs:documentation>

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ConfigXMLReader.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ConfigXMLReader.java
@@ -1044,6 +1044,7 @@ public final class ConfigXMLReader {
         private String strictTransportSecurity;
         private String description;
         private boolean noCache = false;
+        private boolean allowDirectViewRendering = false;
 
         /**
          * Gets name.
@@ -1121,6 +1122,15 @@ public final class ConfigXMLReader {
         }
 
         /**
+         * allow direct view rendering boolean
+         *
+         * @return the boolean
+         */
+        public boolean isAllowDirectViewRendering() {
+            return this.allowDirectViewRendering;
+        }
+
+        /**
          * Gets encoding.
          * @return the encoding
          */
@@ -1135,6 +1145,7 @@ public final class ConfigXMLReader {
             this.info = viewMapElement.getAttribute("info");
             this.contentType = viewMapElement.getAttribute("content-type");
             this.noCache = "true".equals(viewMapElement.getAttribute("no-cache"));
+            this.allowDirectViewRendering = "true".equals(viewMapElement.getAttribute("allow-direct-view-rendering"));
             this.encoding = viewMapElement.getAttribute("encoding");
             this.xFrameOption = viewMapElement.getAttribute("x-frame-options");
             this.strictTransportSecurity = viewMapElement.getAttribute("strict-transport-security");

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
@@ -129,14 +129,18 @@ public final class RequestHandler {
         Map<String, List<RequestMap>> requestMapMap = ccfg.getRequestMapMultiMap();
         Collection<RequestMap> rmaps = resolveTemplateURI(requestMapMap, req);
         if (rmaps.isEmpty()) {
-            Map<String, ConfigXMLReader.ViewMap> viewMapMap = ccfg.getViewMapMap();
             String defaultRequest = ccfg.getDefaultRequest();
             String path = req.getPathInfo();
             String requestUri = getRequestUri(path);
             String overrideViewUri = getOverrideViewUri(path);
+            boolean allowDirectViewRendering = false;
+            // Ensure that overridden view exists and direct view rendering is allowed.
+            if (UtilValidate.isNotEmpty(overrideViewUri)) {
+                ConfigXMLReader.ViewMap overrideViewMap = ccfg.getViewMapMap().get(overrideViewUri);
+                allowDirectViewRendering = (overrideViewMap != null && overrideViewMap.isAllowDirectViewRendering());
+            }
             if (requestMapMap.containsKey(requestUri)
-                    // Ensure that overridden view exists.
-                    && (overrideViewUri == null || viewMapMap.containsKey(overrideViewUri)
+                    && (allowDirectViewRendering
                     || ("SOAPService".equals(requestUri) && "wsdl".equalsIgnoreCase(req.getQueryString())))) {
                 rmaps = requestMapMap.get(requestUri);
                 req.setAttribute("overriddenView", overrideViewUri);

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/RequestHandlerTests.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/RequestHandlerTests.java
@@ -45,6 +45,7 @@ import org.apache.ofbiz.webapp.control.ConfigXMLReader.RequestMap;
 import org.apache.ofbiz.webapp.control.ConfigXMLReader.ViewMap;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.w3c.dom.Element;
 
 public class RequestHandlerTests {
@@ -190,10 +191,12 @@ public class RequestHandlerTests {
             reqMaps.putSingle("foo", foo);
             reqMaps.putSingle("bar", bar);
 
-            viewMaps.put("baz", new ViewMap(dummyElement));
+            //viewMaps.put("baz", new ViewMap(dummyElement));
+            viewMaps.put("baz", Mockito.mock(ViewMap.class)); // Mock the ViewMap
 
             when(req.getPathInfo()).thenReturn("/foo/baz");
             when(ccfg.getDefaultRequest()).thenReturn("bar");
+            when(viewMaps.get("baz").isAllowDirectViewRendering()).thenReturn(true);
             assertThat(RequestHandler.resolveURI(ccfg, req), hasItem(foo));
         }
 


### PR DESCRIPTION
Improved: Added support to allow direct view rendering in override vi…ew functionality (OFBIZ-13117)

Added allow-direct-view-rendering in view-mapping tag, default value will be false. i.e by default now view is allowed to be used as OOTB overridden view functionality. In order to allow the view redirection (override) on all workflows allow-direct-view-rendering must be set to true. This feature may break some existing flow where overridden view workflow is used