### PR TITLE
Backport PR #1296: Fixed: Fix regex pattern matching to escape special characters in fragment name

### DIFF
--- a/framework/common/src/main/java/org/apache/ofbiz/common/CommonEvents.java
+++ b/framework/common/src/main/java/org/apache/ofbiz/common/CommonEvents.java
@@ -35,6 +35,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
@@ -423,7 +424,7 @@ public class CommonEvents {
                         try (LineNumberReader lnr = new LineNumberReader(new FileReader(platformSpecificPath))) {
                             String line;
                             while ((line = lnr.readLine()) != null) {
-                                if (line.matches(".*name=\"" + fragment + "\".*")) {
+                                if (line.matches(".*name=\"" + Pattern.quote(fragment) + "\".*")) {
                                     lineNumber = lnr.getLineNumber();
                                     break;
                                 }


### PR DESCRIPTION
(cherry picked from commit 27373f23848f216233a5187d9ae6bc58e9c16d1d)

This pull request backports PR #1296 