### PR TITLE
Fixed: Transform the ‘Generate Shipment Manifest Report’ menu item into a button and remove the ‘Shipment Action Bar’ menu from the ‘Receive Inventory Against Purchase Order’ screen (OFBIZ-13357)

### DIFF
--- a/applications/product/widget/facility/FacilityMenus.xml
+++ b/applications/product/widget/facility/FacilityMenus.xml
@@ -414,31 +414,4 @@ under the License.
             </link>
         </menu-item>
     </menu>
-    <menu name="ShipmentActionBar" menu-container-style="button-bar button-style-2" default-selected-style="selected">
-        <menu-item name="ReceiveInventory" title="${uiLabelMap.ProductReceiveInventory}">
-            <condition>
-                <and>
-                    <not><if-empty field="facility"/></not>
-                    <not><if-empty field="shipment"/></not>
-                    <if-compare field="shipment.shipmentTypeId" operator="equals" value="PURCHASE_SHIPMENT" />
-                </and>
-            </condition>
-            <link target="ReceiveInventory">
-                <parameter param-name="shipmentId"/>
-                <parameter param-name="facilityId" from-field="facility.facilityId"/>
-                <parameter param-name="purchaseOrderId" from-field="shipment.primaryOrderId"/>
-                <parameter param-name="initialSelected" value="Y"/>
-            </link>
-        </menu-item>
-        <menu-item name="CreateShipmentNote" title="${uiLabelMap.CommonAdd} ${uiLabelMap.CommonNote}">
-            <link target="CreateShipmentNote">
-                <parameter param-name="shipmentId"/>
-            </link>
-        </menu-item>
-        <menu-item name="CreateManifest" title="${uiLabelMap.ProductGenerateShipmentManifestReport}">
-            <link target="ShipmentManifest.pdf" target-window="_BLANK">
-                <parameter param-name="shipmentId"/>
-            </link>
-        </menu-item>
-    </menu>
 </menus>

--- a/applications/product/widget/facility/ShipmentScreens.xml
+++ b/applications/product/widget/facility/ShipmentScreens.xml
@@ -100,7 +100,6 @@ under the License.
                                         <label style="h1" text="${uiLabelMap.ProductShipmentId}: ${shipment.shipmentId}"/>
                                         <container>
                                             <include-menu location="${parameters.mainMenuLocation}" name="ShipmentTabBar"/>
-                                            <include-menu location="${parameters.mainMenuLocation}" name="ShipmentActionBar"/>
                                         </container>
                                     </widgets>
                                 </section>
@@ -123,7 +122,15 @@ under the License.
                                         </container>
                                     </widgets>
                                 </section>
-
+                                <section>
+                                    <widgets>
+                                        <container>
+                                            <link style="buttontext" text="${uiLabelMap.ProductGenerateShipmentManifestReport}" target="ShipmentManifest.pdf" target-window="_BLANK">
+                                                <parameter param-name="shipmentId"/>
+                                            </link>
+                                        </container>
+                                    </widgets>
+                                </section>
                                 <decorator-section-include name="body"/>
                             </widgets>
                             <fail-widgets>


### PR DESCRIPTION
As described in the jira ticket [OFBIZ-13357](https://issues.apache.org/jira/browse/OFBIZ-13357),
the ‘Shipment Action Bar’ menu of the ‘Receive Inventory Against Purchase Order’ screen contains one item, ‘Receive Inventory Into Web Store Warehouse’, that is already defined as a button, and one item, ‘Add Note’, that is linked to a nonexistent request-map.

The changes in the PR transform the only item of the ‘Shipment Action Bar’ menu that is not affected by any issue, ‘Generate Shipment Manifest Report’, in a button defined in the ‘Common Shipment Decorator’ screen, and remove the unnecessary Action Bar menu from the 'Receive Inventory Against Purchase Order' screen.



