### PR TITLE
Improved: [SECURITY] (CVE-2024-36104) Path traversal leading to RCE (OFBIZ-13092)

### DIFF
--- a/framework/security/config/security.properties
+++ b/framework/security/config/security.properties
@@ -277,13 +277,12 @@ csvformat=CSVFormat.DEFAULT
 #--
 #-- If you cross issues while loading an image file because of a token found there, you may try to surround the string by spaces, as " tr " below.
 #-- Actually most of the tokens should but it's now a bit late for me. I mean to test all of them...
-deniedWebShellTokens=java.,beans,freemarker,<script,javascript,<body,body ,<form,<jsp:,<c:out,taglib,<prefix,<%@ page,<?php,exec(,alert(,\
-                    %eval,@eval,eval(,runtime,import,passthru,shell_exec,assert,str_rot13,system,decode,include,page ,\
+deniedWebShellTokens=java,beans,freemarker,script,javascript,body,form,jsp,c:out,taglib,prefix,php,exec,alert,\
+                    eval,runtime,import,passthru,shell_exec,assert,str_rot13,system,decode,include,page,\
                     chmod,mkdir,fopen,fclose,new file,upload,getfilename,download,getoutputstring,readfile,iframe,object,embed,onload,build,\
-                    python,perl ,/perl,ruby ,/ruby,process,function,class,InputStream,to_server,wget ,static,assign,webappPath,\
-                    ifconfig,route,crontab,netstat,uname ,hostname,iptables,whoami,"cmd",*cmd|,+cmd|,=cmd|,localhost,thread,require(,gzdeflate,\
-                    execute,println,calc,touch,curl,base64, tcp ,4444,base32, tr , xxd ,bash, od ,|od ,printf,echo
-
+                    python,ruby,process,function,class,InputStream,to_server,wget,static,assign,webappPath,\
+                    ifconfig,route,crontab,netstat,uname,hostname,iptables,whoami,cmd,localhost,thread,require,gzdeflate,\
+                    execute,println,calc,touch,curl,base64,tcp,4444,base32,tr,xxd,bash,od,printf,echo
 
 #-- SHA-1 versions of tokens containing (as String) at least one deniedWebShellTokens
 #-- This is notably used to allow special values in query parameters.

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -151,8 +151,8 @@ public class SecuredUpload {
     }
 
     public static boolean containsDeniedWebShellToken(List<String> contents, List<String> allowed, Pattern deniedWebShellTokens) {
-        return contents.stream().anyMatch(token -> deniedWebShellTokens.matcher(token.toLowerCase()).find()
-                && !isAllowed(token.toLowerCase(), allowed));
+        return contents.stream().anyMatch(content -> deniedWebShellTokens.matcher(content.toLowerCase()).find()
+                && !isAllowed(content.toLowerCase(), allowed));
     }
 
     public static boolean isValidFileName(String fileToCheck, Delegator delegator) throws IOException {

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -898,9 +898,18 @@ public class SecuredUpload {
         return computeDeniedWebShellTokensPattern(
                 StringUtil.split(UtilProperties.getPropertyValue("security", "deniedWebShellTokens").toLowerCase(), ","));
     }
+
+    /**
+     * Build Pattern from list of token, based on regexp that complies to
+     * 1 - any non word suffix : ^[a-zA-Z0-9_]
+     * 2 - any non word prefix : ^[a-zA-Z0-9_]
+     *   OR any prefix with '%' followed by 2 to 5 chars. (for percent-encoding char in query, ie. %21 for !)
+     * @param tokens to support detection rule
+     * @return built pattern
+     */
     public static Pattern computeDeniedWebShellTokensPattern(List<String> tokens) {
         return Pattern.compile(tokens.stream()
-                .map(token -> ".*(%.{2,5}|[^\\w])" + token + "[^\\w].*")
+                .map(token -> "(%.{2,5}|[^\\w])" + token + "[^\\w]")
                 .collect(Collectors.joining("|")));
     }
 

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -857,20 +857,14 @@ public class SecuredUpload {
     }
 
     private static boolean isAllowed(String content, List<String> allowed) {
-        List<String> allowedContents;
+        List<String> allowedContents = new ArrayList<>(ALLOWEDWEBSHELLTOKENS);
         if (allowed != null) {
-            allowedContents = new ArrayList<>(allowed);
-            allowedContents.addAll(ALLOWEDWEBSHELLTOKENS);
-        } else {
-            allowedContents = ALLOWEDWEBSHELLTOKENS;
-        }
-        if (UtilValidate.isEmpty(allowedContents)) {
-            return false;
+            allowedContents.addAll(allowed);
         }
         for (String allowContent : allowedContents) {
-            if ((allowContent.startsWith("$SHA")
-                    && allowContent.equals(HashCrypt.cryptBytes("SHA", "OFBiz", content.toLowerCase().getBytes(StandardCharsets.UTF_8))))
-                    || content.trim().toLowerCase().contains(allowContent)) {
+            boolean allowedHashedTokenIdentified = allowContent.startsWith("$SHA")
+                    && allowContent.equals(HashCrypt.cryptBytes("SHA", "OFBiz", content.toLowerCase().getBytes(StandardCharsets.UTF_8)));
+            if (allowedHashedTokenIdentified || content.trim().toLowerCase().contains(allowContent)) {
                 return true;
             }
         }

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -907,7 +907,7 @@ public class SecuredUpload {
                 .collect(Collectors.joining("|")));
     }
 
-    private static List<String> getAllowedTokens() {
+    public static List<String> getAllowedTokens() {
         return ALLOWEDWEBSHELLTOKENS;
     }
 

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ControlFilter.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ControlFilter.java
@@ -202,7 +202,8 @@ public class ControlFilter extends HttpFilter {
             if (queryString != null) {
                 queryString = URLDecoder.decode(queryString, "UTF-8");
                 if (UtilValidate.isUrl(queryString)
-                        || !SecuredUpload.isValidText(queryString.toLowerCase(), ALLOWEDTOKENS, true)
+                        || !SecuredUpload.isValidQuery(queryString,
+                        StringUtil.split(req.getServletContext().getInitParameter("allowedQueryTokens"), ","))
                                 && isSolrTest()) {
                     Debug.logError("For security reason this URL is not accepted", MODULE);
                     throw new RuntimeException("For security reason this URL is not accepted");

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ControlFilter.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ControlFilter.java
@@ -90,8 +90,6 @@ public class ControlFilter extends HttpFilter {
     private int errorCode;
     /** The list of all path prefixes that are allowed. */
     private Set<String> allowedPaths;
-    private static final List<String> ALLOWEDTOKENS = getAllowedTokens();
-
 
     @Override
     public void init(FilterConfig conf) throws ServletException {
@@ -151,11 +149,6 @@ public class ControlFilter extends HttpFilter {
         resp.sendRedirect(redirectPathIsUrl ? redirectPath : (contextPath + redirectPath));
     }
 
-    private static List<String> getAllowedTokens() {
-        String allowedTokens = UtilProperties.getPropertyValue("security", "allowedTokens");
-        return UtilValidate.isNotEmpty(allowedTokens) ? StringUtil.split(allowedTokens, ",") : new ArrayList<>();
-    }
-
     /**
      * Makes allowed paths pass through while redirecting the others to a fix location.
      * Reject wrong URLs
@@ -202,8 +195,8 @@ public class ControlFilter extends HttpFilter {
             if (queryString != null) {
                 queryString = URLDecoder.decode(queryString, "UTF-8");
                 if (UtilValidate.isUrl(queryString)
-                        || !SecuredUpload.isValidQuery(queryString,
-                        StringUtil.split(req.getServletContext().getInitParameter("allowedQueryTokens"), ","))
+                        //TODO : Solr dependency in framework, how to avoid, through webapp def ?
+                        || !SecuredUpload.isValidQuery(queryString, List.of())
                                 && isSolrTest()) {
                     Debug.logError("For security reason this URL is not accepted", MODULE);
                     throw new RuntimeException("For security reason this URL is not accepted");


### PR DESCRIPTION
Improved the denied token resolution through regexp pattern. We define each potential token
 and we generate the following regexp for each

****
  .*(%.{2,5}|[^\\w])" + token + "[^\\w].*"
****

We also improved the allowed token with analysed it form security.properties and web.xml
 directly by plain text of with sha signature to manage each special case
