### PR TITLE
Incorrect service call for internal requirement may trigger unnecessary production runs (OFBIZ-13270)

### DIFF
--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
@@ -2531,7 +2531,7 @@ public class ProductionRunServices {
         Map<String, Object> serviceContext = new HashMap<>();
         serviceContext.clear();
         serviceContext.put("productId", requirement.getString("productId"));
-        serviceContext.put("quantity", quantity);
+        serviceContext.put("pRQuantity", quantity);
         serviceContext.put("startDate", requirement.getTimestamp("requirementStartDate"));
         serviceContext.put("facilityId", requirement.getString("facilityId"));
         String workEffortName = null;
@@ -2547,7 +2547,7 @@ public class ProductionRunServices {
         serviceContext.put("userLogin", userLogin);
         Map<String, Object> serviceResult = null;
         try {
-            serviceResult = dispatcher.runSync("createProductionRunsForProductBom", serviceContext);
+            serviceResult = dispatcher.runSync("createProductionRun", serviceContext);
             if (ServiceUtil.isError(serviceResult)) {
                 return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE, "ManufacturingProductionRunNotCreated", locale)
                         + ": " + ServiceUtil.getErrorMessage(serviceResult));


### PR DESCRIPTION
Fixed: Incorrect service call for internal requirement may trigger unnecessary production runs (OFBIZ-13270).

When an internal requirement is approved, a production run should be automatically created to fulfill it. Previously, the system invoked a special service (createProductionRunsForProductBom) instead of the standard one (createProductionRun). As a result, the system not only created the production run for the required product, but also additional runs for all its sub-assemblies, even if those sub-assemblies were already available in the warehouse or had existing requirements in the system.