### PR TITLE
Improved: FreeMarkerViewHandler should load templates via the FreeMarkerWorker (OFBIZ-3546)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/ftl/FreeMarkerViewHandler.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/ftl/FreeMarkerViewHandler.java
@@ -35,6 +35,9 @@ import org.apache.ofbiz.webapp.control.ConfigXMLReader;
 import org.apache.ofbiz.webapp.view.AbstractViewHandler;
 import org.apache.ofbiz.webapp.view.ViewHandlerException;
 
+import freemarker.cache.MultiTemplateLoader;
+import freemarker.cache.TemplateLoader;
+import freemarker.cache.WebappTemplateLoader;
 import freemarker.ext.jsp.TaglibFactory;
 import freemarker.ext.servlet.HttpRequestHashModel;
 import freemarker.ext.servlet.HttpSessionHashModel;
@@ -51,7 +54,15 @@ public class FreeMarkerViewHandler extends AbstractViewHandler {
     @Override
     public void init(ServletContext context) throws ViewHandlerException {
         config.setCacheStorage(new OfbizCacheStorage("unknown"));
-        config.setServletContextForTemplateLoading(context, "/");
+        TemplateLoader webappLoader = new WebappTemplateLoader(context, "/");
+        TemplateLoader defaultLoader = config.getTemplateLoader();
+        TemplateLoader[] loaders;
+        if (defaultLoader != null) {
+            loaders = new TemplateLoader[] {defaultLoader, webappLoader};
+        } else {
+            loaders = new TemplateLoader[] {webappLoader};
+        }
+        config.setTemplateLoader(new MultiTemplateLoader(loaders));
     }
 
     @Override
@@ -106,13 +117,8 @@ public class FreeMarkerViewHandler extends AbstractViewHandler {
 
         // process the template & flush the output
         try {
-            if (page.startsWith("component://")) {
-                FreeMarkerWorker.renderTemplate(page, context, response.getWriter());
-            } else {
-                // backwards compatibility
-                Template template = config.getTemplate(page);
-                FreeMarkerWorker.renderTemplate(template, context, response.getWriter());
-            }
+            Template template = config.getTemplate(page);
+            FreeMarkerWorker.renderTemplate(template, context, response.getWriter());
             response.flushBuffer();
         } catch (TemplateException te) {
             throw new ViewHandlerException("Problems processing Freemarker template", te);


### PR DESCRIPTION
Improved: FreeMarkerViewHandler should load templates via the FreeMarkerWorker
(OFBIZ-3546)

Used MultiTemplateLoader to combine FlexibleTemplateLoader in FreemarkerWorker config with WebappTemplateLoader to allow for both component templates and webapp templates.
