### PR TITLE
Move EntityPermissionChecker from framework/entityext to application/content (OFBIZ-13393)

### DIFF
--- a/applications/content/src/main/java/org/apache/ofbiz/content/ContentManagementWorker.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/ContentManagementWorker.java
@@ -49,7 +49,7 @@ import org.apache.ofbiz.entity.condition.EntityCondition;
 import org.apache.ofbiz.entity.condition.EntityOperator;
 import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.entity.util.EntityUtil;
-import org.apache.ofbiz.entityext.permission.EntityPermissionChecker;
+import org.apache.ofbiz.content.permission.EntityPermissionChecker;
 import org.apache.ofbiz.minilang.MiniLangException;
 import org.apache.ofbiz.security.Security;
 

--- a/applications/content/src/main/java/org/apache/ofbiz/content/content/ContentPermissionServices.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/content/ContentPermissionServices.java
@@ -34,7 +34,7 @@ import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityQuery;
-import org.apache.ofbiz.entityext.permission.EntityPermissionChecker;
+import org.apache.ofbiz.content.permission.EntityPermissionChecker;
 import org.apache.ofbiz.security.Security;
 import org.apache.ofbiz.service.DispatchContext;
 import org.apache.ofbiz.service.GenericServiceException;

--- a/applications/content/src/main/java/org/apache/ofbiz/content/permission/EntityPermissionChecker.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/permission/EntityPermissionChecker.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  *******************************************************************************/
-package org.apache.ofbiz.entityext.permission;
+package org.apache.ofbiz.content.permission;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/applications/content/src/main/java/org/apache/ofbiz/content/webapp/ftl/CheckPermissionTransform.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/webapp/ftl/CheckPermissionTransform.java
@@ -36,7 +36,7 @@ import org.apache.ofbiz.content.content.ContentWorker;
 import org.apache.ofbiz.content.content.PermissionRecorder;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericValue;
-import org.apache.ofbiz.entityext.permission.EntityPermissionChecker;
+import org.apache.ofbiz.content.permission.EntityPermissionChecker;
 import org.apache.ofbiz.security.Security;
 import org.apache.ofbiz.service.ModelService;
 import org.apache.ofbiz.webapp.ftl.LoopWriter;

--- a/framework/widget/dtd/widget-common.xsd
+++ b/framework/widget/dtd/widget-common.xsd
@@ -27,7 +27,6 @@ under the License.
             <xs:element ref="not" />
             <xs:element ref="if-service-permission" />
             <xs:element ref="if-has-permission" />
-            <xs:element ref="if-entity-permission" />
             <xs:element ref="if-validate-method" />
             <xs:element ref="if-compare" />
             <xs:element ref="if-compare-field" />
@@ -85,28 +84,6 @@ under the License.
         <xs:complexType>
             <xs:attribute type="xs:string" name="permission" use="required" />
             <xs:attribute type="xs:string" name="action" />
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="if-entity-permission" substitutionGroup="AllConditionals">
-        <xs:complexType>
-            <xs:choice minOccurs="0">
-                <xs:element minOccurs="0" maxOccurs="1" ref="permission-condition-getter" />
-                <xs:element minOccurs="0" maxOccurs="1" ref="related-role-getter" />
-                <xs:element minOccurs="0" maxOccurs="1" ref="auxiliary-value-getter" />
-            </xs:choice>
-            <xs:attribute type="xs:string" name="entity-name" use="required" />
-            <xs:attribute type="xs:string" name="entity-id" use="required">
-                <xs:annotation>
-                    <xs:documentation>Can have multiple pipe separated values, but don't use spaces.</xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute type="xs:string" name="target-operation" use="required">
-                <xs:annotation>
-                    <xs:documentation>Can have multiple pipe separated values, but don't use spaces.</xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attribute name="display-fail-cond" type="xs:boolean"
-                          default="false"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="permission-condition-getter">

--- a/framework/widget/dtd/widget-screen.xsd
+++ b/framework/widget/dtd/widget-screen.xsd
@@ -63,7 +63,6 @@ under the License.
             <xs:element ref="not" />
             <xs:element ref="if-service-permission" />
             <xs:element ref="if-has-permission" />
-            <xs:element ref="if-entity-permission" />
             <xs:element ref="if-validate-method" />
             <xs:element ref="if-compare" />
             <xs:element ref="if-compare-field" />

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/AbstractModelCondition.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/AbstractModelCondition.java
@@ -38,7 +38,6 @@ import org.apache.ofbiz.base.util.UtilXml;
 import org.apache.ofbiz.base.util.collections.FlexibleMapAccessor;
 import org.apache.ofbiz.base.util.string.FlexibleStringExpander;
 import org.apache.ofbiz.entity.GenericValue;
-import org.apache.ofbiz.entityext.permission.EntityPermissionChecker;
 import org.apache.ofbiz.minilang.operation.BaseCompare;
 import org.apache.ofbiz.security.Security;
 import org.apache.ofbiz.service.DispatchContext;
@@ -209,8 +208,6 @@ public abstract class AbstractModelCondition implements Serializable, ModelCondi
                 return new IfRegexp(factory, modelWidget, conditionElement);
             } else if ("if-empty".equals(nodeName)) {
                 return new IfEmpty(factory, modelWidget, conditionElement);
-            } else if ("if-entity-permission".equals(nodeName)) {
-                return new IfEntityPermission(factory, modelWidget, conditionElement);
             } else {
                 throw new IllegalArgumentException("Condition element not supported with name: " + conditionElement.getNodeName());
             }
@@ -404,33 +401,6 @@ public abstract class AbstractModelCondition implements Serializable, ModelCondi
             return fieldAcsr;
         }
 
-    }
-
-    /**
-     * Models the &lt;if-entity-permission&gt; element.
-     * @see <code>widget-common.xsd</code>
-     */
-    public static final class IfEntityPermission extends AbstractModelCondition {
-        private final EntityPermissionChecker permissionChecker;
-
-        private IfEntityPermission(ModelConditionFactory factory, ModelWidget modelWidget, Element condElement) {
-            super(factory, modelWidget, condElement);
-            this.permissionChecker = new EntityPermissionChecker(condElement);
-        }
-
-        @Override
-        public void accept(ModelConditionVisitor visitor) throws Exception {
-            visitor.visit(this);
-        }
-
-        @Override
-        public boolean eval(Map<String, Object> context) {
-            return permissionChecker.runPermissionCheck(context);
-        }
-
-        public EntityPermissionChecker getPermissionChecker() {
-            return permissionChecker;
-        }
     }
 
     /**

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelConditionVisitor.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelConditionVisitor.java
@@ -22,7 +22,6 @@ import org.apache.ofbiz.widget.model.AbstractModelCondition.And;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfCompare;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfCompareField;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfEmpty;
-import org.apache.ofbiz.widget.model.AbstractModelCondition.IfEntityPermission;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfHasPermission;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfRegexp;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfServicePermission;
@@ -44,8 +43,6 @@ public interface ModelConditionVisitor {
     void visit(IfCompareField ifCompareField) throws Exception;
 
     void visit(IfEmpty ifEmpty) throws Exception;
-
-    void visit(IfEntityPermission ifEntityPermission) throws Exception;
 
     void visit(IfHasPermission ifHasPermission) throws Exception;
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelWidgetCondition.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelWidgetCondition.java
@@ -38,7 +38,6 @@ import org.apache.ofbiz.base.util.UtilXml;
 import org.apache.ofbiz.base.util.collections.FlexibleMapAccessor;
 import org.apache.ofbiz.base.util.string.FlexibleStringExpander;
 import org.apache.ofbiz.entity.GenericValue;
-import org.apache.ofbiz.entityext.permission.EntityPermissionChecker;
 import org.apache.ofbiz.minilang.operation.BaseCompare;
 import org.apache.ofbiz.security.Security;
 import org.apache.ofbiz.service.DispatchContext;
@@ -181,8 +180,6 @@ public abstract class ModelWidgetCondition implements Serializable {
                 return new IfRegexp(this, modelWidget, conditionElement);
             } else if ("if-empty".equals(nodeName)) {
                 return new IfEmpty(this, modelWidget, conditionElement);
-            } else if ("if-entity-permission".equals(nodeName)) {
-                return new IfEntityPermission(this, modelWidget, conditionElement);
             } else {
                 throw new IllegalArgumentException("Condition element not supported with name: " + nodeName);
             }
@@ -315,24 +312,6 @@ public abstract class ModelWidgetCondition implements Serializable {
         public boolean eval(Map<String, Object> context) {
             Object fieldVal = this.fieldAcsr.get(context);
             return ObjectType.isEmpty(fieldVal);
-        }
-    }
-
-    /**
-     * Models the &lt;if-entity-permission&gt; element.
-     * @see <code>widget-common.xsd</code>
-     */
-    public static final class IfEntityPermission extends ModelWidgetCondition implements Condition {
-        private final EntityPermissionChecker permissionChecker;
-
-        private IfEntityPermission(ConditionFactory factory, ModelWidget modelWidget, Element condElement) {
-            super(factory, modelWidget, condElement);
-            this.permissionChecker = new EntityPermissionChecker(condElement);
-        }
-
-        @Override
-        public boolean eval(Map<String, Object> context) {
-            return permissionChecker.runPermissionCheck(context);
         }
     }
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetConditionVisitor.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/XmlWidgetConditionVisitor.java
@@ -24,7 +24,6 @@ import org.apache.ofbiz.widget.model.AbstractModelCondition.And;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfCompare;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfCompareField;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfEmpty;
-import org.apache.ofbiz.widget.model.AbstractModelCondition.IfEntityPermission;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfHasPermission;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfRegexp;
 import org.apache.ofbiz.widget.model.AbstractModelCondition.IfServicePermission;
@@ -88,13 +87,6 @@ public class XmlWidgetConditionVisitor extends XmlAbstractWidgetVisitor implemen
     public void visit(IfEmptySection ifEmptySection) throws Exception {
         writer.append("<if-empty-section");
         visitAttribute("section-name", ifEmptySection.getSectionExdr());
-        writer.append("/>");
-    }
-
-    @Override
-    public void visit(IfEntityPermission ifEntityPermission) throws Exception {
-        writer.append("<if-entity-permission");
-        // TODO: Create EntityPermissionChecker visitor
         writer.append("/>");
     }
 


### PR DESCRIPTION

Relocated EntityPermissionChecker from framework/entityext to application/content due to its strong dependency on the Content data model.
- Moved EntityPermissionChecker implementation to applications/content
- Removed framework-level dependencies related to EntityPermissionChecker
- Removed if-entity-permission handling from framework code
- Reduced framework coupling with Content application entities
- Improved separation between framework and application-specific functionality