### PR TITLE
Fixed: Correct receivedQuantity calculation in getReceivedQuantityForOrderItem by including quantityRejected (OFBIZ-13429)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
@@ -299,6 +299,7 @@ BigDecimal getReceivedQuantityForOrderItem (GenericValue orderItem) {
     List shipmentReceipts = from('ShipmentReceipt').where(orderId: orderItem.orderId, orderItemSeqId: orderItem.orderItemSeqId).queryList()
     for (GenericValue shipmentReceipt : shipmentReceipts) {
         receivedQuantity +=  shipmentReceipt.quantityAccepted
+        receivedQuantity +=  shipmentReceipt.quantityRejected
     }
     return receivedQuantity
 }

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
@@ -295,13 +295,11 @@ Map quickReceiveReturn() {
  * Computes the till now received quantity from all ShipmentReceipts
  */
 BigDecimal getReceivedQuantityForOrderItem (GenericValue orderItem) {
-    BigDecimal receivedQuantity = 0
-    List shipmentReceipts = from('ShipmentReceipt').where(orderId: orderItem.orderId, orderItemSeqId: orderItem.orderItemSeqId).queryList()
-    for (GenericValue shipmentReceipt : shipmentReceipts) {
-        receivedQuantity +=  shipmentReceipt.quantityAccepted
-        receivedQuantity +=  shipmentReceipt.quantityRejected
-    }
-    return receivedQuantity
+    return from('ShipmentReceipt')
+            .where(orderId: orderItem.orderId,
+                    orderItemSeqId: orderItem.orderItemSeqId)
+            .queryList()
+            .sum { (it.quantityAccepted ?: 0) + (it.quantityRejected ?: 0) }
 }
 
 /**


### PR DESCRIPTION
As described in [OFBIZ-13429](https://issues.apache.org/jira/browse/OFBIZ-13429), when the 'Quantity Received' value exceeds the 'Quantity' specified on a purchase order, the system automatically updates the related issuance, shipment, and order items through the updateIssuanceShipmentAndPoOnReceiveInventory shipment receipt service.

However, when one or more receipts contain rejected units, order and shipment updates fail. The issue is caused by a bug in the getReceivedQuantityForOrderItem() function, which is invoked by the updateIssuanceShipmentAndPoOnReceiveInventory service to determine the received quantity.

This PR fixes the issue by including rejected units in the quantity calculation performed by getReceivedQuantityForOrderItem(), which previously considered only accepted units and ignored rejected quantities.
