### PR TITLE
Improved: Improve validation method on service parameter (OFBIZ-13197)

### DIFF
--- a/applications/content/servicedef/services_data.xml
+++ b/applications/content/servicedef/services_data.xml
@@ -286,6 +286,16 @@
             location="org.apache.ofbiz.content.data.DataServices" invoke="createFileNoPerm" auth="false">
         <description>Create a File No Permission Required</description>
         <implements service="createFile"/>
+        <override name="dataResourceName">
+            <type-validate class="org.apache.ofbiz.security.SecuredUpload" method="isValidFileName">
+                <fail-property resource="SecurityUiLabels" property="SupportedFileFormatsIncludingSvg"/>
+            </type-validate>
+        </override>
+        <override name="objectInfo">
+            <type-validate class="org.apache.ofbiz.security.SecuredUpload" method="isValidAllFile">
+                <fail-property resource="SecurityUiLabels" property="SupportedFileFormatsIncludingSvg"/>
+            </type-validate>
+        </override>
     </service>
     <service name="updateFile" engine="java"
             location="org.apache.ofbiz.content.data.DataServices" invoke="updateFile" auth="true">

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -238,6 +238,17 @@ public class SecuredUpload {
 
     /**
      * @param fileToCheck
+     * @param delegator
+     * @return true if the file is valid
+     * @throws IOException
+     * @throws ImageReadException
+     */
+    public static boolean isValidAllFile(String fileToCheck, Delegator delegator) throws IOException, ImageReadException {
+        return isValidFile(fileToCheck, "All", delegator);
+    }
+
+    /**
+     * @param fileToCheck
      * @param fileType
      * @return true if the file is valid
      * @throws IOException

--- a/framework/service/src/main/groovy/org/apache/ofbiz/service/engine/GroovyBaseScript.groovy
+++ b/framework/service/src/main/groovy/org/apache/ofbiz/service/engine/GroovyBaseScript.groovy
@@ -50,27 +50,6 @@ abstract class GroovyBaseScript extends Script {
         inputMap.locale = inputMap.locale ?: this.binding.hasVariable('locale')
                 ? this.binding.getVariable('locale')
                 : this.binding.getVariable('parameters').locale
-        if (serviceName == 'createAnonFile') {
-            String fileName = inputMap.get('dataResourceName')
-            String fileNameAndPath = inputMap.get('objectInfo')
-            File file = new File(fileNameAndPath)
-            if (!fileName.isEmpty()) {
-                // Check the file name
-                if (!org.apache.ofbiz.security.SecuredUpload.isValidFileName(fileName, delegator)) {
-                    String errorMessage = UtilProperties.getMessage('SecurityUiLabels', 'SupportedFileFormatsIncludingSvg', inputMap.locale)
-                    throw new ExecutionServiceException(errorMessage)
-                }
-                // TODO we could verify the file type (here "All") with dataResourceTypeId. Anyway it's done with isValidFile()
-                // We would just have a better error message
-                if (file.exists()) {
-                    // Check if a webshell is not uploaded
-                    if (!org.apache.ofbiz.security.SecuredUpload.isValidFile(fileNameAndPath, 'All', delegator)) {
-                        String errorMessage = UtilProperties.getMessage('SecurityUiLabels', 'SupportedFileFormatsIncludingSvg', inputMap.locale)
-                        throw new ExecutionServiceException(errorMessage)
-                    }
-                }
-            }
-        }
         Map serviceContext = dctx.makeValidContext(serviceName, ModelService.IN_PARAM, inputMap)
         Map result = dispatcher.runSync(serviceName, serviceContext)
         if (ServiceUtil.isError(result)) {

--- a/framework/service/src/main/java/org/apache/ofbiz/service/ServiceDispatcher.java
+++ b/framework/service/src/main/java/org/apache/ofbiz/service/ServiceDispatcher.java
@@ -405,7 +405,7 @@ public final class ServiceDispatcher {
                         try {
                             // FIXME without this line all simple test failed
                             context = ctx.makeValidContext(modelService.getName(), ModelService.IN_PARAM, context);
-                            modelService.validate(context, ModelService.IN_PARAM, locale);
+                            modelService.validate(getLocalDispatcher(localName), context, ModelService.IN_PARAM, locale);
                         } catch (ServiceValidationException e) {
                             Debug.logError(e, "Incoming context (in runSync : " + modelService.getName()
                                     + ") does not match expected requirements", MODULE);
@@ -520,7 +520,7 @@ public final class ServiceDispatcher {
                     }
                     try {
                         result = ctx.makeValidContext(modelService.getName(), ModelService.OUT_PARAM, result);
-                        modelService.validate(result, ModelService.OUT_PARAM, locale);
+                        modelService.validate(getLocalDispatcher(localName), result, ModelService.OUT_PARAM, locale);
                     } catch (ServiceValidationException e) {
                         rs.setEndStamp();
                         throw new GenericServiceException("Outgoing result (in runSync : " + modelService.getName()
@@ -755,7 +755,7 @@ public final class ServiceDispatcher {
                 // validate the context
                 if (service.isValidate() && !isError && !isFailure) {
                     try {
-                        service.validate(context, ModelService.IN_PARAM, locale);
+                        service.validate(getLocalDispatcher(localName), context, ModelService.IN_PARAM, locale);
                     } catch (ServiceValidationException e) {
                         Debug.logError(e, "Incoming service context (in runAsync: " + service.getName()
                                 + ") does not match expected requirements", MODULE);

--- a/framework/service/src/test/groovy/org/apache/ofbiz/service/ModelServiceTest.groovy
+++ b/framework/service/src/test/groovy/org/apache/ofbiz/service/ModelServiceTest.groovy
@@ -18,6 +18,10 @@
  *******************************************************************************/
 package org.apache.ofbiz.service
 
+
+import org.apache.ofbiz.entity.DelegatorFactory
+import org.junit.Before
+
 import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.eq
 
@@ -39,6 +43,15 @@ class ModelServiceTest {
     private static final UtilCache<String, Map<String, ModelService>> MODEL_SERVICE_MAP_BY_MODEL =
             UtilCache.createUtilCache(SERVICE_CACHE_NAME, 0, 0, false)
     private MockedStatic<UtilProperties> utilities
+    private LocalDispatcher dispatcher
+
+    @Before
+    void initialize() {
+        System.setProperty("ofbiz.home", System.getProperty("user.dir"))
+        System.setProperty("derby.system.home", "./runtime/data/derby")
+        dispatcher = Mockito.mock(LocalDispatcher.class)
+        Mockito.when(dispatcher.getDelegator()).thenReturn(DelegatorFactory.getDelegator("default"))
+    }
 
     @BeforeEach
     void initMock() {
@@ -61,7 +74,7 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([message: 'ok'],
+                    .validate(dispatcher, [message: 'ok'],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Required parameters not validated')
@@ -76,7 +89,7 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([message: 'ok'],
+                    .validate(dispatcher, [message: 'ok'],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Optional parameter not validated')
@@ -92,7 +105,7 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([message: 'ok'],
+                    .validate(dispatcher, [message: 'ok'],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Optional parameter not validated')
@@ -106,7 +119,7 @@ class ModelServiceTest {
                <attribute name="message" type="String" mode="IN"/>
            </service>'''
         createModelService(serviceXml)
-                .validate([message: null],
+                .validate(dispatcher, [message: null],
                         'IN', Locale.default)
     }
 
@@ -118,7 +131,7 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([message: null],
+                    .validate(dispatcher, [message: null],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Optional parameter not validated')
@@ -132,7 +145,7 @@ class ModelServiceTest {
                <attribute name="message" type="String" mode="IN"/>
            </service>'''
         createModelService(serviceXml)
-                .validate([missing: 'ok'],
+                .validate(dispatcher, [missing: 'ok'],
                         'IN', Locale.default)
     }
 
@@ -146,7 +159,7 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([header: [headerParam: 'foo']],
+                    .validate(dispatcher, [header: [headerParam: 'foo']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Paramètre complexe non identifié')
@@ -163,7 +176,7 @@ class ModelServiceTest {
                </attribute>
            </service>'''
         createModelService(serviceXml)
-                .validate([header: [headerParam: 'foo']],
+                .validate(dispatcher, [header: [headerParam: 'foo']],
                         'IN', Locale.default)
     }
 
@@ -178,7 +191,7 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([header: [headerParam: 'foo']],
+                    .validate(dispatcher, [header: [headerParam: 'foo']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Missing optional should not throw exception')
@@ -196,7 +209,7 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([header: [headerParam: 'foo', otherParam: 'Good']],
+                    .validate(dispatcher, [header: [headerParam: 'foo', otherParam: 'Good']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Complex parameter control error')
@@ -213,7 +226,7 @@ class ModelServiceTest {
                </attribute>
            </service>'''
         createModelService(serviceXml)
-                .validate([header: [headerParam: 'foo', otherParam: 'Good', unexpectedParam: 'Bad']],
+                .validate(dispatcher, [header: [headerParam: 'foo', otherParam: 'Good', unexpectedParam: 'Bad']],
                         'IN', Locale.default)
     }
 
@@ -227,7 +240,7 @@ class ModelServiceTest {
                </attribute>
            </service>'''
         createModelService(serviceXml)
-                .validate([header: ['headerParam', 'otherParam']],
+                .validate(dispatcher, [header: ['headerParam', 'otherParam']],
                         'IN', Locale.default)
     }
 
@@ -244,8 +257,8 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([header: [headerParam: [subHeaderParam: 'true'],
-                                        otherParam: 'true']],
+                    .validate(dispatcher, [header: [headerParam: [subHeaderParam: 'true'],
+                                                    otherParam: 'true']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Paramètre complexe non identifié')
@@ -264,8 +277,8 @@ class ModelServiceTest {
                </attribute>
            </service>'''
         createModelService(serviceXml)
-                .validate([header: [headerParam: [subHeaderParam: 'true', otherParam: 'false'],
-                                    otherParam: 'true']],
+                .validate(dispatcher, [header: [headerParam: [subHeaderParam: 'true', otherParam: 'false'],
+                                                otherParam: 'true']],
                         'IN', Locale.default)
     }
 
@@ -277,8 +290,8 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([header: [headerParam: [subHeaderParam: 'true', otherParam: 'false'],
-                                        otherParam: 'true']],
+                    .validate(dispatcher, [header: [headerParam: [subHeaderParam: 'true', otherParam: 'false'],
+                                                    otherParam: 'true']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Map should not have been analyzed')
@@ -296,8 +309,8 @@ class ModelServiceTest {
            </service>'''
         try {
             createModelService(serviceXml)
-                    .validate([header: [[headerParam: 'line1', otherParam: 'Good'],
-                                        [headerParam: 'line2', otherParam: 'Good']]],
+                    .validate(dispatcher, [header: [[headerParam: 'line1', otherParam: 'Good'],
+                                                    [headerParam: 'line2', otherParam: 'Good']]],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Complex List Parameter Error')
@@ -314,7 +327,7 @@ class ModelServiceTest {
                </attribute>
            </service>'''
         createModelService(serviceXml)
-                .validate([header: [[headerParam: 'line1', otherParam: 'Good'],
+                .validate(dispatcher, [header: [[headerParam: 'line1', otherParam: 'Good'],
                                     [headerParam: 'line2', otherParam: 'Good',
                                      unwanted: 'Bad']]],
                         'IN', Locale.default)
@@ -343,7 +356,7 @@ class ModelServiceTest {
                                             'testParam': modelService])
 
         try {
-            modelService.validate([header: [headerParam: 'line1', otherParam: 'Good']], 'IN', Locale.default)
+            modelService.validate(dispatcher, [header: [headerParam: 'line1', otherParam: 'Good']], 'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
             Assert.fail('Complex implement not valid')
         }
@@ -407,4 +420,19 @@ class ModelServiceTest {
                 .createModelService(serviceElement, 'TEST')
     }
 
+    @Test
+    void callValidatorCreationWithDelegator() {
+        String serviceXml = '''<service name="testParam" engine="java"
+               location="org.apache.ofbiz.common.CommonServices" invoke="ping">
+               <attribute name="fileNameToTest" type="String" mode="IN">
+                   <type-validate class="org.apache.ofbiz.security.SecuredUpload" method="isValidFileName">
+                       <fail-property resource="SecurityUiLabels" property="SupportedFileFormatsIncludingSvg"/>
+                   </type-validate>
+               </attribute>
+           </service>'''
+        ModelService fo = createModelService(serviceXml)
+        ModelParam.ModelParamValidator validator = fo.getParam('fileNameToTest').getValidators().first()
+        assert validator
+        assert ModelService.typeValidate(dispatcher, validator, "myFileName")
+    }
 }


### PR DESCRIPTION
Since the Remote Code Execution (File Upload) Vulnerability fixed by OFBIZ-11948, the class GroovyBaseScript.groovy contains a dependency with a service definition 'createAnonFile' to control the security.

This solution works but break the dependency between each component and the mandatory for a service to protect it himself.

Normally a service can secure each parameter with element type-validate unfortunately, this element can call only method with one parameter. In your case the method to validate a file upload need to have the delegator.

To solve it, we improve the element type-validate to analyze the method call for validate the attribute value and pass the delegator or dispatcher if it detected.

Like this we can move the code present on GroovyBaseScript to the service definition and offer the possibility to create more complex validate method for custom site.