### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,8 +15,8 @@
 
 github:
   description: "Apache OFBiz is an open source product for the automation of enterprise processes. It includes framework components and business applications for ERP, CRM, E-Business/E-Commerce, Supply Chain Management and Manufacturing Resource Planning. OFBiz provides a foundation and starting point for reliable, secure and scalable enterprise solutions."
-  homepage:  https://ofbiz.apache.org/
-  dependabot_alerts:  true
+  homepage: https://ofbiz.apache.org/
+  dependabot_alerts: true
   dependabot_updates: false
   labels:
     - ofbiz
@@ -34,18 +34,31 @@ github:
     - hacktoberfest
   enabled_merge_buttons:
     # enable squash button:
-    squash:  true
+    squash: true
     # default commit message when merging with a squash commit
     # can either be: DEFAULT | PR_TITLE | PR_TITLE_AND_COMMIT_DETAILS | PR_TITLE_AND_DESC
     squash_commit_message: PR_TITLE_AND_DESC
     # enable merge button:
-    merge:   true
+    merge: true
     # default commit message when merging with a merge commit
     # can either be: DEFAULT | PR_TITLE | PR_TITLE_AND_DESC
     merge_commit_message: PR_TITLE_AND_DESC
     # enable rebase button:
-    rebase:  true
+    rebase: true
 
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
-  jobs:  notifications@ofbiz.apache.org
+  jobs: notifications@ofbiz.apache.org
   jira_options: link label

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file is used to configure ASF GitHub repositories.
+# It is used by the ASF GitHub bot to automate various tasks such as labeling,
+# merging, and notifications.
+# For more information, see https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
+
 github:
   description: "Apache OFBiz is an open source product for the automation of enterprise processes. It includes framework components and business applications for ERP, CRM, E-Business/E-Commerce, Supply Chain Management and Manufacturing Resource Planning. OFBiz provides a foundation and starting point for reliable, secure and scalable enterprise solutions."
   homepage: https://ofbiz.apache.org/
@@ -32,20 +37,13 @@ github:
     - content
     - geospatial
     - hacktoberfest
+  
   enabled_merge_buttons:
-    # enable squash button:
-    squash: true
-    # default commit message when merging with a squash commit
-    # can either be: DEFAULT | PR_TITLE | PR_TITLE_AND_COMMIT_DETAILS | PR_TITLE_AND_DESC
-    squash_commit_message: PR_TITLE_AND_DESC
-    # enable merge button:
-    merge: true
-    # default commit message when merging with a merge commit
-    # can either be: DEFAULT | PR_TITLE | PR_TITLE_AND_DESC
-    merge_commit_message: PR_TITLE_AND_DESC
-    # enable rebase button:
+    merge: false
     rebase: true
-
+    squash: true
+    squash_commit_message: PR_TITLE_AND_DESC
+  
   rulesets:
     - name: "Default Branch Protection"
       type: branch

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,8 +21,6 @@
 github:
   description: "Apache OFBiz is an open source product for the automation of enterprise processes. It includes framework components and business applications for ERP, CRM, E-Business/E-Commerce, Supply Chain Management and Manufacturing Resource Planning. OFBiz provides a foundation and starting point for reliable, secure and scalable enterprise solutions."
   homepage: https://ofbiz.apache.org/
-  dependabot_alerts: true
-  dependabot_updates: false
   labels:
     - ofbiz
     - plugins
@@ -57,6 +55,9 @@ github:
       restrict_deletion: true
       restrict_force_push: true
       required_linear_history: true
+
+  dependabot_alerts: true
+  dependabot_updates: false
 
 notifications:
   jobs: notifications@ofbiz.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -60,5 +60,9 @@ github:
   dependabot_updates: false
 
 notifications:
+  commits: commits@ofbiz.apache.org
+  discussions: notifications@ofbiz.apache.org # discussions are not used, but we want to be notified if they are created
+  issues: notifications@ofbiz.apache.org # issues are not used, but we want to be notified if they are created
+  pullrequests: notifications@ofbiz.apache.org
   jobs: notifications@ofbiz.apache.org
-  jira_options: link label
+  jira_options: link label # if a JIRA issue is mentioned in the title of a pull request, add to the JIRA issue a comment with a link to the pull request and add the "has-pull-request" label to the JIRA issue

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,13 +52,14 @@ github:
       branches:
         includes:
           - "~DEFAULT_BRANCH"
-          - "release/*"
-          - "rel/*"
+          - "release*"
         excludes: []
       bypass_teams:
         - root
       restrict_deletion: true
       restrict_force_push: true
+      required_linear_history: true
+
 notifications:
   jobs: notifications@ofbiz.apache.org
   jira_options: link label


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
