### PR TITLE
Fixed the display value of allocateInventory on the Store screen. 

### DIFF
--- a/applications/product/widget/catalog/StoreForms.xml
+++ b/applications/product/widget/catalog/StoreForms.xml
@@ -420,6 +420,9 @@ under the License.
         <field name="orderDecimalQuantity" tooltip="${uiLabelMap.ProductOrderDecimalQuantityExistsToOverride}">
             <drop-down allow-empty="true" ><option key="Y" description="${uiLabelMap.CommonY}"/><option key="N" description="${uiLabelMap.CommonN}"/></drop-down>
         </field>
+        <field name="allocateInventory">
+            <drop-down allow-empty="false" no-current-selected-key="N"><option key="Y" description="${uiLabelMap.CommonY}"/><option key="N" description="${uiLabelMap.CommonN}"/></drop-down>
+        </field>
         <field name="submitButton" title="${uiLabelMap.CommonUpdate}"><submit button-type="button"/></field>
         <sort-order>
             <field-group>


### PR DESCRIPTION
Fixed: Fixed the display value of allocateInventory on the Store screen.  Allocate Inventory flag is designed to be treated as N. However, on the Catalog screen, it shows Y when the flag value is null in the database, which is confusing. OFBIZ-12001
