### PR TITLE
Fixed: Wrong OrderAdjustments (because of tax) when cancelling an Order (OFBIZ-9205)

### DIFF
--- a/applications/order/src/main/java/org/apache/ofbiz/order/order/OrderReadHelper.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/order/OrderReadHelper.java
@@ -3246,6 +3246,7 @@ public class OrderReadHelper {
 
         List<GenericValue> promoAdjustments = EntityUtil.filterByAnd(allOrderAdjustments, UtilMisc.toMap("orderAdjustmentTypeId",
                 "PROMOTION_ADJUSTMENT"));
+        promoAdjustments = getOrderHeaderAdjustments(promoAdjustments, null);
 
         if (UtilValidate.isNotEmpty(promoAdjustments)) {
             Iterator<GenericValue> promoAdjIter = promoAdjustments.iterator();


### PR DESCRIPTION
Fixed: Wrong OrderAdjustments (because of tax) when cancelling an Order
(OFBIZ-9205)

During order cancellation, OrderReadHelper.calcOrderPromoAdjustmentsBd double-counted item-level promotions in the tax recalculation because it was aggregating both order-level and item-level adjustments. Pre-filtered the promotions list in calcOrderPromoAdjustmentsBd to strictly aggregate only order-level (header-level) promotions.

Thanks: Maurice Meyer for reporting the issue.
