### PR TITLE
Move order PDF link to header actions for 24.09

### DIFF
--- a/applications/order/template/order/OrderInfo.ftl
+++ b/applications/order/template/order/OrderInfo.ftl
@@ -24,9 +24,10 @@ under the License.
                <#assign externalOrder = "(" + orderHeader.externalId + ")"/>
             </#if>
             <#assign orderType = orderHeader.getRelatedOne("OrderType", false)/>
-            <li class="h3">&nbsp;${(orderType.get("description", locale))?default(uiLabelMap.OrderOrder)}&nbsp;${uiLabelMap.CommonNbr}&nbsp;<a href="<@ofbizUrl>orderview?orderId=${orderId}</@ofbizUrl>">${orderId}</a> ${externalOrder!} [&nbsp;<a href="<@ofbizUrl>order.pdf?orderId=${orderId}</@ofbizUrl>" target="_blank">${uiLabelMap.CommonPdf}</a>&nbsp;]</li>
+            <li class="h3">&nbsp;${(orderType.get("description", locale))?default(uiLabelMap.OrderOrder)}&nbsp;${uiLabelMap.CommonNbr}&nbsp;<a href="<@ofbizUrl>orderview?orderId=${orderId}</@ofbizUrl>">${orderId}</a> ${externalOrder!}</li>
             <div class="basic-nav">
               <ul>
+              <li><a href="<@ofbizUrl>order.pdf?orderId=${orderId}</@ofbizUrl>" target="_blank">${uiLabelMap.CommonPdf}</a></li>
             <#if "ORDER_APPROVED" == currentStatus.statusId && "SALES_ORDER" == orderHeader.orderTypeId>
               <li><a href="javascript:document.PrintOrderPickSheet.submit()">${uiLabelMap.FormFieldTitle_printPickSheet}</a>
               <form name="PrintOrderPickSheet" method="post" action="<@ofbizUrl>orderPickSheet.pdf</@ofbizUrl>" target="_BLANK">

--- a/themes/helveticus/webapp/helveticus/helveticus-main-theme.less
+++ b/themes/helveticus/webapp/helveticus/helveticus-main-theme.less
@@ -761,6 +761,7 @@ a.buttontext {
                 }
             }
         }
+        h1 a, .h1 a, h2 a, .h2 a, h3 a, .h3 a { display: inline; }
     }
 
     .screenlet-body {


### PR DESCRIPTION
## Summary
- Backport the order header PDF button placement change to the 24.09 release line.
- Move the order PDF link out of the order title text and into the existing order header action list.
- Keep order title links inline in the Helveticus screenlet header so the order number remains on the same line.

##Issue
- https://issues.apache.org/jira/browse/OFBIZ-13390

## Why
The Helveticus title-bar link styling renders heading links as block elements, which caused the order number and PDF link to wrap awkwardly in the order view header.

## Validation
- git diff --check