### PR TITLE
Improved: Add display result format for auto-completion on lookup 

### DIFF
--- a/applications/workeffort/widget/LookupScreens.xml
+++ b/applications/workeffort/widget/LookupScreens.xml
@@ -34,6 +34,7 @@ under the License.
                 <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
                 <set field="entityName" value="WorkEffort"/>
                 <set field="searchFields" value="[workEffortId, workEffortName, description]"/>
+                <set field="displayFieldFormat" value="\${workEffortName} - \${groovy: description?.length() &gt; 20 ? description.substring(0, 20) + '…': description}"/>
             </actions>
             <widgets>
                 <decorator-screen name="LookupDecorator" location="component://common/widget/CommonScreens.xml">

--- a/themes/common-theme/template/includes/AjaxAutocompleteOptions.ftl
+++ b/themes/common-theme/template/includes/AjaxAutocompleteOptions.ftl
@@ -35,16 +35,22 @@ under the License.
 <script type="text/javascript">
     var autocomp = [
         <#if autocompleteOptions?has_content>
+          <#if displayFieldFormat?has_content>
+            <#assign displayStringExpdander = Static["org.apache.ofbiz.base.util.string.FlexibleStringExpander"].getInstance(displayFieldFormat)>
+          </#if>
           <#list autocompleteOptions as autocompleteOption>
               {
                 <#assign displayString = ""/>
                 <#assign returnField = ""/>
+                <#if displayStringExpdander?has_content>
+                  <#assign displayString = displayStringExpdander.expand(autocompleteOption.getAllFields())>
+                </#if>
                 <#list displayFieldsSet as key>
                   <#assign field = autocompleteOption.get(key)!>
                   <#if field?has_content>
                     <#if (key == context.returnField)>
                       <#assign returnField = field/>
-                    <#else>
+                    <#elseif !displayStringExpdander?has_content>
                       <#assign displayString = displayString + StringUtil.wrapString(field?string) + " ">
                     </#if>
                   </#if>


### PR DESCRIPTION
Currently, when you have a lookup with autoCompletion, the result contains the fields to display or by default search fields.

The format is strict. This improvement add new field  displayFieldFormat to send a UEL schema that we want.

This commit introduce an example with LookupWorkEffort :

****
      <set field="displayFieldFormat" value="\${workEffortName} - \${groovy: description?.length() &gt; 20 ? description.substring(0, 20) + '…': description}"/>
****

We want display the workEffortName and the description limited to 20 chars. To forward the UEL string, we need to use the escape char \ like this the screen engine doesn't parse displayFieldFormat and let the ftl AjaxAutocompleteOptions.ftl realized the translation.