### PR TITLE
Fixed: Set template directory permissions in docker container images (OFBIZ-13363)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,8 @@ RUN echo '${uiLabelMap.CommonJavaVersion}:' "$(java --version | grep Runtime | s
 COPY --chmod=555 docker/docker-entrypoint.sh docker/send_ofbiz_stop_signal.sh .
 
 COPY --chmod=444 docker/disable-component.xslt .
+
+RUN mkdir templates
 COPY --chmod=444 docker/templates templates
 
 EXPOSE 8443


### PR DESCRIPTION
It appears that a change in docker-build's handling of the COPY command has resulted in some incorrect permissions being applied to the templates directory in the ofbiz docker images. These permissions stop the ofbiz-docker container from starting.

This commit explicitly sets permissions on the templates directory, allowing the ofbiz-docker container to access the files it needs and start up.