### PR TITLE
Improvement: Prevent potential resource leak in CoreEvents.java (OFBIZ-13421)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/event/CoreEvents.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/event/CoreEvents.java
@@ -516,10 +516,8 @@ public class CoreEvents {
         if (file.exists()) {
             Long longLen = file.length();
             int length = longLen.intValue();
-            try {
-                FileInputStream fis = new FileInputStream(file);
+            try (FileInputStream fis = new FileInputStream(file)) {
                 UtilHttp.streamContentToBrowser(response, fis, length, null);
-                fis.close();
             } catch (IOException e) {
                 Debug.logError(e, MODULE);
                 return "error";


### PR DESCRIPTION
Improved: Prevent potential resource leak in CoreEvents.java 
(OFBIZ-13421)

Refactor streamFile in CoreEvents.java to use try-with-resources. This prevents a potential file descriptor resource leak if the file streaming process throws an Exception.