### PR TITLE
(OFBIZ-13366) : Improved performance and implementation of database-level pagination in FindGeneric.groovy

### DIFF
--- a/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/FindGeneric.groovy
+++ b/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/FindGeneric.groovy
@@ -121,6 +121,8 @@ if (modelEntity) {
 
         if (prepareFindResult.orderByList) {
             query.orderBy(prepareFindResult.orderByList)
+        } else {
+            query.orderBy(modelEntity.getPkFieldNames())
         }
 
         if (fieldsToSelect) {

--- a/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/FindGeneric.groovy
+++ b/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/FindGeneric.groovy
@@ -20,7 +20,6 @@ package org.apache.ofbiz.webtools.entity
 
 import org.apache.ofbiz.base.util.UtilXml
 import org.apache.ofbiz.entity.util.EntityQuery
-
 import org.apache.ofbiz.entity.GenericEntityException
 import org.apache.ofbiz.entity.model.ModelEntity
 import org.apache.ofbiz.entity.model.ModelFieldType
@@ -103,9 +102,9 @@ if (modelEntity) {
     int viewSize = [parameters.VIEW_SIZE_1, parameters.VIEW_SIZE, parameters.viewSize].find { String val -> val?.isInteger() }?.toInteger() ?: 20
 
     Map prepareFindResult = dispatcher.runSync('prepareFind', [
-            entityName     : entityName,
-            inputFields    : parameters,
-            orderBy        : parameters.sortField,
+            entityName: entityName,
+            inputFields: parameters,
+            orderBy: parameters.sortField,
             noConditionFind: parameters.noConditionFind ?: 'Y'
     ])
 

--- a/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/FindGeneric.groovy
+++ b/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/FindGeneric.groovy
@@ -19,6 +19,8 @@
 package org.apache.ofbiz.webtools.entity
 
 import org.apache.ofbiz.base.util.UtilXml
+import org.apache.ofbiz.entity.util.EntityQuery
+
 import org.apache.ofbiz.entity.GenericEntityException
 import org.apache.ofbiz.entity.model.ModelEntity
 import org.apache.ofbiz.entity.model.ModelFieldType
@@ -96,25 +98,52 @@ if (modelEntity) {
     dynamicAutoEntitySearchFormRenderer.render(writer, context)
     context.dynamicAutoEntitySearchForm = writer
 
-    //prepare the result list from performFind
+    // Prepare the data retrieval using EntityQuery with limit and offset for better performance
+    int viewIndex = [parameters.VIEW_INDEX_1, parameters.VIEW_INDEX, parameters.viewIndex].find { String val -> val?.isInteger() }?.toInteger() ?: 0
+    int viewSize = [parameters.VIEW_SIZE_1, parameters.VIEW_SIZE, parameters.viewSize].find { String val -> val?.isInteger() }?.toInteger() ?: 20
+
+    Map prepareFindResult = dispatcher.runSync('prepareFind', [
+            entityName     : entityName,
+            inputFields    : parameters,
+            orderBy        : parameters.sortField,
+            noConditionFind: parameters.noConditionFind ?: 'Y'
+    ])
+
+    if (prepareFindResult.entityConditionList || parameters.noConditionFind == 'Y') {
+        EntityQuery query = EntityQuery.use(delegator)
+                .from(entityName)
+                .limit(viewSize)
+                .offset(viewIndex * viewSize)
+                .cursorScrollInsensitive()
+
+        if (prepareFindResult.entityConditionList) {
+            query.where(prepareFindResult.entityConditionList)
+        }
+
+        if (prepareFindResult.orderByList) {
+            query.orderBy(prepareFindResult.orderByList)
+        }
+
+        if (fieldsToSelect) {
+            query.select(fieldsToSelect as Set)
+        }
+
+        if (parameters.distinct == 'Y') {
+            query.distinct()
+        }
+
+        context.listIt = query.queryIterator()
+        context.listSize = context.listIt.getResultsSizeAfterPartialList()
+    }
+
+    //prepare the result list
     String dynamicAutoEntityFieldListForm = """<?xml version="1.0" encoding="UTF-8"?>
         <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xmlns="http://ofbiz.apache.org/Widget-Form"
             xsi:schemaLocation="http://ofbiz.apache.org/Widget-Form http://ofbiz.apache.org/dtds/widget-form.xsd">
             <form name="ListGeneric" type="list" target="entity/find/${entityName}" list-name="listIt" paginate-target="entity/find/${entityName}"
+              override-list-size="${context.listSize ?: 0}"
               odd-row-style="alternate-row" default-table-style="basic-table light-grid hover-bar" header-row-style="header-row-2">
-            <actions>
-                <service service-name="performFind">
-                    <field-map field-name="inputFields" from-field="parameters"/>
-                    <field-map field-name="entityName" value="${entityName}"/>"""
-    if (fieldsToSelect) {
-        dynamicAutoEntityFieldListForm += """
-                    <field-map field-name="fieldList" value="${fieldsToSelect}"/>"""
-    }
-    dynamicAutoEntityFieldListForm += """
-                    <field-map field-name="orderBy" from-field="parameters.sortField"/>
-                </service>
-            </actions>
             <auto-fields-entity entity-name="${entityName}" default-field-type="display" include-internal="true"/>
             <field name="_method"><hidden value="POST"/></field>
             <field name="entityName"><hidden value="${entityName}"/></field>"""


### PR DESCRIPTION
Improved: Improved performance and implementation of database-level pagination in FindGeneric.groovy (OFBIZ-13366)


Efficiency of the generic entity search and listing functionality within WebTools (FindGeneric.groovy) when handling large datasets.

Implemented:
Database-level pagination using limit() and offset() via direct EntityQuery execution in the Groovy script, eliminating in-memory filtering for large result sets.

Completed:
Refactoring of the data retrieval logic to ensure EntityListIterator is used with a fixed result size, and updating the dynamic form generation to support pre-paginated data.

Fixed:
Performance-related system timeouts and memory exhaustion issues encountered when performing searches on large entities (e.g., Product) without search conditions.

Explanation

The previous implementation of FindGeneric.groovy relied on the performFind service within the dynamically generated XML form’s <actions> block. This approach was inefficient for large datasets because pagination was not consistently applied at the database level, often leading to excessive memory usage, timeouts, or server crashes when browsing large entities without filters.

This change moves the data retrieval logic directly into the Groovy script. By using EntityQuery with explicit limit and offset values derived from the VIEW_INDEX and VIEW_SIZE request parameters, only the required subset of records is fetched from the database. Additionally, getResultsSizeAfterPartialList() is used to provide accurate total counts for the UI without loading all records into memory, and the dynamic form renderer is informed that the data is already paginated via the override-list-size attribute. Support for suffixed pagination parameters (e.g., VIEW_INDEX_1) has also been added.

Thanks: The OFBiz community and reviewers for their feedback and guidance.