### PR TITLE
Fixed: Disable 'New Shipment For Ship Group' buttons for purchase orders that are not approved (OFBIZ-13337)

### DIFF
--- a/applications/order/template/order/OrderShippingInfo.ftl
+++ b/applications/order/template/order/OrderShippingInfo.ftl
@@ -802,7 +802,7 @@ under the License.
                <#else>
                  <#assign facilities = facilitiesForShipGroup.get(shipGroup.shipGroupSeqId)>
                  <#if "ORDER_APPROVED" == orderHeader.statusId>
-                 <#if facilities?has_content>
+                   <#if facilities?has_content>
                      <div>
                       <form name="createShipment2_${shipGroup.shipGroupSeqId}" method="post" action="/facility/control/createShipment">
                          <input type="hidden" name="primaryOrderId" value="${orderId}"/>
@@ -820,7 +820,7 @@ under the License.
                          <input type="submit" class="smallSubmit" value="${uiLabelMap.OrderNewShipmentForShipGroup} [${shipGroup.shipGroupSeqId}]"/>
                       </form>
                       </div>
-                 <#else>
+                   <#else>
                      <a href="javascript:document.quickDropShipOrder_${shipGroup_index}.submit();" class="buttontext">${uiLabelMap.ProductShipmentQuickComplete}</a>
                      <a href="javascript:document.createShipment3_${shipGroup.shipGroupSeqId}.submit();" class="buttontext">${uiLabelMap.OrderNewDropShipmentForShipGroup} [${shipGroup.shipGroupSeqId}]</a>
                      <form name="quickDropShipOrder_${shipGroup_index}" method="post" action="<@ofbizUrl>quickDropShipOrder</@ofbizUrl>">
@@ -835,7 +835,7 @@ under the License.
                           <input type="hidden" name="statusId" value="PURCH_SHIP_CREATED" />
                           <input type="hidden" name="externalLoginKey" value="${externalLoginKey}" />
                       </form>
-                 </#if>
+                   </#if>
                  </#if>
                </#if>
               </td>

--- a/applications/order/template/order/OrderShippingInfo.ftl
+++ b/applications/order/template/order/OrderShippingInfo.ftl
@@ -801,6 +801,7 @@ under the License.
                  </#if>
                <#else>
                  <#assign facilities = facilitiesForShipGroup.get(shipGroup.shipGroupSeqId)>
+                 <#if "ORDER_APPROVED" == orderHeader.statusId>
                  <#if facilities?has_content>
                      <div>
                       <form name="createShipment2_${shipGroup.shipGroupSeqId}" method="post" action="/facility/control/createShipment">
@@ -834,6 +835,7 @@ under the License.
                           <input type="hidden" name="statusId" value="PURCH_SHIP_CREATED" />
                           <input type="hidden" name="externalLoginKey" value="${externalLoginKey}" />
                       </form>
+                 </#if>
                  </#if>
                </#if>
               </td>


### PR DESCRIPTION
Explanation: When a PO is created but not yet approved, the Order Details screen displays the “New Shipment For Ship Group” buttons, which allows shipments to be created prior to order approval. This PR fixes this behavior by hiding the buttons until the order has been approved.

This is one of the issues reported in [Step-by-step workflow: purchase orders with multiple shipments and invoices](https://cwiki.apache.org/confluence/display/OFBENDUSER/Step-by-step+workflow%3A+purchase+orders+with+multiple+shipments+and+invoices)

