### PR TITLE
Improved: Add permission check for view-maps and change defaults for request-maps (OFBIZ-13130)

### DIFF
--- a/applications/accounting/webapp/accounting/WEB-INF/controller.xml
+++ b/applications/accounting/webapp/accounting/WEB-INF/controller.xml
@@ -2630,7 +2630,7 @@ under the License.
     <!-- end of request mappings -->
 
     <!-- View Mappings -->
-    <view-map name="main" type="screen" page="component://accounting/widget/CommonScreens.xml#main"/>
+    <view-map name="main" type="screen" page="component://accounting/widget/CommonScreens.xml#main" auth="false"/>
 
     <!-- BillingAccount -->
     <view-map name="FindBillingAccount" type="screen" page="component://accounting/widget/BillingAccountScreens.xml#FindBillingAccount"/>

--- a/applications/content/webapp/content/WEB-INF/controller.xml
+++ b/applications/content/webapp/content/WEB-INF/controller.xml
@@ -49,6 +49,7 @@ under the License.
     </request-map>
 
     <request-map uri="chain">
+        <security https="false" auth="false"/>
         <event type="java" path="org.apache.ofbiz.webapp.event.TestEvent" invoke="test"/>
         <response name="success" type="request" value="/view"/>
         <response name="error" type="view" value="error"/>

--- a/applications/order/webapp/ordermgr/WEB-INF/controller.xml
+++ b/applications/order/webapp/ordermgr/WEB-INF/controller.xml
@@ -653,6 +653,7 @@ under the License.
     </request-map>
 
     <request-map uri="setDesiredAlternateGwpProductId">
+        <security https="false" auth="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.ShoppingCartEvents" invoke="setDesiredAlternateGwpProductId"/>
         <response name="success" type="view" value="showcart"/>
         <response name="error" type="view" value="showcart"/>
@@ -673,6 +674,7 @@ under the License.
         <response name="error" type="request" value="orderentry"/>
     </request-map>
     <request-map uri="quickadd">
+        <security https="false" auth="false"/>
         <response name="success" type="view" value="quickadd"/>
     </request-map>
 
@@ -770,19 +772,19 @@ under the License.
     <!-- For checkout steps that use finalizeOrder: This request chain is for calculating shipping & tax before getting to the payments page, so that the visitor
         will know the full shipping & tax charges when trying to split payments between various payment methods -->
     <request-map uri="calcShippingBeforePayment">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.shipping.ShippingEvents" invoke="getShipEstimate"/>
         <response name="success" type="request" value="calcTaxBeforePayment"/>
         <response name="error" type="request" value="orderentry"/>
     </request-map>
     <request-map uri="calcTaxBeforePayment">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.CheckOutEvents" invoke="calcTax"/>
         <response name="success" type="request" value="validatePaymentMethodsBeforePayment"/>
         <response name="error" type="request" value="orderentry"/>
     </request-map>
     <request-map uri="validatePaymentMethodsBeforePayment">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.CheckOutEvents" invoke="checkPaymentMethods"/>
         <response name="success" type="view" value="billsetting"/>
         <response name="error" type="request" value="orderentry"/>
@@ -885,13 +887,13 @@ under the License.
     </request-map>
 
     <request-map uri="calcShipping">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.shipping.ShippingEvents" invoke="getShipEstimate"/>
         <response name="success" type="request" value="calcTax"/>
         <response name="error" type="request" value="orderentry"/>
     </request-map>
     <request-map uri="calcTax">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.CheckOutEvents" invoke="calcTax"/>
         <response name="success" type="view" value="confirm"/>
         <response name="error" type="request" value="orderentry"/>
@@ -1003,20 +1005,20 @@ under the License.
         <response name="error" type="view" value="confirm"/>
     </request-map>
     <request-map uri="checkDenyList">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.CheckOutEvents" invoke="checkOrderDenylist"/>
         <response name="success" type="request" value="processpayment"/>
         <response name="failed" type="request" value="failedDenylist"/>
         <response name="error" type="view" value="confirm"/>
     </request-map>
     <request-map uri="failedDenylist">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.CheckOutEvents" invoke="failedDenylistCheck"/>
         <response name="success" type="view" value="main"/>
         <response name="error" type="view" value="main"/>
     </request-map>
     <request-map uri="processpayment">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.CheckOutEvents" invoke="processPayment"/>
         <response name="success" type="request" value="clearcart"/>
         <response name="fail" type="view" value="confirm"/>
@@ -1029,7 +1031,7 @@ under the License.
         <response name="error" type="view" value="confirm"/>
     </request-map>
     <request-map uri="clearpocart">
-        <security https="true" direct-request="false"/>
+        <security https="true" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.order.shoppingcart.ShoppingCartEvents" invoke="destroyCart"/>
         <response name="success" type="request-redirect" value="orderview">
             <redirect-parameter name="orderId"/>
@@ -1037,7 +1039,7 @@ under the License.
         <response name="error" type="view" value="confirm"/>
     </request-map>
     <request-map uri="emailorder">
-        <security https="true" direct-request="false"/>
+        <security https="true" auth="false" direct-request="false"/>
         <event type="service" path="async" invoke="sendOrderConfirmation"/>
         <response name="success" type="request-redirect" value="orderview">
             <redirect-parameter name="orderId"/>
@@ -2020,7 +2022,7 @@ under the License.
     <!-- View Mappings -->
     <view-map name="LookupProductCategory" type="screen" page="component://product/widget/catalog/LookupScreens.xml#LookupProductCategory"/>
 
-    <view-map name="main" type="screen" page="component://order/widget/ordermgr/OrderViewScreens.xml#Main"/>
+    <view-map name="main" type="screen" page="component://order/widget/ordermgr/OrderViewScreens.xml#Main" auth="false"/>
 
     <view-map name="orderstats" type="screen" page="component://order/widget/ordermgr/OrderViewScreens.xml#OrderStats"/>
     <view-map name="findorders" type="screen" page="component://order/widget/ordermgr/OrderViewScreens.xml#OrderFindOrder"/>
@@ -2037,7 +2039,7 @@ under the License.
 
 
     <view-map name="survey" type="screen" page="component://order/widget/ordermgr/OrderEntryCartScreens.xml#survey"/>
-    <view-map name="showcart" type="screen" page="component://order/widget/ordermgr/OrderEntryCartScreens.xml#ShowCart"/>
+    <view-map name="showcart" type="screen" page="component://order/widget/ordermgr/OrderEntryCartScreens.xml#ShowCart" auth="false"/>
     <view-map name="checkinits" type="screen" page="component://order/widget/ordermgr/OrderEntryScreens.xml#CheckInits"/>
     <view-map name="orderagreements" type="screen" page="component://order/widget/ordermgr/OrderEntryScreens.xml#OrderAgreements"/>
     <view-map name="viewshoppinglists" type="screen" page="component://order/widget/ordermgr/OrderEntryScreens.xml#ViewShoppingLists"/>
@@ -2055,7 +2057,7 @@ under the License.
     <view-map name="category" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#category"/>
     <view-map name="product" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#product"/>
     <view-map name="compareProducts" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#compareProducts"/>
-    <view-map name="quickadd" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#quickadd"/>
+    <view-map name="quickadd" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#quickadd" auth="false"/>
     <view-map name="AddGiftCertificate" type="screen" page="component://order/widget/ordermgr/OrderEntryCartScreens.xml#AddGiftCertificate"/>
 
     <view-map name="custsetting" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#CustSettings"/>
@@ -2063,9 +2065,9 @@ under the License.
     <view-map name="EditShipAddress" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#EditShipAddress"/>
     <view-map name="SetItemShipGroups" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#SetItemShipGroups"/>
     <view-map name="optionsetting" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#OptionSettings"/>
-    <view-map name="billsetting" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#BillSettings"/>
-    <view-map name="confirm" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#ConfirmOrder"/>
-    <view-map name="ordercomplete" type="screen" page="component://order/widget/ordermgr/OrderViewScreens.xml#OrderHeaderView"/>
+    <view-map name="billsetting" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#BillSettings" auth="false"/>
+    <view-map name="confirm" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#ConfirmOrder" auth="false"/>
+    <view-map name="ordercomplete" type="screen" page="component://order/widget/ordermgr/OrderViewScreens.xml#OrderHeaderView" auth="false"/>
     <view-map name="orderTerm" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#OrderTerms"/>
     <view-map name="setAdditionalParty" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#SetAdditionalParty"/>
 

--- a/applications/product/webapp/catalog/WEB-INF/controller.xml
+++ b/applications/product/webapp/catalog/WEB-INF/controller.xml
@@ -45,6 +45,7 @@ under the License.
         <response name="success" type="request" value="main"/>
     </request-map>
     <request-map uri="chain">
+        <security https="false" auth="false"/>
         <event type="java" path="org.apache.ofbiz.webapp.event.TestEvent" invoke="test"/>
         <response name="success" type="request" value="/view"/>
         <response name="error" type="view" value="error"/>

--- a/applications/product/webapp/facility/WEB-INF/controller.xml
+++ b/applications/product/webapp/facility/WEB-INF/controller.xml
@@ -1159,6 +1159,7 @@ under the License.
     </request-map>
     <!-- note: this is an insecure version of above for purposes of rendering via fop, which cannot access over https -->
     <request-map uri="viewShipmentLabel">
+        <security https="false" auth="false"/>
         <event type="java" path="org.apache.ofbiz.shipment.shipment.ShipmentEvents" invoke="viewShipmentPackageRouteSegLabelImage"/>
         <response name="success" type="none" value=""/>
         <response name="error" type="view" value="EditShipmentRouteSegments"/>
@@ -1435,7 +1436,7 @@ under the License.
     <view-map name="EditShipmentPlan" type="screen" page="component://product/widget/facility/ShipmentScreens.xml#EditShipmentPlan"/>
     <view-map name="ViewShipmentReceipts" type="screen" page="component://product/widget/facility/ShipmentScreens.xml#ViewShipmentReceipts"/>
     <view-map name="EditShipmentPackages" type="screen" page="component://product/widget/facility/ShipmentScreens.xml#EditShipmentPackages"/>
-    <view-map name="EditShipmentRouteSegments" type="screen" page="component://product/widget/facility/ShipmentScreens.xml#EditShipmentRouteSegments"/>
+    <view-map name="EditShipmentRouteSegments" type="screen" page="component://product/widget/facility/ShipmentScreens.xml#EditShipmentRouteSegments" auth="false"/>
     <view-map name="AddItemsFromOrder" type="screen" page="component://product/widget/facility/ShipmentScreens.xml#AddItemsFromOrder"/>
     <view-map name="AddItemsFromInventory" type="screen" page="component://product/widget/facility/ShipmentScreens.xml#AddItemsFromInventory"/>
     <view-map name="ReceiveInventoryAgainstPurchaseOrder" type="screen" page="component://product/widget/facility/ShipmentScreens.xml#ReceiveInventoryAgainstPurchaseOrder"/>

--- a/applications/workeffort/webapp/workeffort/WEB-INF/controller.xml
+++ b/applications/workeffort/webapp/workeffort/WEB-INF/controller.xml
@@ -46,6 +46,7 @@ under the License.
     </request-map>
 
     <request-map uri="chain">
+        <security https="false" auth="false"/>
         <event type="java" path="org.apache.ofbiz.webapp.event.TestEvent" invoke="test"/>
         <response name="success" type="request" value="/view"/>
         <response name="error" type="view" value="error"/>

--- a/framework/common/webcommon/WEB-INF/common-controller.xml
+++ b/framework/common/webcommon/WEB-INF/common-controller.xml
@@ -182,14 +182,17 @@ under the License.
     </request-map>
 
     <request-map uri="main">
+        <security https="false" auth="false"/>
         <response name="success" type="view" value="main"/>
     </request-map>
 
     <request-map uri="viewBlocked">
+        <security https="false" auth="false"/>
         <response name="success" type="view" value="viewBlocked"/>
     </request-map>
 
     <request-map uri="LookupTimeDuration">
+        <security https="false" auth="false"/>
         <response name="success" type="view" value="LookupTimeDuration"/>
     </request-map>
 
@@ -206,7 +209,7 @@ under the License.
     <!-- Common json response events, chain these after events to send json responses -->
     <!-- Standard json response, For security reason (OFBIZ-5409) tries to keep only the initially called service attributes -->
     <request-map uri="json">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.common.CommonEvents" invoke="jsonResponseFromRequestAttributes"/>
         <response name="success" type="none"/>
     </request-map>
@@ -245,7 +248,7 @@ under the License.
         <response name="error" type="request" value="js"/>
     </request-map>
     <request-map uri="js">
-        <security direct-request="false"/>
+        <security https="false" auth="false" direct-request="false"/>
         <event type="java" path="org.apache.ofbiz.common.CommonEvents" invoke="jsResponseFromRequest"/>
         <response name="success" type="none"/>
     </request-map>
@@ -339,33 +342,32 @@ under the License.
     <!--========================== AJAX events =====================-->
 
     <!-- View Mappings -->
-    <view-map name="error" type="ftl" page="component://common/webcommon/error/Error.ftl"/>
-    <view-map name="main" type="none"/>
-    <view-map name="login" type="screen" page="component://common/widget/CommonScreens.xml#login"/>
+    <view-map name="error" type="ftl" page="component://common/webcommon/error/Error.ftl" auth="false"/>
+    <view-map name="main" type="none" auth="false"/>
+    <view-map name="login" type="screen" page="component://common/widget/CommonScreens.xml#login" auth="false"/>
     <view-map name="impersonated" type="screen" page="component://common/widget/CommonScreens.xml#impersonated"/>
-    <view-map name="ajaxLogin" type="screen" page="component://common/widget/CommonScreens.xml#ajaxNotLoggedIn"/>
+    <view-map name="ajaxLogin" type="screen" page="component://common/widget/CommonScreens.xml#ajaxNotLoggedIn" auth="false"/>
     <view-map name="requirePasswordChange" type="screen" page="component://common/widget/CommonScreens.xml#requirePasswordChange"/>
-    <view-map name="forgotPassword" type="screen" page="component://common/widget/CommonScreens.xml#forgotPassword"/>
-    <view-map name="EventMessages" type="screen" page="component://common/widget/CommonScreens.xml#EventMessages"/>
+    <view-map name="forgotPassword" type="screen" page="component://common/widget/CommonScreens.xml#forgotPassword" auth="false"/>
+    <view-map name="EventMessages" type="screen" page="component://common/widget/CommonScreens.xml#EventMessages" auth="false"/>
 
-    <view-map name="ListLocales" type="screen" page="component://common/widget/LookupScreens.xml#ListLocales"/>
-    <view-map name="ListSetCompanies" type="screen" page="component://common/widget/LookupScreens.xml#ListSetCompanies"/>
-    <view-map name="LookupTimeDuration" type="screen" page="component://common/widget/LookupScreens.xml#TimeDuration"/>
+    <view-map name="ListLocales" type="screen" page="component://common/widget/LookupScreens.xml#ListLocales" auth="false"/>
+    <view-map name="ListSetCompanies" type="screen" page="component://common/widget/LookupScreens.xml#ListSetCompanies" auth="false"/>
+    <view-map name="LookupTimeDuration" type="screen" page="component://common/widget/LookupScreens.xml#TimeDuration" auth="false"/>
     <view-map name="ListTimezones" type="screen" page="component://common/widget/LookupScreens.xml#ListTimezones"/>
     <view-map name="ListVisualThemes" type="screen" page="component://common/widget/LookupScreens.xml#ListVisualThemes"/>
 
     <view-map name="ajaxAutocompleteOptions" type="screen" page="component://common/widget/CommonScreens.xml#ajaxAutocompleteOptions"/>
 
     <view-map name="help" type="screen" page="component://common/widget/CommonScreens.xml#help"/>
-    <view-map name="showHelp" type="screen" page="component://common/widget/HelpScreens.xml#ShowHelp"/>
-    <view-map name="ShowDocument" type="screen" page="component://common/widget/HelpScreens.xml#showDocument"/>
+    <view-map name="showHelp" type="screen" page="component://common/widget/HelpScreens.xml#ShowHelp" auth="false"/>
+    <view-map name="ShowDocument" type="screen" page="component://common/widget/HelpScreens.xml#showDocument" auth="false"/>
 
-    <view-map name="viewBlocked" type="screen" page="component://common/widget/CommonScreens.xml#viewBlocked"/>
+    <view-map name="viewBlocked" type="screen" page="component://common/widget/CommonScreens.xml#viewBlocked" auth="false"/>
 
     <view-map name="LookupGeo" type="screen" page="component://common/widget/LookupScreens.xml#LookupGeo"/>
     <view-map name="LookupGeoName" type="screen" page="component://common/widget/LookupScreens.xml#LookupGeoName"/>
     <view-map name="LookupLocale" type="screen" page="component://common/widget/LookupScreens.xml#LookupLocale"/>
-    <view-map name="forgotPassword" type="screen" page="component://common/widget/CommonScreens.xml#forgotPassword"/>
-    <view-map name="GetUiLabels" type="screentext" page="component://common/widget/CommonScreens.xml#GetUiLabels" content-type="application/json"/>
+    <view-map name="GetUiLabels" type="screentext" page="component://common/widget/CommonScreens.xml#GetUiLabels" auth="false" content-type="application/json"/>
 
 </site-conf>

--- a/framework/common/webcommon/WEB-INF/portal-controller.xml
+++ b/framework/common/webcommon/WEB-INF/portal-controller.xml
@@ -23,6 +23,7 @@ under the License.
     <description>Portal ControlServlet Configuration File</description>
 
     <request-map uri="main">
+        <security https="false" auth="false"/>
         <response name="success" type="view" value="showPortalPage"/>
     </request-map>
     <!-- Portlet show requests -->
@@ -161,7 +162,7 @@ under the License.
     </request-map>
     <request-map uri="LookupPortalPage"><security https="true" auth="true"/><response name="success" type="view" value="LookupPortalPage"/></request-map>
     <!-- View Mappings -->
-    <view-map name="showPortalPage" type="screen" page="component://common/widget/PortalPageScreens.xml#showPortalPage"/>
+    <view-map name="showPortalPage" type="screen" page="component://common/widget/PortalPageScreens.xml#showPortalPage" auth="false"/>
     <view-map name="showPortlet" type="screen" page="component://common/widget/PortalPageScreens.xml#showPortlet"/>
     <view-map name="showPortletMainDecorator" type="screen" page="component://common/widget/PortalPageScreens.xml#showPortletMainDecorator"/>
     <view-map name="showPortletSimpleDecorator" type="screen" page="component://common/widget/PortalPageScreens.xml#showPortletSimpleDecorator"/>
@@ -169,6 +170,6 @@ under the License.
     <view-map name="NewPortalPage" type="screen" page="component://common/widget/PortalPageScreens.xml#NewPortalPage"/>
     <view-map name="addPortlet" type="screen" page="component://common/widget/PortalPageScreens.xml#AddPortlet"/>
     <view-map name="editPortalPortletAttributes" type="screen" page="component://common/widget/PortalPageScreens.xml#EditPortalPortletAttributes"/>
-    <view-map name="editPortalPageColumnWidth" type="screen" page="component://common/widget/PortalPageScreens.xml#EditPortalPageColumnWidth"/>
+    <view-map name="editPortalPageColumnWidth" type="screen" page="component://common/widget/PortalPageScreens.xml#EditPortalPageColumnWidth" auth="false"/>
     <view-map name="LookupPortalPage" type="screen" page="component://common/widget/LookupScreens.xml#LookupPortalPage"/>
 </site-conf>

--- a/framework/webapp/dtd/site-conf.xsd
+++ b/framework/webapp/dtd/site-conf.xsd
@@ -776,6 +776,14 @@ under the License.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute type="xs:boolean" name="auth" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    If auth=true, RequestHandler.renderView requires an active login to access the view-map.
+                    If direct-view-rendering-with-auth=false, no active login is required.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="x-frame-options" default="sameorigin">
             <xs:annotation>
                 <xs:documentation>

--- a/framework/webapp/dtd/site-conf.xsd
+++ b/framework/webapp/dtd/site-conf.xsd
@@ -267,14 +267,14 @@ under the License.
         </xs:complexType>
     </xs:element>
     <xs:attributeGroup name="attlist.security">
-        <xs:attribute type="xs:boolean" name="https" default="false">
+        <xs:attribute type="xs:boolean" name="https" default="true">
             <xs:annotation>
                 <xs:documentation>
                     If https=true, redirect to/use/generate the secured HTTPS protocol if necessary and possible.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute type="xs:boolean" name="auth" default="false">
+        <xs:attribute type="xs:boolean" name="auth" default="true">
             <xs:annotation>
                 <xs:documentation>
                     If auth=true, when you hit the request if you are not logged in you will be forwarded to the login page.

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ConfigXMLReader.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ConfigXMLReader.java
@@ -1044,6 +1044,7 @@ public final class ConfigXMLReader {
         private String strictTransportSecurity;
         private String description;
         private boolean noCache = false;
+        private boolean securityAuth = false;
 
         /**
          * Gets name.
@@ -1121,6 +1122,14 @@ public final class ConfigXMLReader {
         }
 
         /**
+         * Is securityAuth boolean.
+         * @return the boolean
+         */
+        public boolean isSecurityAuth() {
+            return securityAuth;
+        }
+
+        /**
          * Gets encoding.
          * @return the encoding
          */
@@ -1135,6 +1144,7 @@ public final class ConfigXMLReader {
             this.info = viewMapElement.getAttribute("info");
             this.contentType = viewMapElement.getAttribute("content-type");
             this.noCache = "true".equals(viewMapElement.getAttribute("no-cache"));
+            this.securityAuth = "true".equals(viewMapElement.getAttribute("auth"));
             this.encoding = viewMapElement.getAttribute("encoding");
             this.xFrameOption = viewMapElement.getAttribute("x-frame-options");
             this.strictTransportSecurity = viewMapElement.getAttribute("strict-transport-security");

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
@@ -1195,6 +1195,22 @@ public final class RequestHandler {
             throw new RequestHandlerException("No definition found for view with name [" + view + "]");
         }
 
+        // Perform security check.
+        if (viewMap.isSecurityAuth() && UtilValidate.isEmpty(userLogin)) {
+            ConfigXMLReader.Event checkLoginEvent = ccfg.getRequestMapMap().get("checkLogin").getEvent();
+            String checkLoginReturnString = null;
+
+            try {
+                checkLoginReturnString = this.runEvent(req, resp, checkLoginEvent, null, "security-auth");
+            } catch (EventHandlerException e) {
+                throw new RequestHandlerException(e.getMessage(), e);
+            }
+
+            if (!"success".equalsIgnoreCase(checkLoginReturnString)) {
+                throw new RequestHandlerException("An active login is required for view with name [" + view + "]");
+            }
+        }
+
         String nextPage;
 
         if (viewMap.getPage() == null) {

--- a/framework/webtools/webapp/webtools/WEB-INF/controller.xml
+++ b/framework/webtools/webapp/webtools/WEB-INF/controller.xml
@@ -99,13 +99,16 @@ under the License.
         <response name="success" type="none"/>
     </request-map> -->
     <request-map uri="ping">
-        <security auth="true"/>
+        <security https="false" auth="true"/>
         <event type="service" invoke="ping"/>
         <response name="error" type="view" value="ping"/>
         <response name="success" type="view" value="ping"/>
     </request-map>
 
-    <request-map uri="showDateTime"><response name="success" type="view" value="showDateTime"/></request-map>
+    <request-map uri="showDateTime">
+        <security auth="false" https="false"/>
+        <response name="success" type="view" value="showDateTime"/>
+    </request-map>
     <request-map uri="secureCertDateTime">
         <security auth="false" https="true" cert="true"/>
         <response name="success" type="view" value="showDateTime"/>
@@ -116,17 +119,20 @@ under the License.
     </request-map>
 
     <request-map uri="TestService">
+        <security https="false" auth="false"/>
         <event type="service" invoke="testScv"/>
         <response name="error" type="view" value="error"/>
         <response name="success" type="view" value="error"/>
     </request-map>
     <request-map uri="streamTest">
+        <security https="false" auth="false"/>
         <event type="service-stream" invoke="serviceStreamTest"/>
         <response name="success" type="none"/>
         <response name="error" type="none"/>
     </request-map>
 
     <request-map uri="yahoo">
+        <security https="false" auth="false"/>
         <response name="success" type="url" value="http://www.yahoo.com"/>
     </request-map>
 
@@ -135,6 +141,7 @@ under the License.
         <response name="success" type="view" value="main"/>
     </request-map>
     <request-map uri="chain">
+        <security https="false" auth="false"/>
         <event type="java" path="org.apache.ofbiz.webapp.event.TestEvent" invoke="test"/>
         <response name="success" type="request" value="/view"/>
         <response name="error" type="view" value="error"/>
@@ -563,7 +570,7 @@ under the License.
 
     <!-- cert requests -->
     <request-map uri="myCertificates">
-        <security https="true"/>
+        <security https="true" auth="false"/>
         <response name="success" type="view" value="viewbrowsercerts"/>
     </request-map>
 
@@ -631,9 +638,9 @@ under the License.
     <!-- end of request mappings -->
 
     <!-- View Mappings -->
-    <view-map name="main" type="screen" page="component://webtools/widget/CommonScreens.xml#main"/>
+    <view-map name="main" type="screen" page="component://webtools/widget/CommonScreens.xml#main" auth="false"/>
     <view-map name="ping" type="ftl" page="component://webtools/template/Ping.ftl"/>
-    <view-map name="showDateTime" type="ftl" page="component://webtools/template/ShowDateTime.ftl"/>
+    <view-map name="showDateTime" type="ftl" page="component://webtools/template/ShowDateTime.ftl" auth="false"/>
 
     <view-map name="entityref" type="screen" page="component://webtools/widget/EntityScreens.xml#EntityRef"/>
     <view-map name="entityref_list" type="screen" page="component://webtools/widget/EntityScreens.xml#EntityRefList"/>
@@ -704,7 +711,7 @@ under the License.
     <view-map name="EntityImportReaders" type="screen" page="component://webtools/widget/EntityScreens.xml#EntityImportReaders"/>
 
     <!-- cert views -->
-    <view-map name="viewbrowsercerts" type="screen" page="component://webtools/widget/CommonScreens.xml#browsercerts"/>
+    <view-map name="viewbrowsercerts" type="screen" page="component://webtools/widget/CommonScreens.xml#browsercerts" auth="false"/>
 
     <!-- Artifact Info Views -->
     <view-map name="ViewComponents" type="screen" page="component://webtools/widget/ArtifactInfoScreens.xml#ViewComponents"/>


### PR DESCRIPTION
Improved: Add permission check for view-maps and change defaults for request-maps (OFBIZ-13130)

Implemented an additional view-map parameter "auth" with a security check in RequestHandler.renderView. The default is set to "true".

The defaults for the request-map parameters "https" and "auth" were also changed to "true".

Alle request-maps and view-maps in framework, applications and plugins were checked and missing parameters were added to recreate to original functionality.
