### PR TITLE
Improved: Added support to allow direct view rendering in override vi...

### DIFF
--- a/applications/content/webapp/content/WEB-INF/controller.xml
+++ b/applications/content/webapp/content/WEB-INF/controller.xml
@@ -1851,7 +1851,7 @@ under the License.
     <view-map name="EditWebSitePathAlias" type="screen" page="component://content/widget/WebSiteScreens.xml#EditWebSitePathAlias"/>
     <view-map name="WebSiteContent" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteContent"/>
     <view-map name="WebSiteCMS" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMS"/>
-    <view-map name="WebSiteCMSContent" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSContent"/>
+    <view-map name="WebSiteCMSContent" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSContent" allow-direct-view-rendering="true"/>
     <view-map name="WebSiteCMSEditor" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSEditor"/>
     <view-map name="WebSiteCMSMetaInfo" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSMetaInfo"/>
     <view-map name="WebSiteCMSPathAlias" type="screen" page="component://content/widget/WebSiteScreens.xml#WebSiteCMSPathAlias"/>

--- a/framework/webapp/dtd/site-conf.xsd
+++ b/framework/webapp/dtd/site-conf.xsd
@@ -776,6 +776,25 @@ under the License.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute type="xs:boolean" name="allow-direct-view-rendering" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    This attribute determines whether direct rendering of the view is allowed when using the override view functionality.
+                    If set to true,
+                    the system permits the view to be rendered directly using the override view functionality.
+                    If false or not specified,
+                    direct rendering is not allowed, and system throws Unknown request exception.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute type="xs:boolean" name="direct-view-rendering-with-auth" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If direct-view-rendering-with-auth=true, direct rendering of the view is only allowed with an active login when using the override view functionality.
+                    If direct-view-rendering-with-auth=false, no active login is required.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="x-frame-options" default="sameorigin">
             <xs:annotation>
                 <xs:documentation>

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ConfigXMLReader.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ConfigXMLReader.java
@@ -1044,6 +1044,8 @@ public final class ConfigXMLReader {
         private String strictTransportSecurity;
         private String description;
         private boolean noCache = false;
+        private boolean allowDirectViewRendering = false;
+        private boolean directViewRenderingWithAuth = false;
 
         /**
          * Gets name.
@@ -1121,6 +1123,24 @@ public final class ConfigXMLReader {
         }
 
         /**
+         * allow direct view rendering boolean
+         *
+         * @return the boolean
+         */
+        public boolean isAllowDirectViewRendering() {
+            return this.allowDirectViewRendering;
+        }
+
+        /**
+         * direct view rendering with authentication boolean
+         *
+         * @return the boolean
+         */
+        public boolean isDirectViewRenderingWithAuth() {
+            return this.directViewRenderingWithAuth;
+        }
+
+        /**
          * Gets encoding.
          * @return the encoding
          */
@@ -1135,6 +1155,8 @@ public final class ConfigXMLReader {
             this.info = viewMapElement.getAttribute("info");
             this.contentType = viewMapElement.getAttribute("content-type");
             this.noCache = "true".equals(viewMapElement.getAttribute("no-cache"));
+            this.allowDirectViewRendering = "true".equals(viewMapElement.getAttribute("allow-direct-view-rendering"));
+            this.directViewRenderingWithAuth = "true".equals(viewMapElement.getAttribute("direct-view-rendering-with-auth"));
             this.encoding = viewMapElement.getAttribute("encoding");
             this.xFrameOption = viewMapElement.getAttribute("x-frame-options");
             this.strictTransportSecurity = viewMapElement.getAttribute("strict-transport-security");

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/RequestHandlerTests.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/RequestHandlerTests.java
@@ -46,6 +46,7 @@ import org.apache.ofbiz.webapp.control.ConfigXMLReader.ViewMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Element;
+import org.mockito.Mockito;
 
 public class RequestHandlerTests {
     public static class ResolveURITests {
@@ -190,10 +191,12 @@ public class RequestHandlerTests {
             reqMaps.putSingle("foo", foo);
             reqMaps.putSingle("bar", bar);
 
-            viewMaps.put("baz", new ViewMap(dummyElement));
+            //viewMaps.put("baz", new ViewMap(dummyElement));
+            viewMaps.put("baz", Mockito.mock(ViewMap.class)); // Mock the ViewMap
 
             when(req.getPathInfo()).thenReturn("/foo/baz");
             when(ccfg.getDefaultRequest()).thenReturn("bar");
+            when(viewMaps.get("baz").isAllowDirectViewRendering()).thenReturn(true);
             assertThat(RequestHandler.resolveURI(ccfg, req), hasItem(foo));
         }
 


### PR DESCRIPTION
...ew functionality (OFBIZ-13117)

Added allow-direct-view-rendering and direct-view-rendering-with-auth in view-mapping tag, default values will be false. i.e by default now view is allowed to be used as OOTB overridden view functionality. In order to allow the view redirection (override) on all workflows allow-direct-view-rendering must be set to true.
If view redirection is allowed and direct-view-rendering-with-auth is set to true then login credentials are necessary to use this functionality.
This feature may break some existing flow where overridden view workflow is used

Thanks: Deepak Dixit for providing the initial patch
