### PR TITLE
Improved: Add CORS origins configuration for API security policy (OFBIZ-13377)

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilMisc.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilMisc.java
@@ -617,6 +617,21 @@ public final class UtilMisc {
     }
 
     /**
+     * List of allowed origins for the API CORS policy, read from the
+     * {@code cors.origins.allowed} property in security.properties.
+     * Each entry must be a full origin (scheme + host + optional port),
+     * e.g. {@code https://app.example.com}.
+     * @return unmodifiable list of allowed CORS origins, or null if the property is empty
+     */
+    public static List<String> getCorsOriginsAllowed() {
+        String corsOriginsAllowedString = UtilProperties.getPropertyValue("security", "cors.origins.allowed");
+        if (UtilValidate.isEmpty(corsOriginsAllowedString)) {
+            return null;
+        }
+        return Collections.unmodifiableList(StringUtil.split(corsOriginsAllowedString, ","));
+    }
+
+    /**
      * @deprecated use Thread.sleep()
      */
     @Deprecated

--- a/framework/security/config/security.properties
+++ b/framework/security/config/security.properties
@@ -208,6 +208,14 @@ content.data.url.resource.max.response.size=10485760
 # -- no spaces after commas,no wildcard, can be extended of course...
 host-headers-allowed=localhost,127.0.0.1,demo-trunk.ofbiz.apache.org,demo-stable.ofbiz.apache.org,demo-next.ofbiz.apache.org,demo-trunk.ofbiz-test.apache.org,demo-stable-test.ofbiz.apache.org,demo-next.ofbiz-test.apache.org
 
+# -- Allowed origins for the API CORS policy (Access-Control-Allow-Origin).
+# -- Comma-separated list of origins (scheme + host + optional port), no spaces after commas, no wildcards.
+# -- Only requests whose Origin header exactly matches one of these values will receive
+# -- an Access-Control-Allow-Origin response header echoing that origin.
+# -- Requests from unlisted origins will not receive the header and will be blocked by the browser.
+# -- Example: cors.origins.allowed=https://app.example.com,https://admin.example.com
+cors.origins.allowed=
+
 # -- By default the SameSite value in SameSiteFilter is 'strict'.
 # -- This property allows to change to 'lax' if needed.
 # -- If you use 'lax' we recommend that you set


### PR DESCRIPTION
This PR is related to the issue raised by @gsperi on the dev-list on March 23, 2026 (subject: "rest-api plugin and CORS filter") regarding incorrect management of CORS origins in the rest-api plugin.

To address the issue, this PR:
- introduces the new property cors.origins.allowed in security.properties, allowing the list of permitted origins to be specified;
- adds the new method getCorsOriginsAllowed() to UtilMisc to retrieve the list of allowed origins from cors.origins.allowed.

