### PR TITLE
Improved: Refactor readHtmlDocument in UelFunctions to obtain an instance of org.w3c.dom.Document using the standard javax.xml.parsers.* APIs instead of org.cyberneko.html.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,10 +206,6 @@ allprojects {
             url 'https://clojars.org/repo'
         }
         maven {
-            // org.cyberneko.html.parsers (used by UELFunctions, was in esapi before 2.3)
-            url "https://repository.ow2.org/nexus/content/repositories/public/"
-        }
-        maven {
             url "https://artifacts.alfresco.com/nexus/content/repositories/public/"
         }
         /* maven {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -70,7 +70,6 @@ dependencies {
     implementation 'org.apache.groovy:groovy-all:5.0.0-alpha-11'
     implementation 'org.freemarker:freemarker:2.3.34' // Remember to change the version number in FreeMarkerWorker class when upgrading. See OFBIZ-10019 if >= 2.4
     implementation 'org.owasp.esapi:esapi:2.6.0.0'
-    implementation 'org.cyberneko:html:1.9.8'
     implementation 'org.springframework:spring-test:6.1.16'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
     implementation 'oro:oro:2.0.8'

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/string/UelFunctions.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/string/UelFunctions.java
@@ -36,6 +36,9 @@ import java.util.Map;
 import java.util.TimeZone;
 
 import jakarta.el.FunctionMapper;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -49,7 +52,6 @@ import org.apache.ofbiz.base.util.UtilDateTime;
 import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilXml;
 import org.apache.ofbiz.widget.renderer.ScreenRenderer;
-import org.cyberneko.html.parsers.DOMParser;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
@@ -365,14 +367,14 @@ public class UelFunctions {
         try {
             URL url = FlexibleLocation.resolveLocation(str);
             if (url != null) {
-                DOMParser parser = new DOMParser();
-                parser.setFeature("http://xml.org/sax/features/namespaces", false);
-                parser.parse(url.toExternalForm());
-                document = parser.getDocument();
+                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                DocumentBuilder builder = factory.newDocumentBuilder();
+                document = builder.parse(url.openStream());
+                document.getDocumentElement().normalize();
             } else {
                 Debug.logError("Unable to locate HTML document " + str, MODULE);
             }
-        } catch (IOException | SAXException e) {
+        } catch (IOException | ParserConfigurationException | SAXException e) {
             Debug.logError(e, "Error while reading HTML document " + str, MODULE);
         }
         return document;


### PR DESCRIPTION
Removing the Cyberneko dependency allows us to drop the Maven repository https://repository.ow2.org/nexus/content/repositories/public/, which is offline at the time of this commit (due to a license issue) and was causing OFBiz builds to fail. This repository has also had issues in the recent past, as reported in https://issues.apache.org/jira/browse/OFBIZ-13206.