### PR TITLE
Fixed: IndexOutOfBoundsException in UtilHttp for unlisted TLDs (OFBIZ-13389)

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
@@ -428,14 +428,19 @@ public final class UtilHttp {
                 if (stringValues.length > 0 && !paramEntry.getKey().equals("DUMMYPAGE")) {
                     for (String s : stringValues) {
                         // if the string contains only an URL beginning by http or ftp => no change to keep special chars
-                        if (UtilValidate.isValidUrl(s) && (s.indexOf("://") == 4 || s.indexOf("://") == 3)) {
+                        if (UtilValidate.isValidUrl(s)) {
                             params = params + s + " ";
                         } else if (UtilValidate.isUrlInString(s) && !s.isEmpty()) {
                             // if the string contains not only an URL => concatenate possible canonicalized before and after, w/o changing the URL
-                            String url = extractUrls(s).get(0); // There should be only 1 URL in a block, makes no sense else
-                            int start = s.indexOf(url);
-                            String after = (String) s.subSequence(start + url.length(), s.length());
-                            params = params + canonicalizeParameter((String) s.subSequence(0, start)) + url + canonicalizeParameter(after) + " ";
+                            List<String> extractedUrls = extractUrls(s);
+                            if (!extractedUrls.isEmpty()) {
+                                String url = extractedUrls.get(0); // There should be only 1 URL in a block, makes no sense else
+                                int start = s.indexOf(url);
+                                String after = (String) s.subSequence(start + url.length(), s.length());
+                                params = params + canonicalizeParameter((String) s.subSequence(0, start)) + url + canonicalizeParameter(after) + " ";
+                            } else {
+                                params = params + canonicalizeParameter(s) + " ";
+                            }
                         } else {
                             // Simple string to canonicalize
                             params = params + canonicalizeParameter(s) + " ";
@@ -1774,9 +1779,7 @@ public final class UtilHttp {
 
         Pattern pattern = Pattern.compile(
                 "\\b(((ht|f)tp(s?)\\:\\/\\/|~\\/|\\/)|www.)"
-                        + "(\\w+:\\w+@)?(([-\\w]+\\.)+(com|org|net|gov"
-                        + "|mil|biz|info|mobi|name|aero|jobs|museum"
-                        + "|travel|[a-z]{2}))(:[\\d]{1,5})?"
+                        + "(\\w+:\\w+@)?(([-\\w]+\\.)+([a-zA-Z]{2,}))(:[\\d]{1,5})?"
                         + "(((\\/([-\\w~!$+|.,=]|%[a-f\\d]{2})+)+|\\/)+|\\?|#)?"
                         + "((\\?([-\\w~!$+|.,*:]|%[a-f\\d{2}])+=?"
                         + "([-\\w~!$+|.,*:=]|%[a-f\\d]{2})*)"
@@ -1794,7 +1797,10 @@ public final class UtilHttp {
         if (result.isEmpty()) {
             Matcher matcher = pattern.matcher(input);
             while (matcher.find()) {
-                result.add(matcher.group());
+                String candidate = matcher.group();
+                if (UtilValidate.isValidUrl(candidate)) {
+                    result.add(candidate);
+                }
             }
         }
 


### PR DESCRIPTION
Fixed: IndexOutOfBoundsException in UtilHttp for unlisted TLDs (OFBIZ-13389).

- Exact URL match had redundant indexOf checks for protocols which `UtilValidate.isValidUrl()` already validates, causing https urls to slip thru. Removed redundant checks.
- The `extractUrls()` regex had a hardcoded list of TLDs, made the regex generic and validating the URL with `UtilValidate.isValidUrl()` now.
- Added empty check to avoid `IndexOutOfBoundsException`.

Thanks: Vitaly Repetenko for reporting the issue.
