### PR TITLE
Fixed: various bugs in receive against purchase orders (OFBIZ-13327)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
@@ -134,13 +134,16 @@ orderItems.each { orderItemAndShipGroupAssoc ->
     fulfilledReservations = [] as ArrayList
     if (receipts) {
         receipts.each { rec ->
-            accepted = rec.getDouble('quantityAccepted')
-            rejected = rec.getDouble('quantityRejected')
-            if (accepted) {
-                totalReceived += accepted.doubleValue()
-            }
-            if (rejected) {
-                totalReceived += rejected.doubleValue()
+            orderShipment = from('OrderShipment').where('orderId', orderId, 'orderItemSeqId', orderItem.orderItemSeqId, 'shipGroupSeqId', shipGroupSeqId, 'shipmentId', rec.shipmentId, 'shipmentItemSeqId', rec.shipmentItemSeqId).queryOne()
+            if (orderShipment) {
+                accepted = rec.getDouble('quantityAccepted')
+                rejected = rec.getDouble('quantityRejected')
+                if (accepted) {
+                    totalReceived += accepted.doubleValue()
+                }
+                if (rejected) {
+                    totalReceived += rejected.doubleValue()
+                }
             }
             // Get the reservations related to this receipt
             oisgirs = from('OrderItemShipGrpInvRes').where('inventoryItemId', rec.inventoryItemId).queryList()

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
@@ -134,7 +134,9 @@ orderItems.each { orderItemAndShipGroupAssoc ->
     fulfilledReservations = [] as ArrayList
     if (receipts) {
         receipts.each { rec ->
-            orderShipment = from('OrderShipment').where('orderId', orderId, 'orderItemSeqId', orderItem.orderItemSeqId, 'shipGroupSeqId', shipGroupSeqId, 'shipmentId', rec.shipmentId, 'shipmentItemSeqId', rec.shipmentItemSeqId).queryOne()
+            orderShipment = from('OrderShipment')
+                .where('orderId', orderId, 'orderItemSeqId', orderItem.orderItemSeqId, 'shipGroupSeqId', shipGroupSeqId,
+                       'shipmentId', rec.shipmentId, 'shipmentItemSeqId', rec.shipmentItemSeqId).queryOne()
             if (orderShipment) {
                 accepted = rec.getDouble('quantityAccepted')
                 rejected = rec.getDouble('quantityRejected')

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
@@ -28,7 +28,6 @@ shipmentId = request.getParameter('shipmentId')
 orderId = request.getParameter('purchaseOrderId')
 shipGroupSeqId = request.getParameter('shipGroupSeqId')
 context.shipmentId = shipmentId
-context.shipGroupSeqId = shipGroupSeqId
 
 // Retrieve the map resident in session which stores order item quantities to receive
 itemQuantitiesToReceive = session.getAttribute('purchaseOrderItemQuantitiesToReceive')
@@ -63,6 +62,7 @@ context.now = UtilDateTime.nowTimestamp()
 
 orderId = orderId ?: shipment.primaryOrderId
 shipGroupSeqId = shipGroupSeqId ?: shipment.primaryShipGroupSeqId
+context.shipGroupSeqId = shipGroupSeqId
 context.orderId = orderId
 
 if (!orderId) {

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy
@@ -117,13 +117,15 @@ orderItems.each { orderItemAndShipGroupAssoc ->
 
     // Get the item's ordered quantity
     totalOrdered = 0
-    ordered = orderItem.getDouble('quantity')
+    ordered = orderItemAndShipGroupAssoc.getDouble('quantity')
     if (ordered) {
         totalOrdered += ordered.doubleValue()
+        orderItemData.ordered = ordered
     }
-    cancelled = orderItem.getDouble('cancelQuantity')
+    cancelled = orderItemAndShipGroupAssoc.getDouble('cancelQuantity')
     if (cancelled) {
         totalOrdered -= cancelled.doubleValue()
+        orderItemData.cancelled = cancelled
     }
 
     // Get the item quantity received from all shipments via the ShipmentReceipt entity

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
@@ -308,6 +308,7 @@ Map issueOrderItemToShipmentAndReceiveAgainstPO() {
     }
     if (shipmentItem) {
         Map inputMap = parameters
+        shipmentItemSeqId = shipmentItem.shipmentItemSeqId
         inputMap.orderItem = orderItem
         Map serviceResult = run service: 'getTotalIssuedQuantityForOrderItem', with: inputMap
         BigDecimal totalIssuedQuantity = serviceResult.totalIssuedQuantity
@@ -324,8 +325,6 @@ Map issueOrderItemToShipmentAndReceiveAgainstPO() {
             BigDecimal quantityToAdd = receivedQuantity - totalIssuedQuantity
             shipmentItem.quantity += quantityToAdd
             shipmentItem.store()
-            shipmentItemSeqId = shipmentItem.shipmentItemSeqId
-
             orderShipment.quantity = orderShipment.quantity + quantityToAdd
             orderShipment.store()
         }
@@ -334,6 +333,7 @@ Map issueOrderItemToShipmentAndReceiveAgainstPO() {
         Map serviceResult = run service: 'createShipmentItem', with: shipmentItemCreate
         Map shipmentItemLookupPk = [shipmentItemSeqId: serviceResult.shipmentItemSeqId, shipmentId: parameters.shipmentId]
         shipmentItem = from('ShipmentItem').where(shipmentItemLookupPk).queryOne()
+        shipmentItemSeqId = shipmentItem.shipmentItemSeqId
 
         // Create OrderShipment for this ShipmentItem
         Map orderShipmentCreate = [quantity: parameters.quantity,

--- a/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
+++ b/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
@@ -106,6 +106,7 @@ under the License.
                 <input type="hidden" name="facilityId" value="${facilityId}"/>
                 <input type="hidden" name="purchaseOrderId" value="${orderId}"/>
                 <input type="hidden" name="shipmentId" value="${shipmentId}" />
+                <input type="hidden" name="shipGroupSeqId" value="${shipGroupSeqId}" />
                 <input type="hidden" name="_useRowSubmit" value="Y"/>
                 <table cellspacing="0" class="basic-table">
                     <tr class="header-row">

--- a/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
+++ b/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
@@ -72,27 +72,16 @@ under the License.
     </#if>
 </#if>
 
-<form name="ReceiveInventoryAgainstPurchaseOrder" action="<@ofbizUrl>ReceiveInventoryAgainstPurchaseOrder</@ofbizUrl>">
-  <input type="hidden" name="clearAll" value="Y"/>
   <table class="basic-table" cellspacing="0">
     <tr>
-      <td class="label">${uiLabelMap.ProductShipmentId}</td>
-      <td><input type="text" size="20" name="shipmentId" value="${shipmentId!}"/></td>
-    </tr>
-    <tr>
       <td class="label">${uiLabelMap.ProductOrderId}</td>
-      <td><@htmlTemplate.lookupField value="${orderId!}" formName="ReceiveInventoryAgainstPurchaseOrder" name="purchaseOrderId" id="purchaseOrderId" fieldFormName="LookupOrderHeaderAndShipInfo"/></td>
+      <td>${orderId!}</td>
     </tr>
     <tr>
       <td class="label">${uiLabelMap.ProductOrderShipGroupId}</td>
-      <td><input type="text" size="20" name="shipGroupSeqId" value="${shipGroupSeqId!}"/></td>
-    </tr>
-    <tr>
-      <td>&nbsp;</td>
-      <td><input type="submit" value="${uiLabelMap.CommonSelect}" class="smallSubmit"/></td>
+      <td>${shipGroupSeqId!}</td>
     </tr>
   </table>
-</form>
 
 <#if shipment??>
     <#if isPurchaseShipment>

--- a/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
+++ b/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
@@ -148,15 +148,15 @@ under the License.
                                     </#if>
                                 </div>
                             </td>
-                            <td>${orderItem.quantity}</td>
-                            <td>${orderItem.cancelQuantity?default(0)}</td>
+                            <td>${orderItemData.ordered}</td>
+                            <td>${orderItemData.cancelled?default(0)}</td>
                             <td>
                                 <div ${(backOrderedQuantity &gt; 0)?string(" errorMessage","")}">
                                     ${backOrderedQuantity}
                                 </div>
                             </td>
                             <td>${totalQuantityReceived}</td>
-                            <td>${orderItem.quantity - orderItem.cancelQuantity?default(0) - totalQuantityReceived}</td>
+                            <td>${orderItemData.ordered - orderItemData.cancelled?default(0) - totalQuantityReceived}</td>
                             <td>
                                 <div>
                                     <#if fulfilledReservations?has_content>


### PR DESCRIPTION
- Ensure shipGroupSeqId is correctly set in context and passed to the template.
- Display order items quantities for the selected ship group.
- Make Order ID and Ship Group ID read-only fields and remove Shipment ID field in the Receive Against PO screen, because the screen is one of the sub-tabs of the shipment screen.
- Add logic to filter shipment receipts by ship group, in order to properly display receive quantity in the Receive Against PO screen, in case of order items split into  multiple ship groups.
- Fix bug that causes creation of shipment receipt records with shipment id, but no shipment item sequence id

Explanation: various bugs were discovered when receiving an order item split into more than one ship group, by means of the Receive Against PO screen.  The PR fixes those regarding the correct determination and visualization of quantities per ship group, e.g., 'order', 'received', etc. 
There are still outstanding bugs in the trunk, such as the 'Force Complete Purchase Order' that still doesn't support order items split into multiple ship groups, wrong invoice creation, etc.   
