### PR TITLE
OFBIZ-13319 Implemented exit early for loops with only check

### DIFF
--- a/applications/product/src/main/java/org/apache/ofbiz/product/store/ProductStoreWorker.java
+++ b/applications/product/src/main/java/org/apache/ofbiz/product/store/ProductStoreWorker.java
@@ -293,6 +293,7 @@ public final class ProductStoreWorker {
                         for (BigDecimal size: itemSizes) {
                             if (size.compareTo(minSize) < 0) {
                                 allMatch = false;
+                                break;
                             }
                         }
                     }
@@ -308,6 +309,7 @@ public final class ProductStoreWorker {
                         for (BigDecimal size: itemSizes) {
                             if (size.compareTo(maxSize) > 0) {
                                 allMatch = false;
+                                break;
                             }
                         }
                     }

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/model/ModelReader.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/model/ModelReader.java
@@ -577,6 +577,7 @@ public final class ModelReader implements Serializable {
                 for (String packageFilter : packageFilterSet) {
                     if (packageName.contains(packageFilter)) {
                         foundMatch = true;
+                        break;
                     }
                 }
                 if (!foundMatch) {

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
@@ -635,6 +635,7 @@ public final class RequestHandler {
             for (int i = 0; i < loginUris.length; i++) {
                 if (requestUri.equals(loginUris[i])) {
                     removePreviousRequest = false;
+                    break;
                 }
             }
             if (removePreviousRequest) {


### PR DESCRIPTION
Improved:  [optimization] There are several locations where in the loop we can exit early (OFBIZ-13319) #925

It concerns loops where the only action is searching for match.
For example:
                for (String packageFilter : packageFilterSet) {
                    if (packageName.contains(packageFilter)) {
                        foundMatch = true;
                        break; // to be added
                    }
                }

Thanks: Dmitriy Kryukov
