### PR TITLE
Fixed: Decimal numbers not displayed correctly in input type=number (OFBIZ-13297)

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/conversion/NumberConverters.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/conversion/NumberConverters.java
@@ -32,7 +32,7 @@ import org.apache.ofbiz.base.util.StringUtil;
 public class NumberConverters implements ConverterLoader {
 
     private static Number fromString(String str, Locale locale) throws ConversionException {
-        NumberFormat nf = NumberFormat.getNumberInstance(locale);
+        NumberFormat nf = NumberFormat.getNumberInstance(Locale.getDefault());
         if (nf instanceof DecimalFormat) {
             // CHECKSTYLE_OFF: ALMOST_ALL
             ((DecimalFormat) nf).setParseBigDecimal(true);

--- a/framework/widget/dtd/widget-form.xsd
+++ b/framework/widget/dtd/widget-form.xsd
@@ -1560,6 +1560,11 @@ under the License.
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="step" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Controls the "step" attribute of the input element. Ignored if the "type" attribute of the field is not "number". See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/step</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="pattern" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>Controls the pattern attribute of the input element. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern</xs:documentation>

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -366,7 +366,7 @@ public final class ModelFormField {
             if (retVal != null) {
                 // format string based on the user's locale and time zone
                 if (retVal instanceof Double || retVal instanceof Float || retVal instanceof BigDecimal) {
-                    NumberFormat nf = NumberFormat.getInstance(locale);
+                    NumberFormat nf = NumberFormat.getInstance(Locale.getDefault());
                     nf.setMaximumFractionDigits(10);
                     return nf.format(retVal);
                 } else if (retVal instanceof java.sql.Date) {

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -5918,6 +5918,7 @@ public final class ModelFormField {
         private final SubHyperlink subHyperlink;
         private final String type;
         private final String pattern;
+        private final String step;
 
         public TextField(Element element, ModelFormField modelFormField) {
             super(element, modelFormField);
@@ -5925,6 +5926,7 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance(element.getAttribute("default-value"));
             this.mask = element.getAttribute("mask");
             this.type = element.getAttribute("type");
+            this.step = element.getAttribute("step");
             this.pattern = element.getAttribute("pattern");
             Integer maxlength = null;
             String maxlengthStr = element.getAttribute("maxlength");
@@ -5964,6 +5966,7 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.mask = "";
             this.type = "";
+            this.step = "";
             this.pattern = "";
             this.maxlength = maxlength;
             this.placeholder = FlexibleStringExpander.getInstance("");
@@ -5978,6 +5981,7 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.mask = "";
             this.type = type;
+            this.step = "";
             this.pattern = "";
             this.maxlength = maxlength;
             this.placeholder = FlexibleStringExpander.getInstance("");
@@ -5992,6 +5996,7 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.mask = "";
             this.type = "";
+            this.step = "";
             this.pattern = "";
             this.maxlength = null;
             this.placeholder = FlexibleStringExpander.getInstance("");
@@ -6014,6 +6019,7 @@ public final class ModelFormField {
             this.defaultValue = original.defaultValue;
             this.mask = original.mask;
             this.type = original.type;
+            this.step = original.step;
             this.pattern = original.pattern;
             this.placeholder = original.placeholder;
             this.size = original.size;
@@ -6133,6 +6139,14 @@ public final class ModelFormField {
          */
         public String getType() {
             return this.type;
+        }
+
+        /**
+         * Gets step.
+         * @return the step
+         */
+        public String getStep() {
+            return this.step;
         }
 
         /**

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
@@ -255,6 +255,13 @@ public final class RenderableFtlFormElementsBuilder {
         if (UtilValidate.isEmpty(type)) {
             type = "text";
         }
+        String step = "";
+        if (type.equals("number")) {
+            step = textField.getStep();
+            if (UtilValidate.isEmpty(step)) {
+                step = "any";
+            }
+        }
         String pattern = "";
         if (List.of("text", "email", "url", "tel").contains(type)) {
             pattern = textField.getPattern();
@@ -308,6 +315,7 @@ public final class RenderableFtlFormElementsBuilder {
                 .stringParameter("name", name)
                 .stringParameter("className", String.join(" ", classes))
                 .stringParameter("type", type)
+                .stringParameter("step", step)
                 .stringParameter("pattern", pattern)
                 .stringParameter("alert", alert)
                 .stringParameter("value", value)

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
@@ -252,6 +252,7 @@ public class RenderableFtlFormElementsBuilderTest {
         final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textField(Map.of("session", httpSession), textField, true);
         assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "text")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "")));
     }
 
     @Test
@@ -266,6 +267,23 @@ public class RenderableFtlFormElementsBuilderTest {
         final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textField(Map.of("session", httpSession), textField, true);
         assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "number")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "any")));
+    }
+
+    @Test
+    public void textFieldTypeNumberCustomStep(@Mocked final ModelFormField.TextField textField) {
+        new Expectations() {
+            {
+                textField.getType(); result = "number";
+                textField.getStep(); result = "0.1";
+                httpSession.getAttribute("delegatorName"); result = "DelegatorName";
+            }
+        };
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textField(Map.of("session", httpSession), textField, true);
+        assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "number")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "0.1")));
     }
 
     @Test
@@ -280,6 +298,7 @@ public class RenderableFtlFormElementsBuilderTest {
         final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textField(Map.of("session", httpSession), textField, true);
         assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "email")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "")));
     }
 
     @Test
@@ -294,6 +313,7 @@ public class RenderableFtlFormElementsBuilderTest {
         final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textField(Map.of("session", httpSession), textField, true);
         assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "url")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "")));
     }
 
     @Test
@@ -308,6 +328,7 @@ public class RenderableFtlFormElementsBuilderTest {
         final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textField(Map.of("session", httpSession), textField, true);
         assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "tel")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "")));
     }
 
     @Test

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -43,7 +43,7 @@ under the License.
 </#macro>
 <#macro renderHyperlinkField></#macro>
 
-<#macro renderTextField type pattern name className alert value="" textSize="" maxlength="" id="" event="" action=""
+<#macro renderTextField type step pattern name className alert value="" textSize="" maxlength="" id="" event="" action=""
         disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" required=false
         placeholder="" delegatorName="default">
   <input type="${type}" name="${name?default("")?html}"<#t/>
@@ -69,6 +69,7 @@ under the License.
     <#if tabindex?has_content> tabindex="${tabindex}"</#if><#rt/>
     <#if required?has_content && required> required</#if>
     <#if pattern?has_content> pattern="${pattern}"</#if>
+    <#if step?has_content> step="${step}"</#if>
   /><#t/>
 </#macro>
 


### PR DESCRIPTION
Fixed: Decimal numbers not displayed correctly in input type=number
(OFBIZ-13297)

### `<input type="number"/>` does not accept decimals

Now that we use `<input type="number"/>` (https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/number, https://issues.apache.org/jira/browse/OFBIZ-13183) to display numeric values in forms, it is not possible to enter decimal values.

We need to support the `step` attribute (https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#step), and use `any` as default value, since `any` will allow any decimal value. This means adding a new `step` attribute on the `<text/>` form field, and render it as a `step` attribute on the HTML `<input type="number"/>`.
Supporting this attribute, developer will be able to define which kind of value he expects (integer, one decimal, two decimals...).

### `<input type="number"/>` does not display decimal values correctly

`<input type="number"/>` are sensitive to the decimal separator used in their `value` attribute. Depending on the browser and the [lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang) used, an input may or may not display its value in the HTML field. For example :

* Firefox 143.03
     * `<input type="number" lang="en" value="1.2"/>` -> displays `1.2`
     * `<input type="number" lang="en" value="1,2"/>` -> displays `1,2`
     * `<input type="number" lang="fr" value="1.2"/>` -> displays `1,2`
     * `<input type="number" lang="fr" value="1,2"/>` -> displays `1,2`
 * Chrome 141
     * `<input type="number" lang="en" value="1.2"/>` -> displays `1,2`
     * `<input type="number" lang="en" value="1,2"/>` -> displays nothing
     * `<input type="number" lang="fr" value="1.2"/>` -> displays `1,2`
     * `<input type="number" lang="fr" value="1,2"/>` -> displays nothing

It vould seem reasonable to always use the same locale (`en` for example) to format numeric values before inserting it in a HTML input, and let the browser decide which decimal separator to use.

Thanks: Néréide team
