### PR TITLE
OFBIZ-13215 Fix billing account balance after payment receipt

### DIFF
--- a/applications/order/src/main/java/org/apache/ofbiz/order/OrderManagerEvents.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/OrderManagerEvents.java
@@ -276,6 +276,7 @@ public class OrderManagerEvents {
         // get the current payment prefs
         GenericValue offlineValue = null;
         List<GenericValue> currentPrefs = null;
+        List<GenericValue> billingAccountPrefs = new LinkedList<GenericValue>();
         BigDecimal paymentTally = BigDecimal.ZERO;
         try {
             EntityConditionList<EntityExpr> ecl = EntityCondition.makeCondition(UtilMisc.toList(
@@ -292,22 +293,34 @@ public class OrderManagerEvents {
                 if ("EXT_OFFLINE".equals(paymentMethodType)) {
                     offlineValue = cp;
                 } else {
+                    if ("EXT_BILLACT".equals(paymentMethodType)
+                            && !"PAYMENT_RECEIVED".equals(cp.getString("statusId"))) {
+                        billingAccountPrefs.add(cp);
+                    }
+
                     BigDecimal cpAmt = cp.getBigDecimal("maxAmount");
                     if (cpAmt != null) {
                         paymentTally = paymentTally.add(cpAmt);
                     }
                 }
+                }
             }
-        }
+
 
         // now finish up
         boolean okayToApprove = false;
         if (paymentTally.compareTo(grandTotal) >= 0) {
             // cancel the offline preference
             okayToApprove = true;
+
             if (offlineValue != null) {
                 offlineValue.set("statusId", "PAYMENT_CANCELLED");
                 toBeStored.add(offlineValue);
+            }
+
+            for (GenericValue billingAccountPref : billingAccountPrefs) {
+                billingAccountPref.set("statusId", "PAYMENT_RECEIVED");
+                toBeStored.add(billingAccountPref);
             }
         }
 


### PR DESCRIPTION
Fixed billing account balance update after receiving payment for an order paid through a billing account.

Changes:
- Detect billing account payment preferences using paymentMethodTypeId EXT_BILLACT.
- Mark billing account payment preferences as PAYMENT_RECEIVED when the received payment covers the order total.
- Preserve existing offline payment cancellation behavior.

Tested:
- Created sales order WSCO10010 using billing account 9010.
- Completed/shipped the order.
- Received offline payment for the billing account amount.
- Verified billing account available balance returned to the pre-order balance.

Build:
- ./gradlew.bat compileJava
- git diff --check