### PR TITLE
OFBIZ-13409 : Eliminate redundant sort-field declarations in ProductForms

### DIFF
--- a/applications/product/widget/catalog/ProductForms.xml
+++ b/applications/product/widget/catalog/ProductForms.xml
@@ -306,8 +306,6 @@ under the License.
                 <sort-field name="shippingWeight"/>
                 <sort-field name="quantityIncluded"/>
                 <sort-field name="quantityUomId"/>
-                <sort-field name="quantityIncluded"/>
-                <sort-field name="quantityUomId"/>
             </field-group>
             <field-group title="${uiLabelMap.CommonShipping}" collapsible="true" initially-collapsed="true">
                 <sort-field name="piecesIncluded"/>


### PR DESCRIPTION
OFBIZ-13409 : Removed redundant <sort-field> entries for quantityIncluded and quantityUomId in the [ProductForms].