### PR TITLE
Fixed: Enables larger Zip for Gradle Tasks (OFBIZ-13344)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,9 @@ tasks.withType(JavaCompile) {
     }
 }
 
+// Enables Zip larger than 4 GB and more than 65535 entries
+tasks.withType(Zip) { zip64 = true }
+
 // Only used for release branches
 def getCurrentGitBranch() {
     return "git branch --show-current".execute().text.trim()


### PR DESCRIPTION
Explanation
Sets the org.gradle.api.tasks.bundling.Zip zip64 property value to true. Prevents distZip from failing if the archive contains more than 65535 entries or is larger than 4 GB.
