### PR TITLE
Improved: <text/> form widget supports "range" and "color" types

### DIFF
--- a/framework/widget/dtd/widget-form.xsd
+++ b/framework/widget/dtd/widget-form.xsd
@@ -1525,8 +1525,7 @@ under the License.
             <xs:attribute type="xs:positiveInteger" name="size" default="25" />
             <xs:attribute type="xs:positiveInteger" name="maxlength" />
             <xs:attribute type="xs:string" name="default-value" />
-            <xs:attribute name="client-autocomplete-field"
-                          type="xs:boolean" default="true">
+            <xs:attribute name="client-autocomplete-field" type="xs:boolean" default="true">
                 <xs:annotation>
                     <xs:documentation>Tells the browser whether or not to try and autocomplete with values previously entered. Default to true.</xs:documentation>
                 </xs:annotation>
@@ -1557,17 +1556,38 @@ under the License.
                         <xs:enumeration value="email" />
                         <xs:enumeration value="url" />
                         <xs:enumeration value="tel" />
+                        <xs:enumeration value="color" />
+                        <xs:enumeration value="range" />
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
             <xs:attribute name="step" type="xs:string">
                 <xs:annotation>
-                    <xs:documentation>Controls the "step" attribute of the input element. Ignored if the "type" attribute of the field is not "number". See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/step</xs:documentation>
+                    <xs:documentation>
+                        Controls the "step" attribute of the input element. Ignored if the "type" attribute of the field is not "number" or "range".
+                        See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/step
+                    </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
             <xs:attribute name="pattern" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>Controls the pattern attribute of the input element. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="min" type="xs:float">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the "min" attribute for "number" and "range" input types. The default value is 0 for range inputs.
+                        See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range#min)
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="max" type="xs:float">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the "max" attribute for "number" and "range" input types. The default value is 100 for range inputs.
+                        See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range#max)
+                    </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
         </xs:complexType>

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelFormField.java
@@ -5916,6 +5916,8 @@ public final class ModelFormField {
         private final String type;
         private final String pattern;
         private final String step;
+        private final String min;
+        private final String max;
 
         public TextField(Element element, ModelFormField modelFormField) {
             super(element, modelFormField);
@@ -5923,8 +5925,10 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance(element.getAttribute("default-value"));
             this.mask = element.getAttribute("mask");
             this.type = element.getAttribute("type");
-            this.step = element.getAttribute("step");
             this.pattern = element.getAttribute("pattern");
+            this.step = element.getAttribute("step");
+            this.min = element.getAttribute("min");
+            this.max = element.getAttribute("max");
             Integer maxlength = null;
             String maxlengthStr = element.getAttribute("maxlength");
             if (!maxlengthStr.isEmpty()) {
@@ -5963,8 +5967,10 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.mask = "";
             this.type = "";
-            this.step = "";
             this.pattern = "";
+            this.step = "";
+            this.min = "";
+            this.max = "";
             this.maxlength = maxlength;
             this.placeholder = FlexibleStringExpander.getInstance("");
             this.readonly = false;
@@ -5978,8 +5984,10 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.mask = "";
             this.type = type;
-            this.step = "";
             this.pattern = "";
+            this.step = "";
+            this.min = "";
+            this.max = "";
             this.maxlength = maxlength;
             this.placeholder = FlexibleStringExpander.getInstance("");
             this.readonly = false;
@@ -5993,8 +6001,10 @@ public final class ModelFormField {
             this.defaultValue = FlexibleStringExpander.getInstance("");
             this.mask = "";
             this.type = "";
-            this.step = "";
             this.pattern = "";
+            this.step = "";
+            this.min = "";
+            this.max = "";
             this.maxlength = null;
             this.placeholder = FlexibleStringExpander.getInstance("");
             this.readonly = false;
@@ -6016,8 +6026,10 @@ public final class ModelFormField {
             this.defaultValue = original.defaultValue;
             this.mask = original.mask;
             this.type = original.type;
-            this.step = original.step;
             this.pattern = original.pattern;
+            this.step = original.step;
+            this.min = original.min;
+            this.max = original.max;
             this.placeholder = original.placeholder;
             this.size = original.size;
             this.maxlength = original.maxlength;
@@ -6139,6 +6151,14 @@ public final class ModelFormField {
         }
 
         /**
+         * Gets pattern.
+         * @return the pattern
+         */
+        public String getPattern() {
+            return this.pattern;
+        }
+
+        /**
          * Gets step.
          * @return the step
          */
@@ -6147,11 +6167,19 @@ public final class ModelFormField {
         }
 
         /**
-         * Gets pattern.
-         * @return the pattern
+         * Gets min.
+         * @return the min
          */
-        public String getPattern() {
-            return this.pattern;
+        public String getMin() {
+            return this.min;
+        }
+
+        /**
+         * Gets max.
+         * @return the max
+         */
+        public String getMax() {
+            return this.max;
         }
     }
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilder.java
@@ -255,16 +255,20 @@ public final class RenderableFtlFormElementsBuilder {
         if (UtilValidate.isEmpty(type)) {
             type = "text";
         }
+        String pattern = "";
+        if (List.of("text", "email", "url", "tel").contains(type)) {
+            pattern = textField.getPattern();
+        }
         String step = "";
-        if (type.equals("number")) {
+        String min = "";
+        String max = "";
+        if (List.of("number", "range").contains(type)) {
+            min = textField.getMin();
+            max = textField.getMax();
             step = textField.getStep();
             if (UtilValidate.isEmpty(step)) {
                 step = "any";
             }
-        }
-        String pattern = "";
-        if (List.of("text", "email", "url", "tel").contains(type)) {
-            pattern = textField.getPattern();
         }
         List<String> classes = new ArrayList<>();
         String alert = "false";
@@ -315,8 +319,10 @@ public final class RenderableFtlFormElementsBuilder {
                 .stringParameter("name", name)
                 .stringParameter("className", String.join(" ", classes))
                 .stringParameter("type", type)
-                .stringParameter("step", step)
                 .stringParameter("pattern", pattern)
+                .stringParameter("step", step)
+                .stringParameter("min", min)
+                .stringParameter("max", max)
                 .stringParameter("alert", alert)
                 .stringParameter("value", value)
                 .stringParameter("textSize", textSize)

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
@@ -260,6 +260,8 @@ public class RenderableFtlFormElementsBuilderTest {
         new Expectations() {
             {
                 textField.getType(); result = "number";
+                textField.getMin(); result = "2";
+                textField.getMax(); result = "8";
                 httpSession.getAttribute("delegatorName"); result = "DelegatorName";
             }
         };
@@ -268,6 +270,8 @@ public class RenderableFtlFormElementsBuilderTest {
         assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "number")));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "any")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("min", "2")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("max", "8")));
     }
 
     @Test
@@ -329,6 +333,26 @@ public class RenderableFtlFormElementsBuilderTest {
         assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "tel")));
         assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "")));
+    }
+
+    @Test
+    public void textFieldTypeRange(@Mocked final ModelFormField.TextField textField) {
+        new Expectations() {
+            {
+                textField.getType(); result = "range";
+                textField.getMin(); result = "15";
+                textField.getMax(); result = "30";
+                textField.getStep(); result = "3";
+                httpSession.getAttribute("delegatorName"); result = "DelegatorName";
+            }
+        };
+
+        final RenderableFtl renderableFtl = renderableFtlFormElementsBuilder.textField(Map.of("session", httpSession), textField, true);
+        assertThat(renderableFtl, MacroCallMatcher.hasName("renderTextField"));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("type", "range")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("min", "15")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("max", "30")));
+        assertThat(renderableFtl, MacroCallMatcher.hasParameters(MacroCallParameterMatcher.hasNameAndStringValue("step", "3")));
     }
 
     @Test

--- a/themes/common-theme/template/macro/CsvFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/CsvFormMacroLibrary.ftl
@@ -24,7 +24,7 @@ under the License.
 </#macro>
 <#macro renderHyperlinkField></#macro>
 
-<#macro renderTextField type pattern name className alert value="" textSize="" maxlength="" id="" event="" action=""
+<#macro renderTextField type pattern name className alert min max value="" textSize="" maxlength="" id="" event="" action=""
 disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" required=false
 placeholder="" delegatorName="default"><@renderField value /></#macro>
 

--- a/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/FoFormMacroLibrary.ftl
@@ -51,7 +51,7 @@ under the License.
 </#macro>
 <#macro renderHyperlinkField><!--hyper--></#macro>
 
-<#macro renderTextField type pattern name className alert value="" textSize="" maxlength="" id="" event="" action=""
+<#macro renderTextField type pattern name className alert min max value="" textSize="" maxlength="" id="" event="" action=""
 disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" required=false
 placeholder="" delegatorName="default"><@makeBlock className value /></#macro>
 

--- a/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlFormMacroLibrary.ftl
@@ -43,8 +43,8 @@ under the License.
 </#macro>
 <#macro renderHyperlinkField></#macro>
 
-<#macro renderTextField type step pattern name className alert value="" textSize="" maxlength="" id="" event="" action=""
-        disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" required=false
+<#macro renderTextField type step pattern name className alert min max value="" textSize="" maxlength="" id="" event=""
+        action="" disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" required=false
         placeholder="" delegatorName="default">
   <input type="${type}" name="${name?default("")?html}"<#t/>
   <#if ajaxEnabled?has_content && ajaxEnabled && ajaxUrl?has_content>
@@ -70,6 +70,8 @@ under the License.
     <#if required?has_content && required> required</#if>
     <#if pattern?has_content> pattern="${pattern}"</#if>
     <#if step?has_content> step="${step}"</#if>
+    <#if min?has_content> min="${min}"</#if>
+    <#if max?has_content> max="${max}"</#if>
   /><#t/>
 </#macro>
 

--- a/themes/common-theme/template/macro/TextFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/TextFormMacroLibrary.ftl
@@ -24,7 +24,7 @@ under the License.
 </#macro>
 <#macro renderHyperlinkField></#macro>
 
-<#macro renderTextField type pattern name className alert value="" textSize="" maxlength="" id="" event="" action=""
+<#macro renderTextField type pattern name className alert min max value="" textSize="" maxlength="" id="" event="" action=""
 disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" required=false
 placeholder="" delegatorName="default"><@renderField value /></#macro>
 

--- a/themes/common-theme/template/macro/XlsFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XlsFormMacroLibrary.ftl
@@ -30,7 +30,7 @@ under the License.
 </#macro>
 <#macro renderHyperlinkField></#macro>
 
-<#macro renderTextField type pattern name className alert value="" textSize="" maxlength="" id="" event="" action=""
+<#macro renderTextField type pattern name className alert min max value="" textSize="" maxlength="" id="" event="" action=""
 disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" required=false
 placeholder="" delegatorName="default"><@renderItemField value "txf" className/></#macro>
 

--- a/themes/common-theme/template/macro/XmlFormMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XmlFormMacroLibrary.ftl
@@ -40,7 +40,7 @@ under the License.
 </#macro>
 <#macro renderHyperlinkField></#macro>
 
-<#macro renderTextField type pattern name className alert value="" textSize="" maxlength="" id="" event="" action=""
+<#macro renderTextField type pattern name className alert min max value="" textSize="" maxlength="" id="" event="" action=""
 disabled=false clientAutocomplete="" ajaxUrl="" ajaxEnabled="" mask="" tabindex="" readonly="" required=false
 placeholder="" delegatorName="default"><@renderField value/></#macro>
 


### PR DESCRIPTION
Improved: <text/> form widget supports "range" and "color" types

OFBIZ-13361

## Supports 2 HTML input types for the `<text/>` form widget.

<img width="540" height="457" alt="image" src="https://github.com/user-attachments/assets/3ff6e310-989b-4bbf-b13c-bc79832d1600" />

(Chromium 145)

### range

`<input type="range" min="5" max="16" step="0.5"/>`

Allows to define a number between two values (`min` and `max`), in a context where the precise value is not considered important.
Typically rendered as a slider rather that a text entry.
`min` and `max` attributes are also supported by the `<text/>` widget.
`step` attribute can be used to define snapping points on the slider.
Input widget may vary across browsers.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range

### color

`<input type="color"/>`

Allows to choose a color (text representing a valid CSS color : hexadecimal, RGBA...), typically with a visual color picker.
Input widget may vary across browsers.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/color

Thanks: Néréide team