### PR TITLE
Fixed: Correct receivedQuantity calculation in updatePurchaseShipmentFromReceipt (OFBIZ-13425)

### DIFF
--- a/applications/product/src/main/java/org/apache/ofbiz/shipment/shipment/ShipmentServices.java
+++ b/applications/product/src/main/java/org/apache/ofbiz/shipment/shipment/ShipmentServices.java
@@ -761,6 +761,8 @@ public class ShipmentServices {
             Map<String, BigDecimal> receivedCountMap = new HashMap<>();
             for (GenericValue item: shipmentReceipts) {
                 BigDecimal receivedQuantity = item.getBigDecimal("quantityAccepted");
+                BigDecimal rejectedQuantity = item.getBigDecimal("quantityRejected");
+                receivedQuantity = rejectedQuantity == null ? receivedQuantity : receivedQuantity.add(rejectedQuantity);
                 BigDecimal quantity = receivedCountMap.get(item.getString("productId"));
                 quantity = quantity == null ? receivedQuantity : receivedQuantity.add(quantity);
                 receivedCountMap.put(item.getString("productId"), quantity);


### PR DESCRIPTION
This PR solves the issue described in [OFBIZ-13425](https://issues.apache.org/jira/browse/OFBIZ-13425) by adding rejected units to accepted ones, when determining the received quantity in the updatePurchaseShipmentFromReceipt service
