### PR TITLE
Improved: Support Trumbowyg configuration parameter

### DIFF
--- a/applications/content/widget/forum/ForumForms.xml
+++ b/applications/content/widget/forum/ForumForms.xml
@@ -227,7 +227,7 @@ under the License.
         <field name="ownerContentId"><hidden value="${parameters.forumId}"/></field>
         <field name="caContentId"><hidden value="${parameters.forumMessageIdTo}"/></field>
         <field name="caContentAssocTypeId"><hidden value="RESPONSE"/></field>
-        <field name="forumMessageText" parameter-name="textData"><textarea rows="10" visual-editor-enable="true" visual-editor-buttons="compact"/></field>
+        <field name="forumMessageText" parameter-name="textData"><textarea rows="10" visual-editor-enable="true"/></field>
         <field name="addButton" title="${uiLabelMap.CommonAdd}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
     <form name="AddForumThreadMessage" type="single" extends="AddForumMessage" target="updateForumThreadMessage"

--- a/applications/party/widget/partymgr/PartyForms.xml
+++ b/applications/party/widget/partymgr/PartyForms.xml
@@ -271,6 +271,11 @@ under the License.
         focus-field-name="groupName" header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="partyGroup==null" target="createPartyGroup"/>
         <auto-fields-service service-name="updatePartyGroup"/>
+        <field name="test">
+            <textarea visual-editor-enable="true" visual-editor-buttons="[
+                ['formatting'],['strong','em','del'],['link'],['unorderedList','orderedList'],
+                ['horizontalRule'],['removeformat'],['indent','outdent'],['fullscreen']]"/>
+        </field>
         <field use-when="partyGroup!=null" name="partyId" title="${uiLabelMap.PartyPartyId}"><display/></field>
         <field use-when="partyGroup==null&amp;&amp;partyId==null" name="partyId" title="${uiLabelMap.PartyPartyId}" tooltip="${uiLabelMap.CommonIdGeneratedIfEmpty}"><text/></field>
         <field use-when="partyGroup==null&amp;&amp;partyId!=null" name="partyId" title="${uiLabelMap.PartyPartyId}" tooltip="${uiLabelMap.CommonCannotBeFound}: [${partyId}]"><display also-hidden="false"/></field>

--- a/applications/party/widget/partymgr/PartyForms.xml
+++ b/applications/party/widget/partymgr/PartyForms.xml
@@ -271,11 +271,6 @@ under the License.
         focus-field-name="groupName" header-row-style="header-row" default-table-style="basic-table">
         <alt-target use-when="partyGroup==null" target="createPartyGroup"/>
         <auto-fields-service service-name="updatePartyGroup"/>
-        <field name="test">
-            <textarea visual-editor-enable="true" visual-editor-buttons="[
-                ['formatting'],['strong','em','del'],['link'],['unorderedList','orderedList'],
-                ['horizontalRule'],['removeformat'],['indent','outdent'],['fullscreen']]"/>
-        </field>
         <field use-when="partyGroup!=null" name="partyId" title="${uiLabelMap.PartyPartyId}"><display/></field>
         <field use-when="partyGroup==null&amp;&amp;partyId==null" name="partyId" title="${uiLabelMap.PartyPartyId}" tooltip="${uiLabelMap.CommonIdGeneratedIfEmpty}"><text/></field>
         <field use-when="partyGroup==null&amp;&amp;partyId!=null" name="partyId" title="${uiLabelMap.PartyPartyId}" tooltip="${uiLabelMap.CommonCannotBeFound}: [${partyId}]"><display also-hidden="false"/></field>

--- a/framework/widget/dtd/widget-form.xsd
+++ b/framework/widget/dtd/widget-form.xsd
@@ -1581,13 +1581,18 @@ under the License.
             <xs:attribute name="visual-editor-enable"
                           type="xs:boolean" default="false">
                 <xs:annotation>
-                    <xs:documentation>This will enable the html editor on this text area from www.unverse.net (more info there), only one textarea can be used on one page</xs:documentation>
+                    <xs:documentation>
+                        This will enable the HTML editor on this text area from https://alex-d.github.io/Trumbowyg/
+                    </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
             <xs:attribute type="xs:string" name="visual-editor-buttons">
                 <xs:annotation>
-                    <xs:documentation>In here you can specify which buttons you want to see and in which order separated by blanks. Available buttons are:formatblock fontname fontsize newline bold italic underline left center right number bullet indent outdent undo redo color hilite rule link image
-                        table clean html spellcheck |(separator) Default is that all buttons are shown</xs:documentation>
+                    <xs:documentation>
+                        Trumbowyg buttons configuration object, as a JSON.parse parsable string (2 dimensions string array).
+                        Ex: [['formatting'],['strong','em','del'],['link'],['unorderedList','orderedList'],['horizontalRule']]
+                        See https://alex-d.github.io/Trumbowyg/documentation/#button-pane
+                    </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
             <xs:attribute type="xs:string" name="placeholder">

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
@@ -364,9 +364,7 @@ public final class RenderableFtlFormElementsBuilder {
 
         if (textareaField.getVisualEditorEnable()) {
             builder.booleanParameter("visualEditorEnable", true);
-
-            String buttons = textareaField.getVisualEditorButtons(context);
-            builder.stringParameter("buttons", UtilValidate.isEmpty(buttons) ? "maxi" : buttons);
+            builder.stringParameter("buttons", textareaField.getVisualEditorButtons(context));
         }
 
         if (textareaField.isReadOnly()) {

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
@@ -464,7 +464,8 @@ public class RenderableFtlFormElementsBuilderTest {
 
     @Test
     public void textareaFieldVisualEditorEnabledButtons(@Mocked final ModelFormField.TextareaField textareaField) {
-        String editorConfiguration = "[['formatting'],['strong','em','del'],['link'],['unorderedList','orderedList'],['horizontalRule'],['removeformat'],['indent','outdent'],['fullscreen']]";
+        String editorConfiguration = "[['formatting'],['strong','em','del'],['link'],['unorderedList','orderedList'],"
+                + "['horizontalRule'],['removeformat'],['indent','outdent'],['fullscreen']]";
 
         new Expectations() {
             {
@@ -484,7 +485,9 @@ public class RenderableFtlFormElementsBuilderTest {
         final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textArea(context, textareaField);
         assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderTextareaField",
                 MacroCallParameterMatcher.hasNameAndBooleanValue("visualEditorEnable", true)));
-        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderTextareaField", MacroCallParameterMatcher.hasNameAndStringValue("buttons", editorConfiguration)));
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters(
+                "renderTextareaField",
+                MacroCallParameterMatcher.hasNameAndStringValue("buttons", editorConfiguration)));
     }
 
     @Test

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
@@ -441,6 +441,53 @@ public class RenderableFtlFormElementsBuilderTest {
     }
 
     @Test
+    public void textareaFieldVisualEditorEnabledNoButtons(@Mocked final ModelFormField.TextareaField textareaField) {
+        new Expectations() {
+            {
+                modelFormField.getDisabled(withNotNull());
+                result = true;
+
+                textareaField.getVisualEditorEnable();
+                result = true;
+
+                textareaField.getVisualEditorButtons(withNotNull());
+                result = "";
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textArea(context, textareaField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderTextareaField",
+                MacroCallParameterMatcher.hasNameAndBooleanValue("visualEditorEnable", true)));
+    }
+
+    @Test
+    public void textareaFieldVisualEditorEnabledButtons(@Mocked final ModelFormField.TextareaField textareaField) {
+        String editorConfiguration = "[['formatting'],['strong','em','del'],['link'],['unorderedList','orderedList'],['horizontalRule'],['removeformat'],['indent','outdent'],['fullscreen']]";
+
+        new Expectations() {
+            {
+                modelFormField.getDisabled(withNotNull());
+                result = true;
+
+                textareaField.getVisualEditorEnable();
+                result = true;
+
+                textareaField.getVisualEditorButtons(withNotNull());
+                result = editorConfiguration;
+            }
+        };
+
+        final HashMap<String, Object> context = new HashMap<>();
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textArea(context, textareaField);
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderTextareaField",
+                MacroCallParameterMatcher.hasNameAndBooleanValue("visualEditorEnable", true)));
+        assertThat(renderableFtl, MacroCallMatcher.hasNameAndParameters("renderTextareaField", MacroCallParameterMatcher.hasNameAndStringValue("buttons", editorConfiguration)));
+    }
+
+    @Test
     public void fieldGroupOpenRendersCollapsibleAreaId(@Mocked final ModelForm.FieldGroup fieldGroup) {
         new Expectations() {
             {

--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -147,34 +147,23 @@ function bindObservers(bind_element) {
         })
     });
     jQuery(bind_element).find(".visual-editor").each(function () {
-        var self = this;
-        var libraryFiles = ["/common/js/node_modules/trumbowyg/dist/trumbowyg.min.js",
-            "/common/js/node_modules/trumbowyg/dist/plugins/indent/trumbowyg.indent.min.js"];
-        importLibrary(libraryFiles, function () {
-            var element = jQuery(self);
-            var language = element.data('language');
-            var buttons = [['viewHTML'],
-                ['undo', 'redo'],
-                ['formatting'],
-                ['strong', 'em', 'del'],
-                ['superscript', 'subscript'],
-                ['link'],
-                ['insertImage'],
-                ['justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull'],
-                ['unorderedList', 'orderedList'],
-                ['horizontalRule'],
-                ['removeformat'],
-                ['indent', 'outdent'],
-                ['fullscreen']
-            ]
-            var opts = {
-                lang: language,
-                btns: buttons,
-                semantic: false,
-                tagsToRemove: ['script', 'link'],
-                svgPath: '/common/js/node_modules/trumbowyg/dist/ui/icons.svg'
-            }
-            element.trumbowyg(opts);
+        const element = $(this);
+        const lang = element.data('language');
+        const toolbarAttr = element.data('toolbar');
+        const providedBtns = toolbarAttr ? JSON.parse(toolbarAttr.replace(/'/g, '"')) : undefined;
+        const defaultBtns = [
+            ['undo', 'redo'], ['formatting'], ['strong', 'em', 'del'], ['superscript', 'subscript'], ['link'],
+            ['justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull'], ['unorderedList', 'orderedList'],
+            ['horizontalRule'], ['removeformat'], ['indent', 'outdent'], ['fullscreen']
+        ];
+        element.trumbowyg({
+            lang,
+            btns: providedBtns ?? defaultBtns,
+            semantic: false,
+            tagsToRemove: ['script', 'link'],
+            svgPath: '/common/js/node_modules/trumbowyg/dist/ui/icons.svg',
+            resetCss: true,
+            linkTargets: ['_blank']
         });
     });
     jQuery(bind_element).find(".ajaxAutoCompleter").each(function () {

--- a/themes/common-theme/widget/Theme.xml
+++ b/themes/common-theme/widget/Theme.xml
@@ -66,6 +66,8 @@ under the License.
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/moment/min/moment-with-locales.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/moment-timezone/builds/moment-timezone-with-data.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/daterangepicker/daterangepicker.js"/>
+        <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/trumbowyg/dist/trumbowyg.min.js"/>
+        <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/trumbowyg/dist/plugins/indent/trumbowyg.indent.min.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/util/OfbizUtil.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/util/fieldlookup.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/plugins/date/date.timezone-min.js"/>
@@ -79,6 +81,7 @@ under the License.
         <property name="VT_STYLESHEET['add']" value="/common/js/node_modules/jquery-ui-dist/jquery-ui.min.css"/>
         <property name="VT_STYLESHEET['add']" value="/common/css/info.css"/>
         <property name="VT_STYLESHEET['add']" value="/common/js/node_modules/daterangepicker/daterangepicker.css"/>
+        <property name="VT_STYLESHEET['add']" value="/common/js/node_modules/trumbowyg/dist/ui/trumbowyg.min.css"/>
     </theme-properties>
 
     <templates><!-- Freemarker template use by this theme to render widget model-->

--- a/themes/helveticus/webapp/helveticus/helveticus-main-theme.less
+++ b/themes/helveticus/webapp/helveticus/helveticus-main-theme.less
@@ -62,8 +62,18 @@ body {
     background: @grey-lighter;
 }
 
-ul, li {
+ul li {
     list-style-type: none
+}
+
+/* restore list styles for Trumbowyg text editor */
+.trumbowyg-editor.trumbowyg-reset-css {
+    ul li {
+        list-style-type: disc;
+    }
+    ol li {
+        list-style-type: decimal;
+    }
 }
 
 br.clear, .clear {

--- a/themes/rainbowstone/webapp/rainbowstone/rainbowstone-main-theme.less
+++ b/themes/rainbowstone/webapp/rainbowstone/rainbowstone-main-theme.less
@@ -1339,7 +1339,9 @@ a.user-pref-btn {
   padding: 0.4em;
 }
 
-.screenlet-body div {
+/* this rule is way too broad, targets all divs in screenlets (which is a lot of divs :) */
+/* just excluding Trumbowyg elements to avoid a visual glitch */
+.screenlet-body div:not([class^="trumbowyg"]) {
   margin: 0.8em 0.1em
 }
 

--- a/themes/rainbowstone/webapp/rainbowstone/style.css
+++ b/themes/rainbowstone/webapp/rainbowstone/style.css
@@ -1928,15 +1928,3 @@ html > /**/ body .jstree-default a {
 a[data-featherlight] {
     cursor: pointer;
 }
-
-/*The custom css for Trumbowyg*/
-.trumbowyg-button-pane {
-    margin: 0 !important;
-}
-.trumbowyg-button-pane .trumbowyg-button-group {
-    display: inline-block; 
-    margin: 0 !important;
-}
-.trumbowyg-button-pane button {
-    color: #000;
-}


### PR DESCRIPTION
OFBIZ-13224

Explanation:
On textarea field, uses "visual-editor-buttons" attribute value as a configuration description for Trumbowyg, as described in [the documentation](https://alex-d.github.io/Trumbowyg/documentation/#button-pane).
Also fixes visual glitches on Trumbowyg for some themes.

Thanks: Néréide team