### PR TITLE
Migrate Apache OFBiz test suite from JUnit 4 to JUnit 6 (Jupiter)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -369,8 +369,11 @@ eclipse.classpath.file.whenMerged { classpath ->
 tasks.eclipse.dependsOn(cleanEclipse)
 
 test {
-    useJUnit()
+    useJUnitPlatform()
     jvmArgs "-javaagent:${classpath.find { it.name.contains('jmockit') }.absolutePath}"
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -86,10 +86,12 @@ dependencies {
       exclude group: 'xpp3', module: 'xpp3'
     }
 
-    testImplementation 'org.hamcrest:hamcrest-library:2.2' // Enable junit4 to not depend on hamcrest-1.3
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:6.1.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:6.1.0'
+    testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.jmockit:jmockit:1.50'
-    testImplementation 'com.pholser:junit-quickcheck-generators:1.0'
 
     runtimeOnly 'javax.xml.soap:javax.xml.soap-api:1.4.0'
     runtimeOnly 'net.sf.barcode4j:barcode4j-fop-ext:2.1'

--- a/framework/base/src/test/java/org/apache/ofbiz/base/collections/MultivaluedMapContextAdapterTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/collections/MultivaluedMapContextAdapterTests.java
@@ -19,23 +19,23 @@
 package org.apache.ofbiz.base.collections;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 
 import org.apache.ofbiz.base.util.collections.MultivaluedMapContext;
 import org.apache.ofbiz.base.util.collections.MultivaluedMapContextAdapter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MultivaluedMapContextAdapterTests {
     private MultivaluedMapContext<String, Integer> adaptee;
     private MultivaluedMapContextAdapter<String, Integer> adapter;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         adaptee = new MultivaluedMapContext<>();
         adaptee.add("foo", 0);

--- a/framework/base/src/test/java/org/apache/ofbiz/base/collections/MultivaluedMapContextAdapterTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/collections/MultivaluedMapContextAdapterTests.java
@@ -31,7 +31,7 @@ import org.apache.ofbiz.base.util.collections.MultivaluedMapContextAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class MultivaluedMapContextAdapterTests {
+public final class MultivaluedMapContextAdapterTests {
     private MultivaluedMapContext<String, Integer> adaptee;
     private MultivaluedMapContextAdapter<String, Integer> adapter;
 

--- a/framework/base/src/test/java/org/apache/ofbiz/base/collections/MultivaluedMapContextTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/collections/MultivaluedMapContextTests.java
@@ -24,13 +24,13 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.ofbiz.base.util.collections.MultivaluedMapContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MultivaluedMapContextTests {
     private MultivaluedMapContext<String, Integer> m;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         m = new MultivaluedMapContext<>();
     }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/collections/MultivaluedMapContextTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/collections/MultivaluedMapContextTests.java
@@ -27,7 +27,7 @@ import org.apache.ofbiz.base.util.collections.MultivaluedMapContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class MultivaluedMapContextTests {
+public final class MultivaluedMapContextTests {
     private MultivaluedMapContext<String, Integer> m;
 
     @BeforeEach

--- a/framework/base/src/test/java/org/apache/ofbiz/base/container/ComponentContainerTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/container/ComponentContainerTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 
-public class ComponentContainerTest {
+public final class ComponentContainerTest {
     private static final Path ORDER_CONFIG = Paths.get("applications", "order", "config");
     private static final Path ACCOUNTING_CONFIG = Paths.get("applications", "accounting", "config");
     private static final Path[] CONFIGS = {ORDER_CONFIG, ACCOUNTING_CONFIG};

--- a/framework/base/src/test/java/org/apache/ofbiz/base/container/ComponentContainerTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/container/ComponentContainerTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.ofbiz.base.container;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -30,9 +30,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.ofbiz.base.component.ComponentConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 public class ComponentContainerTest {
@@ -45,7 +45,7 @@ public class ComponentContainerTest {
 
     public ComponentContainerTest() throws URISyntaxException { }
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         cleanUp();
         for (Path cfg : CONFIGS) {
@@ -53,7 +53,7 @@ public class ComponentContainerTest {
         }
     }
 
-    @After
+    @AfterEach
     public void cleanUp() throws IOException {
         for (Path cfg : CONFIGS) {
             Files.deleteIfExists(ofbizHome.resolve(cfg));

--- a/framework/base/src/test/java/org/apache/ofbiz/base/conversion/CollectionConvertersTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/conversion/CollectionConvertersTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.ofbiz.base.conversion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Map;
 
 import org.apache.ofbiz.base.util.UtilMisc;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CollectionConvertersTest {
 
@@ -38,11 +38,11 @@ public class CollectionConvertersTest {
             } catch (ConversionException e) {
                 caught = e;
             } finally {
-                assertNotNull("bad(" + s + ")", caught);
+                assertNotNull(caught, "bad(" + s + ")");
             }
         }
-        assertEquals("single", UtilMisc.toMap("1", "one"), cvt.convert("{1=one}"));
-        assertEquals("double", UtilMisc.toMap("2", "two", "1", "one"), cvt.convert("{1=one, 2=two}"));
-        assertEquals("double-space", UtilMisc.toMap("2", "two ", " 1", "one"), cvt.convert("{ 1=one, 2=two }"));
+        assertEquals(UtilMisc.toMap("1", "one"), cvt.convert("{1=one}"), "single");
+        assertEquals(UtilMisc.toMap("2", "two", "1", "one"), cvt.convert("{1=one, 2=two}"), "double");
+        assertEquals(UtilMisc.toMap("2", "two ", " 1", "one"), cvt.convert("{ 1=one, 2=two }"), "double-space");
     }
 }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/conversion/DateTimeTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/conversion/DateTimeTests.java
@@ -18,11 +18,11 @@
  */
 package org.apache.ofbiz.base.conversion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.ibm.icu.util.Calendar;
 
@@ -30,8 +30,8 @@ public class DateTimeTests {
 
     private static <S, T> void assertConversion(String label, Converter<S, T> converter, S source, T target)
             throws Exception {
-        assertTrue(label + " can convert", converter.canConvert(source.getClass(), target.getClass()));
-        assertEquals(label + " converted", target, converter.convert(source));
+        assertTrue(converter.canConvert(source.getClass(), target.getClass()), label + " can convert");
+        assertEquals(target, converter.convert(source), label + " converted");
     }
 
     @Test
@@ -41,7 +41,7 @@ public class DateTimeTests {
         cal.set(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH), 0, 0, 0);
         cal.set(Calendar.MILLISECOND, 0);
         long longTime = cal.getTimeInMillis(); // Start of day today
-        assertNotEquals("currentTime and longTime are not equal", currentTime, longTime);
+        assertNotEquals(currentTime, longTime, "currentTime and longTime are not equal");
         java.util.Date utilDate = new java.util.Date(longTime);
         java.sql.Date sqlDate = new java.sql.Date(longTime);
         java.sql.Timestamp timestamp = new java.sql.Timestamp(longTime);

--- a/framework/base/src/test/java/org/apache/ofbiz/base/conversion/MiscTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/conversion/MiscTests.java
@@ -18,9 +18,9 @@
  */
 package org.apache.ofbiz.base.conversion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.net.URL;
@@ -32,7 +32,7 @@ import java.util.Map;
 import org.apache.ofbiz.base.util.UtilGenerics;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.base.util.UtilURL;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MiscTests {
 
@@ -56,12 +56,12 @@ public class MiscTests {
             throws Exception {
         Converter<S, ? super S> converter = Converters.getConverter(sourceClass, targetClass);
         Object result = converter.convert(UtilGenerics.<S>cast(wanted));
-        assertEquals("pass thru convert", wanted, result);
-        assertSame("pass thru exact equals", wanted, result);
-        assertTrue("pass thru can convert wanted", converter.canConvert(wanted.getClass(), targetClass));
-        assertTrue("pass thru can convert source", converter.canConvert(sourceClass, targetClass));
-        assertEquals("pass thru source class", wanted.getClass(), converter.getSourceClass());
-        assertEquals("pass thru target class", targetClass, converter.getTargetClass());
+        assertEquals(wanted, result, "pass thru convert");
+        assertSame(wanted, result, "pass thru exact equals");
+        assertTrue(converter.canConvert(wanted.getClass(), targetClass), "pass thru can convert wanted");
+        assertTrue(converter.canConvert(sourceClass, targetClass), "pass thru can convert source");
+        assertEquals(wanted.getClass(), converter.getSourceClass(), "pass thru source class");
+        assertEquals(targetClass, converter.getTargetClass(), "pass thru target class");
     }
 
     @Test

--- a/framework/base/src/test/java/org/apache/ofbiz/base/conversion/TestBooleanConverters.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/conversion/TestBooleanConverters.java
@@ -18,45 +18,43 @@
  */
 package org.apache.ofbiz.base.conversion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.ofbiz.base.util.UtilGenerics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestBooleanConverters {
 
     public static <T> void assertFromBoolean(String label, Converter<Boolean, T> converter, T trueResult, T falseResult)
             throws Exception {
-        assertTrue(label + " can convert", converter.canConvert(Boolean.class, trueResult.getClass()));
-        assertEquals(label + " registered", converter.getClass(),
-                Converters.getConverter(Boolean.class, trueResult.getClass()).getClass());
-        assertEquals(label + " converted", trueResult, converter.convert(true));
-        assertEquals(label + " converted", falseResult, converter.convert(false));
+        assertTrue(converter.canConvert(Boolean.class, trueResult.getClass()), label + " can convert");
+        assertEquals(converter.getClass(), Converters.getConverter(Boolean.class, trueResult.getClass()).getClass(), label + " registered");
+        assertEquals(trueResult, converter.convert(true), label + " converted");
+        assertEquals(falseResult, converter.convert(false), label + " converted");
     }
 
     public static <S> void assertToBoolean(String label, Converter<S, Boolean> converter, S trueSource, S falseSource)
             throws Exception {
-        assertTrue(label + " can convert", converter.canConvert(trueSource.getClass(), Boolean.class));
-        assertEquals(label + " registered", converter.getClass(),
-                Converters.getConverter(trueSource.getClass(), Boolean.class).getClass());
-        assertEquals(label + " converted", Boolean.TRUE, converter.convert(trueSource));
-        assertEquals(label + " converted", Boolean.FALSE, converter.convert(falseSource));
+        assertTrue(converter.canConvert(trueSource.getClass(), Boolean.class), label + " can convert");
+        assertEquals(converter.getClass(), Converters.getConverter(trueSource.getClass(), Boolean.class).getClass(), label + " registered");
+        assertEquals(Boolean.TRUE, converter.convert(trueSource), label + " converted");
+        assertEquals(Boolean.FALSE, converter.convert(falseSource), label + " converted");
     }
 
     public static <S> void assertToCollection(String label, S source) throws Exception {
         Converter<S, ? extends Collection<S>> toList =
                 UtilGenerics.cast(Converters.getConverter(source.getClass(), List.class));
         Collection<S> listResult = toList.convert(source);
-        assertEquals(label + " converted to List", source, listResult.toArray()[0]);
+        assertEquals(source, listResult.toArray()[0], label + " converted to List");
         Converter<S, ? extends Collection<S>> toSet =
                 UtilGenerics.cast(Converters.getConverter(source.getClass(), Set.class));
         Collection<S> setResult = toSet.convert(source);
-        assertEquals(label + " converted to Set", source, setResult.toArray()[0]);
+        assertEquals(source, setResult.toArray()[0], label + " converted to Set");
     }
 
     @Test

--- a/framework/base/src/test/java/org/apache/ofbiz/base/conversion/TestJSONConverters.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/conversion/TestJSONConverters.java
@@ -18,7 +18,7 @@
  */
 package org.apache.ofbiz.base.conversion;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import org.apache.ofbiz.base.lang.JSON;
 import org.apache.ofbiz.base.util.UtilGenerics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestJSONConverters {
     public TestJSONConverters() {
@@ -48,7 +48,7 @@ public class TestJSONConverters {
         JSON json = JSON.from(map);
         Object obj = converter.convert(json);
         convertedMap = (obj instanceof Map) ? UtilGenerics.cast(obj) : null;
-        assertEquals("JSON to Map", map, convertedMap);
+        assertEquals(map, convertedMap, "JSON to Map");
     }
 
     @Test
@@ -60,7 +60,7 @@ public class TestJSONConverters {
         JSON json = JSON.from(list);
         Object obj = converter.convert(json);
         List<Object> convertedList = (obj instanceof List) ? UtilGenerics.cast(obj) : null;
-        assertEquals("JSON to List", list, convertedList);
+        assertEquals(list, convertedList, "JSON to List");
     }
 
     @Test
@@ -72,7 +72,7 @@ public class TestJSONConverters {
         map.put("field1", "value1");
         map.put("field2", new BigDecimal("3.7"));
         json = converter.convert(map);
-        assertEquals("Map to JSON", "{\"field1\":\"value1\",\"field2\":3.7}", json.toString());
+        assertEquals("{\"field1\":\"value1\",\"field2\":3.7}", json.toString(), "Map to JSON");
     }
 
     @Test
@@ -83,7 +83,7 @@ public class TestJSONConverters {
         list.add("field1");
         list.add("field2");
         json = converter.convert(list);
-        assertEquals("List to JSON", "[\"field1\",\"field2\"]", json.toString());
+        assertEquals("[\"field1\",\"field2\"]", json.toString(), "List to JSON");
     }
 }
 

--- a/framework/base/src/test/java/org/apache/ofbiz/base/lang/ComparableRangeTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/lang/ComparableRangeTests.java
@@ -21,14 +21,14 @@ package org.apache.ofbiz.base.lang;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.ofbiz.base.util.UtilGenerics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ComparableRangeTests {
 
@@ -41,69 +41,69 @@ public class ComparableRangeTests {
     private static <T extends Comparable<T>, B extends Comparable<B>> void comparableRangeTest(String label, B bad,
             T a, T b, T c, T d) {
         comparableRangeConstructorTest(bad, a);
-        assertTrue(label + ":a-isPoint", new ComparableRange<>(a, a).isPoint());
-        assertTrue(label + ":b-isPoint", new ComparableRange<>(b, b).isPoint());
-        assertTrue(label + ":c-isPoint", new ComparableRange<>(c, c).isPoint());
+        assertTrue(new ComparableRange<>(a, a).isPoint(), label + ":a-isPoint");
+        assertTrue(new ComparableRange<>(b, b).isPoint(), label + ":b-isPoint");
+        assertTrue(new ComparableRange<>(c, c).isPoint(), label + ":c-isPoint");
         ComparableRange<T> first = new ComparableRange<>(a, b);
         ComparableRange<T> second = new ComparableRange<>(c, d);
         ComparableRange<T> all = new ComparableRange<>(a, d);
-        assertEquals(label + ":a-b toString", a + " - " + b, first.toString());
-        assertEquals(label + ":c-d toString", c + " - " + d, second.toString());
-        assertEquals(label + ":a-d toString", a + " - " + d, all.toString());
-        assertFalse(label + ":a-b isPoint", first.isPoint());
-        assertFalse(label + ":c-d isPoint", second.isPoint());
-        assertFalse(label + ":a-d isPoint", all.isPoint());
-        assertEquals(label + ":a-b == a-b", first, first);
-        assertEquals(label + ":a-b.compareTo(a-b)", 0, first.compareTo(first));
-        assertEquals(label + ":a-b equals a-b", first, new ComparableRange<>(a, b));
-        assertEquals(label + ":a-b.compareTo(new a-b)", 0, first.compareTo(new ComparableRange<>(a, b)));
-        assertEquals(label + ":a-b equals b-a", first, new ComparableRange<>(b, a));
-        assertEquals(label + ":a-b.compareTo(new b-a)", 0, first.compareTo(new ComparableRange<>(b, a)));
-        assertNotEquals(label + ":a-b not-equal other", first, ComparableRangeTests.class);
-        assertFalse(label + ":a-d equals null", all.equals(null));
+        assertEquals(a + " - " + b, first.toString(), label + ":a-b toString");
+        assertEquals(c + " - " + d, second.toString(), label + ":c-d toString");
+        assertEquals(a + " - " + d, all.toString(), label + ":a-d toString");
+        assertFalse(first.isPoint(), label + ":a-b isPoint");
+        assertFalse(second.isPoint(), label + ":c-d isPoint");
+        assertFalse(all.isPoint(), label + ":a-d isPoint");
+        assertEquals(first, first, label + ":a-b == a-b");
+        assertEquals(0, first.compareTo(first), label + ":a-b.compareTo(a-b)");
+        assertEquals(first, new ComparableRange<>(a, b), label + ":a-b equals a-b");
+        assertEquals(0, first.compareTo(new ComparableRange<>(a, b)), label + ":a-b.compareTo(new a-b)");
+        assertEquals(first, new ComparableRange<>(b, a), label + ":a-b equals b-a");
+        assertEquals(0, first.compareTo(new ComparableRange<>(b, a)), label + ":a-b.compareTo(new b-a)");
+        assertNotEquals(first, ComparableRangeTests.class, label + ":a-b not-equal other");
+        assertFalse(all.equals(null), label + ":a-d equals null");
         ClassCastException caught = null;
         try {
             UtilGenerics.<Comparable<Object>>cast(first).compareTo(ComparableRangeTests.class);
         } catch (ClassCastException e) {
             caught = e;
         } finally {
-            assertNotNull(label + " compareTo CCE", caught);
+            assertNotNull(caught, label + " compareTo CCE");
         }
-        assertNotEquals(label + ":a-a != a-b", new ComparableRange<>(a, a), first);
+        assertNotEquals(new ComparableRange<>(a, a), first, label + ":a-a != a-b");
         assertThat(label + ":a-a.compareTo(a-b) < 0", 0, greaterThan(new ComparableRange<>(a, a).compareTo(first)));
-        assertNotEquals(label + ":a-a != c-d", new ComparableRange<>(a, a), second);
+        assertNotEquals(new ComparableRange<>(a, a), second, label + ":a-a != c-d");
         assertThat(label + ":a-a.compareTo(c-d) < 0", 0, greaterThan(new ComparableRange<>(a, a).compareTo(second)));
-        assertNotEquals(label + ":a-a != a-d", new ComparableRange<>(a, a), all);
+        assertNotEquals(new ComparableRange<>(a, a), all, label + ":a-a != a-d");
         assertThat(label + ":a-a.compareTo(a-d) < 0", 0, greaterThan(new ComparableRange<>(a, a).compareTo(all)));
-        assertTrue(label + ":b-c after a-b", second.after(first));
+        assertTrue(second.after(first), label + ":b-c after a-b");
         assertThat(label + ":b-c.compareTo(a-b)", 0, lessThan(second.compareTo(first)));
-        assertFalse(label + ":c-d !after c-d", second.after(second));
-        assertEquals(label + ":c-d.compareTo(c-d)", 0, second.compareTo(second));
-        assertTrue(label + ":a-b before c-d", first.before(second));
+        assertFalse(second.after(second), label + ":c-d !after c-d");
+        assertEquals(0, second.compareTo(second), label + ":c-d.compareTo(c-d)");
+        assertTrue(first.before(second), label + ":a-b before c-d");
         assertThat(label + ":a-b.compareTo(c-d)", 0, greaterThan(first.compareTo(second)));
-        assertFalse(label + ":a-b !before a-b", first.before(first));
-        assertEquals(label + ":a-b.compareTo(a-b)", 0, first.compareTo(first));
-        assertTrue(label + ":a-d includes a-b", all.includes(first));
-        assertTrue(label + ":a-b overlaps b-c", first.overlaps(new ComparableRange<>(b, c)));
-        assertTrue(label + ":b-c overlaps c-d", new ComparableRange<>(b, c).overlaps(second));
-        assertTrue(label + ":a-b overlaps a-d", first.overlaps(all));
-        assertTrue(label + ":a-d overlaps a-b", all.overlaps(first));
-        assertTrue(label + ":a-d overlaps b-c", all.overlaps(new ComparableRange<>(b, c)));
-        assertTrue(label + ":b-c overlaps a-d", new ComparableRange<>(b, c).overlaps(all));
-        assertFalse(label + ":a-b overlaps c-d", first.overlaps(second));
-        assertFalse(label + ":c-d overlaps a-b", second.overlaps(first));
-        assertTrue(label + ":a-b includes a", first.includes(a));
-        assertTrue(label + ":a-b includes b", first.includes(b));
-        assertFalse(label + ":a-b includes c", first.includes(c));
-        assertFalse(label + ":a includes a-b", new ComparableRange<>(a, a).includes(first));
-        assertTrue(label + ":c-d after a", second.after(a));
-        assertTrue(label + ":c-d after b", second.after(b));
-        assertFalse(label + ":c-d after c", second.after(c));
-        assertFalse(label + ":c-d after d", second.after(d));
-        assertFalse(label + ":a-b after a", first.before(a));
-        assertFalse(label + ":a-b after b", first.before(b));
-        assertTrue(label + ":a-b after c", first.before(c));
-        assertTrue(label + ":a-b after d", first.before(d));
+        assertFalse(first.before(first), label + ":a-b !before a-b");
+        assertEquals(0, first.compareTo(first), label + ":a-b.compareTo(a-b)");
+        assertTrue(all.includes(first), label + ":a-d includes a-b");
+        assertTrue(first.overlaps(new ComparableRange<>(b, c)), label + ":a-b overlaps b-c");
+        assertTrue(new ComparableRange<>(b, c).overlaps(second), label + ":b-c overlaps c-d");
+        assertTrue(first.overlaps(all), label + ":a-b overlaps a-d");
+        assertTrue(all.overlaps(first), label + ":a-d overlaps a-b");
+        assertTrue(all.overlaps(new ComparableRange<>(b, c)), label + ":a-d overlaps b-c");
+        assertTrue(new ComparableRange<>(b, c).overlaps(all), label + ":b-c overlaps a-d");
+        assertFalse(first.overlaps(second), label + ":a-b overlaps c-d");
+        assertFalse(second.overlaps(first), label + ":c-d overlaps a-b");
+        assertTrue(first.includes(a), label + ":a-b includes a");
+        assertTrue(first.includes(b), label + ":a-b includes b");
+        assertFalse(first.includes(c), label + ":a-b includes c");
+        assertFalse(new ComparableRange<>(a, a).includes(first), label + ":a includes a-b");
+        assertTrue(second.after(a), label + ":c-d after a");
+        assertTrue(second.after(b), label + ":c-d after b");
+        assertFalse(second.after(c), label + ":c-d after c");
+        assertFalse(second.after(d), label + ":c-d after d");
+        assertFalse(first.before(a), label + ":a-b after a");
+        assertFalse(first.before(b), label + ":a-b after b");
+        assertTrue(first.before(c), label + ":a-b after c");
+        assertTrue(first.before(d), label + ":a-b after d");
     }
 
     @Test

--- a/framework/base/src/test/java/org/apache/ofbiz/base/test/BaseUnitTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/test/BaseUnitTests.java
@@ -18,15 +18,15 @@
  */
 package org.apache.ofbiz.base.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.StringUtil;
 import org.apache.ofbiz.base.util.UtilFormatOut;
 import org.apache.ofbiz.base.util.UtilValidate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BaseUnitTests {
 
@@ -49,23 +49,17 @@ public class BaseUnitTests {
 
     @Test
     public void testFormatPrintableCreditCard1() {
-        assertEquals("test 4111111111111111 to ************111",
-                "************1111",
-                UtilFormatOut.formatPrintableCreditCard("4111111111111111"));
+        assertEquals("************1111", UtilFormatOut.formatPrintableCreditCard("4111111111111111"), "test 4111111111111111 to ************111");
     }
 
     @Test
     public void testFormatPrintableCreditCard2() {
-        assertEquals("test 4111 to 4111",
-                "4111",
-                UtilFormatOut.formatPrintableCreditCard("4111"));
+        assertEquals("4111", UtilFormatOut.formatPrintableCreditCard("4111"), "test 4111 to 4111");
     }
 
     @Test
     public void testFormatPrintableCreditCard3() {
-        assertEquals("test null to null",
-                null,
-                UtilFormatOut.formatPrintableCreditCard(null));
+        assertEquals(null, UtilFormatOut.formatPrintableCreditCard(null), "test null to null");
     }
 
     @Test
@@ -92,7 +86,7 @@ public class BaseUnitTests {
     public void testStringUtil() {
         byte[] testArray = {-1};
         byte[] result = StringUtil.fromHexString(StringUtil.toHexString(testArray));
-        assertEquals("Hex conversions", testArray[0], result[0]);
+        assertEquals(testArray[0], result[0], "Hex conversions");
     }
 
 }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/AssertTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/AssertTests.java
@@ -16,14 +16,14 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Assert tests {@link org.apache.ofbiz.base.util.Assert}.

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/DiGraphTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/DiGraphTest.java
@@ -23,20 +23,15 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assume.assumeNoException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
-import com.pholser.junit.quickcheck.Property;
-import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
-
-@RunWith(JUnitQuickcheck.class)
 public class DiGraphTest {
 
     @Test
@@ -51,14 +46,14 @@ public class DiGraphTest {
                 "e", asList("z", "b")));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testWithCycle() {
         Map<String, Collection<String>> g = UtilMisc.toMap(
                 "a", asList("b"),
                 "b", asList("c"),
                 "c", asList("a"));
         Digraph<String> dg = new Digraph<>(g);
-        dg.sort();
+        assertThrows(IllegalStateException.class, () -> dg.sort());
     }
 
     @Test
@@ -67,17 +62,6 @@ public class DiGraphTest {
                 "a", asList("b"),
                 "b", emptyList(),
                 "c", asList("b")));
-    }
-
-    @Property
-    public <T> void topologicalOrderProperty(Map<T, Collection<T>> graphspec) {
-        try {
-            checkTopologicalOrder(graphspec);
-        } catch (IllegalArgumentException e) {
-            assumeNoException("Invalid Graph", e);
-        } catch (IllegalStateException e) {
-            assumeNoException("Not a directed acyclic graph", e);
-        }
     }
 
     private static <T> void checkTopologicalOrder(Map<T, Collection<T>> graphspec) {

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/IndentingWriterTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/IndentingWriterTests.java
@@ -18,12 +18,12 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.StringWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IndentingWriterTests {
 
@@ -45,14 +45,14 @@ public class IndentingWriterTests {
         iw.pop();
         iw.write("e");
         iw.close();
-        assertEquals(label, wanted, sw.toString());
+        assertEquals(wanted, sw.toString(), label);
     }
 
     @Test
     public void testIndentingWriter() throws Exception {
         StringWriter sw = new StringWriter();
         IndentingWriter iw = IndentingWriter.makeIndentingWriter(sw);
-        assertSame("makeIndentingWriter - pass-thru", iw, IndentingWriter.makeIndentingWriter(iw));
+        assertSame(iw, IndentingWriter.makeIndentingWriter(iw), "makeIndentingWriter - pass-thru");
         doTest("IndentingWriter doSpace:doNewline", true, true, "ab\n m\n 1\n 2 \n e");
         doTest("IndentingWriter doNewline", false, true, "ab\nm\n1\n2\ne");
         doTest("IndentingWriter doSpace", true, false, "ab\n m 1\n 2 \n e");

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/ObjectTypeTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/ObjectTypeTests.java
@@ -18,12 +18,12 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -39,7 +39,7 @@ import java.util.TimeZone;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 import com.ibm.icu.util.Calendar;
@@ -114,16 +114,13 @@ public class ObjectTypeTests {
     public static void simpleTypeOrObjectConvertTest(String label, Object toConvert, String type, Object wanted)
             throws GeneralException {
         basicTest(label, toConvert);
-        assertEquals(label + ":null target type", toConvert,
-                simpleTypeOrObjectConvert(toConvert, null, null, null, null, true));
-        assertEquals(label + ":null source object", (Object) null,
-                simpleTypeOrObjectConvert(null, type, null, null, null, true));
-        assertEquals(label, wanted, simpleTypeOrObjectConvert(toConvert, type, null, null, null, true));
+        assertEquals(toConvert, simpleTypeOrObjectConvert(toConvert, null, null, null, null, true), label + ":null target type");
+        assertEquals((Object) null, simpleTypeOrObjectConvert(null, type, null, null, null, true), label + ":null source object");
+        assertEquals(wanted, simpleTypeOrObjectConvert(toConvert, type, null, null, null, true), label);
         if (toConvert instanceof String) {
             String str = (String) toConvert;
             Document doc = UtilXml.makeEmptyXmlDocument();
-            assertEquals(label + ":text-node proxy", wanted,
-                    simpleTypeOrObjectConvert(doc.createTextNode(str), type, null, null, null, true));
+            assertEquals(wanted, simpleTypeOrObjectConvert(doc.createTextNode(str), type, null, null, null, true), label + ":text-node proxy");
         }
     }
 
@@ -135,17 +132,14 @@ public class ObjectTypeTests {
         try {
             Locale.setDefault(localeData.goodLocale);
             TimeZone.setDefault(localeData.goodTimeZone);
-            assertEquals(label + ":default-timezone/locale", wanted,
-                    simpleTypeOrObjectConvert(toConvert, type, format, null, null, true));
-            assertNotEquals(label + ":bad-passed-timezone/locale", wanted,
-                    simpleTypeOrObjectConvert(toConvert, type, format, localeData.badTimeZone, localeData.badLocale,
-                            true));
+            assertEquals(wanted, simpleTypeOrObjectConvert(toConvert, type, format, null, null, true), label + ":default-timezone/locale");
+            assertNotEquals(wanted, simpleTypeOrObjectConvert(toConvert, type, format, localeData.badTimeZone, localeData.badLocale,
+                            true), label + ":bad-passed-timezone/locale");
             Locale.setDefault(localeData.badLocale);
             TimeZone.setDefault(localeData.badTimeZone);
-            assertNotEquals(label + ":bad-default-timezone/locale", wanted,
-                    simpleTypeOrObjectConvert(toConvert, type, format, null, null, true));
-            assertEquals(label + ":passed-timezone/locale", wanted, simpleTypeOrObjectConvert(toConvert, type, format,
-                    localeData.goodTimeZone, localeData.goodLocale, true));
+            assertNotEquals(wanted, simpleTypeOrObjectConvert(toConvert, type, format, null, null, true), label + ":bad-default-timezone/locale");
+            assertEquals(wanted, simpleTypeOrObjectConvert(toConvert, type, format,
+                    localeData.goodTimeZone, localeData.goodLocale, true), label + ":passed-timezone/locale");
         } finally {
             Locale.setDefault(defaultLocale);
             TimeZone.setDefault(defaultTimeZone);
@@ -193,7 +187,7 @@ public class ObjectTypeTests {
         } catch (GeneralException e) {
             caught = e;
         } finally {
-            assertNotNull(label + ":caught", caught);
+            assertNotNull(caught, label + ":caught");
         }
     }
 
@@ -207,7 +201,7 @@ public class ObjectTypeTests {
 
     public static void simpleTypeOrObjectConvertTestNoError(String label, Object toConvert, String type)
             throws GeneralException {
-        assertSame(label, toConvert, simpleTypeOrObjectConvert(toConvert, type, null, null, null, false));
+        assertSame(toConvert, simpleTypeOrObjectConvert(toConvert, type, null, null, null, false), label);
     }
 
     public static void simpleTypeOrObjectConvertTestNoError(String label, Object toConvert, String[] types)
@@ -219,14 +213,10 @@ public class ObjectTypeTests {
     }
 
     public static void basicTest(String label, Object toConvert) throws GeneralException {
-        assertEquals(label + ":PlainString", toConvert.toString(),
-                simpleTypeOrObjectConvert(toConvert, "PlainString", null, null, null, true));
-        assertSame(label + ":same", toConvert,
-                simpleTypeOrObjectConvert(toConvert, toConvert.getClass().getName(), null, null, null, true));
-        assertSame(label + ":to-Object", toConvert,
-                simpleTypeOrObjectConvert(toConvert, "Object", null, null, null, true));
-        assertSame(label + ":to-java.lang.Object",
-                toConvert, simpleTypeOrObjectConvert(toConvert, "java.lang.Object", null, null, null, true));
+        assertEquals(toConvert.toString(), simpleTypeOrObjectConvert(toConvert, "PlainString", null, null, null, true), label + ":PlainString");
+        assertSame(toConvert, simpleTypeOrObjectConvert(toConvert, toConvert.getClass().getName(), null, null, null, true), label + ":same");
+        assertSame(toConvert, simpleTypeOrObjectConvert(toConvert, "Object", null, null, null, true), label + ":to-Object");
+        assertSame(toConvert, simpleTypeOrObjectConvert(toConvert, "java.lang.Object", null, null, null, true), label + ":to-java.lang.Object");
     }
 
     @Test
@@ -237,8 +227,7 @@ public class ObjectTypeTests {
         } catch (Exception e) {
             exception = e;
         }
-        assertTrue("Exception thrown by loadClass(\"foobarbaz\") is not ClassNotFoundException",
-                exception instanceof ClassNotFoundException);
+        assertTrue(exception instanceof ClassNotFoundException, "Exception thrown by loadClass(\"foobarbaz\") is not ClassNotFoundException");
     }
 
     @Test
@@ -246,23 +235,21 @@ public class ObjectTypeTests {
         try {
             Class<?> theClass;
             theClass = ObjectType.loadClass("boolean");
-            assertEquals("Wrong class returned by loadClass(\"boolean\")", (Boolean.TYPE).getName(),
-                    theClass.getName());
+            assertEquals((Boolean.TYPE).getName(), theClass.getName(), "Wrong class returned by loadClass(\"boolean\")");
             theClass = ObjectType.loadClass("short");
-            assertEquals("Wrong class returned by loadClass(\"short\")", (Short.TYPE).getName(), theClass.getName());
+            assertEquals((Short.TYPE).getName(), theClass.getName(), "Wrong class returned by loadClass(\"short\")");
             theClass = ObjectType.loadClass("int");
-            assertEquals("Wrong class returned by loadClass(\"int\")", (Integer.TYPE).getName(), theClass.getName());
+            assertEquals((Integer.TYPE).getName(), theClass.getName(), "Wrong class returned by loadClass(\"int\")");
             theClass = ObjectType.loadClass("long");
-            assertEquals("Wrong class returned by loadClass(\"long\")", (Long.TYPE).getName(), theClass.getName());
+            assertEquals((Long.TYPE).getName(), theClass.getName(), "Wrong class returned by loadClass(\"long\")");
             theClass = ObjectType.loadClass("float");
-            assertEquals("Wrong class returned by loadClass(\"float\")", (Float.TYPE).getName(), theClass.getName());
+            assertEquals((Float.TYPE).getName(), theClass.getName(), "Wrong class returned by loadClass(\"float\")");
             theClass = ObjectType.loadClass("double");
-            assertEquals("Wrong class returned by loadClass(\"double\")", (Double.TYPE).getName(), theClass.getName());
+            assertEquals((Double.TYPE).getName(), theClass.getName(), "Wrong class returned by loadClass(\"double\")");
             theClass = ObjectType.loadClass("byte");
-            assertEquals("Wrong class returned by loadClass(\"byte\")", (Byte.TYPE).getName(), theClass.getName());
+            assertEquals((Byte.TYPE).getName(), theClass.getName(), "Wrong class returned by loadClass(\"byte\")");
             theClass = ObjectType.loadClass("char");
-            assertEquals("Wrong class returned by loadClass(\"char\")", (Character.TYPE).getName(),
-                    theClass.getName());
+            assertEquals((Character.TYPE).getName(), theClass.getName(), "Wrong class returned by loadClass(\"char\")");
         } catch (Exception e) {
             fail("Exception thrown by loadClass: " + e.getMessage());
         }
@@ -274,15 +261,14 @@ public class ObjectTypeTests {
             Class<?> theClass;
             // first try with a class full name
             theClass = ObjectType.loadClass("java.lang.String");
-            assertEquals("Wrong class returned by loadClass(\"java.lang.String\")", "java.lang.String",
-                    theClass.getName());
+            assertEquals("java.lang.String", theClass.getName(), "Wrong class returned by loadClass(\"java.lang.String\")");
             // now try with some aliases
             theClass = ObjectType.loadClass("String");
-            assertEquals("Wrong class returned by loadClass(\"String\")", "java.lang.String", theClass.getName());
+            assertEquals("java.lang.String", theClass.getName(), "Wrong class returned by loadClass(\"String\")");
             theClass = ObjectType.loadClass("Object");
-            assertEquals("Wrong class returned by loadClass(\"Object\")", "java.lang.Object", theClass.getName());
+            assertEquals("java.lang.Object", theClass.getName(), "Wrong class returned by loadClass(\"Object\")");
             theClass = ObjectType.loadClass("Date");
-            assertEquals("Wrong class returned by loadClass(\"Date\")", "java.sql.Date", theClass.getName());
+            assertEquals("java.sql.Date", theClass.getName(), "Wrong class returned by loadClass(\"Date\")");
         } catch (Exception e) {
             fail("Exception thrown by loadClass: " + e.getMessage());
         }
@@ -296,7 +282,7 @@ public class ObjectTypeTests {
         } catch (GeneralException e) {
             caught = e;
         } finally {
-            assertNotNull("class not found", caught);
+            assertNotNull(caught, "class not found");
         }
     }
 
@@ -401,9 +387,8 @@ public class ObjectTypeTests {
 
         // usual pattern assumes that the String->BigDecimal conversion will break with bad timezone/locale
         // which is not the case for this particular test
-        assertEquals("String->BigDecimal supports NBSP",
-                simpleTypeOrObjectConvert("29 000", "BigDecimal", null, LOCALE_DATA.goodTimeZone,
-                        LOCALE_DATA.goodLocale, false), largeBigDecimal);
+        assertEquals(simpleTypeOrObjectConvert("29 000", "BigDecimal", null, LOCALE_DATA.goodTimeZone,
+                        LOCALE_DATA.goodLocale, false), largeBigDecimal, "String->BigDecimal supports NBSP");
     }
 
     @Test

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/ObjectTypeTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/ObjectTypeTests.java
@@ -37,14 +37,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 import com.ibm.icu.util.Calendar;
 
-public class ObjectTypeTests {
+public final class ObjectTypeTests {
     private static final LocaleData LOCALE_DATA = new LocaleData("en_US", "Pacific/Wake", "fr", "GMT");
     private final TimeDuration duration = new TimeDuration(0, 0, 0, 1, 1, 1, 1);
     // These numbers are all based on 1 / 128, which is a binary decimal
@@ -96,12 +96,12 @@ public class ObjectTypeTests {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         System.setProperty("testBigDecimal", "bypassLocaleChange");
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         System.clearProperty("testBigDecimal");
     }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/StringUtilTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/StringUtilTests.java
@@ -46,10 +46,14 @@ public class StringUtilTests {
     @Test
     public void testReplaceString() {
         assertNull(StringUtil.replaceString(null, "old", "new"), "null");
-        assertEquals("the old dog jumped over the old fence", StringUtil.replaceString("the old dog jumped over the old fence", "", "new"), "empty old");
-        assertEquals("the new dog jumped over the new fence", StringUtil.replaceString("the old dog jumped over the old fence", "old", "new"), "replace");
-        assertEquals("the  dog jumped over the  fence", StringUtil.replaceString("the old dog jumped over the old fence", "old", null), "replace-null");
-        assertEquals("the old dog jumped over the old fence", StringUtil.replaceString("the old dog jumped over the old fence", "cat", "feline"), "replace-not-found");
+        assertEquals("the old dog jumped over the old fence",
+                StringUtil.replaceString("the old dog jumped over the old fence", "", "new"), "empty old");
+        assertEquals("the new dog jumped over the new fence",
+                StringUtil.replaceString("the old dog jumped over the old fence", "old", "new"), "replace");
+        assertEquals("the  dog jumped over the  fence",
+                StringUtil.replaceString("the old dog jumped over the old fence", "old", null), "replace-null");
+        assertEquals("the old dog jumped over the old fence",
+                StringUtil.replaceString("the old dog jumped over the old fence", "cat", "feline"), "replace-not-found");
     }
 
     @Test
@@ -257,18 +261,25 @@ public class StringUtilTests {
         assertEquals("this ( are …d )",
                 StringUtil.truncateEncodedStringToLength("this ( are managed correctly, with the end )", 15), "with parenthesis at end");
         assertEquals("this ( are …d )",
-                StringUtil.truncateEncodedStringToLength("this ( are a semicolon far ; managed correctly, with the end )", 15), "with parenthesis and semicolon ignored");
+                StringUtil.truncateEncodedStringToLength("this ( are a semicolon far ; managed correctly, with the end )", 15),
+                "with parenthesis and semicolon ignored");
         assertEquals("this ( are;…d )",
-                StringUtil.truncateEncodedStringToLength("this ( are; a semicolon closer managed correctly, with the end )", 15), "with parenthesis and semicolon closer");
+                StringUtil.truncateEncodedStringToLength("this ( are; a semicolon closer managed correctly, with the end )", 15),
+                "with parenthesis and semicolon closer");
         assertEquals("this ( are&eacut;…end",
-                StringUtil.truncateEncodedStringToLength("this ( are&eacut; managed correctly, with the ) end", 15), "with parenthesis and é managed");
+                StringUtil.truncateEncodedStringToLength("this ( are&eacut; managed correctly, with the ) end", 15),
+                "with parenthesis and é managed");
         assertEquals("this ( a&eacut;e&eacut;…end",
-                StringUtil.truncateEncodedStringToLength("this ( a&eacut;e&eacut; managed correctly, with the ) end", 15), "with parenthesis and é é managed");
+                StringUtil.truncateEncodedStringToLength("this ( a&eacut;e&eacut; managed correctly, with the ) end", 15),
+                "with parenthesis and é é managed");
         assertEquals("this ( are …n&eacut;d",
-                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e ) en&eacut;d", 15), "with parenthesis and é closer");
+                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e ) en&eacut;d", 15),
+                "with parenthesis and é closer");
         assertEquals("this ( are …&eacut;&eacut;d",
-                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e )en&eacut;&eacut;d", 15), "with parenthesis and é é closer");
+                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e )en&eacut;&eacut;d", 15),
+                "with parenthesis and é é closer");
         assertEquals("this ( are …&#235;&#235;d",
-                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e )en&#235;&#235;d", 15), "with parenthesis and # # closer");
+                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e )en&#235;&#235;d", 15),
+                "with parenthesis and # # closer");
     }
 }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/StringUtilTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/StringUtilTests.java
@@ -21,96 +21,89 @@ package org.apache.ofbiz.base.util;
 import com.ibm.icu.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StringUtilTests {
 
     @Test
     public void testInternString() {
-        assertSame("intern-constant", StringUtil.internString("foo"), StringUtil.internString("foo"));
-        assertSame("intern-new", StringUtil.internString("foo"), StringUtil.internString("foo"));
-        assertSame("intern-char", StringUtil.internString("foo"),
-                StringUtil.internString(new String(new char[] {'f', 'o', 'o'})));
-        assertSame("intern-null", StringUtil.internString(null), StringUtil.internString(null));
+        assertSame(StringUtil.internString("foo"), StringUtil.internString("foo"), "intern-constant");
+        assertSame(StringUtil.internString("foo"), StringUtil.internString("foo"), "intern-new");
+        assertSame(StringUtil.internString("foo"), StringUtil.internString(new String(new char[] {'f', 'o', 'o'})), "intern-char");
+        assertSame(StringUtil.internString(null), StringUtil.internString(null), "intern-null");
     }
 
     @Test
     public void testReplaceString() {
-        assertNull("null", StringUtil.replaceString(null, "old", "new"));
-        assertEquals("empty old", "the old dog jumped over the old fence",
-                StringUtil.replaceString("the old dog jumped over the old fence", "", "new"));
-        assertEquals("replace", "the new dog jumped over the new fence",
-                StringUtil.replaceString("the old dog jumped over the old fence", "old", "new"));
-        assertEquals("replace-null", "the  dog jumped over the  fence",
-                StringUtil.replaceString("the old dog jumped over the old fence", "old", null));
-        assertEquals("replace-not-found", "the old dog jumped over the old fence",
-                StringUtil.replaceString("the old dog jumped over the old fence", "cat", "feline"));
+        assertNull(StringUtil.replaceString(null, "old", "new"), "null");
+        assertEquals("the old dog jumped over the old fence", StringUtil.replaceString("the old dog jumped over the old fence", "", "new"), "empty old");
+        assertEquals("the new dog jumped over the new fence", StringUtil.replaceString("the old dog jumped over the old fence", "old", "new"), "replace");
+        assertEquals("the  dog jumped over the  fence", StringUtil.replaceString("the old dog jumped over the old fence", "old", null), "replace-null");
+        assertEquals("the old dog jumped over the old fence", StringUtil.replaceString("the old dog jumped over the old fence", "cat", "feline"), "replace-not-found");
     }
 
     @Test
     public void testJoin() {
-        assertNull("null-list", StringUtil.join(null, ","));
-        assertNull("empty-list", StringUtil.join(Collections.emptyList(), ","));
-        assertEquals("single", "1", StringUtil.join(Collections.singleton("1"), ","));
-        assertEquals("double", "1,2", StringUtil.join(Arrays.asList("1", "2"), ","));
+        assertNull(StringUtil.join(null, ","), "null-list");
+        assertNull(StringUtil.join(Collections.emptyList(), ","), "empty-list");
+        assertEquals("1", StringUtil.join(Collections.singleton("1"), ","), "single");
+        assertEquals("1,2", StringUtil.join(Arrays.asList("1", "2"), ","), "double");
     }
 
     @Test
     public void testSplit() {
-        assertNull("null-string", StringUtil.split(null, ","));
-        assertEquals("single", Arrays.asList("1"), StringUtil.split("1", ","));
-        assertEquals("double", Arrays.asList("1", "2"), StringUtil.split("1,2", ","));
-        assertEquals("no-sep", Arrays.asList("1", "2", "3", "4", "5", "6"), StringUtil.split("1 2\t3\n4\r5\f6", null));
+        assertNull(StringUtil.split(null, ","), "null-string");
+        assertEquals(Arrays.asList("1"), StringUtil.split("1", ","), "single");
+        assertEquals(Arrays.asList("1", "2"), StringUtil.split("1,2", ","), "double");
+        assertEquals(Arrays.asList("1", "2", "3", "4", "5", "6"), StringUtil.split("1 2\t3\n4\r5\f6", null), "no-sep");
     }
 
     @Test
     public void testStrToMap() {
-        assertNull("null-string", StringUtil.strToMap(null, false));
-        assertNull("empty", StringUtil.strToMap("", false));
-        assertEquals("missing =", Collections.emptyMap(), StringUtil.strToMap("1", false));
-        assertEquals("single", UtilMisc.toMap("1", "one"), StringUtil.strToMap("1=one"));
-        assertEquals("double", UtilMisc.toMap("2", "two", "1", "one"), StringUtil.strToMap("1=one|2=two"));
-        assertEquals("double-no-trim", UtilMisc.toMap(" 2 ", " two ", " 1 ", " one "),
-                StringUtil.strToMap(" 1 = one | 2 = two "));
-        assertEquals("double-trim", UtilMisc.toMap("2", "two", "1", "one"),
-                StringUtil.strToMap(" 1 = one | 2 = two ", true));
+        assertNull(StringUtil.strToMap(null, false), "null-string");
+        assertNull(StringUtil.strToMap("", false), "empty");
+        assertEquals(Collections.emptyMap(), StringUtil.strToMap("1", false), "missing =");
+        assertEquals(UtilMisc.toMap("1", "one"), StringUtil.strToMap("1=one"), "single");
+        assertEquals(UtilMisc.toMap("2", "two", "1", "one"), StringUtil.strToMap("1=one|2=two"), "double");
+        assertEquals(UtilMisc.toMap(" 2 ", " two ", " 1 ", " one "), StringUtil.strToMap(" 1 = one | 2 = two "), "double-no-trim");
+        assertEquals(UtilMisc.toMap("2", "two", "1", "one"), StringUtil.strToMap(" 1 = one | 2 = two ", true), "double-trim");
     }
 
     @Test
     public void testMapToStr() {
         // Test Null
-        assertNull("null-string", StringUtil.mapToStr(null));
-        assertNull("empty", StringUtil.mapToStr(Map.of()));
+        assertNull(StringUtil.mapToStr(null), "null-string");
+        assertNull(StringUtil.mapToStr(Map.of()), "empty");
 
         // Test simple case
-        assertEquals("single", "1=one", StringUtil.mapToStr(Map.of("1", "one")));
+        assertEquals("1=one", StringUtil.mapToStr(Map.of("1", "one")), "single");
         LinkedHashMap<String, String> doubleMap = new LinkedHashMap<>();
         doubleMap.put("1", "one");
         doubleMap.put("2", "two");
-        assertEquals("double", "1=one|2=two", StringUtil.mapToStr(doubleMap));
+        assertEquals("1=one|2=two", StringUtil.mapToStr(doubleMap), "double");
 
         // Test with object case
         LinkedHashMap<Object, Object> doubleObjectMap = new LinkedHashMap<>();
         doubleObjectMap.put(Integer.valueOf(1), Long.valueOf(1));
         doubleObjectMap.put(Integer.valueOf(2), BigDecimal.ONE);
-        assertEquals("double with number classe", "1=1|2=1", StringUtil.mapToStr(doubleObjectMap));
+        assertEquals("1=1|2=1", StringUtil.mapToStr(doubleObjectMap), "double with number classe");
 
         // Test with special char
-        assertEquals("single with =", "1=%3Done", StringUtil.mapToStr(Map.of("1", "=one")));
+        assertEquals("1=%3Done", StringUtil.mapToStr(Map.of("1", "=one")), "single with =");
         LinkedHashMap<String, String> doublePipeMap = new LinkedHashMap<>();
         doublePipeMap.put("1", "|one");
         doublePipeMap.put("2|", "two");
-        assertEquals("double with pipe", "1=%7Cone|2%7C=two", StringUtil.mapToStr(doublePipeMap));
+        assertEquals("1=%7Cone|2%7C=two", StringUtil.mapToStr(doublePipeMap), "double with pipe");
     }
 
     @Test
@@ -122,12 +115,12 @@ public class StringUtilTests {
             } catch (IllegalArgumentException e) {
                 caught = e;
             } finally {
-                assertNotNull("bad(" + s + ")", caught);
+                assertNotNull(caught, "bad(" + s + ")");
             }
         }
-        assertEquals("single", Arrays.asList("1"), StringUtil.toList("[1]"));
-        assertEquals("double", Arrays.asList("1", "2"), StringUtil.toList("[1, 2]"));
-        assertEquals("double-space", Arrays.asList(" 1", "2 "), StringUtil.toList("[ 1, 2 ]"));
+        assertEquals(Arrays.asList("1"), StringUtil.toList("[1]"), "single");
+        assertEquals(Arrays.asList("1", "2"), StringUtil.toList("[1, 2]"), "double");
+        assertEquals(Arrays.asList(" 1", "2 "), StringUtil.toList("[ 1, 2 ]"), "double-space");
     }
 
     @Test
@@ -139,12 +132,12 @@ public class StringUtilTests {
             } catch (IllegalArgumentException e) {
                 caught = e;
             } finally {
-                assertNotNull("bad(" + s + ")", caught);
+                assertNotNull(caught, "bad(" + s + ")");
             }
         }
-        assertEquals("single", UtilMisc.toSet("1"), StringUtil.toSet("[1]"));
-        assertEquals("double", UtilMisc.toSet("1", "2"), StringUtil.toSet("[1, 2]"));
-        assertEquals("double-space", UtilMisc.toSet(" 1", "2 "), StringUtil.toSet("[ 1, 2 ]"));
+        assertEquals(UtilMisc.toSet("1"), StringUtil.toSet("[1]"), "single");
+        assertEquals(UtilMisc.toSet("1", "2"), StringUtil.toSet("[1, 2]"), "double");
+        assertEquals(UtilMisc.toSet(" 1", "2 "), StringUtil.toSet("[ 1, 2 ]"), "double-space");
     }
 
     @Test
@@ -158,20 +151,20 @@ public class StringUtilTests {
             } catch (IllegalArgumentException e) {
                 caught = e;
             } finally {
-                assertNotNull("bad(" + i + ")", caught);
+                assertNotNull(caught, "bad(" + i + ")");
             }
         }
-        assertEquals("parse", UtilMisc.toMap("1", "one", "2", "two"), StringUtil.createMap(Arrays.asList("1", "2"),
-                Arrays.asList("one", "two")));
+        assertEquals(UtilMisc.toMap("1", "one", "2", "two"), StringUtil.createMap(Arrays.asList("1", "2"),
+                Arrays.asList("one", "two")), "parse");
     }
 
     @Test
     public void testCleanUpPathPrefix() {
-        assertEquals("null", "", StringUtil.cleanUpPathPrefix(null));
-        assertEquals("empty", "", StringUtil.cleanUpPathPrefix(""));
+        assertEquals("", StringUtil.cleanUpPathPrefix(null), "null");
+        assertEquals("", StringUtil.cleanUpPathPrefix(""), "empty");
         for (String s: new String[] {"\\a\\b\\c", "\\a\\b\\c\\",
                 "a\\b\\c\\", "a\\b\\c", "/a/b/c", "/a/b/c/", "a/b/c/", "a/b/c"}) {
-            assertEquals("cleanup(" + s + ")", "/a/b/c", StringUtil.cleanUpPathPrefix(s));
+            assertEquals("/a/b/c", StringUtil.cleanUpPathPrefix(s), "cleanup(" + s + ")");
         }
     }
 
@@ -184,41 +177,41 @@ public class StringUtilTests {
 
     @Test
     public void testToHexString() {
-        assertEquals("16 bytes", "000102030405060708090a0b0c0d0e0f",
-                StringUtil.toHexString(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}));
+        assertEquals("000102030405060708090a0b0c0d0e0f",
+                StringUtil.toHexString(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}), "16 bytes");
     }
 
     @Test
     public void testCleanHexString() {
-        assertEquals("clean hex", "rtwertetwretw", StringUtil.cleanHexString("rtwer:tetw retw"));
+        assertEquals("rtwertetwretw", StringUtil.cleanHexString("rtwer:tetw retw"), "clean hex");
     }
 
     @Test
     public void testFromHexString() {
-        assertArrayEquals("16 bytes", new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-                StringUtil.fromHexString("000102030405060708090a0b0c0d0e0f"));
+        assertArrayEquals(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+                StringUtil.fromHexString("000102030405060708090a0b0c0d0e0f"), "16 bytes");
         GeneralRuntimeException caught = null;
         try {
             StringUtil.fromHexString("0-");
         } catch (GeneralRuntimeException e) {
             caught = e;
         } finally {
-            assertNotNull("bad-char", caught);
+            assertNotNull(caught, "bad-char");
         }
     }
 
     @Test
     public void testEncodeInt() {
-        assertArrayEquals("one octet", new char[] {'0', '5'}, StringUtil.encodeInt(5, 0, new char[2]));
-        assertArrayEquals("two octets", new char[] {'1', '5'}, StringUtil.encodeInt(21, 0, new char[2]));
+        assertArrayEquals(new char[] {'0', '5'}, StringUtil.encodeInt(5, 0, new char[2]), "one octet");
+        assertArrayEquals(new char[] {'1', '5'}, StringUtil.encodeInt(21, 0, new char[2]), "two octets");
         // these next two are really weird, note the start offset being != 0.
-        assertArrayEquals("three octets", new char[] {'3', '1', '5'}, StringUtil.encodeInt(789, 1, new char[3]));
-        assertArrayEquals("four octets", new char[] {'7', '3', '1', '5'}, StringUtil.encodeInt(29461, 2, new char[4]));
+        assertArrayEquals(new char[] {'3', '1', '5'}, StringUtil.encodeInt(789, 1, new char[3]), "three octets");
+        assertArrayEquals(new char[] {'7', '3', '1', '5'}, StringUtil.encodeInt(29461, 2, new char[4]), "four octets");
     }
 
     @Test
     public void testRemoveNonNumeric() {
-        assertEquals("just numbers", "12345", StringUtil.removeNonNumeric("a1'2;3]4!5("));
+        assertEquals("12345", StringUtil.removeNonNumeric("a1'2;3]4!5("), "just numbers");
     }
 
     @Test
@@ -227,56 +220,55 @@ public class StringUtilTests {
 
     @Test
     public void testAddToNumberString() {
-        assertNull("null pass-thru", StringUtil.addToNumberString(null, 0));
-        assertEquals("no-change", "12345", StringUtil.addToNumberString("12345", 0));
-        assertEquals("increase", "112344", StringUtil.addToNumberString("12345", 99999));
-        assertEquals("subtract", "00345", StringUtil.addToNumberString("12345", -12000));
+        assertNull(StringUtil.addToNumberString(null, 0), "null pass-thru");
+        assertEquals("12345", StringUtil.addToNumberString("12345", 0), "no-change");
+        assertEquals("112344", StringUtil.addToNumberString("12345", 99999), "increase");
+        assertEquals("00345", StringUtil.addToNumberString("12345", -12000), "subtract");
     }
 
     @Test
     public void testPadNumberString() {
-        assertEquals("less", "12345", StringUtil.padNumberString("12345", 3));
-        assertEquals("same", "12345", StringUtil.padNumberString("12345", 5));
-        assertEquals("more", "00012345", StringUtil.padNumberString("12345", 8));
+        assertEquals("12345", StringUtil.padNumberString("12345", 3), "less");
+        assertEquals("12345", StringUtil.padNumberString("12345", 5), "same");
+        assertEquals("00012345", StringUtil.padNumberString("12345", 8), "more");
     }
 
     @Test
     public void testConvertOperatorSubstitutions() {
-        assertNull("null pass-thru", StringUtil.convertOperatorSubstitutions(null));
-        assertEquals("none", "abc", StringUtil.convertOperatorSubstitutions("abc"));
-        assertEquals("none", "a'c", StringUtil.convertOperatorSubstitutions("a'c"));
-        assertEquals("all converions", "one && two || three > four >= five < six <= seven",
-                StringUtil.convertOperatorSubstitutions(
-                        "one @and two @or three @gt four @gteq five @lt six @lteq seven"));
+        assertNull(StringUtil.convertOperatorSubstitutions(null), "null pass-thru");
+        assertEquals("abc", StringUtil.convertOperatorSubstitutions("abc"), "none");
+        assertEquals("a'c", StringUtil.convertOperatorSubstitutions("a'c"), "none");
+        assertEquals("one && two || three > four >= five < six <= seven", StringUtil.convertOperatorSubstitutions(
+                        "one @and two @or three @gt four @gteq five @lt six @lteq seven"), "all converions");
     }
 
     @Test
     public void testTruncateString() {
-        assertEquals("no truncate", "this is a truncated long string",
-                StringUtil.truncateEncodedStringToLength("this is a truncated long string", 40));
-        assertEquals("no truncate to short", "this",
-                StringUtil.truncateEncodedStringToLength("this", 5));
-        assertEquals("normal", "this is a t…ing",
-                StringUtil.truncateEncodedStringToLength("this is a truncated long string", 15));
-        assertEquals("normal short", "this …",
-                StringUtil.truncateEncodedStringToLength("this is a truncated long string", 5));
-        assertEquals("with parenthesis", "this ( are … ok",
-                StringUtil.truncateEncodedStringToLength("this ( are managed correctly ) ok", 15));
-        assertEquals("with parenthesis at end", "this ( are …d )",
-                StringUtil.truncateEncodedStringToLength("this ( are managed correctly, with the end )", 15));
-        assertEquals("with parenthesis and semicolon ignored", "this ( are …d )",
-                StringUtil.truncateEncodedStringToLength("this ( are a semicolon far ; managed correctly, with the end )", 15));
-        assertEquals("with parenthesis and semicolon closer", "this ( are;…d )",
-                StringUtil.truncateEncodedStringToLength("this ( are; a semicolon closer managed correctly, with the end )", 15));
-        assertEquals("with parenthesis and é managed", "this ( are&eacut;…end",
-                StringUtil.truncateEncodedStringToLength("this ( are&eacut; managed correctly, with the ) end", 15));
-        assertEquals("with parenthesis and é é managed", "this ( a&eacut;e&eacut;…end",
-                StringUtil.truncateEncodedStringToLength("this ( a&eacut;e&eacut; managed correctly, with the ) end", 15));
-        assertEquals("with parenthesis and é closer", "this ( are …n&eacut;d",
-                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e ) en&eacut;d", 15));
-        assertEquals("with parenthesis and é é closer", "this ( are …&eacut;&eacut;d",
-                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e )en&eacut;&eacut;d", 15));
-        assertEquals("with parenthesis and # # closer", "this ( are …&#235;&#235;d",
-                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e )en&#235;&#235;d", 15));
+        assertEquals("this is a truncated long string",
+                StringUtil.truncateEncodedStringToLength("this is a truncated long string", 40), "no truncate");
+        assertEquals("this",
+                StringUtil.truncateEncodedStringToLength("this", 5), "no truncate to short");
+        assertEquals("this is a t…ing",
+                StringUtil.truncateEncodedStringToLength("this is a truncated long string", 15), "normal");
+        assertEquals("this …",
+                StringUtil.truncateEncodedStringToLength("this is a truncated long string", 5), "normal short");
+        assertEquals("this ( are … ok",
+                StringUtil.truncateEncodedStringToLength("this ( are managed correctly ) ok", 15), "with parenthesis");
+        assertEquals("this ( are …d )",
+                StringUtil.truncateEncodedStringToLength("this ( are managed correctly, with the end )", 15), "with parenthesis at end");
+        assertEquals("this ( are …d )",
+                StringUtil.truncateEncodedStringToLength("this ( are a semicolon far ; managed correctly, with the end )", 15), "with parenthesis and semicolon ignored");
+        assertEquals("this ( are;…d )",
+                StringUtil.truncateEncodedStringToLength("this ( are; a semicolon closer managed correctly, with the end )", 15), "with parenthesis and semicolon closer");
+        assertEquals("this ( are&eacut;…end",
+                StringUtil.truncateEncodedStringToLength("this ( are&eacut; managed correctly, with the ) end", 15), "with parenthesis and é managed");
+        assertEquals("this ( a&eacut;e&eacut;…end",
+                StringUtil.truncateEncodedStringToLength("this ( a&eacut;e&eacut; managed correctly, with the ) end", 15), "with parenthesis and é é managed");
+        assertEquals("this ( are …n&eacut;d",
+                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e ) en&eacut;d", 15), "with parenthesis and é closer");
+        assertEquals("this ( are …&eacut;&eacut;d",
+                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e )en&eacut;&eacut;d", 15), "with parenthesis and é é closer");
+        assertEquals("this ( are …&#235;&#235;d",
+                StringUtil.truncateEncodedStringToLength("this ( are & closer managed correctly, with th&e )en&#235;&#235;d", 15), "with parenthesis and # # closer");
     }
 }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/TimeDurationTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/TimeDurationTests.java
@@ -18,11 +18,11 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.ibm.icu.util.Calendar;
 import com.ibm.icu.util.TimeZone;
@@ -41,25 +41,24 @@ public class TimeDurationTests {
 
     private static void assertDurationFields(String label, DateTuple d, String string, TimeDuration duration,
             boolean isNegative, boolean isZero) {
-        assertEquals(label + ".years()", d.years, duration.years());
-        assertEquals(label + ".months()", d.months, duration.months());
-        assertEquals(label + ".days()", d.days, duration.days());
-        assertEquals(label + ".hours()", d.hours, duration.hours());
-        assertEquals(label + ".minutes()", d.minutes, duration.minutes());
-        assertEquals(label + ".seconds()", d.seconds, duration.seconds());
-        assertEquals(label + ".milliseconds()", d.milliseconds, duration.milliseconds());
-        assertEquals(label + ".isNegative()", isNegative, duration.isNegative());
-        assertEquals(label + ".toString()", string, duration.toString());
-        assertEquals(label + ".equals(from/to long)", duration, TimeDuration.fromLong(TimeDuration.toLong(duration)));
-        assertEquals(label + ".equals(from/to number)", duration,
-                TimeDuration.fromNumber(TimeDuration.toLong(duration)));
-        assertEquals(label + ".isZero", isZero, duration.isZero());
+        assertEquals(d.years, duration.years(), label + ".years()");
+        assertEquals(d.months, duration.months(), label + ".months()");
+        assertEquals(d.days, duration.days(), label + ".days()");
+        assertEquals(d.hours, duration.hours(), label + ".hours()");
+        assertEquals(d.minutes, duration.minutes(), label + ".minutes()");
+        assertEquals(d.seconds, duration.seconds(), label + ".seconds()");
+        assertEquals(d.milliseconds, duration.milliseconds(), label + ".milliseconds()");
+        assertEquals(isNegative, duration.isNegative(), label + ".isNegative()");
+        assertEquals(string, duration.toString(), label + ".toString()");
+        assertEquals(duration, TimeDuration.fromLong(TimeDuration.toLong(duration)), label + ".equals(from/to long)");
+        assertEquals(duration, TimeDuration.fromNumber(TimeDuration.toLong(duration)), label + ".equals(from/to number)");
+        assertEquals(isZero, duration.isZero(), label + ".isZero");
         if (isZero) {
-            assertEquals(label + ".compareTo(zero) == 0", 0, doCompare(TimeDuration.ZERO_TIME_DURATION, duration));
-            assertEquals(label + ".compareTo(zero) == 0", 0, doCompare(duration, TimeDuration.ZERO_TIME_DURATION));
+            assertEquals(0, doCompare(TimeDuration.ZERO_TIME_DURATION, duration), label + ".compareTo(zero) == 0");
+            assertEquals(0, doCompare(duration, TimeDuration.ZERO_TIME_DURATION), label + ".compareTo(zero) == 0");
         } else {
-            assertNotSame(label + ".compareTo(zero) != 0", 0, doCompare(TimeDuration.ZERO_TIME_DURATION, duration));
-            assertNotSame(label + ".compareTo(zero) != 0", 0, doCompare(duration, TimeDuration.ZERO_TIME_DURATION));
+            assertNotSame(0, doCompare(TimeDuration.ZERO_TIME_DURATION, duration), label + ".compareTo(zero) != 0");
+            assertNotSame(0, doCompare(duration, TimeDuration.ZERO_TIME_DURATION), label + ".compareTo(zero) != 0");
         }
     }
 
@@ -128,16 +127,16 @@ public class TimeDurationTests {
         Calendar added = calDuration.addToCalendar((Calendar) ZERO.clone());
         TimeDuration addDuration = new TimeDuration(ZERO, added);
         assertDurationFields(label + "(cal[add])", d, durationString, addDuration, isNegative, false);
-        assertEquals(label + ".compareTo(string, cal)", 0, doCompare(stringDuration, calDuration));
-        assertEquals(label + ".compareTo(string, string)", 0, doCompare(stringDuration, stringDuration));
-        assertEquals(label + ".compareTo(cal, cal)", 0, doCompare(calDuration, calDuration));
-        assertEquals(label + ".compareTo(cal, string)", 0, doCompare(calDuration, stringDuration));
-        assertEquals(label + ".equals(cal, cal)", calDuration, calDuration);
-        assertEquals(label + ".equals(cal, string)", calDuration, stringDuration);
-        assertEquals(label + ".equals(string, cal)", stringDuration, calDuration);
-        assertEquals(label + ".equals(string, string)", stringDuration, stringDuration);
+        assertEquals(0, doCompare(stringDuration, calDuration), label + ".compareTo(string, cal)");
+        assertEquals(0, doCompare(stringDuration, stringDuration), label + ".compareTo(string, string)");
+        assertEquals(0, doCompare(calDuration, calDuration), label + ".compareTo(cal, cal)");
+        assertEquals(0, doCompare(calDuration, stringDuration), label + ".compareTo(cal, string)");
+        assertEquals(calDuration, calDuration, label + ".equals(cal, cal)");
+        assertEquals(calDuration, stringDuration, label + ".equals(cal, string)");
+        assertEquals(stringDuration, calDuration, label + ".equals(string, cal)");
+        assertEquals(stringDuration, stringDuration, label + ".equals(string, string)");
         if (lastString != null) {
-            assertFalse(label + ".not-equals(string, lastString)", stringDuration.equals(lastString));
+            assertFalse(stringDuration.equals(lastString), label + ".not-equals(string, lastString)");
         }
         return stringDuration;
     }
@@ -162,10 +161,10 @@ public class TimeDurationTests {
     public void testDuration() throws Exception {
         Calendar now = Calendar.getInstance();
         TimeDuration zeroDuration = TimeDuration.ZERO_TIME_DURATION;
-        assertFalse("zero equals null", zeroDuration.equals(null));
+        assertFalse(zeroDuration.equals(null), "zero equals null");
         Calendar newTime = (Calendar) now.clone();
         zeroDuration.addToCalendar(newTime);
-        assertEquals("zero same calendar", now, newTime);
+        assertEquals(now, newTime, "zero same calendar");
         assertDurationFields("zero(same zero calendar)", DateTuple.of(0, 0, 0, 0, 0, 0, 0), "0:0:0:0:0:0:0",
                 new TimeDuration(ZERO, ZERO), false, true);
         assertDurationFields("zero(same now calendar)", DateTuple.of(0, 0, 0, 0, 0, 0, 0), "0:0:0:0:0:0:0",

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilCodecTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilCodecTests.java
@@ -18,15 +18,15 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilCodecTests {
 
@@ -54,7 +54,7 @@ public class UtilCodecTests {
         encoderTest("string", UtilCodec.getEncoder("string"), "abc\\\"def", "abc\"def");
         encoderTest("xml", UtilCodec.getEncoder("xml"), "&#x3c;&#x3e;&#x27;&#x22;", "<>'\"");
         encoderTest("html", UtilCodec.getEncoder("html"), "&lt;&gt;&#x27;&quot;", "<>'\"");
-        assertNull("invalid encoder", UtilCodec.getEncoder("foobar"));
+        assertNull(UtilCodec.getEncoder("foobar"), "invalid encoder");
     }
 
     @Test
@@ -84,15 +84,15 @@ public class UtilCodecTests {
     }
 
     private static void encoderTest(String label, UtilCodec.SimpleEncoder encoder, String wanted, String toEncode) {
-        assertNull(label + "(encoder):null", encoder.encode(null));
-        assertEquals(label + "(encoder):encode", wanted, encoder.encode(toEncode));
+        assertNull(encoder.encode(null), label + "(encoder):null");
+        assertEquals(wanted, encoder.encode(toEncode), label + "(encoder):encode");
     }
     private static void checkStringForHtmlStrictNoneTest(String label, String fixed, String input,
             String... wantedMessages) {
         List<String> gottenMessages = new ArrayList<>();
-        assertEquals(label, fixed, UtilCodec.checkStringForHtmlStrictNone(label, input, gottenMessages,
-                new Locale("test"))); // labels are not available in testClasses Gradle task
-        assertEquals(label, Arrays.asList(wantedMessages), gottenMessages);
+        assertEquals(fixed, UtilCodec.checkStringForHtmlStrictNone(label, input, gottenMessages,
+                new Locale("test")), label); // labels are not available in testClasses Gradle task
+        assertEquals(Arrays.asList(wantedMessages), gottenMessages, label);
     }
 
     @Test

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilGenericsTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilGenericsTest.java
@@ -40,7 +40,8 @@ public class UtilGenericsTest {
 
     @Test
     public void heterogenousCheckCollection() {
-        assertThrows(IllegalArgumentException.class, () -> UtilGenerics.<String, Collection<String>>checkCollection(Arrays.asList("foo", 0), String.class));
+        assertThrows(IllegalArgumentException.class, () ->
+                UtilGenerics.<String, Collection<String>>checkCollection(Arrays.asList("foo", 0), String.class));
     }
 
     @Test

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilGenericsTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilGenericsTest.java
@@ -18,12 +18,13 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilGenericsTest {
 
@@ -32,14 +33,14 @@ public class UtilGenericsTest {
         UtilGenerics.<String, Collection<String>>checkCollection(Arrays.asList("foo", "bar", "baz"), String.class);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void incompatibleCollectionCheckCollection() {
-        UtilGenerics.<String, Collection<String>>checkCollection("not a collection", String.class);
+        assertThrows(ClassCastException.class, () -> UtilGenerics.<String, Collection<String>>checkCollection("not a collection", String.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void heterogenousCheckCollection() {
-        UtilGenerics.<String, Collection<String>>checkCollection(Arrays.asList("foo", 0), String.class);
+        assertThrows(IllegalArgumentException.class, () -> UtilGenerics.<String, Collection<String>>checkCollection(Arrays.asList("foo", 0), String.class));
     }
 
     @Test

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilHtmlTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilHtmlTest.java
@@ -18,11 +18,11 @@
  *******************************************************************************/
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilHtmlTest {
 

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilHttpTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilHttpTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class UtilHttpTest {
+public final class UtilHttpTest {
     private HttpServletRequest req;
 
     @BeforeEach

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilHttpTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilHttpTest.java
@@ -28,7 +28,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
@@ -43,14 +44,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.HttpMethod;
 
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class UtilHttpTest {
     private HttpServletRequest req;
 
-    @Before
+    @BeforeEach
     public void setup() {
         req = Mockito.mock(HttpServletRequest.class);
     }
@@ -204,8 +205,8 @@ public class UtilHttpTest {
         assertThat(UtilHttp.makeParamListWithSuffix(req, extra, "_suf", "b"), containsInAnyOrder("1", "3"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void missingRequestMakeParamListWithSuffix() {
-        UtilHttp.makeParamListWithSuffix(null, "suffix", "prefix");
+        assertThrows(NullPointerException.class, () -> UtilHttp.makeParamListWithSuffix(null, "suffix", "prefix"));
     }
 }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilIOTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilIOTests.java
@@ -19,15 +19,15 @@
 package org.apache.ofbiz.base.util;
 
 import static org.apache.ofbiz.base.util.UtilIO.readString;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilIOTests {
     private static final byte[] TRADEMARK_BYTES = new byte[] {
@@ -68,21 +68,15 @@ public class UtilIOTests {
     }
 
     private static void readStringTest1(String label, String wanted, byte[] toRead) throws IOException {
-        assertEquals("readString bytes default:" + label, wanted, readString(toRead));
-        assertEquals("readString bytes UTF-8:" + label, wanted, readString(toRead, "UTF-8"));
-        assertEquals("readString bytes UTF8:" + label, wanted, readString(toRead, StandardCharsets.UTF_8));
-        assertEquals("readString bytes offset/length default:" + label, wanted,
-                readString(toRead, 0, toRead.length));
-        assertEquals("readString bytes offset/length UTF-8:" + label, wanted,
-                readString(toRead, 0, toRead.length, "UTF-8"));
-        assertEquals("readString bytes offset/length UTF8:" + label, wanted,
-                readString(toRead, 0, toRead.length, StandardCharsets.UTF_8));
-        assertEquals("readString stream default:" + label, wanted,
-                readString(new ByteArrayInputStream(toRead)));
-        assertEquals("readString stream UTF-8:" + label, wanted,
-                readString(new ByteArrayInputStream(toRead), "UTF-8"));
-        assertEquals("readString stream UTF8:" + label, wanted,
-                readString(new ByteArrayInputStream(toRead), StandardCharsets.UTF_8));
+        assertEquals(wanted, readString(toRead), "readString bytes default:" + label);
+        assertEquals(wanted, readString(toRead, "UTF-8"), "readString bytes UTF-8:" + label);
+        assertEquals(wanted, readString(toRead, StandardCharsets.UTF_8), "readString bytes UTF8:" + label);
+        assertEquals(wanted, readString(toRead, 0, toRead.length), "readString bytes offset/length default:" + label);
+        assertEquals(wanted, readString(toRead, 0, toRead.length, "UTF-8"), "readString bytes offset/length UTF-8:" + label);
+        assertEquals(wanted, readString(toRead, 0, toRead.length, StandardCharsets.UTF_8), "readString bytes offset/length UTF8:" + label);
+        assertEquals(wanted, readString(new ByteArrayInputStream(toRead)), "readString stream default:" + label);
+        assertEquals(wanted, readString(new ByteArrayInputStream(toRead), "UTF-8"), "readString stream UTF-8:" + label);
+        assertEquals(wanted, readString(new ByteArrayInputStream(toRead), StandardCharsets.UTF_8), "readString stream UTF8:" + label);
     }
 
     @Test
@@ -107,12 +101,12 @@ public class UtilIOTests {
     private static void writeStringTest1(String label, byte[] wanted, String toWrite) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         UtilIO.writeString(baos, toWrite);
-        assertArrayEquals("writeString default:" + label, wanted, baos.toByteArray());
+        assertArrayEquals(wanted, baos.toByteArray(), "writeString default:" + label);
         baos = new ByteArrayOutputStream();
         UtilIO.writeString(baos, "UTF-8", toWrite);
-        assertArrayEquals("writeString UTF-8:" + label, wanted, baos.toByteArray());
+        assertArrayEquals(wanted, baos.toByteArray(), "writeString UTF-8:" + label);
         baos = new ByteArrayOutputStream();
         UtilIO.writeString(baos, StandardCharsets.UTF_8, toWrite);
-        assertArrayEquals("writeString UTF8:" + label, wanted, baos.toByteArray());
+        assertArrayEquals(wanted, baos.toByteArray(), "writeString UTF8:" + label);
     }
 }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilMiscTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilMiscTests.java
@@ -18,12 +18,12 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Locale;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilMiscTests {
 

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilObjectTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilObjectTests.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 @SourceMonitored
-public class UtilObjectTests {
+public final class UtilObjectTests {
     @AfterEach
     public void cleanUp() {
         // Ensure that the default value of allowed deserialization classes is used.
@@ -122,7 +122,7 @@ public class UtilObjectTests {
         byte[] result = new byte[source.length];
         int r = in.read();
         assertEquals(2, in.read(new byte[2]), "onClose, read short length");
-        assertNotEquals((Object)(-1), (Object)r, "onClose, not read/eof");
+        assertNotEquals((Object) (-1), (Object) r, "onClose, not read/eof");
         assertEquals(source.length - 3, in.read(result, 3, result.length - 3), "onClose, read length");
         Exception caught = null;
         try {
@@ -135,7 +135,7 @@ public class UtilObjectTests {
         in = new ErrorInjector(new ByteArrayInputStream(source), 4);
         result = new byte[source.length];
         r = in.read();
-        assertNotEquals((Object)(-1), (Object)r, "after, not read/eof");
+        assertNotEquals((Object) (-1), (Object) r, "after, not read/eof");
         assertEquals(2, in.read(result, 0, 2), "after, read short length");
         assertEquals(1, in.read(result, 3, result.length - 3), "after, read long length");
         caught = null;
@@ -235,7 +235,7 @@ public class UtilObjectTests {
 
     @Test
     public void testGetByteCount() throws Exception {
-        assertNotEquals((Object)0L, (Object)UtilObject.getByteCount(0L), "long");
+        assertNotEquals((Object) 0L, (Object) UtilObject.getByteCount(0L), "long");
         Exception caught = null;
         try {
             UtilObject.getByteCount(this);

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilObjectTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilObjectTests.java
@@ -23,10 +23,11 @@ import static org.apache.ofbiz.base.util.UtilObject.getObjectException;
 import static org.apache.ofbiz.base.util.UtilObject.getObjectFromFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,12 +44,12 @@ import java.util.Set;
 
 import org.apache.ofbiz.base.lang.Factory;
 import org.apache.ofbiz.base.lang.SourceMonitored;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 @SourceMonitored
 public class UtilObjectTests {
-    @After
+    @AfterEach
     public void cleanUp() {
         // Ensure that the default value of allowed deserialization classes is used.
         UtilProperties.setPropertyValueInMemory("SafeObjectInputStream", "allowList", "");
@@ -120,30 +121,30 @@ public class UtilObjectTests {
         InputStream in = new ErrorInjector(new ByteArrayInputStream(source), true);
         byte[] result = new byte[source.length];
         int r = in.read();
-        assertEquals("onClose, read short length", 2, in.read(new byte[2]));
-        assertNotSame("onClose, not read/eof", -1, r);
-        assertEquals("onClose, read length", source.length - 3, in.read(result, 3, result.length - 3));
+        assertEquals(2, in.read(new byte[2]), "onClose, read short length");
+        assertNotEquals((Object)(-1), (Object)r, "onClose, not read/eof");
+        assertEquals(source.length - 3, in.read(result, 3, result.length - 3), "onClose, read length");
         Exception caught = null;
         try {
             in.close();
         } catch (IOException e) {
             caught = e;
         } finally {
-            assertNotNull("onClose, exception", caught);
+            assertNotNull(caught, "onClose, exception");
         }
         in = new ErrorInjector(new ByteArrayInputStream(source), 4);
         result = new byte[source.length];
         r = in.read();
-        assertNotSame("after, not read/eof", -1, r);
-        assertEquals("after, read short length", 2, in.read(result, 0, 2));
-        assertEquals("after, read long length", 1, in.read(result, 3, result.length - 3));
+        assertNotEquals((Object)(-1), (Object)r, "after, not read/eof");
+        assertEquals(2, in.read(result, 0, 2), "after, read short length");
+        assertEquals(1, in.read(result, 3, result.length - 3), "after, read long length");
         caught = null;
         try {
             in.read(result, 4, result.length - 4);
         } catch (IOException e) {
             caught = e;
         } finally {
-            assertNotNull("read, buffer exception", caught);
+            assertNotNull(caught, "read, buffer exception");
         }
         caught = null;
         try {
@@ -151,7 +152,7 @@ public class UtilObjectTests {
         } catch (IOException e) {
             caught = e;
         } finally {
-            assertNotNull("read, singleton exception", caught);
+            assertNotNull(caught, "read, singleton exception");
         }
         in.close();
     }
@@ -185,13 +186,13 @@ public class UtilObjectTests {
 
     @Test
     public void testGetBytesObject() {
-        assertNotNull("long", UtilObject.getBytes(0L));
-        assertNotNull("injector good", UtilObject.getBytes(new SerializationInjector(false, false)));
+        assertNotNull(UtilObject.getBytes(0L), "long");
+        assertNotNull(UtilObject.getBytes(new SerializationInjector(false, false)), "injector good");
         boolean errorOn = Debug.isOn(Debug.ERROR);
         try {
             Debug.set(Debug.ERROR, false);
-            assertNull("injector bad", UtilObject.getBytes(new SerializationInjector(false, true)));
-            assertNull("long", UtilObject.getBytes(this));
+            assertNull(UtilObject.getBytes(new SerializationInjector(false, true)), "injector bad");
+            assertNull(UtilObject.getBytes(this), "long");
         } finally {
             Debug.set(Debug.ERROR, errorOn);
         }
@@ -201,20 +202,20 @@ public class UtilObjectTests {
     public void testGetObject() {
         Long one = 1L;
         byte[] oneBytes = UtilObject.getBytes(one);
-        assertNotNull("oneBytes", oneBytes);
-        assertEquals("one getObject", one, UtilObject.getObject(oneBytes));
+        assertNotNull(oneBytes, "oneBytes");
+        assertEquals(one, UtilObject.getObject(oneBytes), "one getObject");
         boolean errorOn = Debug.isOn(Debug.ERROR);
         try {
             Debug.set(Debug.ERROR, false);
-            assertNull("parse empty array", UtilObject.getObject(new byte[0]));
+            assertNull(UtilObject.getObject(new byte[0]), "parse empty array");
 
             // simulate a ClassNotFoundException
             Object groovySerializable = GroovyUtil.eval(
                     "class foo implements java.io.Serializable { }; return new foo()",
                     new HashMap<String, Object>());
             byte[] groovySerializableBytes = UtilObject.getBytes(groovySerializable);
-            assertNotNull("groovySerializableBytes", groovySerializableBytes);
-            assertNull("groovyDeserializable", UtilObject.getObject(groovySerializableBytes));
+            assertNotNull(groovySerializableBytes, "groovySerializableBytes");
+            assertNull(UtilObject.getObject(groovySerializableBytes), "groovyDeserializable");
 
             // SerializationInjector is a test-only class; allow it explicitly for this assertion.
             // Note: the allowList value is treated as a regex, so '.' is used instead of '$'
@@ -222,11 +223,11 @@ public class UtilObjectTests {
             UtilProperties.setPropertyValueInMemory("SafeObjectInputStream", "allowList",
                     "org.apache.ofbiz.base.util.UtilObjectTests.SerializationInjector");
             byte[] injectorBytes = UtilObject.getBytes(new SerializationInjector(false, false));
-            assertNotNull("injectorBytes good", injectorBytes);
-            assertNotNull("injector good", UtilObject.getObject(injectorBytes));
+            assertNotNull(injectorBytes, "injectorBytes good");
+            assertNotNull(UtilObject.getObject(injectorBytes), "injector good");
             injectorBytes = UtilObject.getBytes(new SerializationInjector(true, false));
-            assertNotNull("injectorBytes bad", injectorBytes);
-            assertNull("injector bad", UtilObject.getObject(injectorBytes));
+            assertNotNull(injectorBytes, "injectorBytes bad");
+            assertNull(UtilObject.getObject(injectorBytes), "injector bad");
         } finally {
             Debug.set(Debug.ERROR, errorOn);
         }
@@ -234,14 +235,14 @@ public class UtilObjectTests {
 
     @Test
     public void testGetByteCount() throws Exception {
-        assertNotSame("long", 0, UtilObject.getByteCount(0L));
+        assertNotEquals((Object)0L, (Object)UtilObject.getByteCount(0L), "long");
         Exception caught = null;
         try {
             UtilObject.getByteCount(this);
         } catch (IOException e) {
             caught = e;
         } finally {
-            assertNotNull("exception thrown", caught);
+            assertNotNull(caught, "exception thrown");
         }
     }
 
@@ -298,20 +299,20 @@ public class UtilObjectTests {
 
     @Test
     public void testGetObjectFromFactory() throws Exception {
-        assertEquals("first one", "ONE", getObjectFromFactory(TestFactoryIntf.class, toSet("first", "one")));
-        assertEquals("first two", "TWO", getObjectFromFactory(TestFactoryIntf.class, toSet("first", "two")));
-        assertEquals("first three", "THREE", getObjectFromFactory(TestFactoryIntf.class, toSet("first", "three")));
-        assertEquals("first null", "1", getObjectFromFactory(TestFactoryIntf.class, toSet("first", "second", "ONE")));
-        assertEquals("second one", "1", getObjectFromFactory(TestFactoryIntf.class, toSet("second", "ONE")));
-        assertEquals("second two", "2", getObjectFromFactory(TestFactoryIntf.class, toSet("second", "TWO")));
-        assertEquals("second three", "3", getObjectFromFactory(TestFactoryIntf.class, toSet("second", "THREE")));
+        assertEquals("ONE", getObjectFromFactory(TestFactoryIntf.class, toSet("first", "one")), "first one");
+        assertEquals("TWO", getObjectFromFactory(TestFactoryIntf.class, toSet("first", "two")), "first two");
+        assertEquals("THREE", getObjectFromFactory(TestFactoryIntf.class, toSet("first", "three")), "first three");
+        assertEquals("1", getObjectFromFactory(TestFactoryIntf.class, toSet("first", "second", "ONE")), "first null");
+        assertEquals("1", getObjectFromFactory(TestFactoryIntf.class, toSet("second", "ONE")), "second one");
+        assertEquals("2", getObjectFromFactory(TestFactoryIntf.class, toSet("second", "TWO")), "second two");
+        assertEquals("3", getObjectFromFactory(TestFactoryIntf.class, toSet("second", "THREE")), "second three");
         Exception caught = null;
         try {
             getObjectFromFactory(TestFactoryIntf.class, toSet("first"));
         } catch (ClassNotFoundException e) {
             caught = e;
         } finally {
-            assertNotNull("nothing found first", caught);
+            assertNotNull(caught, "nothing found first");
         }
         caught = null;
         try {
@@ -319,7 +320,7 @@ public class UtilObjectTests {
         } catch (ClassNotFoundException e) {
             caught = e;
         } finally {
-            assertNotNull("nothing found second", caught);
+            assertNotNull(caught, "nothing found second");
         }
     }
 
@@ -347,7 +348,7 @@ public class UtilObjectTests {
     }
 
     // Test reading a basic list of string object after forbidding such kind of objects.
-    @Test(expected = ClassCastException.class)
+    @Test
     public void testGetObjectExceptionUnsafe() throws IOException, ClassNotFoundException {
         // Only allow object of type where the package prefix is 'org.apache.ofbiz'
         UtilProperties.setPropertyValueInMemory("SafeObjectInputStream", "allowList", "org.apache.ofbiz..*");
@@ -355,7 +356,7 @@ public class UtilObjectTests {
                 ObjectOutputStream oos = new ObjectOutputStream(bos)) {
             List<String> forbiddenObject = Arrays.asList("foo", "bar", "baz");
             oos.writeObject(forbiddenObject);
-            getObjectException(bos.toByteArray());
+            assertThrows(ClassCastException.class, () -> getObjectException(bos.toByteArray()));
         }
     }
 }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilPropertiesTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilPropertiesTests.java
@@ -18,9 +18,9 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -29,7 +29,7 @@ import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilPropertiesTests {
 

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilValidateTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilValidateTests.java
@@ -18,10 +18,10 @@
  */
 package org.apache.ofbiz.base.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilValidateTests {
 

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/collections/GenericMapTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/collections/GenericMapTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.ofbiz.base.util.collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.ofbiz.base.util.Debug;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GenericMapTest {
     private static final String MODULE = GenericMapTest.class.getName();
@@ -159,22 +159,22 @@ public class GenericMapTest {
         TestGenericMap<String, Integer> map = new TestGenericMap<>();
         map.put("a", 0);
         Debug.logInfo("put a\t\tcounts=" + map.getCounts() + ", modCount=" + map.getModCount(), MODULE);
-        assertEquals("get a", Integer.valueOf(0), map.get("a"));
+        assertEquals(Integer.valueOf(0), map.get("a"), "get a");
         map.put("b", 1);
         Debug.logInfo("put b\t\tcounts=" + map.getCounts() + ", modCount=" + map.getModCount(), MODULE);
-        assertEquals("get b", Integer.valueOf(1), map.get("b"));
+        assertEquals(Integer.valueOf(1), map.get("b"), "get b");
         map.put("c", 2);
         Debug.logInfo("put c\t\tcounts=" + map.getCounts() + ", modCount=" + map.getModCount(), MODULE);
-        assertEquals("get c", Integer.valueOf(2), map.get("c"));
+        assertEquals(Integer.valueOf(2), map.get("c"), "get c");
         map.put("d", 3);
         Debug.logInfo("put d\t\tcounts=" + map.getCounts() + ", modCount=" + map.getModCount(), MODULE);
-        assertEquals("get d", Integer.valueOf(3), map.get("d"));
+        assertEquals(Integer.valueOf(3), map.get("d"), "get d");
         map.put("c", 22);
         Debug.logInfo("put c-2\t\tcounts=" + map.getCounts() + ", modCount=" + map.getModCount(), MODULE);
-        assertEquals("get c-2", Integer.valueOf(22), map.get("c"));
+        assertEquals(Integer.valueOf(22), map.get("c"), "get c-2");
         map.remove("b");
         Debug.logInfo("remove b\tcounts=" + map.getCounts() + ", modCount=" + map.getModCount(), MODULE);
-        assertNull("null b", map.get("b"));
+        assertNull(map.get("b"), "null b");
         map.remove("aaa");
         Debug.logInfo("remove aaa\tcounts=" + map.getCounts() + ", modCount=" + map.getModCount(), MODULE);
         Debug.logInfo("map=" + map, MODULE);

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/collections/MapContextTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/collections/MapContextTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.ofbiz.base.util.UtilMisc;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MapContextTest {
 

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/template/FreeMarkerWorkerTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/template/FreeMarkerWorkerTests.java
@@ -18,17 +18,17 @@
  *******************************************************************************/
 package org.apache.ofbiz.base.util.template;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FreeMarkerWorkerTests {
-    @Before
+    @BeforeEach
     public void initialize() {
         System.setProperty("ofbiz.home", System.getProperty("user.dir"));
     }

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/template/FreeMarkerWorkerTests.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/template/FreeMarkerWorkerTests.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class FreeMarkerWorkerTests {
+public final class FreeMarkerWorkerTests {
     @BeforeEach
     public void initialize() {
         System.setProperty("ofbiz.home", System.getProperty("user.dir"));

--- a/framework/common/src/test/java/org/apache/ofbiz/common/GetLocaleListTests.java
+++ b/framework/common/src/test/java/org/apache/ofbiz/common/GetLocaleListTests.java
@@ -22,7 +22,7 @@ import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashMap;
@@ -33,8 +33,8 @@ import java.util.stream.Collectors;
 
 import org.apache.ofbiz.base.util.GroovyUtil;
 import org.apache.ofbiz.base.util.ScriptUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import groovy.util.GroovyScriptEngine;
 
@@ -42,7 +42,7 @@ public class GetLocaleListTests {
     private Map<String, Object> params;
     private GroovyScriptEngine engine;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         params = new HashMap<>();
         engine = new GroovyScriptEngine(System.getProperty("user.dir"));

--- a/framework/common/src/test/java/org/apache/ofbiz/common/GetLocaleListTests.java
+++ b/framework/common/src/test/java/org/apache/ofbiz/common/GetLocaleListTests.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import groovy.util.GroovyScriptEngine;
 
-public class GetLocaleListTests {
+public final class GetLocaleListTests {
     private Map<String, Object> params;
     private GroovyScriptEngine engine;
 

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/DelegatorUnitTests.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/DelegatorUnitTests.java
@@ -20,30 +20,30 @@ package org.apache.ofbiz.entity;
 
 import org.apache.ofbiz.base.util.Debug;
 import org.hamcrest.MatcherAssert;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DelegatorUnitTests {
     private boolean logErrorOn;
 
-    @Before
+    @BeforeEach
     public void initialize() {
         System.setProperty("ofbiz.home", System.getProperty("user.dir"));
         logErrorOn = Debug.isOn(Debug.ERROR); // save the current setting (to be restored after the tests)
         Debug.set(Debug.ERROR, false); // disable error logging
     }
 
-    @After
+    @AfterEach
     public void restore() {
         Debug.set(Debug.ERROR, logErrorOn); // restore the error log setting
     }

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/DelegatorUnitTests.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/DelegatorUnitTests.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DelegatorUnitTests {
+public final class DelegatorUnitTests {
     private boolean logErrorOn;
 
     @BeforeEach

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/EntityConditionVisitorTests.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/EntityConditionVisitorTests.java
@@ -18,8 +18,8 @@
  */
 package org.apache.ofbiz.entity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -35,7 +35,7 @@ import org.apache.ofbiz.entity.condition.EntityDateFilterCondition;
 import org.apache.ofbiz.entity.condition.EntityExpr;
 import org.apache.ofbiz.entity.condition.EntityFieldMap;
 import org.apache.ofbiz.entity.condition.EntityWhereString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /* Tests adapted from code examples described in the javadoc of the
  * EntityConditionVisitor interface.  They should be kept in sync with

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/util/EntitySaxReaderTests.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/util/EntitySaxReaderTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class EntitySaxReaderTests {
+public final class EntitySaxReaderTests {
     private boolean logVerboseOn;
 
     @BeforeEach

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/util/EntitySaxReaderTests.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/util/EntitySaxReaderTests.java
@@ -18,7 +18,7 @@
  */
 package org.apache.ofbiz.entity.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -28,21 +28,21 @@ import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.model.ModelEntity;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EntitySaxReaderTests {
     private boolean logVerboseOn;
 
-    @Before
+    @BeforeEach
     public void initialize() {
         logVerboseOn = Debug.isOn(Debug.VERBOSE); // save the current setting (to be restored after the tests)
         // disable verbose logging: this is necessary to avoid a test error in the "parse" unit test
         Debug.set(Debug.VERBOSE, false);
     }
 
-    @After
+    @AfterEach
     public void restore() {
         Debug.set(Debug.VERBOSE, logVerboseOn); // restore the verbose log setting
     }

--- a/framework/security/src/test/java/org/apache/ofbiz/security/CsrfUtilTests.java
+++ b/framework/security/src/test/java/org/apache/ofbiz/security/CsrfUtilTests.java
@@ -18,10 +18,10 @@
  */
 package org.apache.ofbiz.security;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -37,7 +37,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.webapp.control.ConfigXMLReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 

--- a/framework/security/src/test/java/org/apache/ofbiz/security/SecurityUtilTest.java
+++ b/framework/security/src/test/java/org/apache/ofbiz/security/SecurityUtilTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SecurityUtilTest {
+public final class SecurityUtilTest {
 
     private static final List<String> FRAMEWORK_ADMIN_PERMISSIONS = Arrays.asList(
             "SECURITY", "COMMON", "ENTITY_DATA");

--- a/framework/security/src/test/java/org/apache/ofbiz/security/SecurityUtilTest.java
+++ b/framework/security/src/test/java/org/apache/ofbiz/security/SecurityUtilTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.ofbiz.security;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -30,9 +30,9 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.ofbiz.base.util.GeneralException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SecurityUtilTest {
 
@@ -43,7 +43,7 @@ public class SecurityUtilTest {
     private Path tempExternal;
     private String previousOfbizHome;
 
-    @Before
+    @BeforeEach
     public void setUpTempDirs() throws Exception {
         tempHome = Files.createTempDirectory("ofbiz-home-test");
         tempExternal = Files.createTempDirectory("ofbiz-ext-test");
@@ -51,7 +51,7 @@ public class SecurityUtilTest {
         System.setProperty("ofbiz.home", tempHome.toString());
     }
 
-    @After
+    @AfterEach
     public void tearDownTempDirs() throws Exception {
         if (previousOfbizHome != null) {
             System.setProperty("ofbiz.home", previousOfbizHome);

--- a/framework/service/src/test/groovy/org/apache/ofbiz/service/ModelServiceTest.groovy
+++ b/framework/service/src/test/groovy/org/apache/ofbiz/service/ModelServiceTest.groovy
@@ -109,15 +109,17 @@ class ModelServiceTest {
         }
     }
 
-    @Test(expected = ServiceValidationException)
+    @Test
     void callValidateServiceWithNullRequiredParam() {
-        String serviceXml = '''<service name="testParam" engine="java"
-               location="org.apache.ofbiz.common.CommonServices" invoke="ping">
-               <attribute name="message" type="String" mode="IN"/>
-           </service>'''
-        createModelService(serviceXml)
-                .validate(dispatcher, [message: null],
-                        'IN', Locale.default)
+        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+            String serviceXml = '''<service name="testParam" engine="java"
+                   location="org.apache.ofbiz.common.CommonServices" invoke="ping">
+                   <attribute name="message" type="String" mode="IN"/>
+               </service>'''
+            createModelService(serviceXml)
+                    .validate(dispatcher, [message: null],
+                            'IN', Locale.default)
+        }
     }
 
     @Test
@@ -135,15 +137,17 @@ class ModelServiceTest {
         }
     }
 
-    @Test(expected = ServiceValidationException)
+    @Test
     void callValidateServiceWithOneSingleRequiredParamMissing() {
-        String serviceXml = '''<service name="testParam" engine="java"
-               location="org.apache.ofbiz.common.CommonServices" invoke="ping">
-               <attribute name="message" type="String" mode="IN"/>
-           </service>'''
-        createModelService(serviceXml)
-                .validate(dispatcher, [missing: 'ok'],
-                        'IN', Locale.default)
+        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+            String serviceXml = '''<service name="testParam" engine="java"
+                   location="org.apache.ofbiz.common.CommonServices" invoke="ping">
+                   <attribute name="message" type="String" mode="IN"/>
+               </service>'''
+            createModelService(serviceXml)
+                    .validate(dispatcher, [missing: 'ok'],
+                            'IN', Locale.default)
+        }
     }
 
     @Test
@@ -163,18 +167,20 @@ class ModelServiceTest {
         }
     }
 
-    @Test(expected = ServiceValidationException)
+    @Test
     void callValidateServiceWithOneComplexParameterAllRequiredEmbeddedMissing() {
-        String serviceXml = '''<service name="testParam" engine="java"
-               location="org.apache.ofbiz.common.CommonServices" invoke="ping">
-               <attribute name="header" type="java.util.Map" mode="IN" optional="false">
-                   <attribute name="headerParam" type="String" mode="IN" optional="false"/>
-                   <attribute name="otherParam" type="String" mode="IN" optional="false"/>
-               </attribute>
-           </service>'''
-        createModelService(serviceXml)
-                .validate(dispatcher, [header: [headerParam: 'foo']],
-                        'IN', Locale.default)
+        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+            String serviceXml = '''<service name="testParam" engine="java"
+                   location="org.apache.ofbiz.common.CommonServices" invoke="ping">
+                   <attribute name="header" type="java.util.Map" mode="IN" optional="false">
+                       <attribute name="headerParam" type="String" mode="IN" optional="false"/>
+                       <attribute name="otherParam" type="String" mode="IN" optional="false"/>
+                   </attribute>
+               </service>'''
+            createModelService(serviceXml)
+                    .validate(dispatcher, [header: [headerParam: 'foo']],
+                            'IN', Locale.default)
+        }
     }
 
     @Test
@@ -213,32 +219,36 @@ class ModelServiceTest {
         }
     }
 
-    @Test(expected = ServiceValidationException)
+    @Test
     void callValidateServiceWithOneComplexParameterAndUnexpectedEmbeededParam() {
-        String serviceXml = '''<service name="testParam" engine="java"
-               location="org.apache.ofbiz.common.CommonServices" invoke="ping">
-               <attribute name="header" type="java.util.Map" mode="IN" optional="false">
-                   <attribute name="headerParam" type="String" mode="IN" optional="false"/>
-                   <attribute name="otherParam" type="String" mode="IN" optional="true"/>
-               </attribute>
-           </service>'''
-        createModelService(serviceXml)
-                .validate(dispatcher, [header: [headerParam: 'foo', otherParam: 'Good', unexpectedParam: 'Bad']],
-                        'IN', Locale.default)
+        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+            String serviceXml = '''<service name="testParam" engine="java"
+                   location="org.apache.ofbiz.common.CommonServices" invoke="ping">
+                   <attribute name="header" type="java.util.Map" mode="IN" optional="false">
+                       <attribute name="headerParam" type="String" mode="IN" optional="false"/>
+                       <attribute name="otherParam" type="String" mode="IN" optional="true"/>
+                   </attribute>
+               </service>'''
+            createModelService(serviceXml)
+                    .validate(dispatcher, [header: [headerParam: 'foo', otherParam: 'Good', unexpectedParam: 'Bad']],
+                            'IN', Locale.default)
+        }
     }
 
-    @Test(expected = ServiceValidationException)
+    @Test
     void callValidateServiceWithOneComplexParameterAndBadListValue() {
-        String serviceXml = '''<service name="testParam" engine="java"
-               location="org.apache.ofbiz.common.CommonServices" invoke="ping">
-               <attribute name="header" type="java.util.Map" mode="IN" optional="false">
-                   <attribute name="headerParam" type="String" mode="IN" optional="false"/>
-                   <attribute name="otherParam" type="String" mode="IN" optional="true"/>
-               </attribute>
-           </service>'''
-        createModelService(serviceXml)
-                .validate(dispatcher, [header: ['headerParam', 'otherParam']],
-                        'IN', Locale.default)
+        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+            String serviceXml = '''<service name="testParam" engine="java"
+                   location="org.apache.ofbiz.common.CommonServices" invoke="ping">
+                   <attribute name="header" type="java.util.Map" mode="IN" optional="false">
+                       <attribute name="headerParam" type="String" mode="IN" optional="false"/>
+                       <attribute name="otherParam" type="String" mode="IN" optional="true"/>
+                   </attribute>
+               </service>'''
+            createModelService(serviceXml)
+                    .validate(dispatcher, [header: ['headerParam', 'otherParam']],
+                            'IN', Locale.default)
+        }
     }
 
     @Test
@@ -262,21 +272,23 @@ class ModelServiceTest {
         }
     }
 
-    @Test(expected = ServiceValidationException)
+    @Test
     void callValidateServiceWithTwoComplexLevelParameterUnwantedParameter() {
-        String serviceXml = '''<service name="testParam" engine="java"
-               location="org.apache.ofbiz.common.CommonServices" invoke="ping">
-               <attribute name="header" type="java.util.Map" mode="IN" optional="false">
-                   <attribute name="headerParam" type="java.util.Map" mode="IN" optional="false">
-                        <attribute name="subHeaderParam" type="String" mode="IN" optional="false"/>
+        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+            String serviceXml = '''<service name="testParam" engine="java"
+                   location="org.apache.ofbiz.common.CommonServices" invoke="ping">
+                   <attribute name="header" type="java.util.Map" mode="IN" optional="false">
+                       <attribute name="headerParam" type="java.util.Map" mode="IN" optional="false">
+                            <attribute name="subHeaderParam" type="String" mode="IN" optional="false"/>
+                       </attribute>
+                       <attribute name="otherParam" type="String" mode="IN" optional="true"/>
                    </attribute>
-                   <attribute name="otherParam" type="String" mode="IN" optional="true"/>
-               </attribute>
-           </service>'''
-        createModelService(serviceXml)
-                .validate(dispatcher, [header: [headerParam: [subHeaderParam: 'true', otherParam: 'false'],
-                                                otherParam: 'true']],
-                        'IN', Locale.default)
+               </service>'''
+            createModelService(serviceXml)
+                    .validate(dispatcher, [header: [headerParam: [subHeaderParam: 'true', otherParam: 'false'],
+                                                    otherParam: 'true']],
+                            'IN', Locale.default)
+        }
     }
 
     @Test
@@ -314,20 +326,22 @@ class ModelServiceTest {
         }
     }
 
-    @Test(expected = ServiceValidationException)
+    @Test
     void callValidateServiceWithOneComplexParameterAsListAndUnwantedParameter() {
-        String serviceXml = '''<service name="testParam" engine="java"
-               location="org.apache.ofbiz.common.CommonServices" invoke="ping">
-               <attribute name="header" type="java.util.List" mode="IN" optional="false">
-                   <attribute name="headerParam" type="String" mode="IN" optional="false"/>
-                   <attribute name="otherParam" type="String" mode="IN" optional="true"/>
-               </attribute>
-           </service>'''
-        createModelService(serviceXml)
-                .validate(dispatcher, [header: [[headerParam: 'line1', otherParam: 'Good'],
-                                                [headerParam: 'line2', otherParam: 'Good',
-                                                 unwanted: 'Bad']]],
-                        'IN', Locale.default)
+        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+            String serviceXml = '''<service name="testParam" engine="java"
+                   location="org.apache.ofbiz.common.CommonServices" invoke="ping">
+                   <attribute name="header" type="java.util.List" mode="IN" optional="false">
+                       <attribute name="headerParam" type="String" mode="IN" optional="false"/>
+                       <attribute name="otherParam" type="String" mode="IN" optional="true"/>
+                   </attribute>
+               </service>'''
+            createModelService(serviceXml)
+                    .validate(dispatcher, [header: [[headerParam: 'line1', otherParam: 'Good'],
+                                                    [headerParam: 'line2', otherParam: 'Good',
+                                                     unwanted: 'Bad']]],
+                            'IN', Locale.default)
+        }
     }
 
     @Test

--- a/framework/start/src/test/java/org/apache/ofbiz/base/start/OfbizStartupUnitTests.java
+++ b/framework/start/src/test/java/org/apache/ofbiz/base/start/OfbizStartupUnitTests.java
@@ -22,11 +22,11 @@ package org.apache.ofbiz.base.start;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OfbizStartupUnitTests {
 

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/WebAppCacheTest.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/WebAppCacheTest.java
@@ -23,21 +23,21 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.ArrayList;
 
 import org.apache.ofbiz.base.component.ComponentConfig;
 import org.apache.ofbiz.base.component.ComponentConfig.WebappInfo;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class WebAppCacheTest {
     private ArrayList<ComponentConfig> ccSource;
     private WebAppCache wac;
     private ArrayList<WebappInfo> wInfos;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ccSource = new ArrayList<>();
         wac = new WebAppCache(() -> ccSource);

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/WebAppCacheTest.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/WebAppCacheTest.java
@@ -32,7 +32,7 @@ import org.apache.ofbiz.base.component.ComponentConfig.WebappInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class WebAppCacheTest {
+public final class WebAppCacheTest {
     private ArrayList<ComponentConfig> ccSource;
     private WebAppCache wac;
     private ArrayList<WebappInfo> wInfos;

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/ControlFilterTests.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/ControlFilterTests.java
@@ -33,7 +33,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-public class ControlFilterTests {
+public final class ControlFilterTests {
 
     private FilterConfig config;
     private ControlFilter filter;

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/ControlFilterTests.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/ControlFilterTests.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -42,7 +42,7 @@ public class ControlFilterTests {
     private FilterChain next;
     private HttpSession session;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         config = mock(FilterConfig.class);
         when(config.getInitParameter(anyString())).thenReturn(null);

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/ExternalLoginKeysManagerTests.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/ExternalLoginKeysManagerTests.java
@@ -18,8 +18,8 @@
  */
 package org.apache.ofbiz.webapp.control;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,7 +28,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
 import org.apache.ofbiz.entity.GenericValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExternalLoginKeysManagerTests {
     @Test

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/RequestHandlerTests.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/RequestHandlerTests.java
@@ -22,9 +22,9 @@ import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,8 +43,8 @@ import org.apache.ofbiz.base.util.collections.MultivaluedMapContext;
 import org.apache.ofbiz.webapp.control.ConfigXMLReader.ControllerConfig;
 import org.apache.ofbiz.webapp.control.ConfigXMLReader.RequestMap;
 import org.apache.ofbiz.webapp.control.ConfigXMLReader.ViewMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
 
 public class RequestHandlerTests {
@@ -55,7 +55,7 @@ public class RequestHandlerTests {
         private Element dummyElement;
         private ControllerConfig ccfg;
 
-        @Before
+        @BeforeEach
         public void setUp() {
             ccfg = mock(ControllerConfig.class);
             reqMaps = new MultivaluedMapContext<>();
@@ -225,7 +225,7 @@ public class RequestHandlerTests {
         private Element dummyElement;
         private Collection<RequestMap> rmaps;
 
-        @Before
+        @BeforeEach
         public void setUp() {
             dummyElement = mock(Element.class);
             rmaps = new ArrayList<>();
@@ -265,7 +265,7 @@ public class RequestHandlerTests {
     public static class CheckCertificatesTests {
         private HttpServletRequest req;
 
-        @Before
+        @BeforeEach
         public void setUp() {
             req = mock(HttpServletRequest.class);
             when(req.getAttribute(anyString())).thenReturn(null);

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/RequestHandlerTests.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/RequestHandlerTests.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
 
 public class RequestHandlerTests {
-    public static class ResolveURITests {
+    public static final class ResolveURITests {
         private MultivaluedMapContext<String, RequestMap> reqMaps;
         private Map<String, ViewMap> viewMaps;
         private HttpServletRequest req;
@@ -221,7 +221,7 @@ public class RequestHandlerTests {
         }
     }
 
-    public static class ResolveMethodTests {
+    public static final class ResolveMethodTests {
         private Element dummyElement;
         private Collection<RequestMap> rmaps;
 
@@ -262,7 +262,7 @@ public class RequestHandlerTests {
         }
     }
 
-    public static class CheckCertificatesTests {
+    public static final class CheckCertificatesTests {
         private HttpServletRequest req;
 
         @BeforeEach

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/WidgetWorkerTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/WidgetWorkerTest.java
@@ -21,8 +21,8 @@ package org.apache.ofbiz.widget;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.ofbiz.security.CsrfUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.hasProperty;
 
 public class WidgetWorkerTest {
 
-    @Before
+    @BeforeEach
     public void setupMockups() {
         new RequestHandlerMockUp();
     }

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/WidgetWorkerTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/WidgetWorkerTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 
-public class WidgetWorkerTest {
+public final class WidgetWorkerTest {
 
     @BeforeEach
     public void setupMockups() {

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.w3c.dom.Element;
 
-public class ModelFormFieldTest {
+public final class ModelFormFieldTest {
     private HashMap<String, Object> context;
 
     @BeforeEach

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormFieldTest.java
@@ -31,15 +31,15 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.w3c.dom.Element;
 
 public class ModelFormFieldTest {
     private HashMap<String, Object> context;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         context = new HashMap<>();
     }

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormTest.java
@@ -30,9 +30,9 @@ import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.webapp.control.JWTManager;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -41,7 +41,7 @@ public class ModelFormTest {
     private HashMap<String, Object> context;
     private Delegator delegator;
 
-    @Before
+    @BeforeEach
     public void setUp() throws GenericEntityException {
         delegator = Mockito.mock(Delegator.class);
         GenericValue genericValue = Mockito.mock(GenericValue.class);
@@ -60,8 +60,8 @@ public class ModelFormTest {
                 Map.of("areaId", "myAreaId",
                         "areaTarget", "myAreaTarget")));
         ModelForm.UpdateArea updateArea = ModelForm.UpdateArea.fromJwtToken(context);
-        Assert.assertEquals("areaId not correct", updateArea.getAreaId(), "myAreaId");
-        Assert.assertEquals("areaTarget not correct", updateArea.getAreaTarget(), "myAreaTarget");
+        Assertions.assertEquals(updateArea.getAreaId(), "myAreaId", "areaId not correct");
+        Assertions.assertEquals(updateArea.getAreaTarget(), "myAreaTarget", "areaTarget not correct");
     }
 
     @Test
@@ -73,8 +73,8 @@ public class ModelFormTest {
                 "parameters", converter.convert(Map.of("entry1", "value1")).toString())));
         ModelForm.UpdateArea updateArea = ModelForm.UpdateArea.fromJwtToken(context);
         CommonWidgetModels.Parameter parameter = getParameterOnly(updateArea);
-        Assert.assertEquals("Parameters key name isn't the same", parameter.getName(), "entry1");
-        Assert.assertEquals("Parameters value isn't the same", parameter.getValue().toString(), "value1");
+        Assertions.assertEquals(parameter.getName(), "entry1", "Parameters key name isn't the same");
+        Assertions.assertEquals(parameter.getValue().toString(), "value1", "Parameters value isn't the same");
     }
 
     @Test
@@ -86,13 +86,13 @@ public class ModelFormTest {
                 "parameters", converter.convert(UtilMisc.toMap("entry1", List.of("1", "2"))).toString())));
         ModelForm.UpdateArea updateArea = ModelForm.UpdateArea.fromJwtToken(context);
         CommonWidgetModels.Parameter parameter = getParameterOnly(updateArea);
-        Assert.assertEquals("Parameters key name isn't the same", parameter.getName(), "entry1");
-        Assert.assertEquals("Parameters value isn't the same", parameter.getValue().toString(), "[1, 2]");
+        Assertions.assertEquals(parameter.getName(), "entry1", "Parameters key name isn't the same");
+        Assertions.assertEquals(parameter.getValue().toString(), "[1, 2]", "Parameters value isn't the same");
     }
 
     private static CommonWidgetModels.Parameter getParameterOnly(ModelForm.UpdateArea updateArea) {
-        Assert.assertNotNull(updateArea.getParameterList());
-        Assert.assertEquals("Parameter size should be one", updateArea.getParameterList().size(), 1);
+        Assertions.assertNotNull(updateArea.getParameterList());
+        Assertions.assertEquals(updateArea.getParameterList().size(), 1, "Parameter size should be one");
         return updateArea.getParameterList().get(0);
     }
 

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/model/ModelFormTest.java
@@ -37,7 +37,7 @@ import org.mockito.Mockito;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-public class ModelFormTest {
+public final class ModelFormTest {
     private HashMap<String, Object> context;
     private Delegator delegator;
 

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -71,7 +71,7 @@ import mockit.Mocked;
 import mockit.Tested;
 import mockit.Verifications;
 
-public class MacroFormRendererTest {
+public final class MacroFormRendererTest {
 
     @Injectable
     private HttpServletRequest request;

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/MacroFormRendererTest.java
@@ -55,8 +55,8 @@ import org.apache.ofbiz.widget.renderer.VisualTheme;
 import org.apache.ofbiz.widget.renderer.macro.renderable.RenderableFtl;
 import org.apache.ofbiz.widget.renderer.macro.renderable.RenderableFtlMacroCall;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -123,7 +123,7 @@ public class MacroFormRendererTest {
             .name("genericTooltip")
             .build();
 
-    @Before
+    @BeforeEach
     public void setupMockups() {
         new FreeMarkerWorkerMockUp();
         new ThemeFactoryMockUp();

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderDatetimeTest.java
@@ -32,7 +32,7 @@ import org.apache.ofbiz.widget.model.ModelFormField;
 import org.apache.ofbiz.widget.model.ModelTheme;
 import org.apache.ofbiz.widget.renderer.VisualTheme;
 import org.apache.ofbiz.widget.renderer.macro.renderable.RenderableFtl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import mockit.Expectations;
 import mockit.Injectable;

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/renderer/macro/RenderableFtlFormElementsBuilderTest.java
@@ -35,7 +35,7 @@ import org.apache.ofbiz.widget.renderer.VisualTheme;
 import org.apache.ofbiz.widget.renderer.macro.renderable.RenderableFtlMacroCall;
 import org.apache.ofbiz.widget.renderer.macro.renderable.RenderableFtl;
 import org.apache.ofbiz.widget.renderer.macro.renderable.RenderableFtlNoop;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;


### PR DESCRIPTION
Migrate Apache OFBiz test suite from JUnit 4 to JUnit 6 (Jupiter)

This commit handles several structural and API changes required for upgrading the testing framework from JUnit 4 to JUnit 6. 

Key changes include:

- Assertions Parameter Order: Updated `assertEquals` calls to match the new 
JUnit 6 method signature. 

The custom failure message is now passed as the last argument rather than the first `assertEquals(expected, actual, "message")`.

- Exception Testing Syntax: Updated `assertThrows` to use JUnit Jupiter API. 


The following import statement has been changed and introduced jupiter specific import statement:

import org.junit.Test; --> import org.junit.jupiter.api.Test;
import org.junit.Before; --> import org.junit.jupiter.api.BeforeEach;
import org.junit.After; --> import org.junit.jupiter.api.AfterEach;
import org.junit.BeforeClass; --> import org.junit.jupiter.api.BeforeAll;
import org.junit.AfterClass; --> import org.junit.jupiter.api.AfterAll;
import org.junit.Ignore; --> import org.junit.jupiter.api.Disabled;
import org.junit.Assert.*; --> import static org.junit.jupiter.api.Assertions.*;

Additionally, JUnit 4 assertions with failure messages must have their parameters swapped because JUnit 4 expects (String message, expected, actual) while JUnit 6 Jupiter expects (expected, actual, String message):

assertEquals(String, Object, Object) --> assertEquals(Object, Object, String)
assertTrue(String, boolean) --> assertTrue(boolean, String)
assertFalse(String, boolean) --> assertFalse(boolean, String)
assertNotNull(String, Object) --> assertNotNull(Object, String)
assertNull(String, Object) --> assertNull(Object, String)
assertSame(String, Object, Object) --> assertSame(Object, Object, String)
assertNotSame(String, Object, Object) --> assertNotSame(Object, Object, String)

And following changes are also done in this commit:

-    @Before
+    @BeforeEach

-    @After
+    @AfterEach

Important Reference Link:
https://docs.junit.org/6.1.0/migrating-from-junit4.html