### PR TITLE
Improved: Add delegator method to create in mass many entities (OFBIZ-13176)

### DIFF
--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/Delegator.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/Delegator.java
@@ -197,6 +197,34 @@ public interface Delegator {
      */
     GenericValue createSingle(String entityName, Object singlePkValue) throws GenericEntityException;
 
+    /**
+     * <p>Create the Entities from the List GenericValue instances to the persistent
+     * store.</p>
+     * <p>This is different than the normal create method, because all creation
+     * will be done with one unique insert to go fast.</p>
+     * <p>For this reason eca can't be raised, so it's useful for process
+     * with huge data to inject into database</p>
+     * @param values
+     *            List of GenericValue instances containing the entities to create
+     */
+    void createAllByBatchProcess(List<GenericValue> values) throws GenericEntityException;
+
+    /**
+     * <p>Create the Entities from the List GenericValue instances to the persistent
+     * store.</p>
+     * <p>This is different than the normal create method, because all creation
+     * will be done with one unique insert to go fast.</p>
+     * <p>For this reason eca can't be raised, so it's useful for process
+     * with huge data to inject on database.</p>
+     * <p>As this is a huge process, we can specify whether we want to alert the ofbiz cluster
+     * if we need to clean their cache or just wait the normal expiration</p>
+     * @param values
+     *            List of GenericValue instances containing the entities to create
+     * @param distribute
+     *            set to true if we want to clean cache entity for ofbiz cluster
+     */
+    void createAllByBatchProcess(List<GenericValue> values, boolean distribute) throws GenericEntityException;
+
     Object decryptFieldValue(String entityName, ModelField.EncryptMethod encryptMethod, String encValue) throws EntityCryptoException;
 
     Object encryptFieldValue(String entityName, ModelField.EncryptMethod encryptMethod, Object fieldValue) throws EntityCryptoException;

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/datasource/GenericHelper.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/datasource/GenericHelper.java
@@ -53,6 +53,13 @@ public interface GenericHelper {
      */
     GenericValue create(GenericValue value) throws GenericEntityException;
 
+    /**
+     * Insert a given list of GenericValue to the database
+     * @param values
+     * @return The list of GenericValue created
+     */
+    List<GenericValue> createAll(List<GenericValue> values) throws GenericEntityException;
+
     /** Find a Generic Entity by its Primary Key
      *@param primaryKey The primary key to find by.
      *@return The GenericValue corresponding to the primaryKey

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/datasource/GenericHelperDAO.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/datasource/GenericHelperDAO.java
@@ -72,6 +72,20 @@ public class GenericHelperDAO implements GenericHelper {
         return value;
     }
 
+    /** Insert a given list of GenericValue to the database
+     *@return List of GenericValue instance created
+     */
+    public List<GenericValue> createAll(List<GenericValue> values) throws GenericEntityException {
+        if (values.isEmpty()) {
+            return null;
+        }
+        int retVal = genericDAO.insertAll(values);
+        if (Debug.verboseOn()) {
+            Debug.logVerbose("Insert Return Value : " + retVal, MODULE);
+        }
+        return values;
+    }
+
     /** Find a Generic Entity by its Primary Key
      *@param primaryKey The primary key to find by.
      *@return The GenericValue corresponding to the primaryKey

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/datasource/ReadOnlyHelperDAO.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/datasource/ReadOnlyHelperDAO.java
@@ -64,6 +64,14 @@ public class ReadOnlyHelperDAO implements GenericHelper {
         return null;
     }
 
+    /** Read only, no creation realize on the database
+     *@return null
+     */
+    @Override
+    public List<GenericValue> createAll(List<GenericValue> value) throws GenericEntityException {
+        return null;
+    }
+
     /** Find a Generic Entity by its Primary Key
      *@param primaryKey The primary key to find by.
      *@return The GenericValue corresponding to the primaryKey

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/jdbc/SQLProcessor.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/jdbc/SQLProcessor.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.ofbiz.base.util.Debug;
@@ -857,5 +858,28 @@ public class SQLProcessor implements AutoCloseable {
                     + ") when executing the SQL [" + sql + "]", MODULE);
             TransactionUtil.printAllThreadsTransactionBeginStacks();
         }
+    }
+
+    /**
+     * Ask the processor to execute the batch and return the number of rows updated
+     * @return The number of rows updated
+     * @throws GenericDataSourceException
+     */
+    public int executeBatch() throws GenericDataSourceException {
+        try {
+            return Arrays.stream(ps.executeBatch()).sum();
+        } catch (SQLException sqle) {
+            this.checkLockWaitInfo(sqle);
+            throw new GenericDataSourceException("SQL Exception while executing the following:" + sql, sqle);
+        }
+    }
+
+    /**
+     * Add to the processor a batch treatment
+     * @throws SQLException
+     */
+    public void addBatch() throws SQLException {
+        this.ind = 1;
+        this.getPreparedStatement().addBatch();
     }
 }

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/test/EntityTestSuite.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/test/EntityTestSuite.java
@@ -194,10 +194,13 @@ public class EntityTestSuite extends EntityTestCase {
             testValues.add(getDelegator().makeValue("TestingType",
                     "testingTypeId", "TEST_CREATE_ALL" + i,
                     "description", "Testing Type #CreateAll" + i));
+            testValues.add(getDelegator().makeValue("Testing", "testingId", "TEST_CREATE_DIST" + i));
         }
         getDelegator().createAllByBatchProcess(testValues);
         assertEquals("create all insert 100 elements", 100, getDelegator().findCountByCondition("TestingType",
                 EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST_CREATE_ALL%"), null, null));
+        assertEquals("create all insert 100 elements", 100, getDelegator().findCountByCondition("Testing",
+                EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "TEST_CREATE_DIST%"), null, null));
     }
 
     /**

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/test/EntityTestSuite.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/test/EntityTestSuite.java
@@ -185,6 +185,22 @@ public class EntityTestSuite extends EntityTestCase {
     }
 
     /**
+     * Test to load huge entity
+     * @throws Exception the exception
+     */
+    public void testCreateAllValues() throws Exception {
+        List<GenericValue> testValues = new ArrayList<>(100);
+        for (int i = 0; i < 100; i++) {
+            testValues.add(getDelegator().makeValue("TestingType",
+                    "testingTypeId", "TEST_CREATE_ALL" + i,
+                    "description", "Testing Type #CreateAll" + i));
+        }
+        getDelegator().createAllByBatchProcess(testValues);
+        assertEquals("create all insert 100 elements", 100, getDelegator().findCountByCondition("TestingType",
+                EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST_CREATE_ALL%"), null, null));
+    }
+
+    /**
      * Tests the entity cache
      * @throws Exception the exception
      */


### PR DESCRIPTION
When you need to load huge record on your database (like system synchronization, data import) OFBiz can have latency with the delegator.create. Incriminated unitary workflow and eeca control. You can disable eeca on use a dedicate delegator but sometime it's not enough.

So for special case, we implement a new function delegator.createAllByBatchProcess that will use an insert with one transaction through the standard sql method INSERT TO ... VALUES ... .

By the way, like the process isn't unitary, the eeca system can't run on this batch, so this function must therefore be used with care

Thanks to Néréide team for this contribution