### PR TITLE
Update best-bet behavior in ContentUrlTag.java

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/taglib/ContentUrlTag.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/taglib/ContentUrlTag.java
@@ -46,8 +46,12 @@ public class ContentUrlTag {
 
     public static void appendContentPrefix(HttpServletRequest request, Appendable urlBuffer) throws IOException {
         if (request == null) {
-            Debug.logWarning("Request was null in appendContentPrefix; this probably means this was used where it shouldn't be, like using ofbizContentUrl in a screen rendered through a service; using best-bet behavior: standard prefix from url.properties (no WebSite or security setting known)", module);
+            Debug.logWarning("Request was null in appendContentPrefix; this probably means this was used where it shouldn't be, like using ofbizContentUrl in a screen rendered through a service; using best-bet behavior: standard prefix from url.properties or secure prefix if no.http is Y  (no WebSite or security setting known)", module);
             String prefix = UtilProperties.getPropertyValue("url", "content.url.prefix.standard");
+            String noHttp = UtilProperties.getPropertyValue("url", "no.http");
+            if (noHttp != null && "Y".equals(noHttp)) {
+                prefix = UtilProperties.getPropertyValue("url", "content.url.prefix.secure");
+            }
             if (prefix != null) {
                 urlBuffer.append(prefix.trim());
             }


### PR DESCRIPTION
Explanation
If no.http is enable the best-bet behavior should probably be to use secure prefix.