### PR TITLE
Adding the latest stable version of H2 database. The ./gradlew cleanA…

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -97,7 +97,7 @@ dependencies {
     runtimeOnly 'org.apache.avalon.framework:avalon-framework-impl:4.3.1'
     runtimeOnly 'org.apache.axis2:axis2-transport-http:1.8.2'
     runtimeOnly 'org.apache.axis2:axis2-transport-local:1.8.2'
-    runtimeOnly 'com.h2database:h2:2.2.224'
+    runtimeOnly 'com.h2database:h2:2.4.240'
     runtimeOnly 'org.apache.geronimo.specs:geronimo-jaxrpc_1.1_spec:2.1'
     runtimeOnly 'org.apache.logging.log4j:log4j-1.2-api:2.25.4' // for external jars using the old log4j1.2: routes logging to log4j 2
     runtimeOnly 'org.apache.logging.log4j:log4j-jul:2.25.4' // for external jars using the java.util.logging: routes logging to log4j 2


### PR DESCRIPTION
…ll loadAll is getting completed in 56 seconds for me. So I will say the latest version is faster than the previous version.

-    runtimeOnly 'com.h2database:h2:2.2.224'
+    runtimeOnly 'com.h2database:h2:2.4.240'

2026-05-16 23:54:23,778 |main                 |JobPoller                     |I| Shutting down JobPoller.
2026-05-16 23:54:23,778 |OFBiz-JobPoller      |JobPoller                     |I| JobPoller thread started.
2026-05-16 23:54:23,778 |main                 |JobPoller                     |I| JobPoller shutdown completed.
2026-05-16 23:54:23,778 |OFBiz-JobPoller      |JobPoller                     |I| JobPoller thread stopped.
2026-05-16 23:54:23,778 |main                 |ServiceContainer              |I| Removing from cache dispatcher: entity-default
2026-05-16 23:54:23,778 |main                 |ServiceDispatcher             |I| De-Registering dispatcher: entity-default
2026-05-16 23:54:23,778 |main                 |ServiceDispatcher             |I| Shutting down the service engine...
2026-05-16 23:54:23,778 |main                 |ContainerLoader               |I| Stopped container service-container
2026-05-16 23:54:23,778 |main                 |ContainerLoader               |I| Stopping container component-container
2026-05-16 23:54:23,778 |main                 |ContainerLoader               |I| Stopped container component-container
2026-05-16 23:54:23,778 |xer_default_products |DocumentIndexer               |I| DocumentIndexer_default_products: indexed Lucene document: productId:dropShip3
2026-05-16 23:54:23,779 |xer_default_products |DocumentIndexer               |I| DocumentIndexer_default_products: indexed Lucene document: productId:dropShip3

> Task :loadAll

[Incubating] Problems report is available at: file:///Users/ashish/ofbiz-dev/ofbiz-trunk/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 56s
38 actionable tasks: 24 executed, 14 up-to-date
ashish@Ashish-Vijaywargiya ofbiz-trunk % ./gradlew cleanAll loadAll

