### PR TITLE
OFBIZ-13321 fixed call of getClass() on instance of Class

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilObject.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilObject.java
@@ -122,6 +122,6 @@ public final class UtilObject {
                 return instance;
             }
         }
-        throw new ClassNotFoundException(factoryInterface.getClass().getName());
+        throw new ClassNotFoundException(factoryInterface.getName());
     }
 }


### PR DESCRIPTION
Fixed: getClass() is called on instance of Class (OFBIZ-13321) #927

Fixes call of getClass() on instance of Class in UtilObject::getObjectFromFactory. That completely erased the type

Thanks: Dmitriy Kryukov
