### PR TITLE
Improved: introduce and use a new label for product receipts with zero accepted and rejected units (OFBIZ-13376)

### DIFF
--- a/applications/product/config/ProductUiLabels.xml
+++ b/applications/product/config/ProductUiLabels.xml
@@ -23144,6 +23144,19 @@
         <value xml:lang="zh">没有要接收的明细</value>
         <value xml:lang="zh-TW">沒有要接收的細項</value>
     </property>
+    <property key="ProductNoItemsToAcceptOrReject">
+        <value xml:lang="de">Nichts zu verarbeiten: Sowohl akzeptierte als auch abgelehnte Mengen sind null</value>
+        <value xml:lang="en">Nothing to process: both accepted and rejected quantities are zero</value>
+        <value xml:lang="es">Nada que procesar: tanto las cantidades aceptadas como las rechazadas son cero</value>
+        <value xml:lang="fr">Rien à traiter : les quantités acceptées et rejetées sont nulles</value>
+        <value xml:lang="it">Niente da processare: le quantità accettate e rifiutate sono entrambe zero</value>
+        <value xml:lang="ja">処理するものがありません: 受入数量と拒否数量はいずれも0です</value>
+        <value xml:lang="ro">Nimic de procesat: atât cantitățile acceptate, cât și cele respinse sunt zero</value>
+        <value xml:lang="ru">Обрабатывать нечего: и принятое, и отклонённое количество равно нулю</value>
+        <value xml:lang="th">ไม่มีข้อมูลให้ประมวลผล: จำนวนที่ยอมรับและจำนวนที่ปฏิเสธเป็นศูนย์ทั้งคู่</value>
+        <value xml:lang="zh">无可处理：接受数量和拒绝数量均为零</value>
+        <value xml:lang="zh-TW">無可處理項目：接受與拒絕的數量皆為零</value>
+    </property>
     <property key="ProductNoKeywordsFound">
         <value xml:lang="de">Keine Schlüsselwörter gefunden</value>
         <value xml:lang="en">No Keywords Found</value>

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
@@ -79,7 +79,7 @@ Map receiveInventoryProduct () {
     BigDecimal quantityRejected = parameters.quantityRejected ?: BigDecimal.ZERO
     if ((quantityRejected == BigDecimal.ZERO && parameters.quantityAccepted == BigDecimal.ZERO)
         || (quantityRejected  < BigDecimal.ZERO || parameters.quantityAccepted < BigDecimal.ZERO)) {
-        return error(UtilProperties.getMessage('ProductUiLabels', 'ProductNoItemsToReceive',  parameters.locale))
+        return error(UtilProperties.getMessage('ProductUiLabels', 'ProductNoItemsToAcceptOrReject',  parameters.locale))
     }
 
     Map result = success()


### PR DESCRIPTION
This PR improves the message displayed when a receipt has both accepted and rejected quantities set to zero.