### PR TITLE
Fix store payment options iterator

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/entry/StorePaymentOptions.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/entry/StorePaymentOptions.groovy
@@ -25,7 +25,8 @@ productStore = ProductStoreWorker.getProductStore(request)
 productStorePaymentMethodTypeIdMap = [:]
 productStorePaymentSettingList = productStore.getRelated('ProductStorePaymentSetting', null, null, true)
 productStorePaymentSettingIter = productStorePaymentSettingList.iterator()
-while ((productStorePaymentSetting = productStorePaymentSettingIter.next()) != null) {
+while (productStorePaymentSettingIter.hasNext()) {
+    productStorePaymentSetting = productStorePaymentSettingIter.next()
     productStorePaymentMethodTypeIdMap.put(productStorePaymentSetting.get('paymentMethodTypeId'), true)
 }
 context.put('productStorePaymentMethodTypeIdMap', productStorePaymentMethodTypeIdMap)


### PR DESCRIPTION
## Summary
- Guard the ProductStorePaymentSetting iterator with hasNext() before calling next().
- Prevent NoSuchElementException when rendering order entry payment options after the final payment setting row.

## Validation
- git diff --check HEAD~1..HEAD
- Pre-push Gradle hook completed successfully: compileJava, compileGroovy, checkstyleMain, codenarcMain