### PR TITLE
FIX: port offset applied twice when loading WebSite properties (OFBIZ-13352)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/website/WebSiteProperties.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/website/WebSiteProperties.java
@@ -81,7 +81,7 @@ public final class WebSiteProperties {
         Assert.notNull("request", request);
         WebSiteProperties webSiteProps = (WebSiteProperties) request.getAttribute("_WEBSITE_PROPS_");
         if (webSiteProps == null) {
-            Boolean addPortoffset = true;
+            Boolean addPortoffset = false;
             Delegator delegator = (Delegator) request.getAttribute("delegator");
             if (delegator != null) {
                 String webSiteId = WebSiteWorker.getWebSiteId(request);
@@ -94,6 +94,7 @@ public final class WebSiteProperties {
             }
             if (webSiteProps == null) {
                 webSiteProps = new WebSiteProperties(delegator);
+                addPortoffset = true;
             }
             if (webSiteProps.getHttpPort().isEmpty() && !request.isSecure()) {
                 webSiteProps = webSiteProps.updateHttpPort(String.valueOf(request.getServerPort()));
@@ -103,7 +104,6 @@ public final class WebSiteProperties {
             }
             if (webSiteProps.getHttpsPort().isEmpty() && request.isSecure()) {
                 webSiteProps = webSiteProps.updateHttpsPort(String.valueOf(request.getServerPort()));
-                addPortoffset = false; // We take the port from the request, don't add the portOffset
             }
             if (webSiteProps.getHttpsHost().isEmpty()) {
                 webSiteProps = webSiteProps.updateHttpsHost(request.getServerName());


### PR DESCRIPTION
Fixed: port offset applied twice when loading WebSite properties (OFBIZ-13352)

Explanation:
In the method from(GenericValue), web site default settings are loaded. Configurations are overridden by the WebSite being used. In particular, a port offset is always added here, which can be set via the start parameters. Therefore, it is not necessary to adjust the WebSite entry in the database to store an alternative port to 8443. The method from(HttpServletRequest) calls the method from(GenericValue) itself and additionally sets the port offset. The result is that an offset is added twice.

Now addPortoffset is initialized with false and only set to true when new WebSiteProperties are created.