### PR TITLE
OFBIZ-13248 Calculate labor cost when production run is completed

### DIFF
--- a/applications/datamodel/data/demo/ManufacturingDemoData.xml
+++ b/applications/datamodel/data/demo/ManufacturingDemoData.xml
@@ -61,4 +61,7 @@ under the License.
 
     <FixedAssetDepMethod depreciationCustomMethodId="STR_LINE_DEP_FORMULA" fixedAssetId="DEMO_PROD_EQUIPMT_1"/>
     <FixedAssetDepMethod depreciationCustomMethodId="DBL_DECL_DEP_FORMULA" fixedAssetId="DEMO_PROD_EQUIPMT_2"/>
+
+    <!-- Labor Cost Data -->
+    <RateAmount rateTypeId="FLC" rateCurrencyUomId="USD" periodTypeId="RATE_HOUR" workEffortId="_NA_" partyId="_NA_" emplPositionTypeId="_NA_" fromDate="2000-01-01 00:00:00.000" rateAmount="100.00"/>
 </entity-engine-xml>

--- a/applications/datamodel/data/seed/ManufacturingSeedData.xml
+++ b/applications/datamodel/data/seed/ManufacturingSeedData.xml
@@ -52,4 +52,8 @@ under the License.
     <Enumeration description="Predecessor" enumCode="PREDECESSOR" enumId="WF_PREDECESSOR" enumTypeId="WORKFLOW" sequenceId="1"/>
     <Enumeration description="Successor" enumCode="SUCCESSOR" enumId="WF_SUCCESSOR" enumTypeId="WORKFLOW" sequenceId="2"/>
 
+    <!-- Rate Type for Labor Cost Data -->
+    <RateType rateTypeId="FLC" description="Fully Loaded Cost (price for WorkEffort)"/>
+
+
 </entity-engine-xml>

--- a/applications/manufacturing/config/ManufacturingUiLabels.xml
+++ b/applications/manufacturing/config/ManufacturingUiLabels.xml
@@ -4265,6 +4265,14 @@
         <value xml:lang="zh">尝试从产品关联（productAssoc）获得物料清单时出错</value>
         <value xml:lang="zh-TW">嘗試從產品結合(productAssoc)獲得物料清單時出錯</value>
     </property>
+   <property key="ManufacturingProductionRunUnableToCreateLaborCosts">
+        <value xml:lang="en">Unable to create labor costs for the production run task ${productionRunTaskId}: ${errorString}</value>
+        <value xml:lang="it">Impossibile creare i costi di manodopera per l'attività di esecuzione dell'ordine di produzione ${productionRunTaskId}: ${errorString}</value>
+        <value xml:lang="ja">生産実行タスク ${productionRunTaskId} に対する作業人件費を作成できませんでした：${errorString}</value>
+        <value xml:lang="vi">Không thể tạo chi phí nhân công cho tác vụ thực hiện lệnh sản xuất ${productionRunTaskId}: ${errorString}</value>
+        <value xml:lang="zh">无法为生产执行任务 ${productionRunTaskId} 创建人工成本：${errorString}</value>
+        <value xml:lang="zh-TW">無法為生產執行任務 ${productionRunTaskId} 建立人工成本：${errorString}</value>
+   </property>
     <property key="ManufacturingProductionRunUnableToCreateMaterialsCosts">
         <value xml:lang="en">Unable to create materials costs for the production run task ${productionRunTaskId}: ${errorString}</value>
         <value xml:lang="it">Non è possibile create i costi dei materiali per il compito dell'ordine di produzione ${productionRunTaskId}: ${errorString}</value>

--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
@@ -1324,6 +1324,57 @@ public class ProductionRunServices {
             return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE, "ManufacturingProductionRunUnableToCreateMaterialsCosts",
                     UtilMisc.toMap("productionRunTaskId", productionRunTaskId, "errorString", ge.getMessage()), locale));
         }
+
+        // labor costs: these are the costs derived from the actual time logged on the production run task decleration
+        try {
+            List<GenericValue> timeEntries = EntityQuery.use(delegator).from("TimeEntry")
+                    .where("workEffortId", productionRunTaskId)
+                    .queryList();
+            for (GenericValue timeEntry : timeEntries) {
+                BigDecimal hours = timeEntry.getBigDecimal("hours");
+                if (UtilValidate.isNotEmpty(hours)) {
+                    // Try to find specific rate for the party with FLC type
+                    GenericValue rateAmount = EntityQuery.use(delegator).from("RateAmount")
+                            .where("partyId", timeEntry.getString("partyId"), "rateTypeId", "FLC")
+                            .filterByDate(timeEntry.getTimestamp("fromDate"))
+                            .queryFirst();
+
+                    // Fallback to generic rate if specific rate not found
+                    if (UtilValidate.isEmpty(rateAmount)) {
+                        rateAmount = EntityQuery.use(delegator).from("RateAmount")
+                                .where("partyId", "_NA_", "rateTypeId", "FLC")
+                                .filterByDate(timeEntry.getTimestamp("fromDate"))
+                                .queryFirst();
+                    }
+
+                    if (UtilValidate.isNotEmpty(rateAmount)) {
+                        BigDecimal rate = rateAmount.getBigDecimal("rateAmount");
+                        if (UtilValidate.isNotEmpty(rate)) {
+                            BigDecimal laborCost = rate.multiply(hours).setScale(DECIMALS, ROUNDING);
+                            Map<String, Object> inMap = UtilMisc.<String, Object>toMap("userLogin", userLogin,
+                                    "workEffortId", productionRunTaskId);
+                            inMap.put("costComponentTypeId", "ACTUAL_LABOR_COST");
+                            inMap.put("costUomId", rateAmount.getString("rateCurrencyUomId"));
+                            inMap.put("cost", laborCost);
+                            serviceResult = dispatcher.runSync("createCostComponent", inMap);
+                            if (ServiceUtil.isError(serviceResult)) {
+                                return ServiceUtil.returnError(ServiceUtil.getErrorMessage(serviceResult));
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (GenericEntityException ge) {
+            return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE,
+                    "ManufacturingProductionRunUnableToCreateLaborCosts",
+                    UtilMisc.toMap("productionRunTaskId", productionRunTaskId, "errorString", ge.getMessage()),
+                    locale));
+        } catch (Exception e) {
+            return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE,
+                    "ManufacturingProductionRunUnableToCreateLaborCosts",
+                    UtilMisc.toMap("productionRunTaskId", productionRunTaskId, "errorString", e.getMessage()),
+                    locale));
+        }
         return ServiceUtil.returnSuccess();
     }
 
@@ -2431,6 +2482,25 @@ public class ProductionRunServices {
                     return ServiceUtil.returnError(errMsg);
                 }
             }
+        }
+
+        
+        // Make TimeEntry records for the labor cost
+        try {
+            if (UtilValidate.isNotEmpty(addTaskTime) && addTaskTime.compareTo(BigDecimal.ZERO) > 0) {
+                Map<String, Object> serviceContext = UtilMisc.toMap("workEffortId", workEffortId,
+                        "rateTypeId", "FLC",
+                        "partyId", partyId,
+                        "userLogin", userLogin);
+                serviceContext.put("hours", addTaskTime.divide(new BigDecimal(3600000), 2, ROUNDING).doubleValue());
+                serviceContext.put("comments", "Task time added via Declaration");
+                Map<String, Object> serviceResult = dispatcher.runSync("createTimeEntry", serviceContext);
+                if (ServiceUtil.isError(serviceResult)) {
+                    return ServiceUtil.returnError(ServiceUtil.getErrorMessage(serviceResult));
+                }
+            }
+        } catch (GenericServiceException exc) {
+            return ServiceUtil.returnError(exc.getMessage());
         }
 
         // Create a new TimeEntry

--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
@@ -2491,7 +2491,7 @@ public class ProductionRunServices {
                         "rateTypeId", "FLC",
                         "partyId", partyId,
                         "userLogin", userLogin);
-                serviceContext.put("hours", addTaskTime.divide(new BigDecimal(3600000), 2, ROUNDING).doubleValue());
+                serviceContext.put("hours", addTaskTime.divide(new BigDecimal(3600000), 6, ROUNDING).doubleValue());
                 serviceContext.put("comments", "Task time added via Declaration");
                 Map<String, Object> serviceResult = dispatcher.runSync("createTimeEntry", serviceContext);
                 if (ServiceUtil.isError(serviceResult)) {

--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunServices.java
@@ -2484,7 +2484,6 @@ public class ProductionRunServices {
             }
         }
 
-        
         // Make TimeEntry records for the labor cost
         try {
             if (UtilValidate.isNotEmpty(addTaskTime) && addTaskTime.compareTo(BigDecimal.ZERO) > 0) {


### PR DESCRIPTION
OFBIZ-13248 Calculate labor cost when production run is completed

Implemented the automatic calculation and recording of labor costs when a production run is completed. This is achieved by creating TimeEntry records associated with the production run task, using a specific labor rate type.

**Changes made:** 

**Data (Seed/Demo):**

- Added FLC (Factory Labor Cost) RateType in ManufacturingSeedData.xml.
- Added sample PartyRate data in ManufacturingDemoData.xml to support testing of labor cost calculations.

**UI Labels:**

- Introduced new UI labels in ManufacturingUiLabels.xml for labor cost visibility.

**Service Logic (ProductionRunServices.java):**

- Enhanced the production run completion flow to calculate labor hours from the reported task time.
- Automatically invokes the createTimeEntry service with rateTypeId="FLC" to record the labor cost for the work effort.


Thanks Pierre Smits and Jacopo for design details on ticket. 