### PR TITLE
Backport PR # 1288: Fixed: Set secure flag for cookies in TrackingCodeEvents, ShoppingListEvents, and LoginWorker

### DIFF
--- a/applications/marketing/src/main/java/org/apache/ofbiz/marketing/tracking/TrackingCodeEvents.java
+++ b/applications/marketing/src/main/java/org/apache/ofbiz/marketing/tracking/TrackingCodeEvents.java
@@ -475,6 +475,7 @@ public class TrackingCodeEvents {
             for (Cookie cookie : cookies) {
                 if (cookie.getName().endsWith("_ACCESS")) {
                     cookie.setMaxAge(0);
+                    cookie.setSecure(true);
                     response.addCookie(cookie);
                 }
             }

--- a/applications/order/src/main/java/org/apache/ofbiz/order/shoppinglist/ShoppingListEvents.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/shoppinglist/ShoppingListEvents.java
@@ -766,6 +766,7 @@ public class ShoppingListEvents {
         Cookie guestShoppingListCookie = new Cookie(guestShoppingUserName, null);
         guestShoppingListCookie.setMaxAge(0);
         guestShoppingListCookie.setPath("/");
+        guestShoppingListCookie.setSecure(true);
         response.addCookie(guestShoppingListCookie);
         return "success";
     }

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/LoginWorker.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/LoginWorker.java
@@ -1172,6 +1172,7 @@ public final class LoginWorker {
             autoLoginCookie.setMaxAge(0);
             autoLoginCookie.setDomain(EntityUtilProperties.getPropertyValue("url", "cookie.domain", delegator));
             autoLoginCookie.setPath("root".equals(applicationName) ? "/" : request.getContextPath());
+            autoLoginCookie.setSecure(true);
             response.addCookie(autoLoginCookie);
         }
         // remove the session attributes


### PR DESCRIPTION
(cherry picked from commit 27b58a914e90bdcfd90dfb7dd4f5248ab6d0c2cb)

Backported from pr #1288 