### PR TITLE
Backward compatibility for internal requirements without a quantity set (OFBIZ-13270)

### DIFF
--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
@@ -2528,6 +2528,9 @@ public class ProductionRunServices {
         if (quantity == null) {
             quantity = requirement.getBigDecimal("quantity");
         }
+        if (quantity == null) {
+            quantity = BigDecimal.ONE;
+        }
         Map<String, Object> serviceContext = new HashMap<>();
         serviceContext.clear();
         serviceContext.put("productId", requirement.getString("productId"));


### PR DESCRIPTION
Fixed: backward compatibility for internal requirements without a quantity set (OFBIZ-13270)

After the changes introduced for OFBIZ-13270 ("Incorrect service call for internal requirement may trigger unnecessary production runs") the system returned an error when an internal requirement without its "quantity" field set was approved. This was a different behavior as before the system was using the default quantity of 1. This commit restore the original behavior.

Thanks to Jacques Le Roux for the report.