### PR TITLE
Removed: Deprecated EntityDateFilterCondition references from EntityConditionVisitor and EntityConditionVisitorTests (OFBIZ-3880)

### DIFF
--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityConditionVisitor.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityConditionVisitor.java
@@ -46,10 +46,6 @@ package org.apache.ofbiz.entity.condition;
  *             system.out.println("EntityFieldMap");
  *         }
  *
- *         public void visit(EntityDateFilterCondition df) {
- *              system.out.println("EntityDateFilterCondition");
- *         }
- *
  *         public void visit(EntityExpr expr) {
  *              system.out.println("EntityExpr");
  *         }
@@ -68,7 +64,6 @@ package org.apache.ofbiz.entity.condition;
  *
  *         public void visit(EntityNotCondition cond) {}
  *         public void visit(EntityFieldMap m) {}
- *         public void visit(EntityDateFilterCondition df) {}
  *
  *         public <T extends EntityCondition> void visit(EntityConditionList<T> l) {
  *             Iterator<T> it = l.getConditionIterator();
@@ -123,13 +118,6 @@ public interface EntityConditionVisitor {
      * @see EntityFieldMap
      */
     void visit(EntityFieldMap m);
-
-    /**
-     * Visits a date filter condition.
-     * @param df the visited class
-     * @see EntityDateFilterCondition
-     */
-    void visit(EntityDateFilterCondition df);
 
     /**
      * Visits an entity expression.

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityDateFilterCondition.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityDateFilterCondition.java
@@ -95,8 +95,9 @@ public final class EntityDateFilterCondition implements EntityCondition {
     }
 
     @Override
+    @Deprecated
     public void accept(EntityConditionVisitor visitor) {
-        visitor.visit(this);
+        throw new UnsupportedOperationException("EntityDateFilterCondition is deprecated and visitor support has been removed.");
     }
 
     @Override

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/EntityConditionVisitorTests.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/EntityConditionVisitorTests.java
@@ -31,7 +31,6 @@ import org.apache.ofbiz.entity.condition.EntityCondition;
 import org.apache.ofbiz.entity.condition.EntityNotCondition;
 import org.apache.ofbiz.entity.condition.EntityConditionList;
 import org.apache.ofbiz.entity.condition.EntityConditionVisitor;
-import org.apache.ofbiz.entity.condition.EntityDateFilterCondition;
 import org.apache.ofbiz.entity.condition.EntityExpr;
 import org.apache.ofbiz.entity.condition.EntityFieldMap;
 import org.apache.ofbiz.entity.condition.EntityWhereString;
@@ -65,11 +64,6 @@ public class EntityConditionVisitorTests {
             }
 
             @Override
-            public void visit(EntityDateFilterCondition df) {
-                pw.print("EntityDateFilterConfition");
-            }
-
-            @Override
             public void visit(EntityExpr expr) {
                 pw.print("EntityExpr");
             }
@@ -92,7 +86,6 @@ public class EntityConditionVisitorTests {
 
             @Override public void visit(EntityNotCondition cond) { }
             @Override public void visit(EntityFieldMap m) { }
-            @Override public void visit(EntityDateFilterCondition df) { }
 
             @Override
             public <T extends EntityCondition> void visit(EntityConditionList<T> l) {


### PR DESCRIPTION
Removed: Deprecated EntityDateFilterCondition references from EntityConditionVisitor and EntityConditionVisitorTests (OFBIZ-3880)
