### PR TITLE
Fixed: PO receipts with zero accepted units are not handled correctly (OFBIZ-13376)

### DIFF
--- a/applications/accounting/minilang/ledger/GeneralLedgerServices.xml
+++ b/applications/accounting/minilang/ledger/GeneralLedgerServices.xml
@@ -1224,6 +1224,9 @@ under the License.
         <call-simple-method method-name="getGlArithmeticSettingsInline"/>
 
         <entity-one entity-name="ShipmentReceipt" value-field="shipmentReceipt"/>
+        <if-compare field="shipmentReceipt.quantityAccepted" operator="less-equals" value="0">
+            <return/>
+        </if-compare>
         <get-related-one value-field="shipmentReceipt" relation-name="InventoryItem" to-value-field="inventoryItem"/>
         <get-related-one value-field="shipmentReceipt" relation-name="Shipment" to-value-field="shipment"/>
         <if-not-empty field="shipmentReceipt.returnId">

--- a/applications/datamodel/entitydef/shipment-entitymodel.xml
+++ b/applications/datamodel/entitydef/shipment-entitymodel.xml
@@ -473,7 +473,7 @@ under the License.
       <alias entity-alias="II" name="availableToPromiseTotal"/>
       <alias entity-alias="II" name="unitCost"/>
       <alias entity-alias="II" name="lotId"/>
-      <view-link entity-alias="SR" rel-entity-alias="II">
+      <view-link entity-alias="SR" rel-entity-alias="II" rel-optional="true">
         <key-map field-name="inventoryItemId"/>
       </view-link>
     </view-entity>

--- a/applications/order/template/order/OrderItems.ftl
+++ b/applications/order/template/order/OrderItems.ftl
@@ -660,9 +660,11 @@ under the License.
                                                class="buttontext">${shipmentReceipt.shipmentId}</a>:${shipmentReceipt.shipmentItemSeqId!}
                                         </#if>
                                         &nbsp;<#if shipmentReceipt.datetimeReceived?has_content>${Static["org.apache.ofbiz.base.util.UtilFormatOut"].formatDateTime(shipmentReceipt.datetimeReceived, "", locale, timeZone)!}</#if>&nbsp;
-                                        <span class="label">${uiLabelMap.CommonInventory}</span>&nbsp;
-                                        <a href="<@ofbizUrl controlPath="/facility/control">EditInventoryItem?inventoryItemId=${shipmentReceipt.inventoryItemId}</@ofbizUrl>"
-                                           class="buttontext">${shipmentReceipt.inventoryItemId}</a>
+                                        <#if shipmentReceipt.inventoryItemId?has_content>
+                                            <span class="label">${uiLabelMap.CommonInventory}</span>&nbsp;
+                                            <a href="<@ofbizUrl controlPath="/facility/control">EditInventoryItem?inventoryItemId=${shipmentReceipt.inventoryItemId}</@ofbizUrl>"
+                                            class="buttontext">${shipmentReceipt.inventoryItemId}</a>
+                                        </#if>
                                     </td>
                                     <td align="center">
                                         ${shipmentReceipt.quantityAccepted?string.number}&nbsp;/&nbsp;${shipmentReceipt.quantityRejected?default(0)?string.number}

--- a/applications/product/servicedef/secas.xml
+++ b/applications/product/servicedef/secas.xml
@@ -134,6 +134,7 @@ under the License.
 
     <!-- Set the average cost of product -->
     <eca service="receiveInventoryProduct" event="commit">
+        <condition field-name="inventoryItemId" operator="is-not-empty"/>
         <action service="updateProductAverageCostOnReceiveInventory" mode="sync"/>
     </eca>
 

--- a/applications/product/servicedef/secas_shipment.xml
+++ b/applications/product/servicedef/secas_shipment.xml
@@ -158,8 +158,11 @@ under the License.
         <action service="updateOrderStatusFromReceipt" mode="sync" run-as-user="system"/>
     </eca>
     <eca service="createShipmentReceipt" event="commit">
-        <condition field-name="shipmentId" operator="is-not-empty"/>
+        <condition field-name="inventoryItemId" operator="is-not-empty"/>
         <action service="checkDecomposeInventoryItem" mode="sync"/>
+    </eca>
+    <eca service="createShipmentReceipt" event="commit">
+        <condition field-name="shipmentId" operator="is-not-empty"/>
         <action service="updatePurchaseShipmentFromReceipt" mode="sync"/>
     </eca>
 

--- a/applications/product/servicedef/services_shipment.xml
+++ b/applications/product/servicedef/services_shipment.xml
@@ -864,6 +864,7 @@ under the License.
 	     </type-validate>
         </attribute>
         <attribute name="affectAccounting" type="Boolean" mode="OUT" optional="true"/>
+        <override name="inventoryItemId" optional="true"/>
     </service>
     <service name="updatePurchaseShipmentFromReceipt" engine="java"
       location="org.apache.ofbiz.shipment.shipment.ShipmentServices" invoke="updatePurchaseShipmentFromReceipt" auth="true">

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/inventory/ReceiveInventory.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/inventory/ReceiveInventory.groovy
@@ -207,6 +207,8 @@ if (purchaseOrderItems) {
 receivedItems = null
 if (purchaseOrder) {
     receivedItems = from('ShipmentReceiptAndItem').where('orderId', purchaseOrderId, 'facilityId', facilityId).queryList()
+    receivedItemsWithNoInventory = from('ShipmentReceiptAndItem').where('orderId', purchaseOrderId, 'inventoryItemId', null).queryList()
+    receivedItems.addAll(receivedItemsWithNoInventory)
     context.receivedItems = receivedItems
 }
 

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
@@ -74,6 +74,14 @@ Map receiveInventoryProduct () {
      * - DEJ20070822: something to consider for the future:
      *  maybe instead of this funny looping maybe for serialized items we should only allow a quantity of 1, ie return an error if it is not 1
      */
+
+    // Return an error if both quantityAccepted and quantityRejected are zero or less than zero
+    BigDecimal quantityRejected = parameters.quantityRejected ?: BigDecimal.ZERO
+    if ((quantityRejected == BigDecimal.ZERO && parameters.quantityAccepted == BigDecimal.ZERO)
+        || (quantityRejected  < BigDecimal.ZERO || parameters.quantityAccepted < BigDecimal.ZERO)) {
+        return error(UtilProperties.getMessage('ProductUiLabels', 'ProductNoItemsToReceive',  parameters.locale))
+    }
+
     Map result = success()
     List successMessageList = []
     String currentInventoryItemId
@@ -85,8 +93,10 @@ Map receiveInventoryProduct () {
             return error(UtilProperties.getMessage('ProductUiLabels', 'FacilityReceiveInventoryProduct', errorLog,  parameters.locale))
             // before getting going, see if there are any validation issues so far
         }
-        loops = parameters.quantityAccepted
-        parameters.quantityAccepted = BigDecimal.ONE
+        if (parameters.quantityAccepted > BigDecimal.ZERO) {
+            loops = parameters.quantityAccepted
+            parameters.quantityAccepted = BigDecimal.ONE
+        }
     }
     parameters.quantityOnHandDiff = parameters.quantityAccepted
     parameters.availableToPromiseDiff = parameters.quantityAccepted
@@ -135,12 +145,14 @@ Map receiveInventoryProduct () {
             run service: 'updateInventoryItem', with: parameters
             currentInventoryItemId = parameters.currentInventoryItemId
         } else {
-            Map serviceResult = run service: 'createInventoryItem', with: parameters
-            currentInventoryItemId = serviceResult.inventoryItemId
+            if (parameters.quantityAccepted > BigDecimal.ZERO) {
+                Map serviceResult = run service: 'createInventoryItem', with: parameters
+                currentInventoryItemId = serviceResult.inventoryItemId
+            }
         }
 
         // do this only for non-serialized inventory
-        if (parameters.inventoryItemTypeId != 'SERIALIZED_INV_ITEM') {
+        if (parameters.inventoryItemTypeId != 'SERIALIZED_INV_ITEM' && parameters.quantityAccepted > BigDecimal.ZERO) {
             serviceInMap = [:]
             serviceInMap = parameters
             serviceInMap.inventoryItemId = currentInventoryItemId
@@ -153,7 +165,7 @@ Map receiveInventoryProduct () {
         run service: 'createShipmentReceipt', with: serviceInMap
 
         //update serialized items to AVAILABLE (only if this is not a return), which then triggers other SECA chains
-        if (parameters.inventoryItemTypeId == 'SERIALIZED_INV_ITEM' && !parameters.returnId) {
+        if (parameters.inventoryItemTypeId == 'SERIALIZED_INV_ITEM' && !parameters.returnId && parameters.quantityAccepted > BigDecimal.ZERO) {
             // Retrieve the new inventoryItem
             GenericValue inventoryItem = from('InventoryItem').where(inventoryItemId: currentInventoryItemId).queryOne()
 
@@ -165,13 +177,18 @@ Map receiveInventoryProduct () {
                 run service: 'updateInventoryItem', with: serviceInMap
             }
         }
-        serviceInMap = [:]
-        serviceInMap = parameters
-        serviceInMap.inventoryItemId = currentInventoryItemId
-        run service: 'balanceInventoryItems', with: serviceInMap
+        if (parameters.quantityAccepted > BigDecimal.ZERO) {
+            serviceInMap = [:]
+            serviceInMap = parameters
+            serviceInMap.inventoryItemId = currentInventoryItemId
+            run service: 'balanceInventoryItems', with: serviceInMap
 
-        successMessageList << "Received ${parameters.quantityAccepted} of ${parameters.productId}"
-                .concat(" in inventory item ${currentInventoryItemId}.") as String
+            successMessageList << "Received ${parameters.quantityAccepted} of ${parameters.productId}"
+                    .concat(" in inventory item ${currentInventoryItemId}.") as String
+        }
+
+        //the following ensures that, for serialized items, the rejected quantity is accounted for only once
+        parameters.quantityRejected = BigDecimal.ZERO
     }
     // return the last inventory item received
     result.inventoryItemId = currentInventoryItemId

--- a/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
+++ b/applications/product/template/shipment/ReceiveInventoryAgainstPurchaseOrder.ftl
@@ -24,8 +24,13 @@ under the License.
         for (var x = 0; x <= rowCount; x++) {
           var quantityAcceptedInput = document.getElementById('quantityAccepted_o_' + x);
           var quantityInput = document.getElementById('quantity_o_' + x);
+          var rowSubmit = document.getElementById('_rowSubmit_o_' + x);
           if (quantityAcceptedInput != null && quantityInput != null) {
             quantityInput.value = quantityAcceptedInput.value;
+            if (quantityAcceptedInput.value == 0) {
+                rowSubmit.checked = false;
+                rowSubmit.value = "N";
+            }
           }
         }
       }
@@ -193,7 +198,7 @@ under the License.
                                     <a href="<@ofbizUrl>ReceiveInventoryAgainstPurchaseOrder?shipmentId=${shipmentId}&amp;purchaseOrderId=${orderId}&amp;productId=${product.productId}</@ofbizUrl>" class="buttontext">${uiLabelMap.CommonClear}</a>
                                 </td>
                                 <td align="right">
-                                  <input type="checkbox" name="_rowSubmit_o_${rowCount}" value="Y" onclick="highlightRow(this,'orderItemData_tableRow_${rowCount}');" />
+                                  <input type="checkbox" name="_rowSubmit_o_${rowCount}" id="_rowSubmit_o_${rowCount}" value="Y" onclick="highlightRow(this,'orderItemData_tableRow_${rowCount}');" />
                                 </td>
                                 <#assign rowCount = rowCount + 1>
                             </#if>


### PR DESCRIPTION
As detailed in [OFBIZ-13376](https://issues.apache.org/jira/browse/OFBIZ-13376), currently, when a PO is received with zero accepted units (e.g., via the ‘ReceiveInventory’ screen), the system creates:

- an inventory item with quantity set to zero
- a receipt with zero accepted units, even when there are no rejected units.

This behavior is not desirable.

When receiving a PO,

- if no item units are accepted, the system should not create an inventory item with zero quantity
- if rejected units are also zero, the system should not create a receipt.

The changes in this PR:

- avoid creating a receipt and an inventory item when both accepted and rejected quantities are zero
- create a receipt, but not an inventory item, when the accepted quantity is zero, but there are rejected units.
