### PR TITLE
Enable Develocity remote build cache

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -44,7 +44,8 @@ buildCache {
     }
 
     remote(develocity.buildCache) {
-        enabled = false
+        enabled = true
+        push = isCI
     }
 }
 


### PR DESCRIPTION
## Summary

Enable the Develocity remote build cache for all builds. Push is limited to CI (`GITHUB_ACTIONS`), so CI populates the cache and developers benefit from it on local builds.

The remote cache was explicitly disabled (`enabled = false`). This change sets `enabled = true` with `push = isCI`, following the standard Develocity configuration pattern.