### PR TITLE
Buildbot locking issue test case failing

### DIFF
--- a/applications/accounting/servicedef/services_invoice.xml
+++ b/applications/accounting/servicedef/services_invoice.xml
@@ -33,14 +33,14 @@ under the License.
         <attribute name="invoiceId" type="String" mode="OUT"/>
     </service>
 
-    <service name="invoiceSequenceEnforced" engine="groovy"
+    <service name="invoiceSequenceEnforced" engine="groovy" require-new-transaction="true"
         location="component://accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceServicesScript.groovy" invoke="invoiceSequenceEnforced">
         <implements service="getNextInvoiceId"/>
         <attribute name="partyAcctgPreference" type="org.apache.ofbiz.entity.GenericValue" mode="IN"/>
         <override name="invoiceId" type="Long" mode="OUT"/>
     </service>
 
-    <service name="invoiceSequenceRestart" engine="groovy"
+    <service name="invoiceSequenceRestart" engine="groovy" require-new-transaction="true"
         location="component://accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceServicesScript.groovy" invoke="invoiceSequenceRestart">
         <implements service="getNextInvoiceId"/>
         <attribute name="partyAcctgPreference" type="org.apache.ofbiz.entity.GenericValue" mode="IN"/>

--- a/applications/order/servicedef/services.xml
+++ b/applications/order/servicedef/services.xml
@@ -869,7 +869,7 @@ under the License.
         </attribute>
     </service>
 
-    <service name="orderSequence_enforced" engine="groovy"
+    <service name="orderSequence_enforced" engine="groovy" require-new-transaction="true"
         location="component://order/src/main/groovy/org/apache/ofbiz/order/order/OrderServicesScript.groovy" invoke="orderSequence_enforced">
         <implements service="getNextOrderId"/>
         <attribute name="partyAcctgPreference" type="org.apache.ofbiz.entity.GenericValue" mode="IN"/>


### PR DESCRIPTION
Fixed: Race condition causing Primary Key violation during Invoice creation
When running the integration test suite (`testIntegration`), a race condition could occur between the main test thread and background asynchronous threads (e.g., triggered by `global-commit-post-run` ECAs). 
If both threads attempted to generate a sequence ID concurrently using the `invoiceSequenceEnforced` or `orderSequence_enforced` services, they would read the same `lastInvoiceNumber` from `PartyAcctgPreference` before either had a chance to store the incremented value. This resulted in both threads attempting to insert an entity with the exact same ID (e.g., `CI3`), leading to a `Unique index or primary key violation` and intermittent test failures on environments like Buildbot.
To fix this, `require-new-transaction="true"` has been added to the following sequence generation services:
- `invoiceSequenceEnforced`
- `invoiceSequenceRestart` 
- `orderSequence_enforced`
By forcing these services into their own transactions, the database handles row-level locking natively for the `PartyAcctgPreference` entity, ensuring the sequence generation is atomic and thread-safe.

Hopefully, this commit will fix the below issue that we are seeing in Buildbot at ASF(I am not seeing any such issue in my laptop).
 
 2026-06-01 02:42:01,092 |Thread-56            |Log                           |I| [CommonPermissionServices.xml#genericBasePermissionCheck line 59] This simple-method-call is deprecated! Please use a service-call of genericBasePermissionCheck instead.
 2026-06-01 02:42:01,093 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/genericBasePermissionCheck] finished in [1] milliseconds
 2026-06-01 02:42:01,093 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/acctgPrefPermissionCheck] finished in [1] milliseconds
 2026-06-01 02:42:01,094 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/getPartyAccountingPreferences] finished in [2] milliseconds
 2026-06-01 02:42:01,094 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/isInvoiceInForeignCurrency] finished in [3] milliseconds
 2026-06-01 02:42:01,100 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/createMatchingPaymentApplication] finished in [11] milliseconds
 2026-06-01 02:42:01,100 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/setInvoiceStatus] finished in [1428] milliseconds
 2026-06-01 02:42:01,100 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/createInvoiceForOrder] finished in [1505] milliseconds
 2026-06-01 02:42:01,100 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/createInvoiceForOrderAllItems] finished in [1505] milliseconds
 2026-06-01 02:42:01,100 |Thread-56            |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/createInvoiceFromOrder] finished in [2382] milliseconds
 2026-06-01 02:42:01,101 |main                 |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/invoiceSequenceEnforced] finished in [69] milliseconds
 2026-06-01 02:42:01,101 |main                 |ServiceDispatcher             |T| Sync service [test-dispatcher-kZ4JsUwoNA/getNextInvoiceId] finished in [71] milliseconds
 2026-06-01 02:42:01,103 |main                 |TransactionUtil               |W| Calling transaction setRollbackOnly; this stack trace shows where this is happening:
 java.lang.Exception: rollback called in Entity Engine SQLProcessor
 	at org.apache.ofbiz.entity.transaction.TransactionUtil.setRollbackOnly(TransactionUtil.java:372)
 	at org.apache.ofbiz.entity.jdbc.SQLProcessor.rollback(SQLProcessor.java:199)
 	at org.apache.ofbiz.entity.datasource.GenericDAO.insert(GenericDAO.java:117)
 	at org.apache.ofbiz.entity.datasource.GenericHelperDAO.create(GenericHelperDAO.java:68)
 	at org.apache.ofbiz.entity.GenericDelegator.create(GenericDelegator.java:903)
 	at org.apache.ofbiz.entity.GenericValue.create(GenericValue.java:76)
 	at org.apache.ofbiz.accounting.invoice.InvoiceServicesScript.createInvoice(InvoiceServicesScript.groovy:149)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
 	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:338)
 	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:274)
 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1251)
 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1024)
 	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:809)
 	at groovy.lang.GroovyObject.invokeMethod(GroovyObject.java:39)
 	at groovy.lang.Script.invokeMethod(Script.java:101)
 	at org.apache.ofbiz.service.engine.GroovyEngine.runSync(GroovyEngine.java:110)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:429)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:244)
 	at org.apache.ofbiz.service.GenericDispatcherFactory$GenericDispatcher.runSync(GenericDispatcherFactory.java:77)
 	at org.apache.ofbiz.accounting.invoice.InvoiceServices.createInvoiceForOrder(InvoiceServices.java:255)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
 	at org.apache.ofbiz.service.engine.StandardJavaEngine.serviceInvoker(StandardJavaEngine.java:101)
 	at org.apache.ofbiz.service.engine.StandardJavaEngine.runSync(StandardJavaEngine.java:57)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:429)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:244)
 	at org.apache.ofbiz.service.GenericDispatcherFactory$GenericDispatcher.runSync(GenericDispatcherFactory.java:77)
 	at org.apache.ofbiz.accounting.invoice.InvoiceServices.createInvoicesFromShipments(InvoiceServices.java:1923)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
 	at org.apache.ofbiz.service.engine.StandardJavaEngine.serviceInvoker(StandardJavaEngine.java:101)
 	at org.apache.ofbiz.service.engine.StandardJavaEngine.runSync(StandardJavaEngine.java:57)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:429)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:244)
 	at org.apache.ofbiz.service.GenericDispatcherFactory$GenericDispatcher.runSync(GenericDispatcherFactory.java:77)
 	at org.apache.ofbiz.accounting.invoice.InvoiceServices.createInvoicesFromShipment(InvoiceServices.java:1253)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
 	at org.apache.ofbiz.service.engine.StandardJavaEngine.serviceInvoker(StandardJavaEngine.java:101)
 	at org.apache.ofbiz.service.engine.StandardJavaEngine.runSync(StandardJavaEngine.java:57)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:429)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:244)
 	at org.apache.ofbiz.service.GenericDispatcherFactory$GenericDispatcher.runSync(GenericDispatcherFactory.java:77)
 	at org.apache.ofbiz.service.eca.ServiceEcaAction.runAction(ServiceEcaAction.java:158)
 	at org.apache.ofbiz.service.eca.ServiceEcaRule.eval(ServiceEcaRule.java:162)
 	at org.apache.ofbiz.service.eca.ServiceEcaUtil.evalRules(ServiceEcaUtil.java:196)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:533)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:244)
 	at org.apache.ofbiz.service.GenericDispatcherFactory$GenericDispatcher.runSync(GenericDispatcherFactory.java:77)
 	at org.apache.ofbiz.shipment.packing.PackingSession.setShipmentToPacked(PackingSession.java:1227)
 	at org.apache.ofbiz.shipment.packing.PackingSession.complete(PackingSession.java:979)
 	at org.apache.ofbiz.shipment.packing.PackingServices.completePack(PackingServices.java:308)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
 	at org.apache.ofbiz.service.engine.StandardJavaEngine.serviceInvoker(StandardJavaEngine.java:101)
 	at org.apache.ofbiz.service.engine.StandardJavaEngine.runSync(StandardJavaEngine.java:57)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:429)
 	at org.apache.ofbiz.service.ServiceDispatcher.runSync(ServiceDispatcher.java:244)
 	at org.apache.ofbiz.service.GenericDispatcherFactory$GenericDispatcher.runSync(GenericDispatcherFactory.java:77)
 	at org.apache.ofbiz.accounting.accounting.InvoicePerShipmentTests.testInvoicePerShipment(InvoicePerShipmentTests.groovy:175)
 	at org.apache.ofbiz.accounting.accounting.InvoicePerShipmentTests.testInvoicePerShipmentSetOrderTrue(InvoicePerShipmentTests.groovy:79)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
 	at junit.framework.TestCase.runTest(TestCase.java:177)
 	at junit.framework.TestCase.runBare(TestCase.java:142)
 	at junit.framework.TestResult$1.protect(TestResult.java:122)
 	at junit.framework.TestResult.runProtected(TestResult.java:142)
 	at junit.framework.TestResult.run(TestResult.java:125)
 	at junit.framework.TestCase.run(TestCase.java:130)
 	at junit.framework.TestSuite.runTest(TestSuite.java:241)
 	at junit.framework.TestSuite.run(TestSuite.java:236)
 	at junit.framework.TestSuite.runTest(TestSuite.java:241)
 	at junit.framework.TestSuite.run(TestSuite.java:236)
 	at org.apache.ofbiz.testtools.TestRunContainer.start(TestRunContainer.java:90)
 	at org.apache.ofbiz.base.container.ContainerLoader.startLoadedContainers(ContainerLoader.java:153)
 	at org.apache.ofbiz.base.container.ContainerLoader.load(ContainerLoader.java:77)
 	at org.apache.ofbiz.base.start.StartupControlPanel.loadContainers(StartupControlPanel.java:146)
 	at org.apache.ofbiz.base.start.StartupControlPanel.start(StartupControlPanel.java:70)
 	at org.apache.ofbiz.base.start.Start.main(Start.java:89)
 2026-06-01 02:42:01,103 |main                 |GenericDelegator              |E| Failure in create operation for entity [Invoice]: org.apache.ofbiz.entity.GenericEntityException: Error while inserting: [GenericEntity:Invoice][billingAccountId,null()][createdStamp,2026-06-01 02:42:01.102(java.sql.Timestamp)][createdTxStamp,2026-06-01 02:41:58.912(java.sql.Timestamp)][currencyUomId,USD(java.lang.String)][dueDate,null()][invoiceDate,2026-06-01 02:42:01.027(java.sql.Timestamp)][invoiceId,CI3(java.lang.String)][invoiceTypeId,SALES_INVOICE(java.lang.String)][lastUpdatedStamp,2026-06-01 02:42:01.102(java.sql.Timestamp)][lastUpdatedTxStamp,2026-06-01 02:41:58.912(java.sql.Timestamp)][partyId,DemoCustomer(java.lang.String)][partyIdFrom,Company(java.lang.String)][statusId,INVOICE_IN_PROCESS(java.lang.String)] (SQL Exception while executing the following:INSERT INTO OFBIZ.INVOICE (INVOICE_ID, INVOICE_TYPE_ID, PARTY_ID_FROM, PARTY_ID, ROLE_TYPE_ID, STATUS_ID, BILLING_ACCOUNT_ID, CONTACT_MECH_ID, INVOICE_DATE, DUE_DATE, PAID_DATE, INVOICE_MESSAGE, REFERENCE_NUMBER, DESCRIPTION, CURRENCY_UOM_ID, RECURRENCE_INFO_ID, LAST_UPDATED_STAMP, LAST_UPDATED_TX_STAMP, CREATED_STAMP, CREATED_TX_STAMP) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) (Unique index or primary key violation: "OFBIZ.CONSTRAINT_9F INDEX OFBIZ.PRIMARY_KEY_9F ON OFBIZ.INVOICE(INVOICE_ID) VALUES ( /* 42 */ 'CI3' )"; SQL statement:
 INSERT INTO OFBIZ.INVOICE (INVOICE_ID, INVOICE_TYPE_ID, PARTY_ID_FROM, PARTY_ID, ROLE_TYPE_ID, STATUS_ID, BILLING_ACCOUNT_ID, CONTACT_MECH_ID, INVOICE_DATE, DUE_DATE, PAID_DATE, INVOICE_MESSAGE, REFERENCE_NUMBER, DESCRIPTION, CURRENCY_UOM_ID, RECURRENCE_INFO_ID, LAST_UPDATED_STAMP, LAST_UPDATED_TX_STAMP, CREATED_STAMP, CREATED_TX_STAMP) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) [23505-240])). Rolling back transaction.
 2026-06-01 02:42:01,103 |main                 |TransactionUtil               |I| Transaction rollback only not set, rollback only is already set.
 2026-06-01 02:42:01,104 |main                 |ServiceDispatcher             |T| [[Sync service failed...- total:0.0,since last(Begin):0.0]] - 'test-dispatcher-kZ4JsUwoNA / createInvoice'
 2026-06-01 02:42:01,104 |main                 |TransactionUtil               |I| Transaction rollback only not set, rollback only is already set.
