### PR TITLE
Fixed the UI Labels on the edit calender exception day screen. (OFBIZ-13257)

### DIFF
--- a/applications/manufacturing/config/ManufacturingUiLabels.xml
+++ b/applications/manufacturing/config/ManufacturingUiLabels.xml
@@ -5558,6 +5558,20 @@
         <value xml:lang="zh">工人</value>
         <value xml:lang="zh-TW">工作者</value>
     </property>
+    <property key="PageTitleAddCalendarExceptionDay">
+        <value xml:lang="de">Kalender-Ausnahmetag hinzufügen</value>
+        <value xml:lang="en">Add Calendar Exception Day</value>
+        <value xml:lang="es">Añadir día de excepción del calendario</value>
+        <value xml:lang="fr">Ajouter un jour d’exception au calendrier</value>
+        <value xml:lang="it">Aggiungi Giorno di Eccezione del Calendario</value>
+        <value xml:lang="ja">カレンダ除外日を追加</value>
+        <value xml:lang="nl">Uitzonderingsdag toevoegen</value>
+        <value xml:lang="pt-BR">Adicionar dia de exceção ao calendário</value>
+        <value xml:lang="th">เพิ่มวันยกเว้นในปฏิทิน</value>
+        <value xml:lang="vi">Thêm ngày ngoại lệ trong lịch</value>
+        <value xml:lang="zh">添加日历例外日</value>
+        <value xml:lang="zh-TW">增加日曆例外日</value>
+    </property>
     <property key="PageTitleAddCalendarExceptionWeek">
         <value xml:lang="de">Kalender-Ausnahme-Woche hinzufügen</value>
         <value xml:lang="en">Add Calendar Exception Week</value>

--- a/applications/manufacturing/template/routing/EditCalendarExceptionDay.ftl
+++ b/applications/manufacturing/template/routing/EditCalendarExceptionDay.ftl
@@ -32,7 +32,7 @@ under the License.
 <#if calendarExceptionDay?has_content>
 <div class="screenlet">
   <div class="screenlet-title-bar">
-    <h3>${uiLabelMap.PageTitleEditCalendarExceptionWeek}</h3>
+    <h3>${uiLabelMap.PageTitleEditCalendarExceptionDay}</h3>
   </div>
   <div class="screenlet-body">
     ${setRequestAttribute("calendarExceptionDay", calendarExceptionDay!)}
@@ -42,7 +42,7 @@ under the License.
 </#if>
 <div class="screenlet">
   <div class="screenlet-title-bar">
-    <h3>${uiLabelMap.PageTitleAddCalendarExceptionWeek}</h3>
+    <h3>${uiLabelMap.PageTitleAddCalendarExceptionDay}</h3>
   </div>
   <div class="screenlet-body">
     ${setRequestAttribute("techDataCalendar", techDataCalendar!)}


### PR DESCRIPTION
Corrected the UI labels on the EditCalendarExceptionDay.ftl.  Thanks to ChatGPT for providing the alternate language labels. 