### PR TITLE
Publish build scans to develocity.apache.org #5165

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
     - name: Harden Runner

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,19 +18,18 @@
  */
 
 plugins {
-    id 'com.gradle.enterprise' version '3.13.3'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+    id 'com.gradle.develocity' version '3.18.2'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
 def isCI = System.getenv('GITHUB_ACTIONS') != null
 
-gradleEnterprise {
+develocity {
     server = "https://develocity.apache.org"
+    projectId = "ofbiz"
     buildScan {
-        capture { taskInputFiles = true }
         uploadInBackground = !isCI
-        publishAlways()
-        publishIfAuthenticated()
+        publishing.onlyIf { it.isAuthenticated() }
         obfuscation {
             // This obfuscates the IP addresses of the build machine in the build scan.
             // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
@@ -44,7 +43,7 @@ buildCache {
         enabled = !isCI
     }
 
-    remote(gradleEnterprise.buildCache) {
+    remote(develocity.buildCache) {
         enabled = false
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,7 @@ plugins {
 def isCI = System.getenv('GITHUB_ACTIONS') != null
 
 gradleEnterprise {
-    server = "https://ge.apache.org"
+    server = "https://develocity.apache.org"
     buildScan {
         capture { taskInputFiles = true }
         uploadInBackground = !isCI


### PR DESCRIPTION
This PR migrates the OFBiz project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR migrates from the legacy Gradle Enterprise plugin to the renamed Develocity plugin and sets a projectId for use by Develocity.

[OFBIZ-13201](https://issues.apache.org/jira/browse/OFBIZ-13201)