### PR TITLE
Framework junit test cases fix

### DIFF
--- a/framework/base/src/test/groovy/org/apache/ofbiz/base/util/FileUtilTests.groovy
+++ b/framework/base/src/test/groovy/org/apache/ofbiz/base/util/FileUtilTests.groovy
@@ -19,7 +19,7 @@
 package org.apache.ofbiz.base.util
 
 import org.apache.commons.io.FileUtils
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class FileUtilTests {
 

--- a/framework/base/src/test/groovy/org/apache/ofbiz/base/util/UtilCacheTest.groovy
+++ b/framework/base/src/test/groovy/org/apache/ofbiz/base/util/UtilCacheTest.groovy
@@ -22,16 +22,13 @@ import static org.apache.ofbiz.base.util.tool.UtilCacheTestTools.createListener
 
 import org.apache.ofbiz.base.util.cache.UtilCache
 import org.apache.ofbiz.base.util.tool.UtilCacheTestTools.Listener
-import org.apache.ofbiz.service.testtools.OFBizTestCase
-import org.junit.Test
+
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeAll
 
 // codenarc-disable JUnitLostTest
-class UtilCacheTest extends OFBizTestCase {
+class UtilCacheTest  {
 
-    UtilCacheTest(String name) {
-        super(name)
-    }
 
     @BeforeAll
     static void clearCaches() { // codenarc-disable UnusedPrivateMethod
@@ -95,6 +92,7 @@ class UtilCacheTest extends OFBizTestCase {
     // codenarc-disable JUnitTestMethodWithoutAssert
     @Test
     void testCreateUtilCache() {
+        String name = 'testCreateUtilCache'
         doUtilCacheCreateTest(UtilCache.createUtilCache(), null, null, null, null)
         doUtilCacheCreateTest(UtilCache.createUtilCache(name), null, null, null, null)
         doUtilCacheCreateTest(UtilCache.createUtilCache(name, false), null, null, null, Boolean.FALSE)
@@ -112,6 +110,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testCacheGetterOnCreation() {
+        String name = 'testCacheGetterOnCreation'
         UtilCache myCache = UtilCache.createUtilCache(name, 5, 0, 0, false)
         assert UtilCache.getUtilCacheTableKeySet().contains(name)
         assert myCache == UtilCache.findCache(name)
@@ -121,6 +120,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testCacheCreateEntry() {
+        String name = 'testCacheCreateEntry'
         UtilCache myCache = UtilCache.createUtilCache(name, 5, 0, 0, false)
         Listener myCacheListener = createListener(myCache)
         Listener controlListener = new Listener()
@@ -136,6 +136,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testCacheCreateEntryWithNullKey() {
+        String name = 'testCacheCreateEntryWithNullKey'
         UtilCache myCache = UtilCache.createUtilCache(name, 5, 0, 0, false)
         Listener myCacheListener = createListener(myCache)
         Listener controlListener = new Listener()
@@ -150,6 +151,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testCacheUpdateEntry() {
+        String name = 'testCacheUpdateEntry'
         UtilCache myCache = UtilCache.createUtilCache(name, 5, 0, 0, false)
         Listener myCacheListener = createListener(myCache)
         Listener controlListener = new Listener()
@@ -171,6 +173,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testRemoveCacheEntry() {
+        String name = 'testRemoveCacheEntry'
         UtilCache myCache = UtilCache.createUtilCache(name, 5, 0, 0, false)
         Listener myCacheListener = createListener(myCache)
         Listener controlListener = new Listener()
@@ -191,6 +194,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testSetExpireCache() {
+        String name = 'testSetExpireCache'
         UtilCache myCache = UtilCache.createUtilCache(name, 5, 0, 0, false)
         Listener myCacheListener = createListener(myCache)
         Listener controlListener = new Listener()
@@ -210,6 +214,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testChangeMemorySize() {
+        String name = 'testChangeMemorySize'
         int size = 5
         UtilCache<String, Serializable> myCache = UtilCache.createUtilCache(name, size, size, 0, false)
         Map controlMap = [:]
@@ -232,6 +237,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testPutIfAbsent() {
+        String name = 'testPutIfAbsent'
         UtilCache<String, String> myCache = UtilCache.createUtilCache(name, 1, 1, 0, false)
         Listener myCacheListener = createListener(myCache)
         Listener controlListener = new Listener()
@@ -252,6 +258,7 @@ class UtilCacheTest extends OFBizTestCase {
 
     @Test
     void testPutIfAbsentAndGet() {
+        String name = 'testPutIfAbsentAndGet'
         UtilCache<String, String> myCache = UtilCache.createUtilCache(name, 1, 1, 0, false)
         Listener myCacheListener = createListener(myCache)
         Listener controlListener = new Listener()

--- a/framework/base/src/test/groovy/org/apache/ofbiz/base/util/UtilCacheTest.groovy
+++ b/framework/base/src/test/groovy/org/apache/ofbiz/base/util/UtilCacheTest.groovy
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeAll
 // codenarc-disable JUnitLostTest
 class UtilCacheTest  {
 
-
     @BeforeAll
     static void clearCaches() { // codenarc-disable UnusedPrivateMethod
         UtilCache.clearAllCaches()

--- a/framework/base/src/test/groovy/org/apache/ofbiz/base/util/collection/FlexibleMapAccessorTest.groovy
+++ b/framework/base/src/test/groovy/org/apache/ofbiz/base/util/collection/FlexibleMapAccessorTest.groovy
@@ -18,16 +18,15 @@
  *******************************************************************************/
 package org.apache.ofbiz.base.util.collection
 
-import junit.framework.TestCase
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.apache.ofbiz.base.util.collections.FlexibleMapAccessor
 import org.apache.ofbiz.base.util.string.tool.TestException
 import org.apache.ofbiz.base.util.string.tool.TestingMap
-import org.junit.Assert
-import org.junit.Test
 
 /* codenarc-disable GStringExpressionWithinString, UnnecessaryBigDecimalInstantiation */
 
-class FlexibleMapAccessorTest extends TestCase {
+class FlexibleMapAccessorTest {
 
     private static final Locale LOCALE_TO_TEST = new Locale('en', 'US')
     private static final FlexibleMapAccessor<?> EMPTY_FMA = FlexibleMapAccessor.getInstance('')
@@ -107,7 +106,7 @@ class FlexibleMapAccessorTest extends TestCase {
         assert !outParameters.isEmpty()
         assert outParameters.keySet().contains('var')
         assert outParameters.('var') === null
-        Assert.assertThrows(IllegalArgumentException, () -> fmaVarInstance.put(null, 'Foo'))
+        Assertions.assertThrows(IllegalArgumentException, () -> fmaVarInstance.put(null, 'Foo'))
     }
 
     @Test
@@ -120,7 +119,7 @@ class FlexibleMapAccessorTest extends TestCase {
         assert !parameters.isEmpty()
         assert parameters.keySet().contains('someList')
         assert parameters.('someList') == []
-        Assert.assertThrows(IllegalArgumentException, () -> fmaVarInstance.put(null, 'Foo'))
+        Assertions.assertThrows(IllegalArgumentException, () -> fmaVarInstance.put(null, 'Foo'))
     }
 
     @Test

--- a/framework/base/src/test/groovy/org/apache/ofbiz/base/util/string/FlexibleStringExpanderBaseCodeTests.groovy
+++ b/framework/base/src/test/groovy/org/apache/ofbiz/base/util/string/FlexibleStringExpanderBaseCodeTests.groovy
@@ -21,7 +21,7 @@ package org.apache.ofbiz.base.util.string
 import groovy.io.FileType
 import org.apache.ofbiz.base.util.Debug
 import org.apache.ofbiz.base.util.ScriptUtil
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 import java.util.regex.MatchResult
 import java.util.regex.Matcher

--- a/framework/base/src/test/groovy/org/apache/ofbiz/base/util/string/FlexibleStringExpanderParserTests.groovy
+++ b/framework/base/src/test/groovy/org/apache/ofbiz/base/util/string/FlexibleStringExpanderParserTests.groovy
@@ -18,7 +18,7 @@
  *******************************************************************************/
 package org.apache.ofbiz.base.util.string
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /* codenarc-disable GStringExpressionWithinString, JUnitTestMethodWithoutAssert */
 

--- a/framework/base/src/test/groovy/org/apache/ofbiz/base/util/string/FlexibleStringExpanderTests.groovy
+++ b/framework/base/src/test/groovy/org/apache/ofbiz/base/util/string/FlexibleStringExpanderTests.groovy
@@ -18,18 +18,17 @@
  *******************************************************************************/
 package org.apache.ofbiz.base.util.string
 
-import junit.framework.TestCase
 import org.apache.ofbiz.base.util.string.tool.SpecialNumber
 import org.apache.ofbiz.base.util.string.tool.TestNpe
 import org.apache.ofbiz.base.util.string.tool.TestException
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /* codenarc-disable GStringExpressionWithinString, JUnitTestMethodWithoutAssert, UnnecessaryBigDecimalInstantiation */
 
 /**
  * Test Class for FlexibleStringExpander object
  */
-class FlexibleStringExpanderTests extends TestCase {
+class FlexibleStringExpanderTests {
 
     private static final Locale LOCALE_TO_TEST = new Locale('en', 'US')
     private static final Locale OTHER_LOCALE = new Locale('fr')

--- a/framework/service/src/test/groovy/org/apache/ofbiz/service/ModelServiceTest.groovy
+++ b/framework/service/src/test/groovy/org/apache/ofbiz/service/ModelServiceTest.groovy
@@ -26,9 +26,8 @@ import org.apache.ofbiz.base.util.UtilURL
 import org.apache.ofbiz.base.util.UtilXml
 import org.apache.ofbiz.base.util.cache.UtilCache
 import org.apache.ofbiz.entity.DelegatorFactory
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.MockedStatic
@@ -43,7 +42,13 @@ class ModelServiceTest {
     private MockedStatic<UtilProperties> utilities
     private LocalDispatcher dispatcher
 
-    @Before
+    @org.junit.jupiter.api.BeforeAll
+    static void initClasses() {
+        // Initialize SecuredUpload before UtilProperties is mocked
+        Class.forName('org.apache.ofbiz.security.SecuredUpload')
+    }
+
+    @BeforeEach
     void initialize() {
         System.setProperty('ofbiz.home', System.getProperty('user.dir'))
         dispatcher = Mockito.mock(LocalDispatcher)
@@ -52,9 +57,9 @@ class ModelServiceTest {
 
     @BeforeEach
     void initMock() {
-        utilities = Mockito.mockStatic(UtilProperties)
-        utilities.when(UtilProperties.getMessage(eq(ModelService.RESOURCE), any(), any())).thenReturn('Failed')
-        utilities.when(UtilProperties.createProperties(eq('debug.properties'))).thenReturn(new Properties())
+        utilities = Mockito.mockStatic(UtilProperties, Mockito.CALLS_REAL_METHODS)
+        utilities.when({ UtilProperties.getMessage(eq(ModelService.RESOURCE), any(), any()) }).thenReturn('Failed')
+        utilities.when({ UtilProperties.createProperties(eq('debug.properties')) }).thenReturn(new Properties())
     }
 
     @AfterEach
@@ -74,7 +79,7 @@ class ModelServiceTest {
                     .validate(dispatcher, [message: 'ok'],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Required parameters not validated')
+            Assertions.fail('Required parameters not validated')
         }
     }
 
@@ -89,7 +94,7 @@ class ModelServiceTest {
                     .validate(dispatcher, [message: 'ok'],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Optional parameter not validated')
+            Assertions.fail('Optional parameter not validated')
         }
     }
 
@@ -105,7 +110,7 @@ class ModelServiceTest {
                     .validate(dispatcher, [message: 'ok'],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Optional parameter not validated')
+            Assertions.fail('Optional parameter not validated')
         }
     }
 
@@ -133,7 +138,7 @@ class ModelServiceTest {
                     .validate(dispatcher, [message: null],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Optional parameter not validated')
+            Assertions.fail('Optional parameter not validated')
         }
     }
 
@@ -163,7 +168,7 @@ class ModelServiceTest {
                     .validate(dispatcher, [header: [headerParam: 'foo']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Paramètre complexe non identifié')
+            Assertions.fail('Paramètre complexe non identifié')
         }
     }
 
@@ -197,7 +202,7 @@ class ModelServiceTest {
                     .validate(dispatcher, [header: [headerParam: 'foo']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Missing optional should not throw exception')
+            Assertions.fail('Missing optional should not throw exception')
         }
     }
 
@@ -215,7 +220,7 @@ class ModelServiceTest {
                     .validate(dispatcher, [header: [headerParam: 'foo', otherParam: 'Good']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Complex parameter control error')
+            Assertions.fail('Complex parameter control error')
         }
     }
 
@@ -268,7 +273,7 @@ class ModelServiceTest {
                                                     otherParam: 'true']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Paramètre complexe non identifié')
+            Assertions.fail('Paramètre complexe non identifié')
         }
     }
 
@@ -303,7 +308,7 @@ class ModelServiceTest {
                                                     otherParam: 'true']],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Map should not have been analyzed')
+            Assertions.fail('Map should not have been analyzed')
         }
     }
 
@@ -322,7 +327,7 @@ class ModelServiceTest {
                                                     [headerParam: 'line2', otherParam: 'Good']]],
                             'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Complex List Parameter Error')
+            Assertions.fail('Complex List Parameter Error')
         }
     }
 
@@ -369,7 +374,7 @@ class ModelServiceTest {
         try {
             modelService.validate(dispatcher, [header: [headerParam: 'line1', otherParam: 'Good']], 'IN', Locale.default)
         } catch (ServiceValidationException ignored) {
-            Assert.fail('Complex implement not valid')
+            Assertions.fail('Complex implement not valid')
         }
     }
 
@@ -384,7 +389,7 @@ class ModelServiceTest {
         try {
             sanitizedContext = DispatchContext.makeValidContext(fo, 'IN', [quantity: 20])
         } catch (GeneralServiceException ignored) {
-            Assert.fail('Error calling with integer for BigDecimal')
+            Assertions.fail('Error calling with integer for BigDecimal')
         }
         assert sanitizedContext.quantity instanceof BigDecimal
     }
@@ -402,7 +407,7 @@ class ModelServiceTest {
         try {
             sanitizedContext = DispatchContext.makeValidContext(fo, 'IN', [someMap: [quantity: 20]])
         } catch (GeneralServiceException ignored) {
-            Assert.fail('Error calling with integer for BigDecimal in Map')
+            Assertions.fail('Error calling with integer for BigDecimal in Map')
         }
         assert sanitizedContext.someMap.quantity instanceof BigDecimal
     }
@@ -420,7 +425,7 @@ class ModelServiceTest {
         try {
             sanitizedContext = DispatchContext.makeValidContext(fo, 'IN', [someList: [[quantity: 20]]])
         } catch (GeneralServiceException ignored) {
-            Assert.fail('Error calling with integer for BigDecimal in List')
+            Assertions.fail('Error calling with integer for BigDecimal in List')
         }
         assert sanitizedContext.someList[0].quantity instanceof BigDecimal
     }

--- a/framework/service/src/test/groovy/org/apache/ofbiz/service/ModelServiceTest.groovy
+++ b/framework/service/src/test/groovy/org/apache/ofbiz/service/ModelServiceTest.groovy
@@ -45,7 +45,7 @@ class ModelServiceTest {
     @org.junit.jupiter.api.BeforeAll
     static void initClasses() {
         // Initialize SecuredUpload before UtilProperties is mocked
-        Class.forName('org.apache.ofbiz.security.SecuredUpload')
+        new org.apache.ofbiz.security.SecuredUpload()
     }
 
     @BeforeEach
@@ -58,8 +58,8 @@ class ModelServiceTest {
     @BeforeEach
     void initMock() {
         utilities = Mockito.mockStatic(UtilProperties, Mockito.CALLS_REAL_METHODS)
-        utilities.when({ UtilProperties.getMessage(eq(ModelService.RESOURCE), any(), any()) }).thenReturn('Failed')
-        utilities.when({ UtilProperties.createProperties(eq('debug.properties')) }).thenReturn(new Properties())
+        utilities.when { UtilProperties.getMessage(eq(ModelService.RESOURCE), any(), any()) }.thenReturn('Failed')
+        utilities.when { UtilProperties.createProperties(eq('debug.properties')) }.thenReturn(new Properties())
     }
 
     @AfterEach
@@ -116,7 +116,7 @@ class ModelServiceTest {
 
     @Test
     void callValidateServiceWithNullRequiredParam() {
-        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+        Assertions.assertThrows(ServiceValidationException) {
             String serviceXml = '''<service name="testParam" engine="java"
                    location="org.apache.ofbiz.common.CommonServices" invoke="ping">
                    <attribute name="message" type="String" mode="IN"/>
@@ -144,7 +144,7 @@ class ModelServiceTest {
 
     @Test
     void callValidateServiceWithOneSingleRequiredParamMissing() {
-        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+        Assertions.assertThrows(ServiceValidationException) {
             String serviceXml = '''<service name="testParam" engine="java"
                    location="org.apache.ofbiz.common.CommonServices" invoke="ping">
                    <attribute name="message" type="String" mode="IN"/>
@@ -174,7 +174,7 @@ class ModelServiceTest {
 
     @Test
     void callValidateServiceWithOneComplexParameterAllRequiredEmbeddedMissing() {
-        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+        Assertions.assertThrows(ServiceValidationException) {
             String serviceXml = '''<service name="testParam" engine="java"
                    location="org.apache.ofbiz.common.CommonServices" invoke="ping">
                    <attribute name="header" type="java.util.Map" mode="IN" optional="false">
@@ -226,7 +226,7 @@ class ModelServiceTest {
 
     @Test
     void callValidateServiceWithOneComplexParameterAndUnexpectedEmbeededParam() {
-        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+        Assertions.assertThrows(ServiceValidationException) {
             String serviceXml = '''<service name="testParam" engine="java"
                    location="org.apache.ofbiz.common.CommonServices" invoke="ping">
                    <attribute name="header" type="java.util.Map" mode="IN" optional="false">
@@ -242,7 +242,7 @@ class ModelServiceTest {
 
     @Test
     void callValidateServiceWithOneComplexParameterAndBadListValue() {
-        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+        Assertions.assertThrows(ServiceValidationException) {
             String serviceXml = '''<service name="testParam" engine="java"
                    location="org.apache.ofbiz.common.CommonServices" invoke="ping">
                    <attribute name="header" type="java.util.Map" mode="IN" optional="false">
@@ -279,7 +279,7 @@ class ModelServiceTest {
 
     @Test
     void callValidateServiceWithTwoComplexLevelParameterUnwantedParameter() {
-        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+        Assertions.assertThrows(ServiceValidationException) {
             String serviceXml = '''<service name="testParam" engine="java"
                    location="org.apache.ofbiz.common.CommonServices" invoke="ping">
                    <attribute name="header" type="java.util.Map" mode="IN" optional="false">
@@ -333,7 +333,7 @@ class ModelServiceTest {
 
     @Test
     void callValidateServiceWithOneComplexParameterAsListAndUnwantedParameter() {
-        org.junit.jupiter.api.Assertions.assertThrows(ServiceValidationException) {
+        Assertions.assertThrows(ServiceValidationException) {
             String serviceXml = '''<service name="testParam" engine="java"
                    location="org.apache.ofbiz.common.CommonServices" invoke="ping">
                    <attribute name="header" type="java.util.List" mode="IN" optional="false">


### PR DESCRIPTION
Framework junit test cases fix. Reported by @gtchaboussie.

Improved: Migrate framework Groovy tests to JUnit 5

The build environment uses Gradle's JUnit Platform which ignores legacy 
JUnit 3 and 4 tests. This commit fully migrates the remaining 7 Groovy 
test files in the framework folder to standard JUnit 5 conventions.

- Replaced `org.junit.Test` and legacy `TestCase` with `org.junit.jupiter.api.Test`
- Replaced `@Before` with `@BeforeEach` and updated assertion imports
- Fixed Mockito static mocking for `UtilProperties` in `ModelServiceTest`
- Ensured test names were isolated in `UtilCacheTest`

UtilCacheTest.groovy and other tests from framework folder can be seen at the following locations

https://drive.google.com/file/d/1g35oet3P8ceY_TDUASv282r6w3ByE5wZ/view?usp=sharing

https://drive.google.com/file/d/1SYuQnX1oWHq9svCXDgxvTHNSUfFZlGH9/view?usp=sharing