### PR TITLE
Improved: Improve ViewHandler interface (OFBIZ-13179)

### DIFF
--- a/applications/content/src/main/java/org/apache/ofbiz/content/cms/CmsEvents.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/cms/CmsEvents.java
@@ -294,7 +294,7 @@ public final class CmsEvents {
                 if (statusCode == HttpServletResponse.SC_OK || hasErrorPage) {
                     // create the template map
                     MapStack<String> templateMap = MapStack.create();
-                    ScreenRenderer.populateContextForRequest(templateMap, null, request, response, servletContext);
+                    ScreenRenderer.populateContextForRequest(templateMap, null, request, response, servletContext, true);
                     templateMap.put("statusCode", statusCode);
 
                     // make the link prefix

--- a/applications/product/src/main/java/org/apache/ofbiz/product/category/SeoContextFilter.java
+++ b/applications/product/src/main/java/org/apache/ofbiz/product/category/SeoContextFilter.java
@@ -48,7 +48,7 @@ import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.StringUtil;
 import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.base.util.UtilValidate;
-import org.apache.ofbiz.security.SecurityUtil;
+import org.apache.ofbiz.security.SecuredFreemarker;
 import org.apache.ofbiz.webapp.SeoConfigUtil;
 import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 import org.apache.ofbiz.webapp.control.ConfigXMLReader.ControllerConfig;
@@ -116,7 +116,7 @@ public final class SeoContextFilter implements Filter {
             uri = uri + "?" + queryString;
         }
 
-        if (SecurityUtil.containsFreemarkerInterpolation(httpRequest, httpResponse, uri)) {
+        if (SecuredFreemarker.containsFreemarkerInterpolation(httpRequest, httpResponse, uri)) {
             return;
         }
 

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredFreemarker.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredFreemarker.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.ofbiz.security;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.ofbiz.base.util.Debug;
+import org.apache.ofbiz.base.util.StringUtil;
+import org.apache.ofbiz.base.util.UtilHttp;
+import org.apache.ofbiz.base.util.UtilProperties;
+import org.apache.ofbiz.base.util.UtilValidate;
+
+public class SecuredFreemarker {
+    private static final String MODULE = SecuredFreemarker.class.getName();
+    private static final List<String> FTL_INTERPOLATION = List.of("%24%7B", "${", "%3C%23", "<#", "%23%7B", "#{", "%5B%3D", "[=", "%5B%23", "[#");
+
+    /*
+     * Prevents Freemarker exploits
+     * @param req
+     * @param resp
+     * @param uri
+     * @throws IOException
+     */
+    public static boolean containsFreemarkerInterpolation(HttpServletRequest req, HttpServletResponse resp, String uri)
+            throws IOException {
+        String urisOkForFreemarker = UtilProperties.getPropertyValue("security", "allowedURIsForFreemarkerInterpolation");
+        List<String> urisOK = UtilValidate.isNotEmpty(urisOkForFreemarker) ? StringUtil.split(urisOkForFreemarker, ",")
+                                                                           : new ArrayList<>();
+        String uriEnd = uri.substring(uri.lastIndexOf("/") + 1, uri.length());
+
+        if (!urisOK.contains(uriEnd)) {
+            Map<String, String[]> parameterMap = req.getParameterMap();
+            if (uri.contains("ecomseo")) { // SeoContextFilter call
+                if (containsFreemarkerInterpolation(resp, uri)) {
+                    return true;
+                }
+            } else if (!parameterMap.isEmpty()) { // ControlFilter call
+                List<BasicNameValuePair> params = new ArrayList<>();
+                parameterMap.forEach((name, values) -> {
+                    for (String value : values) {
+                        params.add(new BasicNameValuePair(name, value));
+                    }
+                });
+                String queryString = URLEncodedUtils.format(params, Charset.forName("UTF-8"));
+                uri = uri + "?" + queryString;
+                if (containsFreemarkerInterpolation(resp, uri)) {
+                    return true;
+                }
+            } else if (!UtilHttp.getAttributeMap(req).isEmpty()) { // Call with Content-Type modified by a MITM attack (rare case)
+                String attributeMap = UtilHttp.getAttributeMap(req).toString();
+                if (containsFreemarkerInterpolation(resp, attributeMap)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param resp
+     * @param stringToCheck
+     * @throws IOException
+     */
+    public static boolean containsFreemarkerInterpolation(HttpServletResponse resp, String stringToCheck) throws IOException {
+        if (containsFreemarkerInterpolation(stringToCheck)) { // not used OOTB in OFBiz, but possible
+            Debug.logError("===== Not saved for security reason, strings '${', '<#', '#{', '[=' or '[#' not accepted in fields! =====", MODULE);
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN,
+                    "Not saved for security reason, strings '${', '<#', '#{', '[=' or '[#' not accepted in fields!");
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Analyze if stringToCheck contains a freemarker template
+     * @param stringToCheck
+     * @return true if freemarker template is detected
+     */
+    public static boolean containsFreemarkerInterpolation(String stringToCheck) {
+        return UtilValidate.isNotEmpty(stringToCheck)
+                && FTL_INTERPOLATION.stream().anyMatch(stringToCheck::contains);
+    }
+
+    /**
+     * Analyse each entry contains on params. If a freemarker template is detected, sanatize it to escape any exploit
+     * @param params
+     * @return Map with all values sanitized
+     */
+    public static Map<String, Object> sanitizeParameterMap(Map<String, Object> params) {
+        List<Map.Entry<String, Object>> unsafeEntries = params.entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof String
+                        && containsFreemarkerInterpolation((String) entry.getValue()))
+                .toList();
+        if (!unsafeEntries.isEmpty()) {
+            Map<String, Object> paramsSanitize = new HashMap<>(params);
+            unsafeEntries.forEach(entry -> {
+                String sanitazedValue = (String) entry.getValue();
+                for (String interpolation : FTL_INTERPOLATION) {
+                    sanitazedValue = sanitazedValue.replace(interpolation, "##");
+                }
+                paramsSanitize.put(entry.getKey(), sanitazedValue);
+            });
+            return paramsSanitize;
+        }
+        return params;
+    }
+}

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecurityUtil.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecurityUtil.java
@@ -19,23 +19,14 @@
 package org.apache.ofbiz.security;
 
 
-import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.message.BasicNameValuePair;
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.StringUtil;
-import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.base.util.UtilMisc;
-import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntityException;
@@ -172,67 +163,4 @@ public final class SecurityUtil {
         return false;
     }
 
-    /*
-     * Prevents Freemarker exploits
-     * @param req
-     * @param resp
-     * @param uri
-     * @throws IOException
-     */
-    public static boolean containsFreemarkerInterpolation(HttpServletRequest req, HttpServletResponse resp, String uri)
-            throws IOException {
-        String urisOkForFreemarker = UtilProperties.getPropertyValue("security", "allowedURIsForFreemarkerInterpolation");
-        List<String> urisOK = UtilValidate.isNotEmpty(urisOkForFreemarker) ? StringUtil.split(urisOkForFreemarker, ",")
-                                                                           : new ArrayList<>();
-        String uriEnd = uri.substring(uri.lastIndexOf("/") + 1, uri.length());
-
-        if (!urisOK.contains(uriEnd)) {
-            Map<String, String[]> parameterMap = req.getParameterMap();
-            if (uri.contains("ecomseo")) { // SeoContextFilter call
-                if (containsFreemarkerInterpolation(resp, uri)) {
-                    return true;
-                }
-            } else if (!parameterMap.isEmpty()) { // ControlFilter call
-                List<BasicNameValuePair> params = new ArrayList<>();
-                parameterMap.forEach((name, values) -> {
-                    for (String value : values) {
-                        params.add(new BasicNameValuePair(name, value));
-                    }
-                });
-                String queryString = URLEncodedUtils.format(params, Charset.forName("UTF-8"));
-                uri = uri + "?" + queryString;
-                if (SecurityUtil.containsFreemarkerInterpolation(resp, uri)) {
-                    return true;
-                }
-            } else if (!UtilHttp.getAttributeMap(req).isEmpty()) { // Call with Content-Type modified by a MITM attack (rare case)
-                String attributeMap = UtilHttp.getAttributeMap(req).toString();
-                if (containsFreemarkerInterpolation(resp, attributeMap)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * @param resp
-     * @param stringToCheck
-     * @throws IOException
-     */
-    public static boolean containsFreemarkerInterpolation(HttpServletResponse resp, String stringToCheck) throws IOException {
-        if (stringToCheck.contains("%24%7B") || stringToCheck.contains("${")
-                || stringToCheck.contains("%3C%23") || stringToCheck.contains("<#")
-                || stringToCheck.contains("%23%7B") || stringToCheck.contains("#{")
-                || stringToCheck.contains("%5B%3D") || stringToCheck.contains("[=")
-                || stringToCheck.contains("%5B%23") || stringToCheck.contains("[#")) { // not used OOTB in OFBiz, but possible
-
-            Debug.logError("===== Not saved for security reason, strings '${', '<#', '#{', '[=' or '[#' not accepted in fields! =====",
-                    MODULE);
-            resp.sendError(HttpServletResponse.SC_FORBIDDEN,
-                    "Not saved for security reason, strings '${', '<#', '#{', '[=' or '[#' not accepted in fields!");
-            return true;
-        } else {
-            return false;
-        }
-    }
 }

--- a/framework/webapp/dtd/site-conf.xsd
+++ b/framework/webapp/dtd/site-conf.xsd
@@ -792,6 +792,16 @@ under the License.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute type="xs:boolean" name="secure-context" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    If secure-context=false, we authorize to forward to the renderer some parameters with interpretable code.
+                    This raise a potential risk of code injection. This can be usefully for some administration page to
+                    configure templating (like ftl for email or dynamic screen template).
+                    For this reason if secure-context=false, auth is set as true.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="x-frame-options" default="sameorigin">
             <xs:annotation>
                 <xs:documentation>

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ConfigXMLReader.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ConfigXMLReader.java
@@ -1044,6 +1044,7 @@ public final class ConfigXMLReader {
         private String strictTransportSecurity;
         private String description;
         private boolean noCache = false;
+        private boolean secureContext = true;
         private boolean securityAuth = false;
 
         /**
@@ -1106,6 +1107,15 @@ public final class ConfigXMLReader {
         }
 
         /**
+         * Is secureContext boolean.
+         *
+         * @return the boolean
+         */
+        public boolean isSecureContext() {
+            return secureContext;
+        }
+
+        /**
          * Gets type.
          * @return the type
          */
@@ -1144,7 +1154,8 @@ public final class ConfigXMLReader {
             this.info = viewMapElement.getAttribute("info");
             this.contentType = viewMapElement.getAttribute("content-type");
             this.noCache = "true".equals(viewMapElement.getAttribute("no-cache"));
-            this.securityAuth = "true".equals(viewMapElement.getAttribute("auth"));
+            this.secureContext = "true".equals(viewMapElement.getAttribute("secure-context"));
+            this.securityAuth = "true".equals(viewMapElement.getAttribute("auth")) || !this.secureContext;
             this.encoding = viewMapElement.getAttribute("encoding");
             this.xFrameOption = viewMapElement.getAttribute("x-frame-options");
             this.strictTransportSecurity = viewMapElement.getAttribute("strict-transport-security");

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ControlFilter.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ControlFilter.java
@@ -41,11 +41,8 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.GenericValue;
+import org.apache.ofbiz.security.SecuredFreemarker;
 import org.apache.ofbiz.security.SecuredUpload;
-import org.apache.ofbiz.security.SecurityUtil;
-
-
-
 
 /**
  * A Filter used to specify an allowlist of allowed paths to the OFBiz application.
@@ -166,7 +163,7 @@ public class ControlFilter extends HttpFilter {
 
             GenericValue userLogin = (GenericValue) session.getAttribute("userLogin");
             if (!LoginWorker.hasBasePermission(userLogin, req)) { // Allows UEL and FlexibleString (OFBIZ-12602)
-                if (isSolrTest() && SecurityUtil.containsFreemarkerInterpolation(req, resp, uri)) {
+                if (isSolrTest() && SecuredFreemarker.containsFreemarkerInterpolation(req, resp, uri)) {
                     return;
                 }
             }

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
@@ -1285,7 +1285,8 @@ public final class RequestHandler {
                 Debug.logVerbose("Rendering view [" + nextPage + "] of type [" + viewMap.getType() + "]", MODULE);
             }
             ViewHandler vh = viewFactory.getViewHandler(viewMap.getType());
-            vh.render(view, nextPage, viewMap.getInfo(), contentType, charset, req, resp);
+            Map<String, Object> context = vh.prepareViewContext(req, resp, viewMap);
+            vh.render(view, nextPage, viewMap.getInfo(), contentType, charset, req, resp, context);
         } catch (ViewHandlerException e) {
             Throwable throwable = e.getNested() != null ? e.getNested() : e;
             throw new RequestHandlerException(e.getNonNestedMessage(), throwable);

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/view/HttpViewHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/view/HttpViewHandler.java
@@ -20,6 +20,7 @@ package org.apache.ofbiz.webapp.view;
 
 import java.io.IOException;
 
+import java.util.Map;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -28,6 +29,7 @@ import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.HttpClient;
 import org.apache.ofbiz.base.util.HttpClientException;
 import org.apache.ofbiz.base.util.UtilValidate;
+import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 
 /**
  * ViewHandlerException - View Handler Exception
@@ -41,8 +43,13 @@ public class HttpViewHandler extends AbstractViewHandler {
     }
 
     @Override
+    public Map<String, Object> prepareViewContext(HttpServletRequest request, HttpServletResponse response, ConfigXMLReader.ViewMap viewMap) {
+        return Map.of();
+    }
+
+    @Override
     public void render(String name, String page, String info, String contentType, String encoding, HttpServletRequest request, HttpServletResponse
-            response) throws ViewHandlerException {
+            response, Map<String, Object> context) throws ViewHandlerException {
         // some containers call filters on EVERY request, even forwarded ones,
         // so let it know that it came from the control servlet
 

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/view/JspViewHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/view/JspViewHandler.java
@@ -20,6 +20,7 @@ package org.apache.ofbiz.webapp.view;
 
 import java.io.IOException;
 
+import java.util.Map;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -29,6 +30,7 @@ import javax.servlet.jsp.JspException;
 
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.UtilValidate;
+import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 import org.apache.ofbiz.webapp.control.ControlFilter;
 
 /**
@@ -37,16 +39,21 @@ import org.apache.ofbiz.webapp.control.ControlFilter;
 public class JspViewHandler extends AbstractViewHandler {
 
     private static final String MODULE = JspViewHandler.class.getName();
-    private ServletContext context;
+    private ServletContext servletContext;
 
     @Override
-    public void init(ServletContext context) throws ViewHandlerException {
-        this.context = context;
+    public void init(ServletContext servletContext) throws ViewHandlerException {
+        this.servletContext = servletContext;
+    }
+
+    @Override
+    public Map<String, Object> prepareViewContext(HttpServletRequest request, HttpServletResponse response, ConfigXMLReader.ViewMap viewMap) {
+        return Map.of();
     }
 
     @Override
     public void render(String name, String page, String contentType, String encoding, String info, HttpServletRequest request, HttpServletResponse
-            response) throws ViewHandlerException {
+            response, Map<String, Object> context) throws ViewHandlerException {
         // some containers call filters on EVERY request, even forwarded ones,
         // so let it know that it came from the control servlet
 
@@ -66,10 +73,10 @@ public class JspViewHandler extends AbstractViewHandler {
 
         if (rd == null) {
             Debug.logInfo("HttpServletRequest.getRequestDispatcher() failed; trying ServletContext", MODULE);
-            rd = context.getRequestDispatcher(page);
+            rd = this.servletContext.getRequestDispatcher(page);
             if (rd == null) {
                 Debug.logInfo("ServletContext.getRequestDispatcher() failed; trying ServletContext.getNamedDispatcher(\"jsp\")", MODULE);
-                rd = context.getNamedDispatcher("jsp");
+                rd = this.servletContext.getNamedDispatcher("jsp");
                 if (rd == null) {
                     throw new ViewHandlerException("Source returned a null dispatcher (" + page + ")");
                 }

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/view/ViewHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/view/ViewHandler.java
@@ -18,9 +18,11 @@
  *******************************************************************************/
 package org.apache.ofbiz.webapp.view;
 
+import java.util.Map;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 
 /**
  * ViewHandler - View Handler Interface
@@ -55,8 +57,18 @@ public interface ViewHandler {
      * @param info An info string attached to this view
      * @param request The HttpServletRequest object used when requesting this page.
      * @param response The HttpServletResponse object to be used to present the page.
+     * @param context  The context prepare by the handler to run
      * @throws ViewHandlerException
      */
     void render(String name, String page, String info, String contentType, String encoding, HttpServletRequest request,
-                HttpServletResponse response) throws ViewHandlerException;
+                HttpServletResponse response, Map<String, Object> context) throws ViewHandlerException;
+
+    /**
+     * Before call the render, this function have to purpose to analyse, secure and prepare the context
+     * @param request
+     * @param response
+     * @param viewMap
+     * @return
+     */
+    Map<String, Object> prepareViewContext(HttpServletRequest request, HttpServletResponse response, ConfigXMLReader.ViewMap viewMap);
 }

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/ScreenRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/ScreenRenderer.java
@@ -49,6 +49,7 @@ import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntity;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityUtilProperties;
+import org.apache.ofbiz.security.SecuredFreemarker;
 import org.apache.ofbiz.security.Security;
 import org.apache.ofbiz.service.DispatchContext;
 import org.apache.ofbiz.service.GenericServiceException;
@@ -219,12 +220,13 @@ public class ScreenRenderer {
      * @param response
      * @param servletContext
      */
-    public void populateContextForRequest(HttpServletRequest request, HttpServletResponse response, ServletContext servletContext) {
-        populateContextForRequest(context, this, request, response, servletContext);
+    public void populateContextForRequest(HttpServletRequest request, HttpServletResponse response,
+                                          ServletContext servletContext, boolean secureParameters) {
+        populateContextForRequest(context, this, request, response, servletContext, secureParameters);
     }
 
     public static void populateContextForRequest(MapStack<String> context, ScreenRenderer screens, HttpServletRequest request,
-                                                 HttpServletResponse response, ServletContext servletContext) {
+                                                 HttpServletResponse response, ServletContext servletContext, boolean secureParameters) {
         HttpSession session = request.getSession();
 
         // attribute names to skip for session and application attributes; these are all handled as special cases,
@@ -232,6 +234,9 @@ public class ScreenRenderer {
         Set<String> attrNamesToSkip = UtilMisc.toSet("delegator", "dispatcher", "security", "webSiteId",
                 "org.apache.catalina.jsp_classpath");
         Map<String, Object> parameterMap = UtilHttp.getCombinedMap(request, attrNamesToSkip);
+        if (secureParameters) {
+            parameterMap = SecuredFreemarker.sanitizeParameterMap(parameterMap);
+        }
 
         GenericValue userLogin = (GenericValue) session.getAttribute("userLogin");
 
@@ -288,7 +293,7 @@ public class ScreenRenderer {
         context.put("requestAttributes", new HttpRequestHashModel(request, FreeMarkerWorker.getDefaultOfbizWrapper()));
         TaglibFactory jspTaglibs = new TaglibFactory(servletContext);
         context.put("JspTaglibs", jspTaglibs);
-        context.put("requestParameters", UtilHttp.getParameterMap(request));
+        context.put("requestParameters", SecuredFreemarker.sanitizeParameterMap(UtilHttp.getParameterMap(request)));
 
         ServletContextHashModel ftlServletContext = (ServletContextHashModel) request.getAttribute("ftlServletContext");
         context.put("Application", ftlServletContext);


### PR DESCRIPTION
We extend *AbstractViewHandler* with a new method to override *prepareViewContext*. For each view handler implementation this will allow to control context used for rendering, applying Scriptlet token detection for security purpose.

A new class *SecuredFreemarker* has been created to manage freemarker specific controls, outside global *SecurityUtil* class.

We also add a new parameter *secure-context* (set true by default) to view-map xml element to indicate that this view allow unsecure rendering, this implies the view-map to required authentication.

Thanks to Gil Portenseigne for help
