### PR TITLE
Fixed: Error when uploading image because of line length (OFBIZ-12639)

### DIFF
--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -251,7 +251,7 @@ public class SecuredUpload {
                         + "and an Excel file to CSV. For other file types try PDF.", MODULE);
                 return false;
             }
-            if (!checkMaxLinesLength(fileToCheck)) {
+            if (!fileType.equalsIgnoreCase("Image") && !checkMaxLinesLength(fileToCheck)) {
                 Debug.logError("For security reason lines over " + MAXLINELENGTH.toString() + " are not allowed", MODULE);
                 return false;
             }


### PR DESCRIPTION
For image files isValidFile should not checkMaxLinesLength, since that was created to check text files. Image validation is done by isValidImageFile

Thanks: Ingo Wolfmayr and Jacques Le Roux for the work so far in (OFBIZ-12639)
