### PR TITLE
OFBIZ-13413 - Fix JdbcSQLDataException during startup caused by null table parameter in getPrimaryKeys

### DIFF
--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/jdbc/DatabaseUtil.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/jdbc/DatabaseUtil.java
@@ -1228,19 +1228,11 @@ public class DatabaseUtil {
 
                     // first try getting all at once for databases that support that and can generally perform WAY better, if that fails get one at
                     // a time so it will at least work
-                    try (ResultSet rsPks = dbData.getPrimaryKeys(null, lookupSchemaName, null)) {
+                    try (ResultSet rsPks = dbData.getPrimaryKeys(null, lookupSchemaName, "%")) {
                         pkCount += checkPrimaryKeyInfo(rsPks, lookupSchemaName, needsUpperCase, colInfo, messages);
                     } catch (Exception e1) {
-                        Debug.logInfo("Error getting primary key info from database with null tableName, will try other means: " + e1.toString(),
+                        Debug.logInfo("Error getting primary key info from database with % tableName, will try other means: " + e1.toString(),
                                       MODULE);
-                    }
-                    if (pkCount == 0) {
-                        try (ResultSet rsPks = dbData.getPrimaryKeys(null, lookupSchemaName, "%")) {
-                            pkCount += checkPrimaryKeyInfo(rsPks, lookupSchemaName, needsUpperCase, colInfo, messages);
-                        } catch (Exception e1) {
-                            Debug.logInfo("Error getting primary key info from database with % tableName, will try other means: " + e1.toString(),
-                                          MODULE);
-                        }
                     }
                     if (pkCount == 0) {
                         Debug.logInfo("Searching in " + tableNames.size() + " tables for primary key fields ...", MODULE);


### PR DESCRIPTION
Fixed: Here is the fix to remove the null parameter attempt entirely and use the "%" wildcard as our primary optimization path. This preserves performance for databases that accept wildcards, while allowing strict databases to silently return zero rows and gracefully fall back to compliant table-by-table iteration without polluting the logs with stack traces.

While some database drivers tolerate a null argument here, the official JDBC specification mandates that this parameter must be an exact table name. Because H2 enforces this specification strictly, it throws an exception before OFBiz eventually catches it and falls back to querying tables individually.

This commit will fix the following error/warnings returned on the console:

2026-05-17 23:51:35,252 |OFBiz-batch-2        |DatabaseUtil                  |I| Getting Column Info From Database
2026-05-17 23:51:35,252 |OFBiz-batch-1        |DatabaseUtil                  |I| Error getting primary key info from database with null tableName, will try other means: org.h2.jdbc.JdbcSQLDataException: Invalid value "null" for parameter "table" [90008-240]
2026-05-17 23:51:35,252 |OFBiz-batch-1        |DatabaseUtil                  |I| Searching in 7 tables for primary key fields ...
2026-05-17 23:51:35,252 |OFBiz-batch-1        |DatabaseUtil                  |I| Reviewed 9 primary key fields from database.
2026-05-17 23:51:35,253 |OFBiz-batch-3        |DatabaseUtil                  |I| Error getting primary key info from database with null tableName, will try other means: org.h2.jdbc.JdbcSQLDataException: Invalid value "null" for parameter "table" [90008-240]
2026-05-17 23:51:35,253 |OFBiz-batch-3        |DatabaseUtil                  |I| Searching in 6 tables for primary key fields ...
2026-05-17 23:51:35,253 |OFBiz-batch-3        |DatabaseUtil                  |I| Reviewed 8 primary key fields from database.
2026-05-17 23:51:35,268 |OFBiz-batch-2        |DatabaseUtil                  |I| Error getting primary key info from database with null tableName, will try other means: org.h2.jdbc.JdbcSQLDataException: Invalid value "null" for parameter "table" [90008-240]
2026-05-17 23:51:35,268 |OFBiz-batch-2        |DatabaseUtil                  |I| Searching in 870 tables for primary key fields ...
2026-05-17 23:51:35,274 |OFBiz-batch-2        |DatabaseUtil                  |I| Reviewed 1697 primary key fields from database.
