### PR TITLE
Fixed: EntityDateFilterCondition causes the entity cache to return false matches (OFBIZ-3880)

### DIFF
--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityCondition.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityCondition.java
@@ -192,8 +192,56 @@ public interface EntityCondition extends IsEmpty, Serializable {
      * @param thruDateName the name of the field corresponding to the thru date
      * @return a condition expression filtering rows that are currently valid
      */
-    static EntityDateFilterCondition makeConditionDate(String fromDateName, String thruDateName) {
-        return new EntityDateFilterCondition(fromDateName, thruDateName);
+    static EntityCondition makeConditionDate(String fromDateName, String thruDateName) {
+        return makeConditionDate(org.apache.ofbiz.base.util.UtilDateTime.nowTimestamp(), fromDateName, thruDateName);
+    }
+
+    /**
+     * Constructs a condition expression to filter rows that are valid at a given timestamp.
+     * @param moment the timestamp used to check validity
+     * @param fromDateName the name of the field corresponding to the from date
+     * @param thruDateName the name of the field corresponding to the thru date
+     * @return a condition expression filtering rows that are valid at the given timestamp
+     */
+    static EntityCondition makeConditionDate(java.sql.Timestamp moment, String fromDateName, String thruDateName) {
+        return EntityCondition.makeCondition(
+                EntityCondition.makeCondition(
+                        EntityCondition.makeCondition(thruDateName, null),
+                        EntityOperator.OR,
+                        EntityCondition.makeCondition(thruDateName, EntityOperator.GREATER_THAN, moment)),
+                EntityCondition.makeCondition(
+                        EntityCondition.makeCondition(fromDateName, null),
+                        EntityOperator.OR,
+                        EntityCondition.makeCondition(fromDateName, EntityOperator.LESS_THAN_EQUAL_TO, moment)));
+    }
+
+    /**
+     * Constructs a condition expression representing a date range filter query to be used against
+     * entities that themselves represent a date range.
+     * @param rangeStart    The start of the range to filter against
+     * @param rangeEnd      The end of the range to filter against
+     * @param fromDateName  The name of the field containing the entity's "fromDate"
+     * @param thruDateName  The name of the field containing the entity's "thruDate"
+     * @return EntityCondition representing the date range filter
+     */
+    static EntityCondition makeConditionRange(java.sql.Timestamp rangeStart, java.sql.Timestamp rangeEnd, String fromDateName, String thruDateName) {
+        return EntityCondition.makeCondition(EntityOperator.OR,
+                EntityCondition.makeConditionMap(thruDateName, null, fromDateName, null),
+                EntityCondition.makeCondition(
+                        EntityCondition.makeCondition(fromDateName, EntityOperator.GREATER_THAN_EQUAL_TO, rangeStart),
+                        EntityCondition.makeCondition(fromDateName, EntityOperator.LESS_THAN, rangeEnd)),
+                EntityCondition.makeCondition(
+                        EntityCondition.makeCondition(thruDateName, EntityOperator.GREATER_THAN_EQUAL_TO, rangeStart),
+                        EntityCondition.makeCondition(thruDateName, EntityOperator.LESS_THAN, rangeEnd)),
+                EntityCondition.makeCondition(
+                        EntityCondition.makeCondition(fromDateName, null),
+                        EntityCondition.makeCondition(thruDateName, EntityOperator.GREATER_THAN_EQUAL_TO, rangeStart)),
+                EntityCondition.makeCondition(
+                        EntityCondition.makeCondition(thruDateName, null),
+                        EntityCondition.makeCondition(fromDateName, EntityOperator.LESS_THAN, rangeEnd)),
+                EntityCondition.makeCondition(
+                        EntityCondition.makeCondition(fromDateName, EntityOperator.LESS_THAN_EQUAL_TO, rangeStart),
+                        EntityCondition.makeCondition(thruDateName, EntityOperator.GREATER_THAN_EQUAL_TO, rangeEnd)));
     }
 
     /**

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityDateFilterCondition.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityDateFilterCondition.java
@@ -33,7 +33,9 @@ import org.apache.ofbiz.entity.model.ModelEntity;
  * Represents Date-range condition expression.
  * <p>
  * This is used to filter rows that are valid in a particular range.
+ * @deprecated Use {@link EntityCondition#makeConditionDate} instead.
  */
+@Deprecated
 @SuppressWarnings("serial")
 public final class EntityDateFilterCondition implements EntityCondition {
     /** The column containing dates before which a row is considered invalid.  */
@@ -47,7 +49,9 @@ public final class EntityDateFilterCondition implements EntityCondition {
      * The <i>current date</i> is the one computed when the SQL query is generated.
      * @param fromDateName the name of the field corresponding to the from date
      * @param thruDateName the name of the field corresponding to the thru date
+     * @deprecated Use {@link EntityCondition#makeConditionDate} instead.
      */
+    @Deprecated
     public EntityDateFilterCondition(String fromDateName, String thruDateName) {
         this.fromDateName = fromDateName;
         this.thruDateName = thruDateName;
@@ -120,17 +124,11 @@ public final class EntityDateFilterCondition implements EntityCondition {
      * @param fromDateName the name of the field corresponding to the from date
      * @param thruDateName the name of the field corresponding to the thru date
      * @return a condition expression filtering rows that are currently valid
+     * @deprecated Use {@link EntityCondition#makeConditionDate} instead.
      */
+    @Deprecated
     public static EntityCondition makeCondition(Timestamp moment, String fromDateName, String thruDateName) {
-        return EntityCondition.makeCondition(
-                EntityCondition.makeCondition(
-                        EntityCondition.makeCondition(thruDateName, null),
-                        EntityOperator.OR,
-                        EntityCondition.makeCondition(thruDateName, EntityOperator.GREATER_THAN, moment)),
-                EntityCondition.makeCondition(
-                        EntityCondition.makeCondition(fromDateName, null),
-                        EntityOperator.OR,
-                        EntityCondition.makeCondition(fromDateName, EntityOperator.LESS_THAN_EQUAL_TO, moment)));
+        return EntityCondition.makeConditionDate(moment, fromDateName, thruDateName);
     }
 
     /**
@@ -148,25 +146,11 @@ public final class EntityDateFilterCondition implements EntityCondition {
      * @param fromDateName  The name of the field containing the entity's "fromDate"
      * @param thruDateName  The name of the field containing the entity's "thruDate"
      * @return EntityCondition representing the date range filter
+     * @deprecated Use {@link EntityCondition#makeConditionRange} instead.
      */
+    @Deprecated
     public static EntityCondition makeRangeCondition(Timestamp rangeStart, Timestamp rangeEnd, String fromDateName,
             String thruDateName) {
-        return EntityCondition.makeCondition(EntityOperator.OR,
-                EntityCondition.makeConditionMap(thruDateName, null, fromDateName, null),
-                EntityCondition.makeCondition(
-                        EntityCondition.makeCondition(fromDateName, EntityOperator.GREATER_THAN_EQUAL_TO, rangeStart),
-                        EntityCondition.makeCondition(fromDateName, EntityOperator.LESS_THAN, rangeEnd)),
-                EntityCondition.makeCondition(
-                        EntityCondition.makeCondition(thruDateName, EntityOperator.GREATER_THAN_EQUAL_TO, rangeStart),
-                        EntityCondition.makeCondition(thruDateName, EntityOperator.LESS_THAN, rangeEnd)),
-                EntityCondition.makeCondition(
-                        EntityCondition.makeCondition(fromDateName, null),
-                        EntityCondition.makeCondition(thruDateName, EntityOperator.GREATER_THAN_EQUAL_TO, rangeStart)),
-                EntityCondition.makeCondition(
-                        EntityCondition.makeCondition(thruDateName, null),
-                        EntityCondition.makeCondition(fromDateName, EntityOperator.LESS_THAN, rangeEnd)),
-                EntityCondition.makeCondition(
-                        EntityCondition.makeCondition(fromDateName, EntityOperator.LESS_THAN_EQUAL_TO, rangeStart),
-                        EntityCondition.makeCondition(thruDateName, EntityOperator.GREATER_THAN_EQUAL_TO, rangeEnd)));
+        return EntityCondition.makeConditionRange(rangeStart, rangeEnd, fromDateName, thruDateName);
     }
 }

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/util/EntityUtil.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/util/EntityUtil.java
@@ -49,7 +49,6 @@ import org.apache.ofbiz.entity.GenericEntity;
 import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.condition.EntityCondition;
-import org.apache.ofbiz.entity.condition.EntityDateFilterCondition;
 import org.apache.ofbiz.entity.condition.OrderByList;
 import org.apache.ofbiz.entity.model.ModelEntity;
 import org.apache.ofbiz.entity.model.ModelField;
@@ -139,15 +138,15 @@ public final class EntityUtil {
     }
 
     public static EntityCondition getFilterByDateExpr(java.util.Date moment) {
-        return EntityDateFilterCondition.makeCondition(new java.sql.Timestamp(moment.getTime()), "fromDate", "thruDate");
+        return EntityCondition.makeConditionDate(new java.sql.Timestamp(moment.getTime()), "fromDate", "thruDate");
     }
 
     public static EntityCondition getFilterByDateExpr(java.sql.Timestamp moment) {
-        return EntityDateFilterCondition.makeCondition(moment, "fromDate", "thruDate");
+        return EntityCondition.makeConditionDate(moment, "fromDate", "thruDate");
     }
 
     public static EntityCondition getFilterByDateExpr(java.sql.Timestamp moment, String fromDateName, String thruDateName) {
-        return EntityDateFilterCondition.makeCondition(moment, fromDateName, thruDateName);
+        return EntityCondition.makeConditionDate(moment, fromDateName, thruDateName);
     }
 
     /**


### PR DESCRIPTION
Fixed: EntityDateFilterCondition causes the entity cache to return false matches
(OFBIZ-3880)

Deprecated EntityDateFilterCondition, migrated its filter logic to EntityCondition factory methods, and updated core references

Thanks: Scott Gray for reporting the issue and suggesting the fix.