### PR TITLE
Fixed: Remove duplicate event handler for collapsible in modals

### DIFF
--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -27,16 +27,16 @@ var AJAX_REQUEST_TIMEOUT = 5000;
 var SP_CLICK_ON = 'clickOn';
 
 // Add observers on DOM ready.
-$(document).ready(function() {
+$(document).ready(function () {
     // add CSRF token to jQuery AJAX calls to the same domain
-    jQuery.ajaxPrefilter(function(options, _, jqXHR) {
-      var token;
-      if (!options.crossDomain) {
-        token = jQuery("meta[name='csrf-token']").attr("content")
-        if (token) {
-          return jqXHR.setRequestHeader("X-CSRF-Token", token);
+    jQuery.ajaxPrefilter(function (options, _, jqXHR) {
+        var token;
+        if (!options.crossDomain) {
+            token = jQuery("meta[name='csrf-token']").attr("content")
+            if (token) {
+                return jqXHR.setRequestHeader("X-CSRF-Token", token);
+            }
         }
-      }
     });
     //initializing UI combobox dropdown by overriding its methods.
     ajaxAutoCompleteDropDown();
@@ -44,27 +44,28 @@ $(document).ready(function() {
     bindObservers("body");
 
     let count = 1;
+
     function initNamedBorders() {
         // clickable link in named border to open source file
         var selectList = jQuery(".info-cursor-none[data-source]");
         // console.log("length="+selectList.length);
-        selectList.each(function(){
+        selectList.each(function () {
             const $this = $(this);
             $this.removeClass("info-cursor-none");
             let sourceLocaton = $this.data("source");
             let target = $this.data("target");
-            $this.addClass("info-cursor").click(function(){
+            $this.addClass("info-cursor").click(function () {
                 jQuery.ajax({
                     url: target,
                     type: "POST",
-                    data: {sourceLocation:sourceLocaton},
-                    success: function(data) {
+                    data: { sourceLocation: sourceLocaton },
+                    success: function (data) {
                         alert("Server has opened \n" + sourceLocaton);
                     }
                 });
             });
-            setTimeout(function (){
-                $this.fadeOut(1000,function() {
+            setTimeout(function () {
+                $this.fadeOut(1000, function () {
                     // fadeout info-overlay labels
                     $this.off();
                     var container = $this.closest(".info-container");
@@ -76,6 +77,7 @@ $(document).ready(function() {
         });
 
     }
+
     initNamedBorders();
     jQuery(document).ajaxSuccess(function () {
         initNamedBorders();
@@ -84,7 +86,7 @@ $(document).ready(function() {
     // if clickOn search parameter is present, click on a#SP_CLICK_ON
     const currentUrl = new URL(window.location.href);
     const openModal = currentUrl.searchParams.get(SP_CLICK_ON);
-    const modalLink = jQuery(`#${openModal}`);
+    const modalLink = jQuery(`#${ openModal }`);
     if (openModal && modalLink.length) {
         modalLink.first().click();
     }
@@ -98,7 +100,7 @@ $(document).ready(function() {
 function bindObservers(bind_element) {
 
     // Adding observer for checkboxes for select all action.
-    jQuery(bind_element).on("click", "[type=checkbox]", function() {
+    jQuery(bind_element).on("click", "[type=checkbox]", function () {
         var action_checkbox = jQuery(this),
             parent_action = action_checkbox.is(".selectAll") ? action_checkbox : action_checkbox.getForm().getFormFields().filter(".selectAll");
         if (parent_action.length !== 0) {
@@ -111,44 +113,44 @@ function bindObservers(bind_element) {
         jQuery(".selectAll").removeAttr("checked").trigger("click");
     }
 
-    jQuery(bind_element).find("[data-mask]").each(function(){
+    jQuery(bind_element).find("[data-mask]").each(function () {
         var self = this;
         var libraryFiles = ["/common/js/node_modules/inputmask/dist/jquery.inputmask.min.js"];
-        importLibrary(libraryFiles, function() {
+        importLibrary(libraryFiles, function () {
             var element = jQuery(self);
             var mask = element.data('mask');
             element.inputmask(mask);
         });
     });
-    jQuery(bind_element).find('.autoCompleteDropDown').each(function(){
+    jQuery(bind_element).find('.autoCompleteDropDown').each(function () {
         jQuery(this).combobox();
     });
-    jQuery(bind_element).find('[data-other-field-name]').each(function(){
+    jQuery(bind_element).find('[data-other-field-name]').each(function () {
         var element = jQuery(this);
         var otherFieldName = element.data("other-field-name");
         var otherFieldValue = element.data("other-field-value");
         var otherFieldSize = element.data("other-field-size");
         var disabled = true;
-        if(other_choice(this))
+        if (other_choice(this))
             disabled = false;
-        var $input = jQuery("<input>", {type: "text", name: otherFieldName})
+        var $input = jQuery("<input>", { type: "text", name: otherFieldName })
             .attr("size", otherFieldSize)
             .val(otherFieldValue)
-            .on("focus", function(e){
+            .on("focus", function (e) {
                 check_choice(element);
             })
             .css('visibility', 'hidden');
-            $input.prop("disabled", disabled);
+        $input.prop("disabled", disabled);
         $input.insertAfter(element.closest(".ui-widget"));
-        element.on("change", function(e) {
+        element.on("change", function (e) {
             process_choice(element[0], $input);
         })
     });
-    jQuery(bind_element).find(".visual-editor").each(function(){
+    jQuery(bind_element).find(".visual-editor").each(function () {
         var self = this;
         var libraryFiles = ["/common/js/node_modules/trumbowyg/dist/trumbowyg.min.js",
             "/common/js/node_modules/trumbowyg/dist/plugins/indent/trumbowyg.indent.min.js"];
-        importLibrary(libraryFiles, function() {
+        importLibrary(libraryFiles, function () {
             var element = jQuery(self);
             var language = element.data('language');
             var buttons = [['viewHTML'],
@@ -166,16 +168,16 @@ function bindObservers(bind_element) {
                 ['fullscreen']
             ]
             var opts = {
-                lang     : language,
-                btns    : buttons,
+                lang: language,
+                btns: buttons,
                 semantic: false,
                 tagsToRemove: ['script', 'link'],
-                svgPath : '/common/js/node_modules/trumbowyg/dist/ui/icons.svg'
+                svgPath: '/common/js/node_modules/trumbowyg/dist/ui/icons.svg'
             }
             element.trumbowyg(opts);
         });
     });
-    jQuery(bind_element).find(".ajaxAutoCompleter").each(function(){
+    jQuery(bind_element).find(".ajaxAutoCompleter").each(function () {
         var element = jQuery(this);
         var ajaxUrl = element.data("ajax-url");
         var showDescription = element.data("show-description");
@@ -183,14 +185,14 @@ function bindObservers(bind_element) {
         var defaultDelay = element.data("default-delay");
         ajaxAutoCompleter(ajaxUrl, showDescription, defaultMinLength, defaultDelay);
     });
-    jQuery(bind_element).find("[data-inplace-editor-url]").each(function(){
+    jQuery(bind_element).find("[data-inplace-editor-url]").each(function () {
         var element = jQuery(this);
-        var id =  element.attr("id");
+        var id = element.attr("id");
         var url = element.data("inplace-editor-url");
         var params = element.data("inplace-editor-params");
         ajaxInPlaceEditDisplayField(id, url, (new Function("return " + params + ";")()));
     });
-    jQuery(bind_element).on("click", "[data-dialog-url]", function(){
+    jQuery(bind_element).on("click", "[data-dialog-url]", function () {
         var element = jQuery(this);
         var url = element.data("dialog-url");
         var title = element.data("dialog-title");
@@ -205,15 +207,15 @@ function bindObservers(bind_element) {
             width: width,
             modal: true,
             closeOnEscape: true,
-            close: function() {
+            close: function () {
                 dialogContainer.dialog('destroy');
             },
-            open: function() {
+            open: function () {
                 jQuery.ajax({
                     url: url,
                     type: "POST",
                     data: params,
-                    success: function(data) {
+                    success: function (data) {
                         dialogContainer.html(data);
                         bindObservers(dialogContainer);
                     },
@@ -225,25 +227,25 @@ function bindObservers(bind_element) {
                             window.location.replace(url.toString());
                         } else {
                             // display some feedback in the modal body
-                            dialogContainer.text(`An unexpected server error occurred (status : ${xhr.status}).`);
+                            dialogContainer.text(`An unexpected server error occurred (status : ${ xhr.status }).`);
                         }
                     }
                 });
             }
         });
         dialogContainer.dialog("open");
-        dialogContainer.on("closeCurrentModalAfterAjaxSubmitFormUpdateAreasInSuccess", function() {
+        dialogContainer.on("closeCurrentModalAfterAjaxSubmitFormUpdateAreasInSuccess", function () {
             dialogContainer.dialog("destroy");
         });
     });
-    jQuery(bind_element).on("click", "[data-confirm-message]", function(e){
+    jQuery(bind_element).on("click", "[data-confirm-message]", function (e) {
         var element = jQuery(this);
         var confirmMessage = element.data("confirm-message");
         if (!confirm(confirmMessage)) {
             e.preventDefault();
         }
     });
-    jQuery(bind_element).find("[data-lookup-presentation]").each(function(){
+    jQuery(bind_element).find("[data-lookup-presentation]").each(function () {
         var element = jQuery(this);
         var form = element._form();
         var formName = form.attr("name");
@@ -261,11 +263,11 @@ function bindObservers(bind_element) {
         var descriptionFieldName = element.data("lookup-description-field");
 
         if (presentation && presentation === "window" && descriptionFieldName) {
-            var descriptionField = form.find("input[name=" + descriptionFieldName+"]").get(0);
+            var descriptionField = form.find("input[name=" + descriptionFieldName + "]").get(0);
             var fieldFormname = element.data("lookup-field-formname");
             var lookupArgs = element.data("lookup-args");
             var args = [];
-            if (lookupArgs){
+            if (lookupArgs) {
                 jQuery.each(lookupArgs.split(', '), function (index, value) {
                     var argValue = form.find("input[name=" + value + "]").get(0).value;
                     args.push(argValue);
@@ -279,11 +281,11 @@ function bindObservers(bind_element) {
             });
             element.parent().append($a);
 
-        } else if (presentation && presentation === "window"){
+        } else if (presentation && presentation === "window") {
             var fieldFormname = element.data("lookup-field-formname");
             var lookupArgs = element.data("lookup-args");
             var args = [];
-            if (lookupArgs){
+            if (lookupArgs) {
                 jQuery.each(lookupArgs.split(', '), function (index, value) {
                     var argValue = form.find("input[name=" + value + "]").get(0).value;
                     args.push(argValue);
@@ -300,10 +302,10 @@ function bindObservers(bind_element) {
             var lookupOptionalTarget = element.data("lookup-optional-target");
             var dialogOptionalTarget = undefined;
             if (lookupOptionalTarget)
-                dialogOptionalTarget = form.find("input[name=" + element.data("lookup-optional-target")+"]").get(0);
+                dialogOptionalTarget = form.find("input[name=" + element.data("lookup-optional-target") + "]").get(0);
             var lookupArgs = element.data("lookup-args");
             var args = [];
-            if (lookupArgs){
+            if (lookupArgs) {
                 jQuery.each(lookupArgs.split(', '), function (index, value) {
                     var argElement = form.find("input[name=" + value + "]").get(0);
                     args.push(argElement);
@@ -311,50 +313,50 @@ function bindObservers(bind_element) {
             }
 
             var options = {
-                requestUrl : element.data("lookup-request-url"),
-                inputFieldId : this.id,
-                dialogTarget : this,
-                dialogOptionalTarget : dialogOptionalTarget,
-                formName : formName,
-                width : element.data("lookup-width"),
-                height : element.data("lookup-height"),
-                position : element.data("lookup-position"),
-                modal : element.data("lookup-modal"),
-                ajaxUrl : ajaxUrl,
-                showDescription : showDescription,
-                presentation : presentation,
-                defaultMinLength : defaultMinLength,
-                defaultDelay : defaultDelay,
-                args : args
+                requestUrl: element.data("lookup-request-url"),
+                inputFieldId: this.id,
+                dialogTarget: this,
+                dialogOptionalTarget: dialogOptionalTarget,
+                formName: formName,
+                width: element.data("lookup-width"),
+                height: element.data("lookup-height"),
+                position: element.data("lookup-position"),
+                modal: element.data("lookup-modal"),
+                ajaxUrl: ajaxUrl,
+                showDescription: showDescription,
+                presentation: presentation,
+                defaultMinLength: defaultMinLength,
+                defaultDelay: defaultDelay,
+                args: args
             };
             new Lookup(options).init();
         }
-        element.siblings(".clearField").on("click", function (){
+        element.siblings(".clearField").on("click", function () {
             element.val("");
             jQuery('#' + element.attr('id') + '_lookupDescription').html('');
         });
 
-        if (ajaxEnabled && presentation && presentation == "window"){
+        if (ajaxEnabled && presentation && presentation == "window") {
             ajaxAutoCompleter(ajaxUrl, showDescription, defaultMinLength, defaultDelay);
         }
     });
-    jQuery(bind_element).find("[data-focus-field]").each(function() {
+    jQuery(bind_element).find("[data-focus-field]").each(function () {
         var element = jQuery(this);
         var focusField = element.data("focus-field");
         element.find("[name=" + focusField + "]").focus();
     });
-    jQuery(bind_element).find(".requireValidation").each(function(){
+    jQuery(bind_element).find(".requireValidation").each(function () {
         var element = jQuery(this);
         element.validate();
     });
-    jQuery(bind_element).find(".date-time-picker").each(function(){
+    jQuery(bind_element).find(".date-time-picker").each(function () {
         initDateTimePicker(this);
     });
-    jQuery(bind_element).on("click", ".fieldgroup  li.collapsed, .fieldgroup  li.expanded", function(e){
+    jQuery(bind_element).on("click", ".fieldgroup  li.collapsed, .fieldgroup  li.expanded", function (e) {
         var element = jQuery(this);
-        var collapsibleAreaId =  element.data("collapsible-area-id");
-        var expandToolTip =  element.data("expand-tooltip");
-        var collapseToolTip =  element.data("collapse-tooltip");
+        var collapsibleAreaId = element.data("collapsible-area-id");
+        var expandToolTip = element.data("expand-tooltip");
+        var collapseToolTip = element.data("collapse-tooltip");
         toggleCollapsiblePanel(element, collapsibleAreaId, expandToolTip, collapseToolTip);
     });
 }
@@ -474,7 +476,7 @@ function addSelectAllObserver(action_checkbox) {
 
     if (is_parent) {
         // Check/ Uncheck child checkboxes when parent checked.
-        jQuery(select_child).attr("checked", function() {
+        jQuery(select_child).attr("checked", function () {
             return parent_checkbox.is(":checked");
         });
     } else {
@@ -482,7 +484,7 @@ function addSelectAllObserver(action_checkbox) {
         if (select_child.size() > 0) {
             var all_checked = true;
 
-            select_child.each(function() {
+            select_child.each(function () {
                 if (all_checked) {
                     all_checked = all_checked && jQuery(this).is(":checked");
                 }
@@ -499,7 +501,7 @@ function addSelectAllObserver(action_checkbox) {
 }
 
 // getFormFields: This utility function return all form fields (inside and outside form)
-jQuery.fn.getFormFields = function() {
+jQuery.fn.getFormFields = function () {
     var id = jQuery(this).attr("id");
     if (id === undefined) {
         return jQuery(this).find(":input");
@@ -509,7 +511,7 @@ jQuery.fn.getFormFields = function() {
 }
 
 // getForm: This utility function return form of the field.
-jQuery.fn.getForm = function() {
+jQuery.fn.getForm = function () {
     var form_id = jQuery(this).attr("form");
     // Get closest form if no form id specified else get the form using id.
     if (form_id === undefined) {
@@ -522,6 +524,7 @@ jQuery.fn.getForm = function() {
 function removeSelectedDefault() {
     removeSelected("selectAllForm");
 }
+
 function removeSelected(formName) {
     var cform = document[formName];
     cform.removeSelected.value = true;
@@ -530,10 +533,10 @@ function removeSelected(formName) {
 
 // highlight the selected row(s)
 
-function highlightRow(e,rowId){
+function highlightRow(e, rowId) {
     var currentClassName = document.getElementById(rowId).className;
     if (e.checked) {
-        if (currentClassName == '' ) {
+        if (currentClassName == '') {
             document.getElementById(rowId).className = 'selected';
         } else if (currentClassName == 'alternate-row') {
             document.getElementById(rowId).className = 'alternate-rowSelected';
@@ -547,13 +550,13 @@ function highlightRow(e,rowId){
     }
 }
 
-function highlightAllRows(e, halfRowId, formName){
+function highlightAllRows(e, halfRowId, formName) {
     var cform = document[formName];
     var len = cform.elements.length;
     for (var i = 0; i < len; i++) {
         var element = cform.elements[i];
         if (element.name.substring(0, 10) == "_rowSubmit") {
-            highlightRow(e, halfRowId+element.name.substring(13));
+            highlightRow(e, halfRowId + element.name.substring(13));
         }
     }
 }
@@ -563,6 +566,7 @@ function highlightAllRows(e, halfRowId, formName){
 function popUp(url, name, height, width) {
     popupWindow = window.open(url, name, 'location=no,scrollbars,width=' + width + ',height=' + height);
 }
+
 function popUpSmall(url, name) {
     popUp(url, name, '300', '450');
 }
@@ -578,6 +582,7 @@ function doPostViaParent(formName) {
     newForm.submit();
     window.opener.focus();
 }
+
 // From a child window, navigate the parent window to the supplied url
 function doGetViaParent(url) {
     window.opener.location = url;
@@ -597,6 +602,7 @@ function getStyleObject(objectId) {
         return false;
     }
 }
+
 function changeObjectVisibility(objectId, newVisibility) {
     var styleObject = getStyleObject(objectId);
     if (styleObject) {
@@ -642,10 +648,10 @@ function serializeFormFromParameters(targetParams) {
 // ===== Ajax Functions - based on jQuery.js ===== //
 
 /** Update an area (HTML container element).
-  * @param areaId The id of the HTML container to update
-  * @param target The URL to call to update the HTML container
-  * @param targetParams The URL parameters
-*/
+ * @param areaId The id of the HTML container to update
+ * @param target The URL to call to update the HTML container
+ * @param targetParams The URL parameters
+ */
 
 function ajaxUpdateArea(areaId, target, targetParams) {
     if (targetParams.indexOf("_FORM_NAME_") !== -1) {
@@ -653,21 +659,23 @@ function ajaxUpdateArea(areaId, target, targetParams) {
     }
 
     if (areaId == "window") {
-        targetUrl = target + "?" + targetParams.replace('?','');
+        targetUrl = target + "?" + targetParams.replace('?', '');
         window.location.assign(targetUrl);
         return;
     }
     waitSpinnerShow(areaId);
-    setTimeout(function() {
+    setTimeout(function () {
         jQuery.ajax({
             url: target,
             type: "POST",
             data: targetParams,
-            success: function(data) {
+            success: function (data) {
                 updateArea(areaId, data)
                 waitSpinnerHide(areaId);
             },
-        error: function(data) { waitSpinnerHide(areaId) }
+            error: function (data) {
+                waitSpinnerHide(areaId)
+            }
         });
     }, 0);
 }
@@ -682,9 +690,9 @@ function updateArea(areaId, data) {
 }
 
 /** Update multiple areas (HTML container elements).
-  * @param areaCsvString The area CSV string. The CSV string is a flat array in the
-  * form of: areaId, target, target parameters [, areaId, target, target parameters...].
-*/
+ * @param areaCsvString The area CSV string. The CSV string is a flat array in the
+ * form of: areaId, target, target parameters [, areaId, target, target parameters...].
+ */
 function ajaxUpdateAreas(areaCsvString) {
     /*split all parameters separate by comma, the regExp manage areaId,target,param1=a&param2={b,c,d}&param3=e as three parameters*/
     var regExpArea = /,(?=(?:[^{}]*{[^{}]*})*[^{}]*$)/g;
@@ -696,20 +704,20 @@ function ajaxUpdateAreas(areaCsvString) {
         var targetParams = areaArray[i + 2];
         // Remove the ? and the anchor flag from the parameters
         // not nice but works
-        targetParams = targetParams.replace('#','');
-        targetParams = targetParams.replace('?','');
+        targetParams = targetParams.replace('#', '');
+        targetParams = targetParams.replace('?', '');
         ajaxUpdateArea(areaId, target, targetParams);
     }
 }
 
 /** Update an area (HTML container element) periodically.
-  * @param areaId The id of the HTML container to update
-  * @param target The URL to call to update the HTML container
-  * @param targetParams The URL parameters
-  * @param interval The update interval, in seconds.
-*/
+ * @param areaId The id of the HTML container to update
+ * @param target The URL to call to update the HTML container
+ * @param targetParams The URL parameters
+ * @param interval The update interval, in seconds.
+ */
 function ajaxUpdateAreaPeriodic(areaId, target, targetParams, interval) {
-    importLibrary(["/common/js/jquery/plugins/fjTimer/jquerytimer-min.js"], function() {
+    importLibrary(["/common/js/jquery/plugins/fjTimer/jquerytimer-min.js"], function () {
         var intervalMillis = interval * 1000;
         jQuery.fjTimer({
             interval: intervalMillis,
@@ -734,13 +742,13 @@ function ajaxUpdateAreaPeriodic(areaId, target, targetParams, interval) {
 }
 
 /** Submit request, update multiple areas (HTML container elements).
-  * @param target The URL to call to update the HTML container
-  * @param targetParams The URL parameters
-  * @param areaCsvString The area CSV string. The CSV string is a flat array in the
-  * form of: areaId, target, target parameters [, areaId, target, target parameters...].
-*/
+ * @param target The URL to call to update the HTML container
+ * @param targetParams The URL parameters
+ * @param areaCsvString The area CSV string. The CSV string is a flat array in the
+ * form of: areaId, target, target parameters [, areaId, target, target parameters...].
+ */
 function ajaxSubmitRequestUpdateAreas(target, targetParams, areaCsvString) {
-    updateFunction = function(transport) {
+    updateFunction = function (transport) {
         ajaxUpdateAreas(areaCsvString);
     }
     jQuery.ajax({
@@ -752,13 +760,13 @@ function ajaxSubmitRequestUpdateAreas(target, targetParams, areaCsvString) {
 }
 
 /** Submit form, update an area (HTML container element).
-  * @param form The form element
-  * @param areaId The id of the HTML container to update
-  * @param submitUrl The URL to call to update the HTML container
-*/
+ * @param form The form element
+ * @param areaId The id of the HTML container to update
+ * @param submitUrl The URL to call to update the HTML container
+ */
 function submitFormInBackground(form, areaId, submitUrl) {
     submitFormDisableSubmits(form);
-    updateFunction = function() {
+    updateFunction = function () {
         jQuery("#" + areaId).load(submitUrl);
     }
     jQuery.ajax({
@@ -771,20 +779,21 @@ function submitFormInBackground(form, areaId, submitUrl) {
 function containsErrorMessages(data) {
     return data._ERROR_MESSAGE_LIST_ !== undefined || data._ERROR_MESSAGE_ !== undefined
 }
+
 function displayErrorMessages(data) {
     if (!jQuery('#content-messages').length) {
         //add this div just after app-navigation
-        if(jQuery('#content-main-section')){
-            jQuery('#content-main-section' ).before('<div id="content-messages" onclick="hideErrorContainer()"></div>');
+        if (jQuery('#content-main-section')) {
+            jQuery('#content-main-section').before('<div id="content-messages" onclick="hideErrorContainer()"></div>');
         }
     }
     jQuery('#content-messages').addClass('errorMessage');
     if (data._ERROR_MESSAGE_LIST_ !== undefined && data._ERROR_MESSAGE_ !== undefined) {
-        jQuery('#content-messages' ).html(data._ERROR_MESSAGE_LIST_ + " " + data._ERROR_MESSAGE_);
+        jQuery('#content-messages').html(data._ERROR_MESSAGE_LIST_ + " " + data._ERROR_MESSAGE_);
     } else if (data._ERROR_MESSAGE_LIST_ !== undefined) {
-        jQuery('#content-messages' ).html(data._ERROR_MESSAGE_LIST_);
+        jQuery('#content-messages').html(data._ERROR_MESSAGE_LIST_);
     } else {
-        jQuery('#content-messages' ).html(data._ERROR_MESSAGE_);
+        jQuery('#content-messages').html(data._ERROR_MESSAGE_);
     }
     showjGrowl();
 }
@@ -792,23 +801,25 @@ function displayErrorMessages(data) {
 function containsEventMessage(data) {
     return data._EVENT_MESSAGE_LIST_ !== undefined || data._EVENT_MESSAGE_ !== undefined
 }
+
 function displayEventMessage(data) {
     if (!jQuery('#content-messages').length) {
         //add this div just after app-navigation
-        if(jQuery('#content-main-section')){
-            jQuery('#content-main-section' ).before('<div id="content-messages" onclick="hideErrorContainer()"></div>');
+        if (jQuery('#content-main-section')) {
+            jQuery('#content-main-section').before('<div id="content-messages" onclick="hideErrorContainer()"></div>');
         }
     }
     jQuery('#content-messages').addClass('eventMessage');
     if (data._EVENT_MESSAGE_LIST_ !== undefined && data._EVENT_MESSAGE_ !== undefined) {
-        jQuery('#content-messages' ).html(data._EVENT_MESSAGE_LIST_ + " " + data._EVENT_MESSAGE_);
+        jQuery('#content-messages').html(data._EVENT_MESSAGE_LIST_ + " " + data._EVENT_MESSAGE_);
     } else if (data._EVENT_MESSAGE_LIST_ != undefined) {
-        jQuery('#content-messages' ).html(data._EVENT_MESSAGE_LIST_);
+        jQuery('#content-messages').html(data._EVENT_MESSAGE_LIST_);
     } else {
-        jQuery('#content-messages' ).html(data._EVENT_MESSAGE_);
+        jQuery('#content-messages').html(data._EVENT_MESSAGE_);
     }
     showjGrowl();
 }
+
 function clearErrorMessages() {
     if (jQuery('#content-messages').length) {
         jQuery('#content-messages').html('');
@@ -820,12 +831,12 @@ function clearErrorMessages() {
 }
 
 function errorRetrievingResponseFromServer(xhr, status, exception) {
-    if(exception != 'abort') {
+    if (exception != 'abort') {
         var errorMessage = '<p> No response from Apache OFBiz</p>';
         if (status !== undefined) {
             errorMessage += '<p> (state: ' + status + ')</p>';
         }
-        displayErrorMessages({_ERROR_MESSAGE_: errorMessage});
+        displayErrorMessages({ _ERROR_MESSAGE_: errorMessage });
     }
 }
 
@@ -833,80 +844,81 @@ function errorRetrievingResponseFromServer(xhr, status, exception) {
  * @param formName The form name
  * @param areaCsvString The area CSV string. The CSV string is a flat array in the
  * form of: areaId, target, target parameters [, areaId, target, target parameters...].
-*/
+ */
 function ajaxSubmitFormUpdateAreas(formName, areaCsvString, close) {
-   waitSpinnerShow();
+    waitSpinnerShow();
 
-   var $form = jQuery("form[name='" + formName + "']");
-   hideErrorContainer = function() {
-       clearErrorMessages()
-   }
-   updateFunction = function(data, status, response) {
-       if (response.getResponseHeader("content-type").indexOf("application/json") === -1) {
-           var areaId = areaCsvString.substring(0, areaCsvString.indexOf(','));
-           if (areaId === "") {
-               areaId = $form[0].target
-           }
-           updateArea(areaId, data)
-       } else {
-           if (containsErrorMessages(data)) {
-               displayErrorMessages(data)
-           } else {
-               clearErrorMessages()
-               if (containsEventMessage(data)) {
-                   displayEventMessage(data)
-               }
-               while (areaCsvString.indexOf("_JS_EVENT_RESULT_") !== -1) {
-                   temp = areaCsvString;
-                   areaCsvString = temp.substring(0, areaCsvString.indexOf("_JS_EVENT_RESULT_"))
-                   endString = temp.substring(temp.indexOf("_JS_EVENT_RESULT_") + 17)
-                   variableName = endString.substring(0, endString.indexOf("_"))
-                   areaCsvString += data[variableName] + endString.substring(endString.indexOf("_") + 1)
-               }
-               ajaxUpdateAreas(areaCsvString);
-               if (close === undefined || close == 'true') {
+    var $form = jQuery("form[name='" + formName + "']");
+    hideErrorContainer = function () {
+        clearErrorMessages()
+    }
+    updateFunction = function (data, status, response) {
+        if (response.getResponseHeader("content-type").indexOf("application/json") === -1) {
+            var areaId = areaCsvString.substring(0, areaCsvString.indexOf(','));
+            if (areaId === "") {
+                areaId = $form[0].target
+            }
+            updateArea(areaId, data)
+        } else {
+            if (containsErrorMessages(data)) {
+                displayErrorMessages(data)
+            } else {
+                clearErrorMessages()
+                if (containsEventMessage(data)) {
+                    displayEventMessage(data)
+                }
+                while (areaCsvString.indexOf("_JS_EVENT_RESULT_") !== -1) {
+                    temp = areaCsvString;
+                    areaCsvString = temp.substring(0, areaCsvString.indexOf("_JS_EVENT_RESULT_"))
+                    endString = temp.substring(temp.indexOf("_JS_EVENT_RESULT_") + 17)
+                    variableName = endString.substring(0, endString.indexOf("_"))
+                    areaCsvString += data[variableName] + endString.substring(endString.indexOf("_") + 1)
+                }
+                ajaxUpdateAreas(areaCsvString);
+                if (close === undefined || close == 'true') {
                     $form.trigger('closeCurrentModalAfterAjaxSubmitFormUpdateAreasInSuccess');
                 }
-           }
-       }
-   }
-   var data = null,
-       processData = true,
-       enctype = $form.attr("enctype"),
-       contentType = "application/x-www-form-urlencoded; charset=UTF-8";
-   if (enctype && enctype.indexOf("multipart") !== -1) {
-       data = new FormData($form[0]);
-       contentType = false;
-       processData = false;
-   } else {
-       data = $form.serialize();
-   }
+            }
+        }
+    }
+    var data = null,
+        processData = true,
+        enctype = $form.attr("enctype"),
+        contentType = "application/x-www-form-urlencoded; charset=UTF-8";
+    if (enctype && enctype.indexOf("multipart") !== -1) {
+        data = new FormData($form[0]);
+        contentType = false;
+        processData = false;
+    } else {
+        data = $form.serialize();
+    }
 
-   jQuery.ajax({
-       type: "POST",
-       contentType: contentType,
-       url: $form.attr("action"),
-       data: data,
-       processData: processData,
-       success: function(data, status, response) {
-           updateFunction(data, status, response);
-           waitSpinnerHide();
-       },
-       error: function(xhr, status, exception) {
-           errorRetrievingResponseFromServer(xhr, status, exception)
-           waitSpinnerHide();
-       }
-   });
+    jQuery.ajax({
+        type: "POST",
+        contentType: contentType,
+        url: $form.attr("action"),
+        data: data,
+        processData: processData,
+        success: function (data, status, response) {
+            updateFunction(data, status, response);
+            waitSpinnerHide();
+        },
+        error: function (xhr, status, exception) {
+            errorRetrievingResponseFromServer(xhr, status, exception)
+            waitSpinnerHide();
+        }
+    });
 }
 
 /** Enable auto-completion for text elements, with a possible span of tooltip class showing description.
  * @param areaCsvString The area CSV string. The CSV string is a flat array in the
  * form of: areaId, target, target parameters [, areaId, target, target parameters...].
-*/
+ */
 
 function ajaxAutoCompleter(areaCsvString, showDescription, defaultMinLength, defaultDelay, formName) {
     ajaxAutoCompleter(areaCsvString, showDescription, defaultMinLength, defaultDelay, formName, null);
 }
+
 function ajaxAutoCompleter(areaCsvString, showDescription, defaultMinLength, defaultDelay, formName, args) {
     var areaArray = areaCsvString.replace(/&amp;/g, '&').split(",");
     var numAreas = parseInt(areaArray.length / 3);
@@ -926,12 +938,12 @@ function ajaxAutoCompleter(areaCsvString, showDescription, defaultMinLength, def
         jQuery("#" + div).autocomplete({
             minLength: defaultMinLength,
             delay: defaultDelay,
-            source: function(request, response){
-                var queryArgs = {"term": request.term};
+            source: function (request, response) {
+                var queryArgs = { "term": request.term };
                 if (typeof args == "object" && jQuery.isArray(args)) {
-                     for (var i = 0; i < args.length; i++) {
-                         queryArgs["parm" + i] = jQuery(DOMPurify.sanitize(args[i]).val())
-                     }
+                    for (var i = 0; i < args.length; i++) {
+                        queryArgs["parm" + i] = jQuery(DOMPurify.sanitize(args[i]).val())
+                    }
                 }
                 jQuery.ajax({
                     url: url,
@@ -943,41 +955,41 @@ function ajaxAutoCompleter(areaCsvString, showDescription, defaultMinLength, def
                             var oldRef = LAST_AUTOCOMP_REF;
                             oldRef.abort();
                             //Here we are aborting the LAST_AUTOCOMP_REF so need to call the response method so that auto-completer pending request count handle in proper way
-                            response( [] );
+                            response([]);
                         }
-                        LAST_AUTOCOMP_REF= jqXHR;
+                        LAST_AUTOCOMP_REF = jqXHR;
                     },
-                    success: function(data) {
+                    success: function (data) {
                         // reset the autocomp field
                         autocomp = undefined;
 
                         jQuery("#" + div + "_auto").html(data);
 
                         if (typeof autocomp != 'undefined') {
-                            jQuery.each(autocomp, function(index, item){
+                            jQuery.each(autocomp, function (index, item) {
                                 item.label = DOMPurify.sanitize(jQuery("<div>").html(item.label).text());
                             })
                             // autocomp is the JSON Object which will be used for the autocomplete box
                             response(autocomp);
                         }
                     },
-                    error: function(xhr, reason, exception) {
-                        if(exception != 'abort') {
+                    error: function (xhr, reason, exception) {
+                        if (exception != 'abort') {
                             alert("An error occurred while communicating with the server:\n\n\nreason=" + reason + "\n\nexception=" + exception);
                         }
                     }
                 });
             },
-            select: function(event, ui){
+            select: function (event, ui) {
                 // search returned something
-                if(ui.item.id !== '') {
-                    $(`#${areaArray[0]}`).val(ui.item.value);
+                if (ui.item.id !== '') {
+                    $(`#${ areaArray[0] }`).val(ui.item.value);
                     if (showDescription && (ui.item.value != undefined && ui.item.value != '')) {
                         setLookDescription(areaArray[0], ui.item.label, areaArray[2], formName, showDescription);
                     }
                 } else {
                     // empty the search input
-                    $(`#${areaArray[0]}`).val('');
+                    $(`#${ areaArray[0] }`).val('');
                     // cancel the selection (do not copy "no result found" in the search field)
                     event.preventDefault();
                 }
@@ -987,14 +999,14 @@ function ajaxAutoCompleter(areaCsvString, showDescription, defaultMinLength, def
         if (showDescription) {
             var lookupDescriptionLoader = new lookupDescriptionLoaded(areaArray[i], areaArray[i + 1], areaArray[i + 2], formName);
             lookupDescriptionLoader.update();
-            jQuery("#" + areaArray[i]).on('change lookup:changed', function(){
+            jQuery("#" + areaArray[i]).on('change lookup:changed', function () {
                 lookupDescriptionLoader.update();
             });
         }
     }
 }
 
-function setLookDescription(textFieldId, description, params, formName, showDescription){
+function setLookDescription(textFieldId, description, params, formName, showDescription) {
     if (description) {
         var start = description.lastIndexOf(' [');
         if (start != -1) {
@@ -1030,43 +1042,43 @@ function setLookDescription(textFieldId, description, params, formName, showDesc
 /** Enable auto-completion for drop-down elements.*/
 
 function ajaxAutoCompleteDropDown() {
-    jQuery.widget( "ui.combobox", {
-        _create: function() {
+    jQuery.widget("ui.combobox", {
+        _create: function () {
             var self = this;
             var select = this.element.hide(),
-                selected = select.children( ":selected" ),
+                selected = select.children(":selected"),
                 value = selected.val() ? selected.text() : "";
-            var input = jQuery( "<input>" )
-                .insertAfter( select )
-                .val( value )
+            var input = jQuery("<input>")
+                .insertAfter(select)
+                .val(value)
                 .autocomplete({
                     delay: 0,
                     minLength: 0,
-                    source: function( request, response ) {
-                        var matcher = new RegExp( jQuery.ui.autocomplete.escapeRegex(request.term), "i" );
-                        response( select.children( "option" ).map(function() {
-                            var text = jQuery( this ).text();
-                            if ( this.value && ( !request.term || matcher.test(text) ) )
+                    source: function (request, response) {
+                        var matcher = new RegExp(jQuery.ui.autocomplete.escapeRegex(request.term), "i");
+                        response(select.children("option").map(function () {
+                            var text = jQuery(this).text();
+                            if (this.value && (!request.term || matcher.test(text)))
                                 return {
                                     label: text.replace(
                                         new RegExp(
                                             "(?![^&;]+;)(?!<[^<>]*)(" +
                                             jQuery.ui.autocomplete.escapeRegex(request.term) +
                                             ")(?![^<>]*>)(?![^&;]+;)", "gi"
-                                        ), "<b>$1</b>" ),
+                                        ), "<b>$1</b>"),
                                     value: text,
                                     option: this
                                 };
-                        }) );
+                        }));
                     },
-                    select: function( event, ui ) {
+                    select: function (event, ui) {
                         ui.item.option.selected = true;
                         //select.val( ui.item.option.value );
-                        self._trigger( "selected", event, {
+                        self._trigger("selected", event, {
                             item: ui.item.option
                         });
                     },
-                    change: function( event, ui ) {
+                    change: function (event, ui) {
                         var element = jQuery(this);
                         if (element.data('other-field-name') != undefined) {
                             var otherField = (element.form()).find("input[name=" + element.data('other-field-name') + "]");
@@ -1074,54 +1086,54 @@ function ajaxAutoCompleteDropDown() {
                                 process_choice(element, jQuery(otherField));
                             }
                         }
-                        if ( !ui.item ) {
-                            var matcher = new RegExp( "^" + jQuery.ui.autocomplete.escapeRegex( jQuery(this).val() ) + "$", "i" ),
+                        if (!ui.item) {
+                            var matcher = new RegExp("^" + jQuery.ui.autocomplete.escapeRegex(jQuery(this).val()) + "$", "i"),
                                 valid = false;
-                            select.children( "option" ).each(function() {
-                                if ( this.value.match( matcher ) ) {
+                            select.children("option").each(function () {
+                                if (this.value.match(matcher)) {
                                     this.selected = valid = true;
                                     return false;
                                 }
                             });
-                            if ( !valid ) {
+                            if (!valid) {
                                 // remove invalid value, as it didn't match anything
-                                jQuery( this ).val( "" );
-                                select.val( "" );
+                                jQuery(this).val("");
+                                select.val("");
                                 return false;
                             }
                         }
                     }
                 })
-                //.addClass( "ui-widget ui-widget-content ui-corner-left" );
+            //.addClass( "ui-widget ui-widget-content ui-corner-left" );
 
-            input.data( "ui-autocomplete" )._renderItem = function( ul, item ) {
-                return jQuery( "<li></li>" )
-                    .data( "item.autocomplete", item )
-                    .append( "<a>" + item.label + "</a>" )
-                    .appendTo( ul );
+            input.data("ui-autocomplete")._renderItem = function (ul, item) {
+                return jQuery("<li></li>")
+                    .data("item.autocomplete", item)
+                    .append("<a>" + item.label + "</a>")
+                    .appendTo(ul);
             };
 
-            jQuery( "<a>&nbsp;</a>" )
-                .attr( "tabIndex", -1 )
-                .attr( "title", "Show All Items" )
-                .insertAfter( input )
+            jQuery("<a>&nbsp;</a>")
+                .attr("tabIndex", -1)
+                .attr("title", "Show All Items")
+                .insertAfter(input)
                 .button({
                     icons: {
                         primary: "ui-icon-triangle-1-s"
                     },
                     text: false
                 })
-                .removeClass( "ui-corner-all" )
-                .addClass( "ui-corner-right ui-button-icon" )
-                .click(function() {
+                .removeClass("ui-corner-all")
+                .addClass("ui-corner-right ui-button-icon")
+                .click(function () {
                     // close if already visible
-                    if ( input.autocomplete( "widget" ).is( ":visible" ) ) {
-                        input.autocomplete( "close" );
+                    if (input.autocomplete("widget").is(":visible")) {
+                        input.autocomplete("close");
                         return;
                     }
 
                     // pass empty string as value to search for, displaying all results
-                    input.autocomplete( "search", "" );
+                    input.autocomplete("search", "");
                     input.focus();
                 });
         }
@@ -1135,22 +1147,22 @@ function ajaxAutoCompleteDropDown() {
  * @param areaId The id of the HTML container to toggle
  * @param expandTxt Localized 'Expand' text
  * @param collapseTxt Localized 'Collapse' text
-*/
-function toggleCollapsiblePanel(link, areaId, expandTxt, collapseTxt){
-   var container = jQuery("#" + areaId);
-   var liElement = jQuery(link).is("li") ? jQuery(link) : jQuery(link).parents('li:first');
+ */
+function toggleCollapsiblePanel(link, areaId, expandTxt, collapseTxt) {
+    var container = jQuery("#" + areaId);
+    var liElement = jQuery(link).is("li") ? jQuery(link) : jQuery(link).parents('li:first');
     if (liElement) {
-      if (container.is(':visible')) {
-        liElement.removeClass('expanded');
-        liElement.addClass('collapsed');
-        link.title = expandTxt;
-      } else {
-        liElement.removeClass('collapsed');
-        liElement.addClass('expanded');
-        link.title = collapseTxt;
-      }
+        if (container.is(':visible')) {
+            liElement.removeClass('expanded');
+            liElement.addClass('collapsed');
+            link.title = expandTxt;
+        } else {
+            liElement.removeClass('collapsed');
+            liElement.addClass('expanded');
+            link.title = collapseTxt;
+        }
     }
-   container.animate({opacity: 'toggle', height: 'toggle'}, "slow");
+    container.animate({ opacity: 'toggle', height: 'toggle' }, "slow");
 }
 
 /** Toggle screenlet visibility on/off.
@@ -1158,64 +1170,64 @@ function toggleCollapsiblePanel(link, areaId, expandTxt, collapseTxt){
  * @param areaId The id of the HTML container to toggle
  * @param expandTxt Localized 'Expand' text
  * @param collapseTxt Localized 'Collapse' text
-*/
-function toggleScreenlet(link, areaId, saveCollapsed, expandTxt, collapseTxt){
-   toggleCollapsiblePanel(link, areaId, expandTxt, collapseTxt);
-   var screenlet = jQuery(link).parents('div:eq(1)').attr('id');
-   var title = jQuery(link).attr('title');
-   if(title == expandTxt){
-       var currentParam = screenlet + "_collapsed=false";
-       var newParam = screenlet + "_collapsed=true";
-       if(saveCollapsed=='true'){
-           setUserLayoutPreferences('GLOBAL_PREFERENCES',screenlet+"_collapsed",'true');
-       }
-   } else {
-       var currentParam = screenlet + "_collapsed=true";
-       var newParam = screenlet + "_collapsed=false";
-       if(saveCollapsed=='true'){
-           setUserLayoutPreferences('GLOBAL_PREFERENCES',screenlet+"_collapsed",'false');
-       }
-   }
-   var paginationMenus = jQuery('div.nav-pager');
-   jQuery.each(paginationMenus, function(index, menu) {
-       if (menu) {
-           var childElements = jQuery(menu).find('a');
-           for (var i = 0; i < childElements.length; i++) {
-               if (childElements[i].href.indexOf("http") == 0) {
-                   childElements[i].href = replaceQueryParam(childElements[i].href, currentParam, newParam);
-               }
-           }
-           childElements = jQuery(menu).find('select');
-           for (i = 0; i < childElements.length; i++) {
-             //FIXME: Not able to understand the purpose of below line, as href is not valid attribute of select element.
-             //if (childElements[i].href.indexOf("location.href") >= 0) {
-               if (childElements[i].value.indexOf("location.href") >= 0) {
-                   Element.extend(childElements[i]);
-                   childElements[i].writeAttribute("onchange", replaceQueryParam(childElements[i].readAttribute("onchange"), currentParam, newParam));
-               }
-           }
-       }
-   });
+ */
+function toggleScreenlet(link, areaId, saveCollapsed, expandTxt, collapseTxt) {
+    toggleCollapsiblePanel(link, areaId, expandTxt, collapseTxt);
+    var screenlet = jQuery(link).parents('div:eq(1)').attr('id');
+    var title = jQuery(link).attr('title');
+    if (title == expandTxt) {
+        var currentParam = screenlet + "_collapsed=false";
+        var newParam = screenlet + "_collapsed=true";
+        if (saveCollapsed == 'true') {
+            setUserLayoutPreferences('GLOBAL_PREFERENCES', screenlet + "_collapsed", 'true');
+        }
+    } else {
+        var currentParam = screenlet + "_collapsed=true";
+        var newParam = screenlet + "_collapsed=false";
+        if (saveCollapsed == 'true') {
+            setUserLayoutPreferences('GLOBAL_PREFERENCES', screenlet + "_collapsed", 'false');
+        }
+    }
+    var paginationMenus = jQuery('div.nav-pager');
+    jQuery.each(paginationMenus, function (index, menu) {
+        if (menu) {
+            var childElements = jQuery(menu).find('a');
+            for (var i = 0; i < childElements.length; i++) {
+                if (childElements[i].href.indexOf("http") == 0) {
+                    childElements[i].href = replaceQueryParam(childElements[i].href, currentParam, newParam);
+                }
+            }
+            childElements = jQuery(menu).find('select');
+            for (i = 0; i < childElements.length; i++) {
+                //FIXME: Not able to understand the purpose of below line, as href is not valid attribute of select element.
+                //if (childElements[i].href.indexOf("location.href") >= 0) {
+                if (childElements[i].value.indexOf("location.href") >= 0) {
+                    Element.extend(childElements[i]);
+                    childElements[i].writeAttribute("onchange", replaceQueryParam(childElements[i].readAttribute("onchange"), currentParam, newParam));
+                }
+            }
+        }
+    });
 }
 
 /** In Place Editor for display elements
-  * @param element The id of the display field
-  * @param url The request to be called to update the display field
-  * @param options Options to be passed to Ajax.InPlaceEditor
-  * https://cwiki.apache.org/confluence/display/OFBIZ/Enhancing+Display+Widget+to+use+Ajax.InPlaceEditor
-*/
+ * @param element The id of the display field
+ * @param url The request to be called to update the display field
+ * @param options Options to be passed to Ajax.InPlaceEditor
+ * https://cwiki.apache.org/confluence/display/OFBIZ/Enhancing+Display+Widget+to+use+Ajax.InPlaceEditor
+ */
 
 function ajaxInPlaceEditDisplayField(element, url, options) {
     var jElement = jQuery("#" + element);
-    jElement.mouseover(function() {
+    jElement.mouseover(function () {
         jQuery(this).css('background-color', 'rgb(255, 255, 153)');
     });
 
-    jElement.mouseout(function() {
+    jElement.mouseout(function () {
         jQuery(this).css('background-color', 'transparent');
     });
 
-    importLibrary(["/common/js/jquery/plugins/jeditable/jquery.jeditable-1.7.3.js"], function() {
+    importLibrary(["/common/js/jquery/plugins/jeditable/jquery.jeditable-1.7.3.js"], function () {
         jElement.editable(function (value, settings) {
             // removes all line breaks from the value param, because the parseJSON Function can't work with line breaks
             value = value.replace(/\n/g, " ");
@@ -1256,7 +1268,7 @@ function replaceQueryParam(queryString, currentParam, newParam) {
 }
 
 function submitFormDisableSubmits(form) {
-    for (var i=0;i<form.length;i++) {
+    for (var i = 0; i < form.length; i++) {
         var formel = form.elements[i];
         if (formel.type == "submit") {
             submitFormDisableButton(formel);
@@ -1309,7 +1321,7 @@ function showjGrowlMessage(errMessage, classEvent, stickyValue, showAllLabel, co
 
     var libraryFiles = ["/common/js/jquery/plugins/Readmore.js-master/readmore.js",
         "/common/js/jquery/plugins/jquery-jgrowl/jquery.jgrowl-1.4.6.min.js"];
-    importLibrary(libraryFiles, function() {
+    importLibrary(libraryFiles, function () {
         $.jGrowl.defaults.closerTemplate = '<div class="closeAllJGrowl">' + hideAllLabel + '</div>';
         if (jGrowlPosition !== null && jGrowlPosition !== undefined) $.jGrowl.defaults.position = jGrowlPosition;
         $.jGrowl(errMessage, {
@@ -1346,6 +1358,7 @@ function submitFormEnableButtonByName(formName, buttonName) {
     var button = form.elements[buttonName];
     submitFormEnableButton(button);
 }
+
 function submitFormEnableButton(button) {
     button.disabled = false;
     button.className = button.className.substring(0, button.className.length - " disabled".length);
@@ -1359,7 +1372,7 @@ function submitFormEnableButton(button) {
  * @param portalPortletId The id of the portlet
  */
 function expandAllP(bool, portalPortletId) {
-    jQuery('#scrlt_'+portalPortletId+' .fieldgroup').each(function() {
+    jQuery('#scrlt_' + portalPortletId + ' .fieldgroup').each(function () {
         var titleBar = jQuery(this).children('.fieldgroup-title-bar'), body = jQuery(this).children('.fieldgroup-body');
         if (titleBar.children().length > 0 && body.is(':visible') != bool) {
             toggleCollapsiblePanel(titleBar.find('a'), body.attr('id'), 'expand', 'collapse');
@@ -1373,7 +1386,7 @@ function expandAllP(bool, portalPortletId) {
  * @param bool <code>true</code> to expand, <code>false</code> otherwise
  */
 function expandAll(bool) {
-    jQuery('.fieldgroup').each(function() {
+    jQuery('.fieldgroup').each(function () {
         var titleBar = jQuery(this).children('.fieldgroup-title-bar'), body = jQuery(this).children('.fieldgroup-body');
         if (titleBar.children().length > 0 && body.is(':visible') != bool) {
             toggleCollapsiblePanel(titleBar.find('li.collapsed, li.expanded'), body.attr('id'), 'expand', 'collapse');
@@ -1382,12 +1395,17 @@ function expandAll(bool) {
 }
 
 //calls ajax request for storing user layout preferences
-function setUserLayoutPreferences(userPrefGroupTypeId, userPrefTypeId, userPrefValue){
+function setUserLayoutPreferences(userPrefGroupTypeId, userPrefTypeId, userPrefValue) {
     jQuery.ajax({
-        url:'ajaxSetUserPreference',
+        url: 'ajaxSetUserPreference',
         type: "POST",
-        data: ({userPrefGroupTypeId: userPrefGroupTypeId, userPrefTypeId: userPrefTypeId, userPrefValue: userPrefValue}),
-        success: function(data) {}
+        data: ({
+            userPrefGroupTypeId: userPrefGroupTypeId,
+            userPrefTypeId: userPrefTypeId,
+            userPrefValue: userPrefValue
+        }),
+        success: function (data) {
+        }
     });
 }
 
@@ -1438,13 +1456,14 @@ function getJSONuiLabels(requiredLabels, callback) {
             url: "getUiLabels",
             type: "POST",
             async: false,
-            data: {"requiredLabels" : requiredLabelsStr, "widgetVerbose": false},
-            complete: function(data) {
+            data: { "requiredLabels": requiredLabelsStr, "widgetVerbose": false },
+            complete: function (data) {
                 callback(data);
             }
         });
     }
 }
+
 /**
  * Read the required uiLabel from the uiLabelXml Resource
  * @param uiResource String
@@ -1463,8 +1482,8 @@ function getJSONuiLabel(uiResource, errUiLabel) {
             url: "getJSONuiLabel",
             type: "POST",
             async: false,
-            data: {"requiredLabel" : requiredLabelStr},
-            success: function(data) {
+            data: { "requiredLabel": requiredLabelStr },
+            success: function (data) {
                 returnVal = data;
             }
         });
@@ -1478,7 +1497,7 @@ function getJSONuiLabel(uiResource, errUiLabel) {
  * @param errMessage String - Required - i18n Error Message
  */
 function showErrorAlert(errBoxTitle, errMessage) {
-    if (errMessage == null || errMessage == "" || errMessage == undefined ) {
+    if (errMessage == null || errMessage == "" || errMessage == undefined) {
         // No Error Message Information is set, Error Msg Box can't be created
         return;
     }
@@ -1490,9 +1509,9 @@ function showErrorAlert(errBoxTitle, errMessage) {
             modal: true,
             title: errBoxTitle,
             buttons: {
-                Ok: function() {
+                Ok: function () {
                     errMsgBox.remove();
-                    jQuery( this ).dialog( "close" );
+                    jQuery(this).dialog("close");
                 }
             }
         });
@@ -1511,14 +1530,14 @@ function submitPagination(obj, url) {
     }
     if (url.length > 2000) {
         var request = url.substring(0, url.indexOf("?"));
-        var params = url.substring(url.indexOf("?")+1, url.length);
+        var params = url.substring(url.indexOf("?") + 1, url.length);
         var paramsArray = params.split("&");
         var form = document.createElement("form");
         form.setAttribute("method", "post");
         form.setAttribute("action", request);
-        for (var i = 0; i < paramsArray.length; i ++) {
+        for (var i = 0; i < paramsArray.length; i++) {
             var param = paramsArray[i];
-            if (param!= "" && param.indexOf("=") > 0) {
+            if (param != "" && param.indexOf("=") > 0) {
                 var keyValue = param.split("=");
                 var hiddenField = document.createElement("input");
                 hiddenField.setAttribute("type", "hidden");
@@ -1540,6 +1559,7 @@ function submitPagination(obj, url) {
         }
     }
 }
+
 function loadJWT() {
     var JwtToken = "";
     jQuery.ajax({
@@ -1547,10 +1567,10 @@ function loadJWT() {
         type: "POST",
         async: false,
         dataType: "text",
-        success: function(response) {
+        success: function (response) {
             JwtToken = response;
         },
-        error: function(textStatus, errorThrown){
+        error: function (textStatus, errorThrown) {
             alert('Failure, errorThrown: ' + errorThrown);
         }
     });
@@ -1565,9 +1585,9 @@ function sendJWT(targetUrl) {
             url: targetUrl,
             async: false,
             type: 'POST',
-            xhrFields: {withCredentials: true},
-            headers: {"Authorization" : "Bearer " + jwtToken},
-            success: function(){
+            xhrFields: { withCredentials: true },
+            headers: { "Authorization": "Bearer " + jwtToken },
+            success: function () {
                 window.location.assign(redirectUrl);
             }
         });
@@ -1581,7 +1601,7 @@ function sendJWT(targetUrl) {
  * @param onSuccessFn function to run when the files are loaded successfully
  * @param onErrorFn optional function to run when any of the files are not loaded correctly
  */
-var importLibrary = function() {
+var importLibrary = function () {
     var importLibraryFiles = new Map();
     return function (urls, onSuccessFn, onErrorFn) {
         function cachedScript(url, options) {
@@ -1603,10 +1623,10 @@ var importLibrary = function() {
                 if (!importLibraryFiles.has(url)) {
                     var deferObj = (url.endsWith(".css") ?
                         jQuery.get(url, function (css) {
-                            var folder = url.substring(0,url.lastIndexOf("/"))
-                            var parentFolder = folder.substring(0,folder.lastIndexOf("/"))
+                            var folder = url.substring(0, url.lastIndexOf("/"))
+                            var parentFolder = folder.substring(0, folder.lastIndexOf("/"))
                             // convert any relative path
-                            var updatedCss = css.replace(/\.\.\/(images|css|js)+/g, parentFolder+"/$1");
+                            var updatedCss = css.replace(/\.\.\/(images|css|js)+/g, parentFolder + "/$1");
                             jQuery("<style>" + updatedCss + "</style>").appendTo("head");
                         }) :
                         cachedScript(url));
@@ -1617,7 +1637,7 @@ var importLibrary = function() {
                 }
             })
         ).then(onSuccessFn).catch(onErrorFn || function (err) {
-            console.error('Error:\n'+err+'\n\nFile(s): \n' + urls.join('\n'))
+            console.error('Error:\n' + err + '\n\nFile(s): \n' + urls.join('\n'))
         });
     }
 }();
@@ -1626,6 +1646,6 @@ var importLibrary = function() {
  * Is browser accessing local server?
  * @returns {boolean}
  */
-function isLocalEnviron(){
-    return ["localhost","127.0.0.1"].includes(window.location.hostname);
+function isLocalEnviron() {
+    return ["localhost", "127.0.0.1"].includes(window.location.hostname);
 }

--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -352,12 +352,11 @@ function bindObservers(bind_element) {
     jQuery(bind_element).find(".date-time-picker").each(function () {
         initDateTimePicker(this);
     });
-    jQuery(bind_element).on("click", ".fieldgroup  li.collapsed, .fieldgroup  li.expanded", function (e) {
-        var element = jQuery(this);
-        var collapsibleAreaId = element.data("collapsible-area-id");
-        var expandToolTip = element.data("expand-tooltip");
-        var collapseToolTip = element.data("collapse-tooltip");
-        toggleCollapsiblePanel(element, collapsibleAreaId, expandToolTip, collapseToolTip);
+    jQuery(bind_element).find('.fieldgroup  li.collapsed, .fieldgroup  li.expanded').each(function (_) {
+        const el = jQuery(this);
+        el.on('click', function (_) {
+            toggleCollapsiblePanel(el, el.data('collapsible-area-id'), el.data('expand-tooltip'), el.data('collapse-tooltip'));
+        });
     });
 }
 


### PR DESCRIPTION
Fixed: Remove duplicate event handler for collapsible in modals

OF-13169

When a modal opens, we search for interactive elements
and trigger jQuery plugins/behaviors in bindObservers
function. This function searches for HTML elements and
starts needed behavior, using this logic:

$(wrappingElement).find(selector).each([behavior]);

This means that all 'selector' in 'wrappingElement'
initially present in the page will be triggered.
When we open a modal, we call bindObservers again
within the modal, to trigger interactive elements
which are in the modal.

For collapsible (and some others behaviors), we use

$(wrappingElement).on('click', doStuff);

...but the jQuery 'on' method also affects
DOM elements that are dynamically added to the
page, like modals content. So for these behaviors,
event handlers for interactive elements are created
twice. So when we click on the "+" of a collapsible
in a modal, "toggleCollapsiblePanel" is called twice,
and the collapsible section is open and closed right
away