### PR TITLE
Add ASF allowlist check workflow

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Verifies all GitHub Actions refs are on the ASF allowlist.
+# See https://github.com/apache/infrastructure-actions/blob/main/README.md
+
+name: "ASF Allowlist Check"
+
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    # Intentionally unpinned to always use the latest allowlist from the ASF.
+    - uses: apache/infrastructure-actions/allowlist-check@main


### PR DESCRIPTION
Adds a CI workflow that verifies all `uses: refs` in workflow files are on the ASF allowlist using apache/infrastructure-actions/allowlist-check.

This new workflow triggers on PRs and pushes that modify .github/**

Intentionally pinned to @main to always check against the latest allowlist
