### PR TITLE
Improved: On the Receive Against PO screen, add a link that allows users to navigate to the order details screen

### DIFF
--- a/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
+++ b/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
@@ -75,7 +75,7 @@ under the License.
   <table class="basic-table" cellspacing="0">
     <tr>
       <td class="label">${uiLabelMap.ProductOrderId}</td>
-      <td>${orderId!}</td>
+      <td><#if orderId??><a href="<@ofbizUrl controlPath="/ordermgr/control">orderview?orderId=${orderId}</@ofbizUrl>" class="buttontext">${orderId}</a></#if></td>
     </tr>
     <tr>
       <td class="label">${uiLabelMap.ProductOrderShipGroupId}</td>


### PR DESCRIPTION
When you navigate to the Receive Inventory Against PO screen, there is no link to return to the order details screen. This PR makes the order ID highlighted in the screenshot a clickable link.
<img width="1824" height="679" alt="receive_against_PO_screen_annotated" src="https://github.com/user-attachments/assets/41a54d06-70ae-4601-82e4-37a51c99353b" />
