### PR TITLE
Fixed: Property call in service attachUploadToDataResource (OFBIZ-13191)

### DIFF
--- a/applications/content/src/main/groovy/org/apache/ofbiz/content/data/DataServicesScript.groovy
+++ b/applications/content/src/main/groovy/org/apache/ofbiz/content/data/DataServicesScript.groovy
@@ -140,7 +140,7 @@ Map getElectronicText() {
  */
 Map attachUploadToDataResource() {
     boolean isUpdate = false
-    boolean forceLocal = UtilProperties.getPropertyValue('content.properties', 'content.upload.always.local.file')
+    boolean forceLocal = UtilProperties.getPropertyAsBoolean('content.properties', 'content.upload.always.local.file', false)
     List validLocalFileTypes = [
         'LOCAL_FILE',
         'OFBIZ_FILE',


### PR DESCRIPTION
The method DataServicesScript::attachUploadToDataResource now uses UtilProperties::getPropertyAsBoolean to properly parse used properties as boolean.
