### PR TITLE
Fixed: Bump Node.js version from 20.19.0 to 24.16.0

### DIFF
--- a/buildSrc/src/main/groovy/ofbiz-node-conventions.gradle
+++ b/buildSrc/src/main/groovy/ofbiz-node-conventions.gradle
@@ -42,7 +42,7 @@ plugins {
 
 node {
     download = true
-    version = "20.19.0"
+    version = "24.16.0"
 
     // If environment variable CI is set, use 'npm ci' instead of 'npm install' to populate node_modules.
     npmInstallCommand = System.getenv("CI") ? 'ci' : 'install'


### PR DESCRIPTION
Node.js 20 reached its official End-of-Life (EOL) on April 30, 2026