### PR TITLE
Fixed: Ensure that the invoice item quantity is set to 1 only if the quantity is null when invoice items are created by the createInvoiceItem service (OFBIZ-13362)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceServicesScript.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceServicesScript.groovy
@@ -350,7 +350,7 @@ Map createInvoiceItem() {
     // if there is no amount and a productItem is supplied fill the amount(price) and description from the product record
     //     TODO: there are return adjustments now that make this code very broken. The check for price was added as a quick fix.
     if (invoiceItem.productId) {
-        invoiceItem.quantity = invoiceItem.quantity ?: 1
+        invoiceItem.quantity = (invoiceItem.quantity != null) ? invoiceItem.quantity : 1
         if (!invoiceItem.amount) {
             GenericValue product = from('Product').where(parameters).cache().queryOne()
             invoiceItem.description = product.description


### PR DESCRIPTION
This PR solves the first issue described in [OFBIZ-13362](https://issues.apache.org/jira/browse/OFBIZ-13362)

When the system creates a receipt with an accepted quantity equal to zero, the service createInvoiceItem erroneously set the item invoice quantity to 1, leading to a wrong invoiced quantity.

The change in the PR makes sure that only quantities equal to null are set to 1.
