### PR TITLE
Fixed payment accounting transaction PDF route for 24.09 (OFBIZ-12818)

### DIFF
--- a/applications/accounting/webapp/accounting/WEB-INF/controller.xml
+++ b/applications/accounting/webapp/accounting/WEB-INF/controller.xml
@@ -408,6 +408,10 @@ under the License.
         <security https="true" auth="true"/>
         <response name="success" type="view" value="InvoiceAcctgTransEntriesPdf"/>
     </request-map>
+    <request-map uri="PaymentAcctgTransEntriesPdf">
+        <security https="true" auth="true"/>
+        <response name="success" type="view" value="AcctgTransEntriesSearchResultsPdf"/>
+    </request-map>
 
     <request-map uri="FindSalesInvoicesByDueDate">
         <security https="true" auth="true"/>


### PR DESCRIPTION
## Summary
- Restores the `PaymentAcctgTransEntriesPdf` controller request on the 24.09 release branch.
- Routes the payment PDF action to the existing FOP `AcctgTransEntriesSearchResultsPdf` view.
- Keeps the existing payment menu target working while avoiding the removed BIRT route.

JIRA: https://issues.apache.org/jira/browse/OFBIZ-12818

## Verification
- `ruby -rrexml/document -e ...` confirmed the payment request maps to the existing `screenfop` view.
- `git diff --check origin/release24.09..HEAD`
