### PR TITLE
Improved: Allow GroovyDSL in FlexibleStringExpander (OFBIZ-13133)

### DIFF
--- a/applications/manufacturing/widget/manufacturing/MrpScreens.xml
+++ b/applications/manufacturing/widget/manufacturing/MrpScreens.xml
@@ -61,7 +61,7 @@ under the License.
                 <set field="tabButtonItem" value="RunMrp"/>
                 <set field="helpAnchor" value="_run_mrp"/>
                 <set field="headerItem" value="mrp"/>
-                <set field="eventMessage" value="${groovy: org.apache.ofbiz.base.util.UtilProperties.getMessage('ManufacturingUiLabels', 'ManufacturingMrpRunScheduledSuccessfully', locale)}"/>
+                <set field="eventMessage" value="${groovy: label('ManufacturingUiLabels','ManufacturingMrpRunScheduledSuccessfully')}"/>
             </actions>
             <widgets>
                 <decorator-screen name="CommonMrpDecorator">

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/GroovyUtil.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/GroovyUtil.java
@@ -187,11 +187,21 @@ public final class GroovyUtil {
         }
     }
 
+    /**
+     * Parses a Groovy class from a text.
+     * @param flexible string to parse
+     * @return the corresponding class object
+     * @throws IOException when parsing fails
+     */
     public static Class<?> parseClass(String text) throws IOException {
-        GroovyClassLoader groovyClassLoader = new GroovyClassLoader();
-        Class<?> classLoader = groovyClassLoader.parseClass(text);
-        groovyClassLoader.close();
-        return classLoader;
+        if (GROOVY_CLASS_LOADER != null) {
+            return GROOVY_CLASS_LOADER.parseClass(text);
+        } else {
+            GroovyClassLoader groovyClassLoader = new GroovyClassLoader();
+            Class<?> classLoader = GROOVY_CLASS_LOADER.parseClass(text);
+            groovyClassLoader.close();
+            return classLoader;
+        }
     }
 
     /**

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/GroovyUtil.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/GroovyUtil.java
@@ -189,7 +189,7 @@ public final class GroovyUtil {
 
     /**
      * Parses a Groovy class from a text.
-     * @param flexible string to parse
+     * @param text as flexible string to parse
      * @return the corresponding class object
      * @throws IOException when parsing fails
      */


### PR DESCRIPTION
Explanation
It will allow to call a GroovyDSL method (label, from, run service ...) directly instead of calling the Java class in flexible string expander.