### PR TITLE
Improved: Add groovydsl method : failure to return a map (OFBIZ-13195)

### DIFF
--- a/framework/service/src/main/groovy/org/apache/ofbiz/service/engine/GroovyBaseScript.groovy
+++ b/framework/service/src/main/groovy/org/apache/ofbiz/service/engine/GroovyBaseScript.groovy
@@ -113,16 +113,10 @@ abstract class GroovyBaseScript extends Script {
     }
 
     /* codenarc-disable NoDef, MethodReturnTypeRequired */
-    def success() {
-        return success(null, null)
-    }
-    def success(String message) {
-        return success(message, null)
-    }
     def success(Map returnValues) {
         return success(null, returnValues)
     }
-    def success(String message, Map returnValues) {
+    def success(String message = '', Map returnValues = [:]) {
         // TODO: implement some clever i18n mechanism based on the userLogin and locale in the binding
         if (this.binding.hasVariable('request')) {
             // the script is invoked as an "event"
@@ -144,12 +138,15 @@ abstract class GroovyBaseScript extends Script {
         return result
     }
     /* codenarc-enable */
-    Map failure(String message) {
+    Map failure(String message, Map returnValues = [:]) {
         // TODO: implement some clever i18n mechanism based on the userLogin and locale in the binding
-        if (message) {
-            return ServiceUtil.returnFailure(message)
+        Map result = message
+                ? ServiceUtil.returnFailure(message)
+                : ServiceUtil.returnFailure()
+        if (returnValues) {
+            result.putAll(returnValues)
         }
-        return ServiceUtil.returnFailure()
+        return result
     }
     /* codenarc-disable NoDef, MethodReturnTypeRequired */
     def error(String message) {


### PR DESCRIPTION
With groovy dsl we have possibility to return in one line when failure appears but we can only sent a failure message like this :

****
    return failure('bad state')
****

If we need to return information on out we need to realize it like :

****
    Map result = failure('bad state')
    result.statusId = 'BAD_STATUS'
    return result
****

Like success() we improved it to do in one line:

****
    return failure('bad state', [statusId: 'BAD_STATUS'])
****

By the way we align success function to refactoring them with default value so remove two unnecessary

