### PR TITLE
Fixed: Resolve test errors in framework-only deployments by adding spring-web dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -72,6 +72,7 @@ dependencies {
     implementation 'org.freemarker:freemarker:2.3.34' // Remember to change the version number in FreeMarkerWorker class when upgrading. See OFBIZ-10019 if >= 2.4
     implementation 'org.owasp.esapi:esapi:2.7.0.0'
     implementation 'org.springframework:spring-test:6.2.17'
+    implementation 'org.springframework:spring-web:6.2.17'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.2'
     implementation 'oro:oro:2.0.8'
     implementation 'wsdl4j:wsdl4j:1.6.3'


### PR DESCRIPTION
Added spring-web version 6.2.17 to dependencies.gradle.

SimpleMethodTest (in the main source set of framework/testtools) statically initializes MockHttpServletResponse, which at class-load time references org.springframework.http.MediaType from spring-web. spring-web was never declared as a direct dependency, it was only arriving transitively via the LDAP plugin's CAS dependency. Without any plugins, it's missing from the classpath.