### PR TITLE
Fixed: Deserializing ModelPermission.java throws an error (OFBIZ-13423)

### DIFF
--- a/framework/base/config/SafeObjectInputStream.properties
+++ b/framework/base/config/SafeObjectInputStream.properties
@@ -31,4 +31,4 @@ allowList=byte\\[\\], foo, SerializationInjector, \\[Z,\\[B,\\[S,\\[I,\\[J,\\[F,
 
 #-- List of strings rejected for serialisation
 #-- The same comments than for allowList apply to denyList
-denyList=rmi, <
+denyList=java.rmi, sun.rmi, <

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/SafeObjectInputStream.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/SafeObjectInputStream.java
@@ -70,7 +70,7 @@ public final class SafeObjectInputStream extends ObjectInputStream {
             "org\\.codehaus\\.groovy\\.runtime\\.GStringImpl",
             "groovy\\.lang\\.GString",
             "sun\\.util\\.calendar\\.ZoneInfo"};
-    private static final String[] DEFAULT_DENYLIST = {"rmi", "<"};
+    private static final String[] DEFAULT_DENYLIST = {"java.rmi", "sun.rmi", "<"};
 
     /** The regular expression used to match serialized types. */
     private final Pattern allowlistPattern;


### PR DESCRIPTION
Fixed: Deserializing ModelPermission.java throws an error
(OFBIZ-13423)

Updated DEFAULT_DENYLIST and SafeObjectInputStream.properties to target 
"java.rmi" and "sun.rmi" specifically.