### PR TITLE
Improved: Extend URL_RESOURCE validation to writeDataResourceText, completing the work of af8ee514a2

### DIFF
--- a/applications/content/src/main/java/org/apache/ofbiz/content/data/DataResourceWorker.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/data/DataResourceWorker.java
@@ -1155,6 +1155,7 @@ public class DataResourceWorker implements org.apache.ofbiz.widget.content.DataR
             URL url = FlexibleLocation.resolveLocation(dataResource.getString("objectInfo"));
 
             if (url.getHost() != null) { // is absolute
+                checkUrlResourceAllowed(url);
                 int c;
                 try (InputStream in = url.openStream(); StringWriter sw = new StringWriter()) {
                     while ((c = in.read()) != -1) {


### PR DESCRIPTION
This PR is a completion of the improvements performed in a previous change in the commit af8ee514a2, related to data resource validation. This change extends the existing validation to writeDataResourceText, ensuring consistent URL_RESOURCE handling across both methods in DataResourceWorker.