### PR TITLE
Fixing the console warnings: No transaction in place, so not suspending.

### DIFF
--- a/applications/accounting/src/main/java/org/apache/ofbiz/accounting/thirdparty/paypal/PayPalServices.java
+++ b/applications/accounting/src/main/java/org/apache/ofbiz/accounting/thirdparty/paypal/PayPalServices.java
@@ -212,7 +212,9 @@ public class PayPalServices {
         boolean beganTransaction = false;
         Transaction parentTransaction = null;
         try {
-            parentTransaction = TransactionUtil.suspend();
+            if (TransactionUtil.isTransactionInPlace()) {
+                parentTransaction = TransactionUtil.suspend();
+            }
             beganTransaction = TransactionUtil.begin();
         } catch (GenericTransactionException e1) {
             Debug.logError(e1, MODULE);

--- a/applications/order/src/main/java/org/apache/ofbiz/order/order/OrderServices.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/order/OrderServices.java
@@ -5623,7 +5623,9 @@ public class OrderServices {
         Transaction trans = null;
         try {
             // disable transaction processing
-            trans = TransactionUtil.suspend();
+            if (TransactionUtil.isTransactionInPlace()) {
+                trans = TransactionUtil.suspend();
+            }
 
             // get the cart
             ShoppingCart cart = (ShoppingCart) context.get("shoppingCart");

--- a/framework/common/src/main/java/org/apache/ofbiz/common/login/LdapAuthenticationServices.java
+++ b/framework/common/src/main/java/org/apache/ofbiz/common/login/LdapAuthenticationServices.java
@@ -123,7 +123,9 @@ public class LdapAuthenticationServices {
                 boolean beganTransaction = false;
                 try {
                     try {
-                        parentTx = TransactionUtil.suspend();
+                        if (TransactionUtil.isTransactionInPlace()) {
+                            parentTx = TransactionUtil.suspend();
+                        }
                     } catch (GenericTransactionException e) {
                         Debug.logError(e, "Could not suspend transaction: " + e.getMessage(), MODULE);
                     }

--- a/framework/common/src/main/java/org/apache/ofbiz/common/login/LoginServices.java
+++ b/framework/common/src/main/java/org/apache/ofbiz/common/login/LoginServices.java
@@ -320,7 +320,9 @@ public class LoginServices {
 
                         try {
                             try {
-                                parentTx = TransactionUtil.suspend();
+                                if (TransactionUtil.isTransactionInPlace()) {
+                                    parentTx = TransactionUtil.suspend();
+                                }
                             } catch (GenericTransactionException e) {
                                 Debug.logError(e, "Could not suspend transaction: " + e.getMessage(), MODULE);
                             }

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/util/SequenceUtil.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/util/SequenceUtil.java
@@ -195,7 +195,9 @@ public class SequenceUtil {
 
             Transaction suspendedTransaction = null;
             try {
-                suspendedTransaction = TransactionUtil.suspend();
+                if (TransactionUtil.isTransactionInPlace()) {
+                    suspendedTransaction = TransactionUtil.suspend();
+                }
 
                 boolean beganTransaction = false;
                 try {

--- a/framework/service/src/main/java/org/apache/ofbiz/service/GenericAbstractDispatcher.java
+++ b/framework/service/src/main/java/org/apache/ofbiz/service/GenericAbstractDispatcher.java
@@ -120,7 +120,9 @@ public abstract class GenericAbstractDispatcher implements LocalDispatcher {
         Transaction suspendedTransaction = null;
         try {
             boolean beganTransaction = false;
-            suspendedTransaction = TransactionUtil.suspend();
+            if (TransactionUtil.isTransactionInPlace()) {
+                suspendedTransaction = TransactionUtil.suspend();
+            }
             try {
                 beganTransaction = TransactionUtil.begin();
                 try {

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/OfbizPathShortener.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/OfbizPathShortener.java
@@ -127,7 +127,9 @@ public class OfbizPathShortener {
         Transaction trans = null;
         try {
             try {
-                trans = TransactionUtil.suspend();
+                if (TransactionUtil.isTransactionInPlace()) {
+                    trans = TransactionUtil.suspend();
+                }
                 TransactionUtil.begin();
                 delegator.create("ShortenedPath", Map.of("shortenedPath", shortenedPath,
                         "originalPath", path,

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/LoginWorker.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/LoginWorker.java
@@ -146,7 +146,9 @@ public final class LoginWorker {
 
         try {
             try {
-                parentTx = TransactionUtil.suspend();
+                if (TransactionUtil.isTransactionInPlace()) {
+                    parentTx = TransactionUtil.suspend();
+                }
             } catch (GenericTransactionException e) {
                 Debug.logError(e, "Cannot suspend current transaction: " + e.getMessage(), MODULE);
             }


### PR DESCRIPTION
./gradlew testIntegration

BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d
2026-06-01 19:18:03,744 |kJoinPool-1-worker-9 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10000, maxSeqId=10010, bankSize=10
2026-06-01 19:18:03,744 |kJoinPool-1-worker-3 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,744 |kJoinPool-1-worker-3 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10010, maxSeqId=10020, bankSize=10
2026-06-01 19:18:03,745 |kJoinPool-1-worker-4 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,745 |kJoinPool-1-worker-4 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10020, maxSeqId=10030, bankSize=10
2026-06-01 19:18:03,745 |kJoinPool-1-worker-8 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,745 |kJoinPool-1-worker-8 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10030, maxSeqId=10040, bankSize=10
2026-06-01 19:18:03,745 |kJoinPool-1-worker-1 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,745 |kJoinPool-1-worker-1 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10040, maxSeqId=10050, bankSize=10
2026-06-01 19:18:03,745 |kJoinPool-1-worker-1 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,745 |kJoinPool-1-worker-1 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10050, maxSeqId=10060, bankSize=10
2026-06-01 19:18:03,745 |kJoinPool-1-worker-6 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,745 |kJoinPool-1-worker-6 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10060, maxSeqId=10070, bankSize=10
2026-06-01 19:18:03,746 |kJoinPool-1-worker-6 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,746 |kJoinPool-1-worker-6 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10070, maxSeqId=10080, bankSize=10
2026-06-01 19:18:03,746 |kJoinPool-1-worker-2 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,746 |kJoinPool-1-worker-2 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10080, maxSeqId=10090, bankSize=10
2026-06-01 19:18:03,746 |kJoinPool-1-worker-3 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,746 |kJoinPool-1-worker-3 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10090, maxSeqId=10100, bankSize=10
2026-06-01 19:18:03,746 |kJoinPool-1-worker-3 |TransactionUtil               |W| No transaction in place, so not suspending.
2026-06-01 19:18:03,746 |kJoinPool-1-worker-3 |SequenceUtil                  |I| Got bank of sequenced IDs for [BogusSequencebe00e860-64ec-4520-a02f-b5b718509d7d]; curSeqId=10100, maxSeqId=10110, bankSize=10

Assumptions:
Log Message: No transaction in place, so not suspending. Thought: Code is attempting to suspend a transaction when no transaction is currently active. Wrapping the suspend call in a check like if (TransactionUtil.isTransactionInPlace()) will eliminate this warning.