### PR TITLE
Implemented: Add new StringUtil function to convert map to encoded string

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/StringUtil.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/StringUtil.java
@@ -20,6 +20,7 @@ package org.apache.ofbiz.base.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -210,6 +211,30 @@ public final class StringUtil {
      */
     public static Map<String, String> strToMap(String str) {
         return strToMap(str, "|", false);
+    }
+
+    /**
+     * Creates an encoded String from a Map of name/value pairs
+     * @param mapToConvert The Map of name/value pairs
+     * @return String The encoded String like key1=value1|key2=value2, null if map is empty
+     */
+    public static String mapToStr(Map<? extends Object, ? extends Object> mapToConvert) {
+        if (UtilValidate.isEmpty(mapToConvert)) {
+            return null;
+        }
+        return mapToConvert.entrySet().stream().map(entry -> {
+            String key = String.valueOf(entry.getKey());
+            String value = String.valueOf(entry.getValue());
+
+            try {
+                return new StringBuilder(URLEncoder.encode(key, "UTF-8"))
+                        .append("=")
+                        .append(URLEncoder.encode(value, "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                Debug.logError(e, MODULE);
+            }
+            return "";
+        }).collect(Collectors.joining("|"));
     }
 
     /**

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/StringUtilTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/StringUtilTests.java
@@ -18,6 +18,9 @@
  */
 package org.apache.ofbiz.base.util;
 
+import com.ibm.icu.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -81,6 +84,33 @@ public class StringUtilTests {
                 StringUtil.strToMap(" 1 = one | 2 = two "));
         assertEquals("double-trim", UtilMisc.toMap("2", "two", "1", "one"),
                 StringUtil.strToMap(" 1 = one | 2 = two ", true));
+    }
+
+    @Test
+    public void testMapToStr() {
+        // Test Null
+        assertNull("null-string", StringUtil.mapToStr(null));
+        assertNull("empty", StringUtil.mapToStr(Map.of()));
+
+        // Test simple case
+        assertEquals("single", "1=one", StringUtil.mapToStr(Map.of("1", "one")));
+        LinkedHashMap<String, String> doubleMap = new LinkedHashMap<>();
+        doubleMap.put("1", "one");
+        doubleMap.put("2", "two");
+        assertEquals("double", "1=one|2=two", StringUtil.mapToStr(doubleMap));
+
+        // Test with object case
+        LinkedHashMap<Object, Object> doubleObjectMap = new LinkedHashMap<>();
+        doubleObjectMap.put(Integer.valueOf(1), Long.valueOf(1));
+        doubleObjectMap.put(Integer.valueOf(2), BigDecimal.ONE);
+        assertEquals("double with number classe", "1=1|2=1", StringUtil.mapToStr(doubleObjectMap));
+
+        // Test with special char
+        assertEquals("single with =", "1=%3Done", StringUtil.mapToStr(Map.of("1", "=one")));
+        LinkedHashMap<String, String> doublePipeMap = new LinkedHashMap<>();
+        doublePipeMap.put("1", "|one");
+        doublePipeMap.put("2|", "two");
+        assertEquals("double with pipe", "1=%7Cone|2%7C=two", StringUtil.mapToStr(doublePipeMap));
     }
 
     @Test


### PR DESCRIPTION
Reverse logical of StringUtil.strToMap, the function StringUtil.mapToStr convert a map to an encoded String