### PR TITLE
Replace generic updateOrRemove service with ProductFeatureDataResource-specific service

### DIFF
--- a/applications/content/servicedef/services.xml
+++ b/applications/content/servicedef/services.xml
@@ -500,28 +500,12 @@
         <attribute mode="IN" name="contentId" optional="true" type="String"/>
     </service>
 
-    <service name="updateOrRemove" engine="java"
-        location="org.apache.ofbiz.content.ContentManagementServices" invoke="updateOrRemove" auth="true" validate="false">
-        <description>Update or remove a child entity based on value of "action"</description>
-        <attribute name="entityName" type="String" mode="IN" optional="false">
-            <type-validate>
-                <fail-property resource="ContentErrorUiLabels" property="ContentRequiredFieldMissingEntityName"/>
-            </type-validate>
-        </attribute>
+    <service name="createOrRemoveProductFeatureDataResource" engine="java"
+             location="org.apache.ofbiz.content.ContentManagementServices" invoke="createOrRemoveProductFeatureDataResource" auth="true" validate="false">
+        <description>Create or remove ProductFeatureDataResource based on value of "action"</description>
         <attribute name="action" type="String" mode="IN" optional="true"/>
-        <attribute name="pkFieldCount" type="String" mode="IN" optional="false">
-            <type-validate>
-                <fail-property resource="ContentErrorUiLabels" property="ContentRequiredFieldMissingPkFieldCount"/>
-            </type-validate>
-        </attribute>
-        <attribute name="fieldName0" type="String" mode="IN" optional="true"/>
-        <attribute name="fieldValue1" type="String" mode="IN" optional="true"/>
-        <attribute name="fieldName2" type="String" mode="IN" optional="true"/>
-        <attribute name="fieldValue2" type="String" mode="IN" optional="true"/>
-        <attribute name="fieldName3" type="String" mode="IN" optional="true"/>
-        <attribute name="fieldValue3" type="String" mode="IN" optional="true"/>
-        <attribute name="fieldName1" type="String" mode="IN" optional="true"/>
-        <attribute name="fieldValue0" type="String" mode="IN" optional="true"/>
+        <attribute name="productFeatureId" type="String" mode="IN"/>
+        <attribute name="dataResourceId" type="String" mode="IN"/>
     </service>
 
     <service name="resequence" auth="true" engine="group">

--- a/applications/content/src/main/java/org/apache/ofbiz/content/ContentManagementServices.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/ContentManagementServices.java
@@ -797,58 +797,41 @@ public class ContentManagementServices {
         return results;
     }
 
-    public static Map<String, Object> updateOrRemove(DispatchContext dctx, Map<String, ? extends Object> context) {
-        Map<String, Object> results = new HashMap<>();
+    /**
+     * Creates or removes a link between a product feature and a data resource based on the provided action.
+     *
+     * @param dctx The DispatchContext instance providing access to the delegator and other utilities.
+     * @param context A map containing the following keys:
+     *                - productFeatureId (String): The ID of the product feature.
+     *                - dataResourceId (String): The ID of the data resource.
+     *                - action (String): Indicates whether to create or remove the link. Use "Y" for create, otherwise the link is removed.
+     * @return A map containing the results of the operation. In case of an error, returns a map with an error message.
+     */
+    public static Map<String, Object> createOrRemoveProductFeatureDataResource(DispatchContext dctx, Map<String, ? extends Object> context) {
         Delegator delegator = dctx.getDelegator();
-        String entityName = (String) context.get("entityName");
+        String productFeatureId = (String) context.get("productFeatureId");
+        String dataResourceId = (String) context.get("dataResourceId");
         String action = (String) context.get("action");
-        String pkFieldCount = (String) context.get("pkFieldCount");
-        Map<String, String> pkFields = new HashMap<>();
-        int fieldCount = Integer.parseInt(pkFieldCount);
-        for (int i = 0; i < fieldCount; i++) {
-            String fieldName = (String) context.get("fieldName" + i);
-            String fieldValue = (String) context.get("fieldValue" + i);
-            if (UtilValidate.isEmpty(fieldValue)) {
-                // It may be the case that the last row in a form is "empty" waiting for
-                // someone to enter a value, in which case we do not want to throw an
-                // error, we just want to ignore it.
-                return results;
-            }
-            pkFields.put(fieldName, fieldValue);
-        }
         boolean doLink = "Y".equalsIgnoreCase(action);
-        if (Debug.infoOn()) {
-            Debug.logInfo("in updateOrRemove, context:" + context, MODULE);
-        }
         try {
-            GenericValue entityValuePK = delegator.makeValue(entityName, pkFields);
-            if (Debug.infoOn()) {
-                Debug.logInfo("in updateOrRemove, entityValuePK:" + entityValuePK, MODULE);
-            }
-            GenericValue entityValueExisting = EntityQuery.use(delegator).from(entityName).where(entityValuePK).cache().queryOne();
-            if (Debug.infoOn()) {
-                Debug.logInfo("in updateOrRemove, entityValueExisting:" + entityValueExisting, MODULE);
-            }
+            GenericValue entityValuePK = delegator.makeValue("ProductFeatureDataResource",
+                    UtilMisc.toMap("productFeatureId", productFeatureId, "dataResourceId", dataResourceId));
+
+            GenericValue entityValueExisting = EntityQuery.use(delegator).from("ProductFeatureDataResource")
+                    .where("productFeatureId", productFeatureId, "dataResourceId", dataResourceId).cache().queryOne();
+
             if (entityValueExisting == null) {
                 if (doLink) {
                     entityValuePK.create();
-                    if (Debug.infoOn()) {
-                        Debug.logInfo("in updateOrRemove, entityValuePK: CREATED", MODULE);
-                    }
                 }
-            } else {
-                if (!doLink) {
-                    entityValueExisting.remove();
-                    if (Debug.infoOn()) {
-                        Debug.logInfo("in updateOrRemove, entityValueExisting: REMOVED", MODULE);
-                    }
-                }
+            } else if (!doLink) {
+                entityValueExisting.remove();
             }
         } catch (GenericEntityException e) {
             Debug.logError(e, MODULE);
             return ServiceUtil.returnError(e.toString());
         }
-        return results;
+        return ServiceUtil.returnSuccess();
     }
 
     /**

--- a/applications/content/template/cms/CMSContentEdit.ftl
+++ b/applications/content/template/cms/CMSContentEdit.ftl
@@ -111,12 +111,8 @@ under the License.
                        <tr>
                           <td class="">[${feature.productFeatureId}] - ${feature.description}</td>
                           <td class=""><input type="checkbox" name="action_o_${rowCount}" value="Y" ${checked}/></td>
-                          <input type="hidden" name="fieldName0_o_${rowCount}" value="productFeatureId"/>
-                          <input type="hidden" name="fieldValue0_o_${rowCount}" value="${feature.productFeatureId}"/>
-                          <input type="hidden" name="fieldName1_o_${rowCount}" value="dataResourceId"/>
-                          <input type="hidden" name="fieldValue1_o_${rowCount}" value="${feature.dataResourceId}"/>
-                          <input type="hidden" name="entityName_o_${rowCount}" value="ProductFeatureDataResource"/>
-                          <input type="hidden" name="pkFieldCount_o_${rowCount}" value="2"/>
+                          <input type="hidden" name="productFeatureId_o_${rowCount}" value="${feature.productFeatureId}"/>
+                          <input type="hidden" name="dataResourceId_o_${rowCount}" value="${feature.dataResourceId}"/>
                        </tr>
                        <#assign rowCount=rowCount + 1/>
                     </#list>
@@ -126,12 +122,8 @@ under the License.
                           <@htmlTemplate.lookupField formName="updatefeatures" name="fieldValue0_o_${rowCount}" id="fieldValue0_o_${rowCount}" fieldFormName="LookupProductFeature"/>
                         </div>
                       </td>
-                          <input type="hidden" name="fieldName0_o_${rowCount}" value="productFeatureId"/>
-                          <input type="hidden" name="fieldValue0_o_${rowCount}" value=""/>
-                          <input type="hidden" name="fieldName1_o_${rowCount}" value="dataResourceId"/>
-                          <input type="hidden" name="fieldValue1_o_${rowCount}" value="${dataResourceId}"/>
-                          <input type="hidden" name="entityName_o_${rowCount}" value="ProductFeatureDataResource"/>
-                          <input type="hidden" name="pkFieldCount_o_${rowCount}" value="2"/>
+                          <input type="hidden" name="productFeatureId_o_${rowCount}" value=""/>
+                          <input type="hidden" name="dataResourceId_o_${rowCount}" value="${dataResourceId}"/>
                           <#assign rowCount=rowCount + 1/>
                     </tr>
                     <tr>

--- a/applications/content/webapp/content/WEB-INF/controller.xml
+++ b/applications/content/webapp/content/WEB-INF/controller.xml
@@ -1561,7 +1561,7 @@ under the License.
     </request-map>
     <request-map uri="updateFeatures">
         <security https="true" auth="true"/>
-        <event type="service-multi" invoke="updateOrRemove"/>
+        <event type="service-multi" invoke="createOrRemoveProductFeatureDataResource"/>
         <response name="success" type="view" value="CMSContentEdit"/>
         <response name="error" type="view" value="CMSContentEdit"/>
     </request-map>


### PR DESCRIPTION
Replaced the ambiguous updateOrRemove service with a dedicated createOrRemoveProductFeatureDataResource service for managing CMS product feature data resource links.

- Added explicit productFeatureId and dataResourceId service parameters
- Removed generic entityName, pkFieldCount, fieldName, and fieldValue handling
- Simplified ProductFeatureDataResource create/remove logic
- Updated CMSContentEdit.ftl to submit defined service parameters
- Updated updateFeatures controller event to invoke the new service