### PR TITLE
Fixed: Avoid displaying quantities equal to zero as 1 in the invoice items grid of the View Invoice screen (OFBIZ-13362)

### DIFF
--- a/applications/accounting/widget/accounting/AccountingInvoiceItemCpd.xml
+++ b/applications/accounting/widget/accounting/AccountingInvoiceItemCpd.xml
@@ -390,7 +390,7 @@ under the License.
             paginate-target="Accounting/Invoice/Items/List" odd-row-style="alternate-row" default-table-style="basic-table hover-bar"
             extends="CommonDynamicGrid" extends-resource="component://common/widget/CommonForms.xml">
             <wf:row-actions>
-                <wf:set field="quantity" value="${groovy: quantity ?: 1}" type="BigDecimal"/>
+                <wf:set field="quantity" value="${groovy: (quantity != null) ? quantity : 1}" type="BigDecimal"/>
                 <wf:set field="total" value="${groovy: quantity * amount ?: 0}" type="BigDecimal"/>
             </wf:row-actions>
             <wf:auto-fields-entity entity-name="InvoiceItem" default-field-type="display"/>


### PR DESCRIPTION
This PR solves the second issue described in [OFBIZ-13362](https://issues.apache.org/jira/browse/OFBIZ-13362)

Even when the invoice item quantity is correctly set to zero in the database, the screen viewInvoice erroneously ‘visualize’ an invoice item reporting one unit of the product.

The problem is due to the fact that the grid 'ListInvoiceItems' used in the viewInvoice screen set the invoice item quantity to one when it is zero. The change in the PR makes sure that the quantity visualized is set to 1 only when the quantity is null.

