### PR TITLE
Revert "Bump docker/login-action from 4.0.0 to 4.1.0"

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: ${{ !env.ACT && vars.DO_DOCKER_PUSH == 'true' }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Reverts apache/ofbiz-framework#1053

The action has not yet been added to the list of approved actions by Infra:

https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml