### PR TITLE
Ofbiz-13320 string comparison

### DIFF
--- a/applications/accounting/src/main/java/org/apache/ofbiz/accounting/thirdparty/eway/GatewayResponse.java
+++ b/applications/accounting/src/main/java/org/apache/ofbiz/accounting/thirdparty/eway/GatewayResponse.java
@@ -185,7 +185,7 @@ public class GatewayResponse {
         Node rootnode = doc.getDocumentElement();
         String root = rootnode.getNodeName();
 
-        if ("ewayResponse" != root) {
+        if (!"ewayResponse".equals(root)) {
             throw new Exception("Bad root element in response: " + root);
         }
 
@@ -195,7 +195,7 @@ public class GatewayResponse {
         for (int i = 0; i < length; i++) {
             Node node = list.item(i);
             String name = node.getNodeName();
-            if ("ewayResponse" == name) {
+            if ("ewayResponse".equals(name)) {
                 continue;
             }
             Text textnode = (Text) node.getFirstChild();

--- a/framework/catalina/src/main/java/org/apache/ofbiz/catalina/container/CatalinaContainer.java
+++ b/framework/catalina/src/main/java/org/apache/ofbiz/catalina/container/CatalinaContainer.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -260,7 +261,7 @@ public class CatalinaContainer implements Container {
         }
 
         virtualHosts.stream()
-            .filter(virtualHost -> virtualHost != hostName).forEach(virtualHost -> host.addAlias(virtualHost));
+            .filter(virtualHost -> !Objects.equals(virtualHost, hostName)).forEach(virtualHost -> host.addAlias(virtualHost));
 
         return host;
     }

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/RequestHandler.java
@@ -1042,7 +1042,7 @@ public final class RequestHandler {
      * @param requestResponse
      */
     private void setUserMessageResponseToRequest(HttpServletRequest request, ConfigXMLReader.RequestResponse requestResponse) {
-        final String fieldMessageName = requestResponse.getName() == "error"
+        final String fieldMessageName = "error".equals(requestResponse.getName())
                 ? "_ERROR_MESSAGE_"
                 : "_EVENT_MESSAGE_";
         final String customMessageField = "_CUSTOM" + fieldMessageName;

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/CommonWidgetModels.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/CommonWidgetModels.java
@@ -400,7 +400,7 @@ public final class CommonWidgetModels {
                 } else {
                     Node formElement = autoFormParamsElement;
                     while (formElement != null
-                            && formElement.getLocalName() != "form") {
+                            && !"form".equals(formElement.getLocalName())) {
                         formElement = formElement.getParentNode();
                     }
                     if (formElement != null && formElement.getLocalName() != null) {

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelForm.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelForm.java
@@ -2323,7 +2323,7 @@ public abstract class ModelForm extends ModelWidget {
                 } else {
                     Node formElement = autoFormParamsElement;
                     while (formElement != null
-                            && formElement.getLocalName() != "form") {
+                            &&  !"form".equals(formElement.getLocalName())) {
                         formElement = formElement.getParentNode();
                     }
                     if (formElement != null && formElement.getLocalName() != null) {

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelForm.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelForm.java
@@ -2323,7 +2323,7 @@ public abstract class ModelForm extends ModelWidget {
                 } else {
                     Node formElement = autoFormParamsElement;
                     while (formElement != null
-                            &&  !"form".equals(formElement.getLocalName())) {
+                            && !"form".equals(formElement.getLocalName())) {
                         formElement = formElement.getParentNode();
                     }
                     if (formElement != null && formElement.getLocalName() != null) {


### PR DESCRIPTION
Fixed: String comparison (OFBIZ-13320) #926 

In several locations strings are compared with == and != 
Should be compared with equals, unless they are interned. But even for interned strings equals() is safe

Thanks: Dmitriy Kryukov
