### PR TITLE
Fix two issues affecting receive against po screen

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
@@ -28,7 +28,6 @@ shipmentId = request.getParameter('shipmentId')
 orderId = request.getParameter('purchaseOrderId')
 shipGroupSeqId = request.getParameter('shipGroupSeqId')
 context.shipmentId = shipmentId
-context.shipGroupSeqId = shipGroupSeqId
 
 // Retrieve the map resident in session which stores order item quantities to receive
 itemQuantitiesToReceive = session.getAttribute('purchaseOrderItemQuantitiesToReceive')
@@ -63,6 +62,7 @@ context.now = UtilDateTime.nowTimestamp()
 
 orderId = orderId ?: shipment.primaryOrderId
 shipGroupSeqId = shipGroupSeqId ?: shipment.primaryShipGroupSeqId
+context.shipGroupSeqId = shipGroupSeqId
 context.orderId = orderId
 
 if (!orderId) {

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
@@ -117,13 +117,15 @@ orderItems.each { orderItemAndShipGroupAssoc ->
 
     // Get the item's ordered quantity
     totalOrdered = 0
-    ordered = orderItem.getDouble('quantity')
+    ordered = orderItemAndShipGroupAssoc.getDouble('quantity')
     if (ordered) {
         totalOrdered += ordered.doubleValue()
+        orderItemData.ordered = ordered
     }
-    cancelled = orderItem.getDouble('cancelQuantity')
+    cancelled = orderItemAndShipGroupAssoc.getDouble('cancelQuantity')
     if (cancelled) {
         totalOrdered -= cancelled.doubleValue()
+        orderItemData.cancelled = cancelled
     }
 
     // Get the item quantity received from all shipments via the ShipmentReceipt entity

--- a/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
+++ b/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
@@ -106,6 +106,7 @@ under the License.
                 <input type="hidden" name="facilityId" value="${facilityId}"/>
                 <input type="hidden" name="purchaseOrderId" value="${orderId}"/>
                 <input type="hidden" name="shipmentId" value="${shipmentId}" />
+                <input type="hidden" name="shipGroupSeqId" value="${shipGroupSeqId}" />
                 <input type="hidden" name="_useRowSubmit" value="Y"/>
                 <table cellspacing="0" class="basic-table">
                     <tr class="header-row">

--- a/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
+++ b/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
@@ -148,15 +148,15 @@ under the License.
                                     </#if>
                                 </div>
                             </td>
-                            <td>${orderItem.quantity}</td>
-                            <td>${orderItem.cancelQuantity?default(0)}</td>
+                            <td>${orderItemData.ordered}</td>
+                            <td>${orderItemData.cancelled?default(0)}</td>
                             <td>
                                 <div ${(backOrderedQuantity &gt; 0)?string(" errorMessage","")}">
                                     ${backOrderedQuantity}
                                 </div>
                             </td>
                             <td>${totalQuantityReceived}</td>
-                            <td>${orderItem.quantity - orderItem.cancelQuantity?default(0) - totalQuantityReceived}</td>
+                            <td>${orderItemData.ordered - orderItemData.cancelled?default(0) - totalQuantityReceived}</td>
                             <td>
                                 <div>
                                     <#if fulfilledReservations?has_content>


### PR DESCRIPTION
Fixed: Ensure shipGroupSeqId is correctly set in context and passed to the template
           Display order items quantities for the selected ship group
 
Explanation: Bugs were discovered while testing the workflows described here https://cwiki.apache.org/confluence/display/OFBENDUSER/Step-by-step+workflow%3A+purchase+orders+with+multiple+shipments+and+invoices