### PR TITLE
OFBIZ-13070 - Fixed missing custom period start by fixing the conditi…

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/period/GPeriodServices.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/period/GPeriodServices.groovy
@@ -33,7 +33,7 @@ Map findCustomTimePeriods() {
         List parentOrganizationPartyIdList = serviceResult.parentOrganizationPartyIdList
         EntityCondition condition = new EntityConditionBuilder().AND {
             IN(organizationPartyId: parentOrganizationPartyIdList)
-            LESS_THAN(fromDate: parameters.findDate)
+            LESS_THAN_EQUAL_TO(fromDate: parameters.findDate)
             OR {
                 GREATER_THAN_EQUAL_TO(thruDate: parameters.findDate)
                 EQUALS(thruDate: null)
@@ -53,7 +53,7 @@ Map findCustomTimePeriods() {
                 EQUALS(organizationPartyId: null)
                 EQUALS(organizationPartyId: '_NA_')
             }
-            LESS_THAN(fromDate: parameters.findDate)
+            LESS_THAN_EQUAL_TO(fromDate: parameters.findDate)
             OR {
                 GREATER_THAN_EQUAL_TO(thruDate: parameters.findDate)
                 EQUALS(thruDate: null)


### PR DESCRIPTION
Fixed: BalanceSheet generates an error (OFBIZ-13070)

Fixes missing custom period start by fixing the condition for fromData

Due to the change from the previous version 22.01, there was a change in the PeriodServices and the condition for finding the period was wrong causing the exception described in the bug.

The correct implementation of the condition was taken from:
https://github.com/apache/ofbiz-framework/blob/release22.01/applications/accounting/minilang/period/PeriodServices.xml#L23

Thanks: https://github.com/pavololbert
