### PR TITLE
Fixed: Remove unnecessary string expansion in EmailServices and simplify permission checks in PartyPermissionServices

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyPermissionServices.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyPermissionServices.groovy
@@ -259,9 +259,9 @@ Map cancelPartyInvitationPermissionCheck() {
  */
 Map partyCommunicationEventPermissionCheck() {
     Map result = success()
-    if (parameters.communicationEventTypeId == 'EMAIL_COMMUNICATION' && parameters.mainAction == 'CREATE') {
+    if (parameters.communicationEventTypeId == 'EMAIL_COMMUNICATION') {
         parameters.altPermission = 'PARTYMGR_CME-EMAIL'
-    } else if (parameters.communicationEventTypeId == 'COMMENT_NOTE' && parameters.mainAction == 'CREATE') {
+    } else if (parameters.communicationEventTypeId == 'COMMENT_NOTE') {
         parameters.altPermission = 'PARTYMGR_CME-NOTE'
     } else if (parameters.partyIdFrom != userLogin.partyId
             && parameters.partyIdTo != userLogin.partyId

--- a/framework/common/src/main/java/org/apache/ofbiz/common/email/EmailServices.java
+++ b/framework/common/src/main/java/org/apache/ofbiz/common/email/EmailServices.java
@@ -110,7 +110,6 @@ public class EmailServices {
         }
         Map<String, Object> results = ServiceUtil.returnSuccess();
         String subject = (String) context.get("subject");
-        subject = FlexibleStringExpander.expandString(subject, context);
 
         String partyId = (String) context.get("partyId");
         String body = (String) context.get("body");
@@ -128,7 +127,6 @@ public class EmailServices {
             results.put("returnId", returnId);
         }
         if (UtilValidate.isNotEmpty(body)) {
-            body = FlexibleStringExpander.expandString(body, context);
             results.put("body", body);
         }
         if (UtilValidate.isNotEmpty(bodyParts)) {


### PR DESCRIPTION
Remove unnecessary string expansion for email subject and body in EmailServices
Simplify permission checks for email and comment note communication events in PartyPermissionServices