### PR TITLE
Fixed : Refactor getMultiPartParameterMap to lazy getter to prevent re-parsing consumed input stream (OFBIZ-13369)

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
@@ -172,9 +172,6 @@ public final class UtilHttp {
             throw new RuntimeException(e);
         }
         params.putAll(multiPartMap);
-        if (req.getAttribute("multiPartMap") == null) {
-            req.setAttribute("multiPartMap", multiPartMap);
-        }
         if (Debug.verboseOn()) {
             Debug.logVerbose("Made Request Parameter Map with [" + params.size() + "] Entries", MODULE);
         }
@@ -222,8 +219,23 @@ public final class UtilHttp {
         return upload;
     }
 
+    /**
+     * Lazy getter for parameters of requests with multipart encoding.
+     * <p>
+     * Sets the multipart data as request attribute "multiPartMap" when called the first time but will refer to that request attribute
+     * for subsequent times.
+     *
+     * @param request
+     * @return
+     */
     public static Map<String, Object> getMultiPartParameterMap(HttpServletRequest request) throws FileUploadException {
-        Map<String, Object> multiPartMap = new HashMap<>();
+        Map<String, Object> multiPartMap = UtilGenerics.checkMap(request.getAttribute("multiPartMap"), String.class, Object.class);
+
+        if (multiPartMap != null) {
+            return multiPartMap;
+        }
+        multiPartMap = new HashMap<>();
+
         Delegator delegator = (Delegator) request.getAttribute("delegator");
         HttpSession session = request.getSession();
         boolean isMultiPart = JakartaServletFileUpload.isMultipartContent(request);
@@ -304,7 +316,7 @@ public final class UtilHttp {
                 }
             }
         }
-
+        request.setAttribute("multiPartMap", multiPartMap);
         return multiPartMap;
     }
 

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/event/ServiceEventHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/event/ServiceEventHandler.java
@@ -157,7 +157,9 @@ public class ServiceEventHandler implements EventHandler {
                 value = paramList;
             } else {
                 // first check the multi-part map
-                value = multiPartMap.get(name);
+                if (UtilValidate.isNotEmpty(multiPartMap)) {
+                    value = multiPartMap.get(name);
+                }
 
                 // next check attributes; do this before parameters so that attribute which can
                 // be changed by code can override parameters which can't


### PR DESCRIPTION
Fixed:  Refactor getMultiPartParameterMap to lazy getter to prevent re-parsing consumed input stream
(OFBIZ-13369)

Explanation: With [OFBIZ-13295](https://issues.apache.org/jira/browse/OFBIZ-13295) ControlFilter#doFilter called UtilHttp#getParameterMap, consuming the request's input stream in the process. Since a multipart stream can only be read once, all subsequent calls return an empty map, which lead to a problem with file uploads in our local setup.

UtilHttp#getMultiPartParameterMap was refactored into a lazy getter: It first checks whether the result is already cached as the request attribute "multiPartMap", and only parses the stream on the first call

Thanks:
