### PR TITLE
Fixed: Form fields are not properly populated with values from the context due to a regression introduced by commit 69697d1 (OFBiz-13331)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -289,8 +289,10 @@ public final class ModelFormField {
     }
 
     public String getEntry(Map<String, ? extends Object> context, String defaultValue) {
-        Boolean useRequestParameters = (Boolean) context.getOrDefault("useRequestParameters", UtilGenerics.cast(Boolean.TRUE))
-                && (Boolean) context.getOrDefault("useRequestParameters." + modelForm.getName(), UtilGenerics.cast(Boolean.TRUE));
+        Boolean isError = (Boolean) context.get("isError");
+        Boolean useRequestParametersGlobal = (Boolean) context.get("useRequestParameters");
+        Boolean useRequestParametersSpecific = (Boolean) context.get("useRequestParameters." + modelForm.getName());
+        Boolean useRequestParameters = useRequestParametersSpecific != null ? useRequestParametersSpecific : useRequestParametersGlobal;
 
         Locale locale = (Locale) context.get("locale");
         if (locale == null) {
@@ -305,7 +307,8 @@ public final class ModelFormField {
 
         String returnValue;
 
-        if (useRequestParameters) {
+        if ((Boolean.TRUE.equals(isError) && !Boolean.FALSE.equals(useRequestParameters))
+                || (Boolean.TRUE.equals(useRequestParameters))) {
             Map<String, Object> parameters = UtilGenerics.checkMap(context.get("parameters"), String.class, Object.class);
             String parameterName = this.getParameterName(context);
             if (parameters != null && parameters.get(parameterName) != null) {


### PR DESCRIPTION
This commit restores the condition that determines whether request or context parameters are used to the behavior prior to commit 69697d1. It also implements the new useRequestParameters.<form_name> context attribute for ModelGrid forms, which was introduced in that commit.

