### PR TITLE
OFBIZ-12561 Remove duplicate payment find action

### DIFF
--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -553,9 +553,6 @@ under the License.
     </menu>
 
     <menu name="PaymentTabBar" extends="CommonTabBarMenu" extends-resource="component://common/widget/CommonMenus.xml">
-        <menu-item name="findPayment" title="${uiLabelMap.CommonFind}" >
-            <link target="findPayments"/>
-        </menu-item>
         <menu-item name="paymentOverview" title="${uiLabelMap.AccountingPaymentTabOverview}">
             <condition>
                 <not><if-empty field="payment.paymentId"/></not>


### PR DESCRIPTION
### Summary
- Backport the OFBIZ-12561 payment menu cleanup to the `release24.09` branch.
- Remove the `findPayment` item from `PaymentTabBar`, which removes the extra Find action above the Find Payment screen while retaining the search form submit button.

### Verification
- `XML_CATALOG_FILES=framework/widget/dtd/widget-catalog.xml xmllint --noout --schema framework/widget/dtd/widget-menu.xsd applications/accounting/widget/AccountingMenus.xml`
- XPath check: `PaymentTabBar` `findPayment` menu item count is `0`
- XPath check: `FindPayments` form `searchButton` submit count is `1`

### Note
- The local Gradle hook could not complete in this environment because only JDK 11 is installed, while the branch requires Java 17 source compatibility (`invalid source release: 17`).