### PR TITLE
Improved: Ensure unique email when sendEmail OFBIZ-13170

### DIFF
--- a/applications/party/src/main/java/org/apache/ofbiz/party/communication/CommunicationEventServices.java
+++ b/applications/party/src/main/java/org/apache/ofbiz/party/communication/CommunicationEventServices.java
@@ -166,7 +166,7 @@ public class CommunicationEventServices {
                 }
 
                 // add other parties from roles, collect all email on map to parse it after
-                List<String> emailAlreadyLoad = UtilMisc.toList(sendTo);
+                List<String> alreadyLoaded = UtilMisc.toList(sendTo);
                 List<String> availableRoleTypeIds = UtilMisc.toList("ADDRESSEE", "CC", "BCC");
                 Map<String, Object> emailsCollector = UtilMisc.toMap("ADDRESSEE", UtilMisc.toList(sendTo));
                 List<GenericValue> commRoles = communicationEvent.getRelated("CommunicationEventRole", null, null, false);
@@ -176,11 +176,11 @@ public class CommunicationEventServices {
                         if (contactMech != null && UtilValidate.isNotEmpty(contactMech.getString("infoString"))) {
                             String infoString = contactMech.getString("infoString");
                             String roleTypeId = commRole.getString("roleTypeId");
-                            if (emailAlreadyLoad.contains(infoString)
+                            if (alreadyLoaded.contains(infoString)
                                     && !availableRoleTypeIds.contains(roleTypeId)) {
                                 continue;
                             }
-                            emailAlreadyLoad.add(infoString);
+                            alreadyLoaded.add(infoString);
                             UtilMisc.addToListInMap(infoString, emailsCollector, roleTypeId);
                         }
                     }

--- a/applications/party/src/main/java/org/apache/ofbiz/party/communication/CommunicationEventServices.java
+++ b/applications/party/src/main/java/org/apache/ofbiz/party/communication/CommunicationEventServices.java
@@ -165,45 +165,35 @@ public class CommunicationEventServices {
                     return ServiceUtil.returnError(errMsg + " " + communicationEventId);
                 }
 
-                // add other parties from roles
-                String sendCc = null;
-                String sendBcc = null;
+                // add other parties from roles, collect all email on map to parse it after
+                List<String> emailAlreadyLoad = UtilMisc.toList(sendTo);
+                List<String> availableRoleTypeIds = UtilMisc.toList("ADDRESSEE", "CC", "BCC");
+                Map<String, Object> emailsCollector = UtilMisc.toMap("ADDRESSEE", UtilMisc.toList(sendTo));
                 List<GenericValue> commRoles = communicationEvent.getRelated("CommunicationEventRole", null, null, false);
                 if (UtilValidate.isNotEmpty(commRoles)) {
                     for (GenericValue commRole : commRoles) { // 'from' and 'to' already defined on communication event
-                        if (commRole.getString("partyId").equals(communicationEvent.getString("partyIdFrom"))
-                                || commRole.getString("partyId").equals(communicationEvent.getString("partyIdTo"))) {
-                            continue;
-                        }
                         GenericValue contactMech = commRole.getRelatedOne("ContactMech", false);
                         if (contactMech != null && UtilValidate.isNotEmpty(contactMech.getString("infoString"))) {
-                            if ("ADDRESSEE".equals(commRole.getString("roleTypeId"))) {
-                                sendTo += "," + contactMech.getString("infoString");
-                            } else if ("CC".equals(commRole.getString("roleTypeId"))) {
-                                if (sendCc != null) {
-                                    sendCc += "," + contactMech.getString("infoString");
-                                } else {
-                                    sendCc = contactMech.getString("infoString");
-                                }
-                            } else if ("BCC".equals(commRole.getString("roleTypeId"))) {
-                                if (sendBcc != null) {
-                                    sendBcc += "," + contactMech.getString("infoString");
-                                } else {
-                                    sendBcc = contactMech.getString("infoString");
-                                }
+                            String infoString = contactMech.getString("infoString");
+                            String roleTypeId = commRole.getString("roleTypeId");
+                            if (emailAlreadyLoad.contains(infoString)
+                                    && !availableRoleTypeIds.contains(roleTypeId)) {
+                                continue;
                             }
+                            emailAlreadyLoad.add(infoString);
+                            UtilMisc.addToListInMap(infoString, emailsCollector, roleTypeId);
                         }
                     }
                 }
+                sendMailParams.put("sendTo", String.join(",", UtilMisc.getListFromMap(emailsCollector, "ADDRESSEE")));
+                sendMailParams.put("sendCc", emailsCollector.containsKey("CC")
+                        ? String.join(",", UtilMisc.getListFromMap(emailsCollector, "CC"))
+                        : null);
+                sendMailParams.put("sendBcc", emailsCollector.containsKey("BCC")
+                        ? String.join(",", UtilMisc.getListFromMap(emailsCollector, "BCC"))
+                        : null);
 
                 sendMailParams.put("communicationEventId", communicationEventId);
-                sendMailParams.put("sendTo", sendTo);
-                if (sendCc != null) {
-                    sendMailParams.put("sendCc", sendCc);
-                }
-                if (sendBcc != null) {
-                    sendMailParams.put("sendBcc", sendBcc);
-                }
                 sendMailParams.put("partyId", communicationEvent.getString("partyIdTo"));  // who it's going to
 
                 // send it - using a new transaction


### PR DESCRIPTION
When you run the service sendCommEventAsEmail if commEvent to send contains multiple party with the same email (through different contactMech), email will be sent to many times to the same box (depending on the smtp configuration).

To avoid this case, we will ensure that an email is unique for the sender list.