### PR TITLE
Fixed: ScreenFopViewHandler-check-adding-PDFEncryption (OFBIZ-13279)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/fo/ScreenFopViewHandler.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/fo/ScreenFopViewHandler.java
@@ -139,7 +139,7 @@ public class ScreenFopViewHandler extends AbstractViewHandler {
                 ? ApacheFopWorker.getAllowEditContentDefault() : (String) context.get("allowEditContent"));
         boolean allowEditAnnotations = Boolean.parseBoolean(UtilValidate.isEmpty(context.get("allowEditAnnotations"))
                 ? ApacheFopWorker.getAllowEditAnnotationsDefault() : (String) context.get("allowEditAnnotations"));
-        if (UtilValidate.isNotEmpty(userPassword) || UtilValidate.isNotEmpty(ownerPassword) || !allowPrint || !allowCopyContent || allowEditContent
+        if (UtilValidate.isNotEmpty(userPassword) || UtilValidate.isNotEmpty(ownerPassword) || !allowPrint || !allowCopyContent || !allowEditContent
                 || !allowEditAnnotations) {
             int encryptionLength = 128;
             try {


### PR DESCRIPTION
Fixed: Missing not in check for adding PDFEncryption (OFBIZ-13279)

This adds a missing (not) in check if PDF encryption should be used after editing

Thanks: Martin Becker
