### PR TITLE
Removed application code dependency from framework (OFBIZ-13418)

### DIFF
--- a/applications/accounting/src/main/java/org/apache/ofbiz/accounting/payment/PaymentMethodServices.java
+++ b/applications/accounting/src/main/java/org/apache/ofbiz/accounting/payment/PaymentMethodServices.java
@@ -36,6 +36,7 @@ import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.entity.util.EntityUtil;
+import org.apache.ofbiz.party.party.PartyWorker;
 import org.apache.ofbiz.security.Security;
 import org.apache.ofbiz.service.DispatchContext;
 import org.apache.ofbiz.service.GenericServiceException;
@@ -140,7 +141,7 @@ public class PaymentMethodServices {
 
         Timestamp now = UtilDateTime.nowTimestamp();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_CREATE", "ACCOUNTING", "_CREATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_CREATE", "ACCOUNTING", "_CREATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -266,7 +267,7 @@ public class PaymentMethodServices {
 
         Timestamp now = UtilDateTime.nowTimestamp();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_UPDATE",
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_UPDATE",
                 "ACCOUNTING", "_UPDATE");
 
         if (!result.isEmpty()) {
@@ -502,7 +503,7 @@ public class PaymentMethodServices {
 
         Timestamp now = UtilDateTime.nowTimestamp();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_CREATE", "ACCOUNTING", "_CREATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_CREATE", "ACCOUNTING", "_CREATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -560,7 +561,7 @@ public class PaymentMethodServices {
 
         Timestamp now = UtilDateTime.nowTimestamp();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_UPDATE", "ACCOUNTING", "_UPDATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_UPDATE", "ACCOUNTING", "_UPDATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -696,7 +697,7 @@ public class PaymentMethodServices {
 
         Timestamp now = UtilDateTime.nowTimestamp();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_CREATE", "ACCOUNTING", "_CREATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_CREATE", "ACCOUNTING", "_CREATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -798,7 +799,7 @@ public class PaymentMethodServices {
 
         Timestamp now = UtilDateTime.nowTimestamp();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_UPDATE", "ACCOUNTING", "_UPDATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_UPDATE", "ACCOUNTING", "_UPDATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -937,7 +938,7 @@ public class PaymentMethodServices {
         Locale locale = (Locale) context.get("locale");
         Timestamp now = UtilDateTime.nowTimestamp();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_CREATE", "ACCOUNTING", "_CREATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_CREATE", "ACCOUNTING", "_CREATE");
         if (!result.isEmpty()) {
             return result;
         }
@@ -1027,7 +1028,7 @@ public class PaymentMethodServices {
 
         Timestamp now = UtilDateTime.nowTimestamp();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_UPDATE", "ACCOUNTING", "_UPDATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PAY_INFO", "_UPDATE", "ACCOUNTING", "_UPDATE");
 
         if (!result.isEmpty()) {
             return result;

--- a/applications/order/src/main/java/org/apache/ofbiz/order/order/OrderServices.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/order/OrderServices.java
@@ -210,7 +210,7 @@ public class OrderServices {
         // final check - will pass if userLogin's partyId = partyId for order or if userLogin has ORDERMGR_CREATE permission
         // jacopoc: what is the meaning of this code block? FIXME
         if (!hasPermission) {
-            partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, resultSecurity, "ORDERMGR", "_CREATE");
+            partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, resultSecurity, "ORDERMGR", "_CREATE");
             if (!resultSecurity.isEmpty()) {
                 return resultSecurity;
             }

--- a/applications/party/src/main/java/org/apache/ofbiz/party/contact/ContactMechServices.java
+++ b/applications/party/src/main/java/org/apache/ofbiz/party/contact/ContactMechServices.java
@@ -42,6 +42,7 @@ import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.entity.util.EntityUtilProperties;
+import org.apache.ofbiz.party.party.PartyWorker;
 import org.apache.ofbiz.security.Security;
 import org.apache.ofbiz.service.DispatchContext;
 import org.apache.ofbiz.service.GenericServiceException;
@@ -79,7 +80,7 @@ public class ContactMechServices {
         Timestamp now = UtilDateTime.nowTimestamp();
         List<GenericValue> toBeStored = new LinkedList<>();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_CREATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_CREATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -146,7 +147,7 @@ public class ContactMechServices {
         List<GenericValue> toBeStored = new LinkedList<>();
         boolean isModified = false;
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_UPDATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_UPDATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -282,7 +283,7 @@ public class ContactMechServices {
         GenericValue userLogin = (GenericValue) context.get("userLogin");
         Locale locale = (Locale) context.get("locale");
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_DELETE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_DELETE");
 
         if (!result.isEmpty()) {
             return result;
@@ -343,7 +344,7 @@ public class ContactMechServices {
         Timestamp now = UtilDateTime.nowTimestamp();
         List<GenericValue> toBeStored = new LinkedList<>();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_CREATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_CREATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -418,7 +419,7 @@ public class ContactMechServices {
         List<GenericValue> toBeStored = new LinkedList<>();
         boolean isModified = false;
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_UPDATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_UPDATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -590,7 +591,7 @@ public class ContactMechServices {
         Timestamp now = UtilDateTime.nowTimestamp();
         List<GenericValue> toBeStored = new LinkedList<>();
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_CREATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_CREATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -648,7 +649,7 @@ public class ContactMechServices {
         List<GenericValue> toBeStored = new LinkedList<>();
         boolean isModified = false;
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_UPDATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_UPDATE");
 
         if (!result.isEmpty()) {
             return result;
@@ -828,7 +829,7 @@ public class ContactMechServices {
         Security security = ctx.getSecurity();
         GenericValue userLogin = (GenericValue) context.get("userLogin");
 
-        String partyId = ServiceUtil.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_CREATE");
+        String partyId = PartyWorker.getPartyIdCheckSecurity(userLogin, security, context, result, "PARTYMGR", "_PCM_CREATE");
         String errMsg = null;
         Locale locale = (Locale) context.get("locale");
 

--- a/applications/party/src/main/java/org/apache/ofbiz/party/party/PartyWorker.java
+++ b/applications/party/src/main/java/org/apache/ofbiz/party/party/PartyWorker.java
@@ -32,6 +32,7 @@ import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.GeneralException;
 import org.apache.ofbiz.base.util.UtilFormatOut;
 import org.apache.ofbiz.base.util.UtilMisc;
+import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntityException;
@@ -44,6 +45,10 @@ import org.apache.ofbiz.entity.condition.EntityOperator;
 import org.apache.ofbiz.entity.model.ModelEntity;
 import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.entity.util.EntityUtil;
+import org.apache.ofbiz.security.Security;
+import org.apache.ofbiz.service.ModelService;
+
+import static org.apache.ofbiz.service.ServiceUtil.getLocale;
 
 /**
  * Worker methods for Party Information
@@ -51,6 +56,7 @@ import org.apache.ofbiz.entity.util.EntityUtil;
 public final class PartyWorker {
 
     private static final String MODULE = PartyWorker.class.getName();
+    private static final String RESOURCE = "ServiceErrorUiLabels";
 
     private PartyWorker() { }
 
@@ -602,6 +608,42 @@ public final class PartyWorker {
 
     public static GenericValue findParty(Delegator delegator, String idToFind) throws GenericEntityException {
         return findParty(delegator, idToFind, null);
+    }
+    /** A small routine used all over to improve code efficiency, get the partyId and does a security check
+     *<b>security check</b>: userLogin partyId must equal partyId, or must have [secEntity][secOperation] permission
+     */
+    public static String getPartyIdCheckSecurity(GenericValue userLogin, Security security, Map<String, ? extends Object> context,
+                                                 Map<String, Object> result, String secEntity, String secOperation) {
+        return getPartyIdCheckSecurity(userLogin, security, context, result, secEntity, secOperation, null, null);
+    }
+    public static String getPartyIdCheckSecurity(GenericValue userLogin, Security security, Map<String, ? extends Object> context,
+                                                 Map<String, Object> result, String secEntity, String secOperation, String adminSecEntity,
+                                                 String adminSecOperation) {
+        String partyId = (String) context.get("partyId");
+        Locale locale = getLocale(context);
+        if (UtilValidate.isEmpty(partyId)) {
+            partyId = userLogin.getString("partyId");
+        }
+
+        // partyId might be null, so check it
+        if (UtilValidate.isEmpty(partyId)) {
+            result.put(ModelService.RESPONSE_MESSAGE, ModelService.RESPOND_ERROR);
+            String errMsg = UtilProperties.getMessage(RESOURCE, "serviceUtil.party_id_missing", locale) + ".";
+            result.put(ModelService.ERROR_MESSAGE, errMsg);
+            return partyId;
+        }
+
+        // <b>security check</b>: userLogin partyId must equal partyId, or must have either of the two permissions
+        if (!partyId.equals(userLogin.getString("partyId"))) {
+            if (!security.hasEntityPermission(secEntity, secOperation, userLogin) && !(adminSecEntity != null && adminSecOperation != null
+                    && security.hasEntityPermission(adminSecEntity, adminSecOperation, userLogin))) {
+                result.put(ModelService.RESPONSE_MESSAGE, ModelService.RESPOND_ERROR);
+                String errMsg = UtilProperties.getMessage(RESOURCE, "serviceUtil.no_permission_to_operation", locale) + ".";
+                result.put(ModelService.ERROR_MESSAGE, errMsg);
+                return partyId;
+            }
+        }
+        return partyId;
     }
 
 }

--- a/framework/security/src/main/java/org/apache/ofbiz/security/CsrfUtil.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/CsrfUtil.java
@@ -81,46 +81,30 @@ public final class CsrfUtil {
 
         HttpSession session = request.getSession();
         GenericValue userLogin = (GenericValue) session.getAttribute("userLogin");
-        String partyId = null;
-        if (userLogin != null && userLogin.get("partyId") != null) {
-            partyId = userLogin.getString("partyId");
-        }
+        String userLoginId = userLogin == null ? null : userLogin.getString("userLoginId");
 
-        Map<String, String> tokenMap = null;
-        if (UtilValidate.isNotEmpty(partyId)) {
-            Map<String, Map<String, String>> partyTokenMap = csrfTokenCache.get(partyId);
-            if (partyTokenMap == null) {
-                partyTokenMap = new HashMap<>();
-                csrfTokenCache.put(partyId, partyTokenMap);
-            }
-
-            tokenMap = partyTokenMap.get(targetContextPath);
+        if (UtilValidate.isEmpty(userLoginId)) {
+            Map<String, String> tokenMap = UtilGenerics.cast(session.getAttribute("CSRF-Token"));
             if (tokenMap == null) {
-                tokenMap = new LinkedHashMap<String, String>() {
-                    private static final long serialVersionUID = 1L;
-
-                    @Override
-                    protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
-                        return size() > cacheSize;
-                    }
-                };
-                partyTokenMap.put(targetContextPath, tokenMap);
-            }
-        } else {
-            tokenMap = UtilGenerics.cast(session.getAttribute("CSRF-Token"));
-            if (tokenMap == null) {
-                tokenMap = new LinkedHashMap<String, String>() {
-                    private static final long serialVersionUID = 1L;
-
-                    @Override
-                    protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
-                        return size() > cacheSize;
-                    }
-                };
+                tokenMap = createTokenMap();
                 session.setAttribute("CSRF-Token", tokenMap);
             }
+            return tokenMap;
         }
-        return tokenMap;
+
+        Map<String, Map<String, String>> userTokenMap = csrfTokenCache.computeIfAbsent(userLoginId, key -> new HashMap<>());
+        return userTokenMap.computeIfAbsent(targetContextPath, key -> createTokenMap());
+    }
+
+    private static Map<String, String> createTokenMap() {
+        return new LinkedHashMap<String, String>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+                return size() > cacheSize;
+            }
+        };
     }
 
     private static String generateToken() {
@@ -353,17 +337,20 @@ public final class CsrfUtil {
 
     public static void cleanupTokenMap(HttpSession session) {
         GenericValue userLogin = (GenericValue) session.getAttribute("userLogin");
-        String partyId = null;
-        if (userLogin != null && userLogin.get("partyId") != null) {
-            partyId = userLogin.getString("partyId");
-            Map<String, Map<String, String>> partyTokenMap = csrfTokenCache.get(partyId);
-            if (partyTokenMap != null) {
-                String contextPath = session.getServletContext().getContextPath();
-                partyTokenMap.remove(contextPath);
-                if (partyTokenMap.isEmpty()) {
-                    csrfTokenCache.remove(partyId);
-                }
-            }
+        String userLoginId = userLogin == null ? null : userLogin.getString("userLoginId");
+        if (UtilValidate.isEmpty(userLoginId)) {
+            return;
+        }
+
+        Map<String, Map<String, String>> userTokenMap = csrfTokenCache.get(userLoginId);
+        if (userTokenMap == null) {
+            return;
+        }
+
+        String contextPath = session.getServletContext().getContextPath();
+        userTokenMap.remove(contextPath);
+        if (userTokenMap.isEmpty()) {
+            csrfTokenCache.remove(userLoginId);
         }
     }
 

--- a/framework/security/src/test/java/org/apache/ofbiz/security/CsrfUtilTests.java
+++ b/framework/security/src/test/java/org/apache/ofbiz/security/CsrfUtilTests.java
@@ -20,6 +20,7 @@ package org.apache.ofbiz.security;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -59,14 +60,19 @@ public class CsrfUtilTests {
 
         // add userLogin to session
         GenericValue userLogin = mock(GenericValue.class);
-        when(userLogin.get("partyId")).thenReturn("10000");
-        when(userLogin.getString("partyId")).thenReturn("10000");
+        when(userLogin.getString("userLoginId")).thenReturn("csrf-test-user");
         when(session.getAttribute("userLogin")).thenReturn(userLogin);
 
         // with userLogin in session, test token map is not retrieved from session
         resultMap = CsrfUtil.getTokenMap(request, "/partymgr");
         assertNull(resultMap.get("uri_1"));
 
+        GenericValue otherUserLogin = mock(GenericValue.class);
+        when(otherUserLogin.getString("userLoginId")).thenReturn("other-test-user");
+        when(session.getAttribute("userLogin")).thenReturn(otherUserLogin);
+
+        Map<String, String> otherUserResultMap = CsrfUtil.getTokenMap(request, "/partymgr");
+        assertNotSame(resultMap, otherUserResultMap);
     }
 
     @Test
@@ -101,8 +107,7 @@ public class CsrfUtilTests {
 
         // add userLogin to session
         GenericValue userLogin = mock(GenericValue.class);
-        when(userLogin.get("partyId")).thenReturn("10000");
-        when(userLogin.getString("partyId")).thenReturn("10000");
+        when(userLogin.getString("userLoginId")).thenReturn("csrf-token-generation-test-user");
         when(session.getAttribute("userLogin")).thenReturn(userLogin);
 
         String token = CsrfUtil.generateTokenForNonAjax(request, "");

--- a/framework/service/src/main/java/org/apache/ofbiz/service/ServiceUtil.java
+++ b/framework/service/src/main/java/org/apache/ofbiz/service/ServiceUtil.java
@@ -32,13 +32,11 @@ import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.UtilDateTime;
 import org.apache.ofbiz.base.util.UtilGenerics;
 import org.apache.ofbiz.base.util.UtilMisc;
-import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityQuery;
-import org.apache.ofbiz.security.Security;
 
 
 /**
@@ -171,43 +169,6 @@ public final class ServiceUtil {
             result.put(ModelService.SUCCESS_MESSAGE, message);
         }
         return result;
-    }
-
-    /** A small routine used all over to improve code efficiency, get the partyId and does a security check
-     *<b>security check</b>: userLogin partyId must equal partyId, or must have [secEntity][secOperation] permission
-     */
-    public static String getPartyIdCheckSecurity(GenericValue userLogin, Security security, Map<String, ? extends Object> context,
-                                                 Map<String, Object> result, String secEntity, String secOperation) {
-        return getPartyIdCheckSecurity(userLogin, security, context, result, secEntity, secOperation, null, null);
-    }
-    public static String getPartyIdCheckSecurity(GenericValue userLogin, Security security, Map<String, ? extends Object> context,
-                                                 Map<String, Object> result, String secEntity, String secOperation, String adminSecEntity,
-                                                 String adminSecOperation) {
-        String partyId = (String) context.get("partyId");
-        Locale locale = getLocale(context);
-        if (UtilValidate.isEmpty(partyId)) {
-            partyId = userLogin.getString("partyId");
-        }
-
-        // partyId might be null, so check it
-        if (UtilValidate.isEmpty(partyId)) {
-            result.put(ModelService.RESPONSE_MESSAGE, ModelService.RESPOND_ERROR);
-            String errMsg = UtilProperties.getMessage(ServiceUtil.RESOURCE, "serviceUtil.party_id_missing", locale) + ".";
-            result.put(ModelService.ERROR_MESSAGE, errMsg);
-            return partyId;
-        }
-
-        // <b>security check</b>: userLogin partyId must equal partyId, or must have either of the two permissions
-        if (!partyId.equals(userLogin.getString("partyId"))) {
-            if (!security.hasEntityPermission(secEntity, secOperation, userLogin) && !(adminSecEntity != null && adminSecOperation != null
-                    && security.hasEntityPermission(adminSecEntity, adminSecOperation, userLogin))) {
-                result.put(ModelService.RESPONSE_MESSAGE, ModelService.RESPOND_ERROR);
-                String errMsg = UtilProperties.getMessage(ServiceUtil.RESOURCE, "serviceUtil.no_permission_to_operation", locale) + ".";
-                result.put(ModelService.ERROR_MESSAGE, errMsg);
-                return partyId;
-            }
-        }
-        return partyId;
     }
 
     public static void setMessages(HttpServletRequest request, String errorMessage, String eventMessage, String defaultMessage) {


### PR DESCRIPTION
- Move EntityPermissionChecker from framework/entityext to application/content (OFBIZ-13393)
    
    Relocated EntityPermissionChecker from framework/entityext to
    application/content due to its strong dependency on the Content data
    model.
    - Moved EntityPermissionChecker implementation to applications/content
    - Removed framework-level dependencies related to
    EntityPermissionChecker
    - Removed if-entity-permission handling from framework code
    - Reduced framework coupling with Content application entities
    - Improved separation between framework and application-specific
    functionality

- Use userLoginId for CSRF token cache keys (OFBIZ-13305)
    Key authenticated CSRF token maps by UserLogin.userLoginId instead of
    partyId. userLoginId is the UserLogin primary key, while partyId belongs
    to the application party domain; framework security code should not rely
    on application-level party identity.
    
    Keep cleanup aligned with the same cache key and simplify token map
    creation with early returns and computeIfAbsent.
    
    Update CsrfUtil tests to mock userLoginId and verify separate token maps