### PR TITLE
Fixing below console warning coming on buildbot.

### DIFF
--- a/framework/base/src/main/groovy/org/apache/ofbiz/base/test/uel/DateUelTest.groovy
+++ b/framework/base/src/main/groovy/org/apache/ofbiz/base/test/uel/DateUelTest.groovy
@@ -103,7 +103,7 @@ class DateUelTest extends OFBizTestCase {
 
     void testNowTimestampUel() {
         FlexibleStringExpander fse = FlexibleStringExpander.getInstance('${date:nowTimestamp()}')
-        assert (fse.expand([:]).time - UtilDateTime.nowTimestamp().time).abs() < 15 // less than 10 ns appart
+        assert (fse.expand([:]).time - UtilDateTime.nowTimestamp().time).abs() < 500 // less than 500 ms apart
     }
 
     private void doUelDateTest(String uelInput, Closure uelFunction) {


### PR DESCRIPTION
2026-06-02 12:21:22,276 |main                 |TestRunContainer              |I| [JUNIT] : testSecurity finished.
2026-06-02 12:21:22,276 |main                 |TestRunContainer              |I| [JUNIT] : testNowTimestampUel starting...
2026-06-02 12:21:22,740 |main                 |TestRunContainer              |W| [JUNIT (error)] - testNowTimestampUel : Assertion failed:

assert (fse.expand([:]).time - UtilDateTime.nowTimestamp().time).abs() < 15
        |   |           |    |              |              |     |     |
        |   |           |    -20            |              |     20    false
        |   |           1780402882494       |              1780402882514
        |   2026-06-02 12:21:22.494         2026-06-02 12:21:22.514
        ${date:nowTimestamp()}

Assertion failed:

assert (fse.expand([:]).time - UtilDateTime.nowTimestamp().time).abs() < 15
        |   |           |    |              |              |     |     |
        |   |           |    -20            |              |     20    false
        |   |           1780402882494       |              1780402882514
        |   2026-06-02 12:21:22.494         2026-06-02 12:21:22.514
        ${date:nowTimestamp()}

	at org.codehaus.groovy.runtime.InvokerHelper.createAssertError(InvokerHelper.java:412)
	at org.apache.ofbiz.base.test.uel.DateUelTest.testNowTimestampUel(DateUelTest.groovy:106)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.apache.ofbiz.testtools.TestRunContainer.start(TestRunContainer.java:90)
	at org.apache.ofbiz.base.container.ContainerLoader.startLoadedContainers(ContainerLoader.java:153)
	at org.apache.ofbiz.base.container.ContainerLoader.load(ContainerLoader.java:77)
	at org.apache.ofbiz.base.start.StartupControlPanel.loadContainers(StartupControlPanel.java:146)
	at org.apache.ofbiz.base.start.StartupControlPanel.start(StartupControlPanel.java:70)
	at org.apache.ofbiz.base.start.Start.main(Start.java:89)
2026-06-02 12:21:22,753 |main                 |TestRunContainer              |I| [JUNIT] : testNowTimestampUel finished.
2026-06-02 12:21:22,754 |main                 |TestRunContainer              |I| [JUNIT] : testDateUel starting...
2026-06-02 12:21:22,883 |main                 |TestRunContainer              |I| [JUNIT] : testDateUel finished.
2026-06-02 12:21:22,883 |main                 |TestRunContainer              |I| [JUNIT] : testMathUel starting...
2026-06-02 12:21:23,163 |main                 |TestRunContainer              |I| [JUNIT] : testMathUel finished.

This was the 2nd issue, which I was unable to reproduce on my laptop. :-(

