### PR TITLE
Fixed: Ajax request fail on restful page (OFBIZ-13231)

### DIFF
--- a/applications/commonext/ofbiz-component.xml
+++ b/applications/commonext/ofbiz-component.xml
@@ -40,7 +40,14 @@ under the License.
         location="webapp/ofbizsetup"
         base-permission="OFBTOOLS,SETUP"
         mount-point="/ofbizsetup"/>
-    
+
+    <webapp name="common-js"
+        title="common-js"
+        server="default-server"
+        location="webapp/common-js"
+        mount-point="/common-js"
+        app-bar-display="false"/>
+
     <webapp name="ordermgr-js"
         title="ordermgr-js"
         server="default-server"

--- a/applications/commonext/webapp/common-js/WEB-INF/controller.xml
+++ b/applications/commonext/webapp/common-js/WEB-INF/controller.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<site-conf xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://ofbiz.apache.org/Site-Conf" xsi:schemaLocation="http://ofbiz.apache.org/Site-Conf http://ofbiz.apache.org/dtds/site-conf.xsd">
+    <include location="component://common/webcommon/WEB-INF/common-controller.xml"/>
+
+    <preprocessor>
+        <event name="securedUserLoginByJWTCookie" type="java" path="org.apache.ofbiz.webapp.control.LoginWorker" invoke="securedUserLoginByJWTCookie"/>
+    </preprocessor>
+</site-conf>

--- a/applications/commonext/webapp/common-js/WEB-INF/web.xml
+++ b/applications/commonext/webapp/common-js/WEB-INF/web.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    
+    http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<web-app version="4.0" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
+    <display-name>Apache OFBiz - Setup Manager</display-name>
+    <description>Common Ext Module of the Apache OFBiz Project</description>
+    
+    <context-param>
+        <description>The Name of the Entity Delegator to use, defined in entityengine.xml</description>
+        <param-name>entityDelegatorName</param-name>
+        <param-value>default</param-value>
+    </context-param>
+    <context-param>
+        <description>A unique name used to identify/recognize the local dispatcher for the Service Engine</description>
+        <param-name>localDispatcherName</param-name>
+        <param-value>common-js</param-value>
+    </context-param>
+
+    <filter>
+        <display-name>ControlFilter</display-name>
+        <filter-name>ControlFilter</filter-name>
+        <filter-class>org.apache.ofbiz.webapp.control.ControlFilter</filter-class>
+        <init-param>
+            <param-name>allowedPaths</param-name>
+            <param-value>/error:/control:/js</param-value>
+        </init-param>
+    </filter>
+    <filter>
+        <display-name>ContextFilter</display-name>
+        <filter-name>ContextFilter</filter-name>
+        <filter-class>org.apache.ofbiz.webapp.control.ContextFilter</filter-class>
+    </filter>
+    <filter>
+        <display-name>SameSiteFilter</display-name>
+        <filter-name>SameSiteFilter</filter-name>
+        <filter-class>org.apache.ofbiz.webapp.control.SameSiteFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>ControlFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>ContextFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>SameSiteFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <listener><listener-class>org.apache.ofbiz.webapp.control.ControlEventListener</listener-class></listener>
+    <listener><listener-class>org.apache.ofbiz.webapp.control.LoginEventListener</listener-class></listener>
+    
+    <servlet>
+        <description>Main Control Servlet</description>
+        <display-name>ControlServlet</display-name>
+        <servlet-name>ControlServlet</servlet-name>
+        <servlet-class>org.apache.ofbiz.webapp.control.ControlServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ControlServlet</servlet-name>
+        <url-pattern>/control/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/applications/commonext/webapp/ordermgr-js/geoAutoCompleter.js
+++ b/applications/commonext/webapp/ordermgr-js/geoAutoCompleter.js
@@ -80,12 +80,8 @@ function setKeyAsParameter(event, ui) {
 //Generic function for fetching country's associated state list.
 function getAssociatedStateList(countryId, stateId, errorId, divId) {
     var countryGeoId = jQuery("#" + countryId).val();
-    var requestToSend = "getAssociatedStateList";
-    if (jQuery('#orderViewed').length) {
-        requestToSend = "/ordermgr/control/getAssociatedStateList"
-    }
     jQuery.ajax({
-        url: requestToSend,
+        url: '/common-js/control/getAssociatedStateList',
         type: "POST",
         data: {countryGeoId: countryGeoId},
         success: function(data) {

--- a/applications/party/webapp/partymgr/static/PartyProfileContent.js
+++ b/applications/party/webapp/partymgr/static/PartyProfileContent.js
@@ -97,7 +97,7 @@ function getUploadProgressStatus(event){
             tick: function(counter, timerId) {
                 var timerId = timerId;
                 jQuery.ajax({
-                    url: 'getFileUploadProgressStatus',
+                    url: '/common-js/control/getFileUploadProgressStatus',
                     dataType: 'json',
                     success: function(data) {
                         if (data._ERROR_MESSAGE_LIST_ != undefined) {

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecurityUtil.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecurityUtil.java
@@ -153,9 +153,11 @@ public final class SecurityUtil {
         if (UtilValidate.isNotEmpty(jwtToken)) {
             try {
                 GenericValue userLogin = EntityQuery.use(delegator).from("UserLogin").where("userLoginId", userLoginId).queryOne();
-                Map<String, Object> claims = JWTManager.validateToken(delegator, jwtToken,
-                        userLogin.getString("userLoginId") + userLogin.getString("currentPassword"));
-                return (!ServiceUtil.isError(claims)) && userLoginId.equals(claims.get("userLoginId"));
+                if (userLoginId != null) {
+                    Map<String, Object> claims = JWTManager.validateToken(delegator, jwtToken,
+                            userLogin.getString("userLoginId") + userLogin.getString("currentPassword"));
+                    return (!ServiceUtil.isError(claims)) && userLoginId.equals(claims.get("userLoginId"));
+                }
             } catch (GenericEntityException e) {
                 Debug.logWarning("failed to validate a jwToken for user " + userLoginId, MODULE);
             }

--- a/framework/webtools/widget/GeoManagementScreens.xml
+++ b/framework/webtools/widget/GeoManagementScreens.xml
@@ -168,7 +168,7 @@
                 <set field="asm_title" from-field="uiLabelMap.WebtoolsGeosSelect"/>
                 <!-- selectMultipleRelatedValues parameters -->
                 <set field="asm_relatedField" value="LinkGeos_geoId"/>
-                <set field="asm_requestName" value="getRelatedGeos"/>
+                <set field="asm_requestName" value="/common-js/control/getRelatedGeos"/>
                 <set field="asm_paramKey" value="geoId"/>
                 <set field="asm_type" value="geoAssocTypeId"/>
                 <set field="asm_typeField" value="LinkGeos_geoAssocTypeId"/>

--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -1437,7 +1437,7 @@ function getJSONuiLabels(requiredLabels, callback) {
 
     if (requiredLabels != null && requiredLabels != "") {
         jQuery.ajax({
-            url: "getUiLabels",
+            url: "/common-js/control/getUiLabels",
             type: "POST",
             async: false,
             data: { "requiredLabels": requiredLabelsStr, "widgetVerbose": false },
@@ -1547,7 +1547,7 @@ function submitPagination(obj, url) {
 function loadJWT() {
     var JwtToken = "";
     jQuery.ajax({
-        url: "loadJWT",
+        url: "/common-js/control/loadJWT",
         type: "POST",
         async: false,
         dataType: "text",

--- a/themes/common-theme/webapp/common-theme/js/util/miscAjaxFunctions.js
+++ b/themes/common-theme/webapp/common-theme/js/util/miscAjaxFunctions.js
@@ -141,7 +141,7 @@ function getServiceResult(){
     var data;
     jQuery.ajax({
         type: 'POST',
-        url: request,
+        url: '/common-js/control/' + request,
         data: prepareAjaxData(arguments),
         async: false,
         cache: false,

--- a/themes/common-theme/webapp/common-theme/js/util/setUserTimeZone.js
+++ b/themes/common-theme/webapp/common-theme/js/util/setUserTimeZone.js
@@ -21,7 +21,7 @@ under the License.
 if (sessionStorage.getItem("SetTimeZoneFromBrowser") === null || sessionStorage.getItem("SetTimeZoneFromBrowser") !== "done") {
     const timezone = moment.tz.guess();
     $.ajax({
-        url: "SetTimeZoneFromBrowser",
+        url: "/common-js/control/SetTimeZoneFromBrowser",
         type: "POST",
         async: false,
         data: "localeName=" + timezone,


### PR DESCRIPTION
A problem was detected with some ajax call did by js script that failed with error 405 like : https://demo-next.ofbiz.apache.org/webtools/control/entity/find/SetTimeZoneFromBrowser

Reason :

SetTimeZoneFromBrowser is a request define in common-controller.xml, so available on all component. In js the call is realized by :

            $.ajax({
                url: "SetTimeZoneFromBrowser",
                type: "POST",
                async: false,...

So the navigator use the relative url to execute the call. In general case we have a page like https://demo-next.ofbiz.apache.org/$component/control/$request so js script realized their call with https://demo-next.ofbiz.apache.org/$component/control/$request-js. Like each request-js are present on common-controller.xml all component that include it can response.

With rest url, the uri pattern is more complex and the script js that generate a relative call like we have upper : _https://demo-next.ofbiz.apache.org/webtools/control/entity/find/SetTimeZoneFromBrowse_. The ControlServlet behind failed to retrieve the correct request and generate a http error 405

To fix :

we remove all relative js call and create a dedicated webapp for that.

        $.ajax({
                url: "/common-js/control/SetTimeZoneFromBrowser",
                type: "POST",
                async: false,...

To pass through the authentification (we implement a new webapp), we store a jwt token with the current userLogin after the authentification that will use by common-ext to confirm authentification. This cookie is available during all the session time
