### PR TITLE
Fixed:Include handling for rejected quantities in cancelRemaingPurchaseOrderItems service (OFBIZ-13373)

### DIFF
--- a/applications/order/src/main/java/org/apache/ofbiz/order/order/OrderServices.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/order/OrderServices.java
@@ -5490,6 +5490,9 @@ public class OrderServices {
                     if (!UtilValidate.isEmpty(shipmentReceipt.get("quantityAccepted"))) {
                         receivedQuantity = receivedQuantity.add(shipmentReceipt.getBigDecimal("quantityAccepted"));
                     }
+                    if (!UtilValidate.isEmpty(shipmentReceipt.get("quantityRejected"))) {
+                        receivedQuantity = receivedQuantity.add(shipmentReceipt.getBigDecimal("quantityRejected"));
+                    }
                 }
 
                 BigDecimal quantityToCancel = orderItemQuantity.subtract(orderItemCancelQuantity).subtract(receivedQuantity);


### PR DESCRIPTION
When a PO receipt contains rejected units, clicking the “Force Complete Purchase Order” button in the Order Details screen generates an error because the cancelRemainingPurchaseOrderItems service ignores rejected items. Please refer to [OFBIZ-13373](https://issues.apache.org/jira/browse/OFBIZ-13373) for further details.

The changes in this PR fix the issue in the cancelRemainingPurchaseOrderItems service.

