### PR TITLE
OFBIZ-12561 Remove duplicate payment find action

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -553,9 +553,6 @@ under the License.
     </menu>
 
     <menu name="PaymentTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
-        <menu-item name="findPayment" title="${uiLabelMap.CommonFind}" >
-            <link target="findPayments"/>
-        </menu-item>
         <menu-item name="paymentOverview" title="${uiLabelMap.AccountingPaymentTabOverview}">
             <condition>
                 <not><if-empty field="payment.paymentId"/></not>


### PR DESCRIPTION
### Summary
- Remove the `findPayment` item from `PaymentTabBar`.
- This removes the extra Find action above the Find Payment screen while retaining the search form submit button.

### Issue
- https://issues.apache.org/jira/browse/OFBIZ-12561

### Verification
- `XML_CATALOG_FILES=framework/widget/dtd/widget-catalog.xml xmllint --noout --schema framework/widget/dtd/widget-menu.xsd applications/accounting/widget/AccountingMenus.xml`
- XPath check: `PaymentTabBar` `findPayment` menu item count is `0`
- XPath check: `FindPayments` form `searchButton` submit count is `1`
- Pre-push Gradle hook: `BUILD SUCCESSFUL`