### PR TITLE
Implemented: Add group option on drow-down in xml screen form (OFBIZ-13157)

### DIFF
--- a/framework/widget/dtd/widget-form.xsd
+++ b/framework/widget/dtd/widget-form.xsd
@@ -873,6 +873,7 @@ under the License.
     <xs:element name="check" substitutionGroup="AllFields">
         <xs:complexType>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="group-options" />
                 <xs:element ref="entity-options" />
                 <xs:element ref="list-options" />
                 <xs:element ref="option" />
@@ -1100,6 +1101,7 @@ under the License.
             <xs:sequence>
                 <xs:element ref="auto-complete" minOccurs="0" maxOccurs="1" />
                 <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element ref="group-options" />
                     <xs:element ref="entity-options" />
                     <xs:element ref="list-options" />
                     <xs:element ref="option" />
@@ -1383,6 +1385,7 @@ under the License.
     <xs:element name="radio" substitutionGroup="AllFields">
         <xs:complexType>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="group-options" />
                 <xs:element ref="entity-options" />
                 <xs:element ref="list-options" />
                 <xs:element ref="option" />
@@ -1669,6 +1672,26 @@ under the License.
     <xs:element name="entity-order-by">
         <xs:complexType>
             <xs:attribute type="xs:string" name="field-name" use="required" />
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="group-options">
+        <xs:annotation>
+            <xs:documentation>group the options </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="group-options" />
+                <xs:element ref="entity-options" />
+                <xs:element ref="list-options" />
+                <xs:element ref="option" />
+            </xs:choice>
+            <xs:attribute type="xs:string" name="id" />
+            <xs:attribute type="xs:string" name="widget-style" />
+            <xs:attribute type="xs:string" name="description" default="${description}">
+                <xs:annotation>
+                    <xs:documentation>Will be presented to the user with field values substituted using the ${} syntax.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     <xs:element name="in-place-editor">

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -36,6 +36,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -2183,6 +2184,152 @@ public final class ModelFormField {
         }
     }
 
+    public static class GroupOptions {
+        private final FlexibleStringExpander description;
+        private final FlexibleStringExpander id;
+        private final FlexibleStringExpander widgetStyle;
+
+        private final List<OptionSource> optionSources;
+        private final List<GroupOptions> groupOptions;
+
+        public GroupOptions(Element groupOptionsElement, ModelFormField modelFormField) {
+            super();
+            this.description = FlexibleStringExpander.getInstance(groupOptionsElement.getAttribute("description"));
+            this.id = FlexibleStringExpander.getInstance(groupOptionsElement.getAttribute("id"));
+            this.widgetStyle = FlexibleStringExpander.getInstance(groupOptionsElement.getAttribute("widgetStyle"));
+
+            List<? extends Element> childElements = UtilXml.childElementList(groupOptionsElement);
+            List<OptionSource> optionSources = new ArrayList<>();
+            List<GroupOptions> groupOptions = new ArrayList<>();
+            if (!childElements.isEmpty()) {
+                for (Element childElement : childElements) {
+                    switch (childElement.getLocalName()) {
+                    case "option":
+                        optionSources.add(new SingleOption(childElement, modelFormField));
+                        break;
+                    case "list-options":
+                        optionSources.add(new ListOptions(childElement, modelFormField));
+                        break;
+                    case "entity-options":
+                        optionSources.add(new EntityOptions(childElement, modelFormField));
+                        break;
+                    case "group-options":
+                        groupOptions.add(new GroupOptions(childElement, modelFormField));
+                        break;
+                    }
+                }
+            }
+            this.optionSources = Collections.unmodifiableList(optionSources);
+            this.groupOptions = Collections.unmodifiableList(groupOptions);
+        }
+
+        private GroupOptions(GroupOptions original, ModelFormField modelFormField) {
+            super();
+            this.description = original.description;
+            this.id = original.id;
+            this.widgetStyle = original.widgetStyle;
+            List<OptionSource> optionSources = new ArrayList<>(original.optionSources.size());
+            for (OptionSource source : original.optionSources) {
+                optionSources.add(source.copy(modelFormField));
+            }
+            this.optionSources = Collections.unmodifiableList(optionSources);
+            List<GroupOptions> groupOptions = new ArrayList<>(original.groupOptions.size());
+            for (GroupOptions group : original.groupOptions) {
+                groupOptions.add(group.copy(modelFormField));
+            }
+            this.groupOptions = Collections.unmodifiableList(groupOptions);
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public GroupOptions(ModelFormField modelFormField) {
+            super();
+            this.description = FlexibleStringExpander.getInstance("");
+            this.id = FlexibleStringExpander.getInstance("");
+            this.widgetStyle = FlexibleStringExpander.getInstance("");
+            this.optionSources = Collections.emptyList();
+            this.groupOptions = Collections.emptyList();
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public FlexibleStringExpander getDescription() {
+            return description;
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public String getDescription(Map<String, Object> context) {
+            return this.description.expandString(context);
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public FlexibleStringExpander getId() {
+            return id;
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public String getId(Map<String, Object> context) {
+            String id = this.id.expandString(context);
+            return UtilValidate.isNotEmpty(id) ? id
+                    : UUID.randomUUID().toString().replace("-", "");
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public FlexibleStringExpander getWidgetStyle() {
+            return widgetStyle;
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public String getWidgetStyle(Map<String, Object> context) {
+            return this.widgetStyle.expandString(context);
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public List<OptionValue> getAllOptionValues(Map<String, Object> context, Delegator delegator) {
+            List<OptionValue> optionValues = new LinkedList<>();
+            for (OptionSource optionSource : this.optionSources) {
+                optionSource.addOptionValues(optionValues, context, delegator);
+            }
+            return optionValues;
+        }
+        /**
+         * TODO
+         * @return
+         */
+        public List<GroupOptions> getGroupOptions() {
+            return groupOptions;
+        }
+
+        /**
+         * TODO
+         * @return
+         */
+        public GroupOptions copy(ModelFormField modelFormField) {
+            return new GroupOptions(this, modelFormField);
+        }
+    }
     /**
      * Models the &lt;entity-options&gt; element.
      * @see <code>widget-form.xsd</code>
@@ -2409,12 +2556,14 @@ public final class ModelFormField {
 
         private final FlexibleStringExpander noCurrentSelectedKey;
         private final List<OptionSource> optionSources;
+        private final List<GroupOptions> groupOptions;
 
         public FieldInfoWithOptions(Element element, ModelFormField modelFormField) {
             super(element, modelFormField);
             this.noCurrentSelectedKey = FlexibleStringExpander.getInstance(element.getAttribute("no-current-selected-key"));
             // read all option and entity-options sub-elements, maintaining order
             ArrayList<OptionSource> optionSources = new ArrayList<>();
+            ArrayList<GroupOptions> groupSources = new ArrayList<>();
             List<? extends Element> childElements = UtilXml.childElementList(element);
             if (!childElements.isEmpty()) {
                 for (Element childElement : childElements) {
@@ -2425,6 +2574,8 @@ public final class ModelFormField {
                         optionSources.add(new ListOptions(childElement, modelFormField));
                     } else if ("entity-options".equals(childName)) {
                         optionSources.add(new EntityOptions(childElement, modelFormField));
+                    } else if ("group-options".equals(childName)) {
+                        groupSources.add(new GroupOptions(childElement, modelFormField));
                     }
                 }
             } else {
@@ -2433,6 +2584,7 @@ public final class ModelFormField {
             }
             optionSources.trimToSize();
             this.optionSources = Collections.unmodifiableList(optionSources);
+            this.groupOptions = Collections.unmodifiableList(groupSources);
         }
 
         // Copy constructor.
@@ -2448,18 +2600,25 @@ public final class ModelFormField {
                 }
                 this.optionSources = Collections.unmodifiableList(optionSources);
             }
+            List<GroupOptions> groupOptions = new ArrayList<>(original.groupOptions.size());
+            for (GroupOptions group: original.groupOptions) {
+                groupOptions.add(group.copy(modelFormField));
+            }
+            this.groupOptions = groupOptions;
         }
 
         protected FieldInfoWithOptions(int fieldSource, int fieldType, List<OptionSource> optionSources) {
             super(fieldSource, fieldType, null);
             this.noCurrentSelectedKey = FlexibleStringExpander.getInstance("");
             this.optionSources = Collections.unmodifiableList(new ArrayList<>(optionSources));
+            this.groupOptions = Collections.emptyList();
         }
 
         public FieldInfoWithOptions(int fieldSource, int fieldType, ModelFormField modelFormField) {
             super(fieldSource, fieldType, modelFormField);
             this.noCurrentSelectedKey = FlexibleStringExpander.getInstance("");
             this.optionSources = Collections.emptyList();
+            this.groupOptions = Collections.emptyList();
         }
 
         /**
@@ -2499,6 +2658,13 @@ public final class ModelFormField {
          */
         public List<OptionSource> getOptionSources() {
             return optionSources;
+        }
+        /**
+         * Gets group options.
+         * @return the group options
+         */
+        public List<GroupOptions> getGroupOptions() {
+            return groupOptions;
         }
     }
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -2184,6 +2184,10 @@ public final class ModelFormField {
         }
     }
 
+    /**
+     * Models the &lt;group-options&gt; element.
+     * @see <code>widget-form.xsd</code>
+     */
     public static class GroupOptions {
         private final FlexibleStringExpander description;
         private final FlexibleStringExpander id;
@@ -2192,6 +2196,11 @@ public final class ModelFormField {
         private final List<OptionSource> optionSources;
         private final List<GroupOptions> groupOptions;
 
+        /**
+         * Create a new groupOptions instance from xml element
+         * @param groupOptionsElement
+         * @param modelFormField
+         */
         public GroupOptions(Element groupOptionsElement, ModelFormField modelFormField) {
             super();
             this.description = FlexibleStringExpander.getInstance(groupOptionsElement.getAttribute("description"));
@@ -2223,6 +2232,11 @@ public final class ModelFormField {
             this.groupOptions = Collections.unmodifiableList(groupOptions);
         }
 
+        /**
+         * Copy an existing groupOptions to a new one
+         * @param original
+         * @param modelFormField
+         */
         private GroupOptions(GroupOptions original, ModelFormField modelFormField) {
             super();
             this.description = original.description;
@@ -2241,8 +2255,8 @@ public final class ModelFormField {
         }
 
         /**
-         * TODO
-         * @return
+         * create a groupOptions from a modelFormField
+         * @return GroupOptions instance
          */
         public GroupOptions(ModelFormField modelFormField) {
             super();
@@ -2254,32 +2268,28 @@ public final class ModelFormField {
         }
 
         /**
-         * TODO
-         * @return
+         * @return description present for a groupOptions instance
          */
         public FlexibleStringExpander getDescription() {
             return description;
         }
 
         /**
-         * TODO
-         * @return
+         * @return parsed description with context for a groupOptions instance
          */
         public String getDescription(Map<String, Object> context) {
             return this.description.expandString(context);
         }
 
         /**
-         * TODO
-         * @return
+         * @return unique reference for a groupOptions instance
          */
         public FlexibleStringExpander getId() {
             return id;
         }
 
         /**
-         * TODO
-         * @return
+         * @return parsed unique reference with context for a groupOptions instance
          */
         public String getId(Map<String, Object> context) {
             String id = this.id.expandString(context);
@@ -2288,24 +2298,22 @@ public final class ModelFormField {
         }
 
         /**
-         * TODO
-         * @return
+         * @return widgetStyle present for a groupOptions instance
          */
         public FlexibleStringExpander getWidgetStyle() {
             return widgetStyle;
         }
 
         /**
-         * TODO
-         * @return
+         * @return parsed widgetStyle with context for a groupOptions instance
          */
         public String getWidgetStyle(Map<String, Object> context) {
             return this.widgetStyle.expandString(context);
         }
 
         /**
-         * TODO
-         * @return
+         * Compute all options define for groupOptions instance
+         * @return options list present on this groupOptions
          */
         public List<OptionValue> getAllOptionValues(Map<String, Object> context, Delegator delegator) {
             List<OptionValue> optionValues = new LinkedList<>();
@@ -2315,21 +2323,21 @@ public final class ModelFormField {
             return optionValues;
         }
         /**
-         * TODO
-         * @return
+         * @return groupOptions sub list
          */
         public List<GroupOptions> getGroupOptions() {
             return groupOptions;
         }
 
         /**
-         * TODO
-         * @return
+         * Duplicate the groupOptions
+         * @return new groupOptions instance
          */
         public GroupOptions copy(ModelFormField modelFormField) {
             return new GroupOptions(this, modelFormField);
         }
     }
+
     /**
      * Models the &lt;entity-options&gt; element.
      * @see <code>widget-form.xsd</code>

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -2256,7 +2256,7 @@ public final class ModelFormField {
 
         /**
          * create a groupOptions from a modelFormField
-         * @return GroupOptions instance
+         * @param modelFormField
          */
         public GroupOptions(ModelFormField modelFormField) {
             super();

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/model/GroupOption.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/model/GroupOption.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ofbiz.widget.renderer.macro.model;
+
+import java.util.List;
+
+/**
+ * Record representing a group option in a drop-down (select) list.
+ */
+public record GroupOption(String id,
+                          String description,
+                          String widgetStyle,
+                          List<Object> options) {
+}

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -156,6 +156,35 @@ under the License.
   </span>
 </#macro>
 
+<#macro renderDropDownOptionList items currentValue multiple dDFCurrent noCurrentSelectedKey>
+  <#list items as item>
+    <#if item.options?has_content>
+      <#if groupOpen??></optgroup></#if>
+      <optgroup label="${item.description}"<#if item.id??> id="${item.id}"</#if><#if item.widgetStyle??> class="${item.widgetStyle}"</#if>/>
+      <@renderDropDownOptionList item.options currentValue multiple dDFCurrent noCurrentSelectedKey/>
+      <#assign groupOpen = true/>
+    <#else>
+      <#if multiple>
+        <option
+        <#if currentValue?has_content && item.selected()>
+          selected
+        <#elseif !currentValue?has_content && noCurrentSelectedKey?has_content && noCurrentSelectedKey == item.key()>
+          selected
+        </#if>
+        value="${item.key()}">${item.description()}</option><#rt/>
+      <#else>
+        <option
+        <#if currentValue?has_content && currentValue == item.key() && dDFCurrent?has_content && "selected" == dDFCurrent>
+          selected
+        <#elseif !currentValue?has_content && noCurrentSelectedKey?has_content && noCurrentSelectedKey == item.key()>
+          selected
+        </#if>
+        value="${item.key()}">${item.description()}</option><#rt/>
+      </#if>
+    </#if>
+  </#list>
+  <#if groupOpen??></optgroup></#if>
+</#macro>
 <#macro renderDropDownField name className id formName explicitDescription options ajaxEnabled
         otherFieldName="" otherValue="" otherFieldSize=""
         alert="" conditionGroup="" tabindex="" multiple=false event="" size="" placeCurrentValueAsFirstOption=false
@@ -184,25 +213,7 @@ under the License.
       <#elseif !options?has_content>
           <option value="">&nbsp;</option>
       </#if>
-      <#list options as item>
-        <#if multiple>
-          <option
-            <#if currentValue?has_content && item.selected()>
-              selected
-            <#elseif !currentValue?has_content && noCurrentSelectedKey?has_content && noCurrentSelectedKey == item.key()>
-              selected
-            </#if>
-            value="${item.key()}">${item.description()}</option><#rt/>
-        <#else>
-          <option
-            <#if currentValue?has_content && currentValue == item.key() && dDFCurrent?has_content && "selected" == dDFCurrent>
-              selected
-            <#elseif !currentValue?has_content && noCurrentSelectedKey?has_content && noCurrentSelectedKey == item.key()>
-              selected
-            </#if>
-            value="${item.key()}">${item.description()}</option><#rt/>
-        </#if>
-      </#list>
+      <@renderDropDownOptionList options currentValue multiple dDFCurrent noCurrentSelectedKey/>
     </select>
   </span>
   <#if otherFieldName?has_content>


### PR DESCRIPTION
When you define a drop-down field in xml form, add new optional level with group-options to organize options.

        <field name="group">
            <drop-down>
                <group-options description="A">
                    <option key="A1" description="Ad1"/>
                    <option key="A2" description="Ad2"/>
                </group-options>
                <group-options description="B">
                    <option key="B1" description="Bd1"/>
                    <option key="B2" description="Bd2"/>
                </group-options>
            </drop-down>
        </field>

Group-options can receive all options type :

        <field name="roleTypeId">
            <drop-down>
                <group-options description="Customer roles">
                    <entity-options entity-name="RoleType">
                        <entity-constraint name="parentType" vale="CUSTOMER"/>
                    </entity-options>
                </group-options>
                <group-options description="Supplier roles">
                    <entity-options entity-name="RoleType">
                        <entity-constraint name="parentType" vale="SUPPLIER"/>
                    </entity-options>
                </group-options>
                <group-options description="Other roles">
                    <list-options list-name="otherRoles"/>
                </group-options>
            </drop-down>
        </field>

At this time only the drop-down is supported, group-option can works for radio and check but not implement on ftl macro library.
