### PR TITLE
Fixed: Canceling an item from the order view and refreshing the page caused promotional items to endlessly duplicate in the ITEM_CREATED status.

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/order/OrderServicesScript.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/order/OrderServicesScript.groovy
@@ -31,7 +31,6 @@ import org.apache.ofbiz.order.shoppingcart.ShoppingCart
 import org.apache.ofbiz.order.shoppingcart.ShoppingCartItem
 
 import java.sql.Timestamp
-
 /**
  * Service to create OrderHeader
  */
@@ -214,21 +213,37 @@ Map recreateOrderAdjustments() {
             // a new order item is created
             GenericValue newOrderItem = makeValue('OrderItem')
             newOrderItem.with {
-                orderId = parameters.orderId
+                orderId = order.get("orderId")
                 orderItemTypeId = item.getItemType()
                 selectedAmount = item.getSelectedAmount()
                 unitPrice = item.getBasePrice()
                 unitListPrice = item.getListPrice()
-                itemDescription = item.getName(dispatcher)
+                itemDescription = item.getDescription()
                 statusId = item.getStatusId()
                 productId = item.getProductId()
                 quantity = item.getQuantity()
                 isModifiedPrice = 'N'
                 isPromo = 'Y'
-                statusId = newOrderItem.statusId ?: 'ITEM_CREATED'
+                statusId = order.statusId == 'ORDER_APPROVED' ? 'ITEM_APPROVED' : 'ITEM_CREATED'
             }
             newOrderItem.orderItemSeqId = delegator.getNextSeqId('OrderItem')
             newOrderItem.create()
+
+            // create the OrderItemShipGroupAssoc
+            int itemIndex = cart.getItemIndex(item)
+            int shipGroupIndex = cart.getItemShipGroupIndex(itemIndex)
+            def csi = cart.getShipInfo(shipGroupIndex)
+            String shipGroupSeqId = csi.getShipGroupSeqId()
+
+            GenericValue newOisga = makeValue('OrderItemShipGroupAssoc')
+            newOisga.with {
+                orderId = order.orderId
+                orderItemSeqId = newOrderItem.orderItemSeqId
+                shipGroupSeqId = shipGroupSeqId
+                quantity = newOrderItem.quantity
+            }
+            newOisga.create()
+
             // And the orderItemSeqId is assigned to the shopping cart item
             item.setOrderItemSeqId(newOrderItem.orderItemSeqId)
         }


### PR DESCRIPTION
Fixed: Canceling an item from the order view and refreshing the page caused promotional items to endlessly duplicate in the ITEM_CREATED status. (OFBIZ-12104)

Explanation: 
1. The recreateOrderAdjustments service created new promotional items but failed to link them to their ship groups (OrderItemShipGroupAssoc). Without this link, the cancellation service could not identify or remove them during subsequent runs, causing items to accumulate.
2. New promotional items were hardcoded to the ITEM_CREATED status, even if the parent order was already ORDER_APPROVED.


Thanks to Rashi Dhagat for reporting issue.
