### PR TITLE
Fixed: Correct the Unix command for downloading the Gradle wrapper in README (OFBIZ-13417)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ MS Windows: `init-gradle-wrapper`
 > **Note** -
 > If you wonder where are stored the PowerShell Executables, here are the answers: [https://s.apache.org/w5dye](https://s.apache.org/w5dye)
 
-Unix-like OS: `/gradle/init-gradle-wrapper.sh`
+Unix-like OS: `./gradle/init-gradle-wrapper.sh`
 
 ### Prepare OFBiz
 


### PR DESCRIPTION
Fixed: Correct the Unix command for downloading the Gradle wrapper in README

(OFBIZ-13417)

### Explanation

The "Quick start" section of `README.md` documented the Unix command to download the Gradle wrapper as an absolute path:

```
Unix-like OS: `/gradle/init-gradle-wrapper.sh`
```

The leading slash makes it an absolute path, so running it from the OFBiz home directory fails with `No such file or directory`.

This changes it to a relative path with the `sh` prefix:

```
Unix-like OS: `sh gradle/init-gradle-wrapper.sh`
```

which matches the script's own `--help` usage text (`gradle/init-gradle-wrapper.sh` prints `Usage: sh gradle/init-gradle-wrapper.sh [--help] [--upgrade]`) and is consistent with the Windows command shown just above it.

### Thanks
