### PR TITLE
Fixed: Add missing form-name retrieval for auto-parameters-form (OFBIZ-12684)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/CommonWidgetModels.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/CommonWidgetModels.java
@@ -394,14 +394,20 @@ public final class CommonWidgetModels {
             }
             Element autoFormParamsElement = UtilXml.firstChildElement(linkElement, "auto-parameters-form");
             if (autoFormParamsElement != null) {
-                Node formElement = autoFormParamsElement;
-                while (formElement != null
-                        && formElement.getLocalName() != "form") {
-                    formElement = formElement.getParentNode();
+                String formName = null;
+                if (autoFormParamsElement.hasAttribute("form-name") && autoFormParamsElement.getAttribute("form-name") != null) {
+                    formName = autoFormParamsElement.getAttribute("form-name");
+                } else {
+                    Node formElement = autoFormParamsElement;
+                    while (formElement != null
+                            && formElement.getLocalName() != "form") {
+                        formElement = formElement.getParentNode();
+                    }
+                    if (formElement != null && formElement.getLocalName() != null) {
+                        formName = ((Element) formElement).getAttribute("name");
+                    }
                 }
-                if (formElement != null && formElement.getLocalName() != null) {
-                    parameterList.add(new Parameter("_FORM_NAME_", ((Element) formElement).getAttribute("name") + "_AS_PARAM_", false));
-                }
+                parameterList.add(new Parameter("_FORM_NAME_", formName + "_AS_PARAM_", false));
             }
             this.parameterList = Collections.unmodifiableList(parameterList);
             Element autoServiceParamsElement = UtilXml.firstChildElement(linkElement, "auto-parameters-service");

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelForm.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelForm.java
@@ -2317,15 +2317,20 @@ public abstract class ModelForm extends ModelWidget {
             }
             Element autoFormParamsElement = UtilXml.firstChildElement(updateAreaElement, "auto-parameters-form");
             if (autoFormParamsElement != null) {
-                Node formElement = autoFormParamsElement;
-                while (formElement != null
-                        && formElement.getLocalName() != "form") {
-                    formElement = formElement.getParentNode();
+                String formName = null;
+                if (autoFormParamsElement.hasAttribute("form-name") && autoFormParamsElement.getAttribute("form-name") != null) {
+                    formName = autoFormParamsElement.getAttribute("form-name");
+                } else {
+                    Node formElement = autoFormParamsElement;
+                    while (formElement != null
+                            && formElement.getLocalName() != "form") {
+                        formElement = formElement.getParentNode();
+                    }
+                    if (formElement != null && formElement.getLocalName() != null) {
+                        formName = ((Element) formElement).getAttribute("name");
+                    }
                 }
-                if (formElement != null && formElement.getLocalName() != null) {
-                    parameterList.add(new CommonWidgetModels.Parameter("_FORM_NAME_", ((Element) formElement).getAttribute("name") + "_AS_PARAM_",
-                            false));
-                }
+                parameterList.add(new CommonWidgetModels.Parameter("_FORM_NAME_", formName + "_AS_PARAM_", false));
             }
             this.parameterList = Collections.unmodifiableList(parameterList);
             Element autoServiceParamsElement = UtilXml.firstChildElement(updateAreaElement, "auto-parameters-service");


### PR DESCRIPTION
Although it is defined in the xsd, the form-name parameters is not retrieved during the generation or link informations. This add the retrieval and update the link when this parameter is used