### PR TITLE
We are getting 3,713 occurrences of below message when we run below command

### DIFF
--- a/framework/service/src/main/java/org/apache/ofbiz/service/eca/ServiceEcaCondition.java
+++ b/framework/service/src/main/java/org/apache/ofbiz/service/eca/ServiceEcaCondition.java
@@ -202,8 +202,9 @@ public class ServiceEcaCondition implements java.io.Serializable {
                 Debug.logWarning(message.toString(), MODULE);
             }
         }
-        if (!cond) {
+        if (cond == null) {
             Debug.logWarning("doRealCompare returned null, returning false", MODULE);
+            return false;
         }
         return cond;
     }


### PR DESCRIPTION
./gradlew testIntegration

2026-06-02 23:43:46,054 |main                 |ServiceEcaCondition           |W| doRealCompare returned null, returning false
2026-06-02 23:43:46,054 |main                 |ServiceEcaCondition           |W| doRealCompare returned null, returning false
2026-06-02 23:43:46,054 |main                 |ServiceEcaCondition           |W| doRealCompare returned null, returning false

Here's a quick summary of the change at ServiceEcaCondition.java:205:

  Before:
  if (!cond) {   // fires every time comparison returns false — ~3,713 warnings
      Debug.logWarning("doRealCompare returned null, returning false", MODULE);
  }
  return cond;

  After:
  if (cond == null) {   // fires only if doRealCompare returns null (never, currently)
      Debug.logWarning("doRealCompare returned null, returning false", MODULE);
      return false;
  }
  return cond;

  !cond (unboxed Boolean inversion) was being evaluated as "is false?", causing the warning to log on every normal false result from an ECA
  condition check. The intent was cond == null — guarding against an unexpected null return. The added return false inside the guard also
  prevents a future NullPointerException if doRealCompare ever returns null and the caller tries to unbox it.

