### PR TITLE
Fixed: Change position of the Receive Against PO menu item and remove redundant link (OFBIZ-13353)

### DIFF
--- a/applications/product/widget/facility/FacilityMenus.xml
+++ b/applications/product/widget/facility/FacilityMenus.xml
@@ -399,6 +399,20 @@ under the License.
                 <parameter param-name="shipmentId"/>
             </link>
         </menu-item>
+        <menu-item name="ReceiveInventoryAgainstPurchaseOrder" title="${uiLabelMap.ProductReceiveInventoryAgainstPO}">
+            <condition>
+                <and>
+                    <not><if-empty field="facility"/></not>
+                    <not><if-empty field="shipment"/></not>
+                    <not><if-empty field="shipment.primaryOrderId"/></not>
+                    <if-compare field="shipment.shipmentTypeId" operator="equals" value="PURCHASE_SHIPMENT" />
+                </and>
+            </condition>
+            <link target="ReceiveInventoryAgainstPurchaseOrder">
+                <parameter param-name="shipmentId"/>
+                <parameter param-name="purchaseOrderId" from-field="shipment.primaryOrderId"/>
+            </link>
+        </menu-item>
     </menu>
     <menu name="ShipmentActionBar" menu-container-style="button-bar button-style-2" default-selected-style="selected">
         <menu-item name="ReceiveInventory" title="${uiLabelMap.ProductReceiveInventory}">
@@ -414,26 +428,6 @@ under the License.
                 <parameter param-name="facilityId" from-field="facility.facilityId"/>
                 <parameter param-name="purchaseOrderId" from-field="shipment.primaryOrderId"/>
                 <parameter param-name="initialSelected" value="Y"/>
-            </link>
-        </menu-item>
-        <menu-item name="ReceiveInventoryAgainstPurchaseOrder" title="${uiLabelMap.ProductReceiveInventoryAgainstPO}">
-            <condition>
-                <and>
-                    <not><if-empty field="facility"/></not>
-                    <not><if-empty field="shipment"/></not>
-                    <not><if-empty field="shipment.primaryOrderId"/></not>
-                    <if-compare field="shipment.shipmentTypeId" operator="equals" value="PURCHASE_SHIPMENT" />
-                </and>
-            </condition>
-            <link target="ReceiveInventoryAgainstPurchaseOrder">
-                <parameter param-name="shipmentId"/>
-                <parameter param-name="purchaseOrderId" from-field="shipment.primaryOrderId"/>
-            </link>
-        </menu-item>
-        <menu-item name="ReceiveInventoryAgainstPurchaseOrder" title="${uiLabelMap.ProductReceiveInventoryAgainstPO}">
-            <link target="ReceiveInventoryAgainstPurchaseOrder">
-                <parameter param-name="shipmentId"/>
-                <parameter param-name="purchaseOrderId" from-field="shipment.primaryOrderId"/>
             </link>
         </menu-item>
         <menu-item name="CreateShipmentNote" title="${uiLabelMap.CommonAdd} ${uiLabelMap.CommonNote}">

--- a/applications/product/widget/facility/ShipmentScreens.xml
+++ b/applications/product/widget/facility/ShipmentScreens.xml
@@ -123,24 +123,6 @@ under the License.
                                         </container>
                                     </widgets>
                                 </section>
-                                <section>
-                                    <condition>
-                                        <and>
-                                            <not><if-empty field="shipment"/></not>
-                                            <not><if-empty field="facility"/></not>
-                                            <if-compare field="shipment.shipmentTypeId" operator="equals" value="PURCHASE_SHIPMENT"/>
-                                            <not><if-empty field="shipment.primaryOrderId"/></not>
-                                        </and>
-                                    </condition>
-                                    <widgets>
-                                        <container>
-                                            <link style="buttontext" text="${uiLabelMap.ProductReceiveInventoryAgainstPO}" target="ReceiveInventoryAgainstPurchaseOrder">
-                                                <parameter param-name="shipmentId" from-field="shipment.shipmentId"/>
-                                                <parameter param-name="purchaseOrderId" from-field="shipment.primaryOrderId"/>
-                                            </link>
-                                        </container>
-                                    </widgets>
-                                </section>
 
                                 <decorator-section-include name="body"/>
                             </widgets>
@@ -564,7 +546,7 @@ under the License.
                 <property-map resource="ProductEntityLabels" map-name="uiLabelMap" global="true"/>
                 <set field="titleProperty" value="ProductReceiveInventoryAgainstPurchaseOrder"/>
                 <set field="headerItem" value="shipment"/>
-                <set field="tabButtonItem" value="ProductReceiveInventoryAgainstPO"/>
+                <set field="tabButtonItem" value="ReceiveInventoryAgainstPurchaseOrder"/>
                 <property-map resource="OrderUiLabels" map-name="uiLabelMap" global="true"/>
                 <script location="component://product/src/main/groovy/org/apache/ofbiz/product/facility/shipment/ReceiveInventoryAgainstPurchaseOrder.groovy"/>
             </actions>


### PR DESCRIPTION
In shipment screens the Receive Against PO menu item should be placed in the main shipment menu, instead of the "Action" bar.

Moreover, currently, the menu item is duplicated and doesn't retain focus when the screen is selected. 