### PR TITLE
OFBIZ-XXXX:Corrected phrasing 'On Windows don\'t put OFBiz in a direc…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,7 @@ https://medium.com/@javachampions/java-is-still-free-2-0-0-6b9aa8d6d244[To know 
 
 [WARNING]
 ==================
-On Windows don't put OFBiz in a directory with space/s in the path.
+On Windows, do not install OFBiz in a directory whose path contains spaces.
 ==================
 
 * If on Windows, a Powershell version >= 7.1.3 installed that you can download from the below link. +


### PR DESCRIPTION
 Documented: Corrected phrasing in README.adoc for Windows installation path
(OFBIZ-13360)

Explanation:
Replaced informal wording "On Windows don't put OFBIZ in a directory with space/s in the path"
with clearer phrasing "On Windows, do not install OFBIZ in a directory whose path contains spaces".

 