### PR TITLE
Enable linenumber log4j

### DIFF
--- a/framework/base/config/log4j2.xml
+++ b/framework/base/config/log4j2.xml
@@ -18,6 +18,18 @@ specific language governing permissions and limitations
 under the License.
 -->
 <Configuration monitorInterval="60" packages="org.apache.ofbiz.base.log4j">
+    <!--
+      Source line numbers in log output are enabled by default.
+      To disable for production, set/uncomment systemProp.ofbiz.env=prod in gradle.properties.
+    -->
+    <Properties>
+        <Property name="lineToken_dev">:%line</Property>
+        <Property name="lineToken_prod"></Property>
+        <Property name="includeLocation_dev">true</Property>
+        <Property name="includeLocation_prod">false</Property>
+        <Property name="logPattern">%date{DEFAULT} |%-20.20thread |%-30.30logger{1}${lineToken_${sys:ofbiz.env:-dev}}|%level{length=1}| %message%n</Property>
+        <Property name="includeLocation">${includeLocation_${sys:ofbiz.env:-dev}}</Property>
+    </Properties>
     <OFBizDynamicThresholdFilter key="uri" onMatch="ACCEPT" onMismatch="DENY">
         <KeyValuePair key="/getJs" value="ERROR"/>
         <KeyValuePair key="/control/getJs" value="ERROR"/>
@@ -40,11 +52,11 @@ under the License.
     -->
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%date{DEFAULT} |%-20.20thread |%-30.30logger{1}|%level{length=1}| %message%n"/>
+            <PatternLayout pattern="${logPattern}"/>
         </Console>
 
         <RollingFile name="ofbiz" fileName="runtime/logs/ofbiz.log" filePattern="runtime/logs/ofbiz.log.%i">
-            <PatternLayout pattern="%date{DEFAULT} |%-20.20thread |%-30.30logger{1}|%level{length=1}| %message%n"/>
+            <PatternLayout pattern="${logPattern}"/>
             <Policies>
                 <OnStartupTriggeringPolicy/>
                 <SizeBasedTriggeringPolicy size="10 MB"/>
@@ -54,7 +66,7 @@ under the License.
 
         <RollingFile name="error" fileName="runtime/logs/error.log" filePattern="runtime/logs/error.log.%i">
             <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
-            <PatternLayout pattern="%date{DEFAULT} |%-20.20thread |%-30.30logger{1}|%level{length=1}| %message%n"/>
+            <PatternLayout pattern="${logPattern}"/>
             <Policies>
                 <OnStartupTriggeringPolicy/>
                 <SizeBasedTriggeringPolicy size="10 MB"/>
@@ -62,7 +74,7 @@ under the License.
             <DefaultRolloverStrategy fileIndex="min" max="10"/>
         </RollingFile>
 
-        <Async name="async">
+        <Async name="async" includeLocation="${includeLocation}">
             <AppenderRef ref="ofbiz"/>
             <AppenderRef ref="stdout"/>
             <AppenderRef ref="error"/>

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/Debug.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/Debug.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.spi.ExtendedLogger;
 
 /**
  * Configurable Debug logging wrapper class
@@ -115,8 +116,9 @@ public final class Debug {
             }
 
             // log
-            Logger logger = getLogger(module);
-            logger.log(LEVEL_OBJS[level], msg, t);
+            ExtendedLogger logger = (ExtendedLogger) getLogger(module);
+            logger.logMessage(Debug.class.getName(), LEVEL_OBJS[level], null,
+                    logger.getMessageFactory().newMessage(msg != null ? msg : ""), t);
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ org.gradle.console=plain
 # If you experience heap memory problems during the Gradle build, for example
 # building with integrated plugins, the following setting might help
 #org.gradle.jvmargs=-Xms128m -Xmx1024m -XX:+CMSClassUnloadingEnabled
+
+# Uncomment to disable source line numbers in log output (e.g. for production).
+#systemProp.ofbiz.env=prod


### PR DESCRIPTION
A few years ago, support for line numbers in the OFBiz console was removed due to performance concerns.

Since then, I have been thinking about bringing back line number support in the console.

IMO, It's a very important feature for developers. :-)

Today, I finally got the opportunity to provide a fix for this feature.

If you wish to disable line numbers in the console in a production environment, simply uncomment the following setting in the gradle.properties file:

#systemProp.ofbiz.env=prod

Now the user console will look like below with line #:

2026-06-04 00:23:24,351 |main                 |ComponentContainer            :81|I| All components loaded
2026-06-04 00:23:24,352 |main                 |ContainerLoader               :73|I| [Startup] Loading containers...
2026-06-04 00:23:24,352 |main                 |ContainerLoader               :103|I| Loading container: admin-container
2026-06-04 00:23:24,358 |main                 |ContainerLoader               :106|I| Loaded container: admin-container
2026-06-04 00:23:24,358 |main                 |ContainerLoader               :103|I| Loading container: delegator-container
2026-06-04 00:23:24,359 |main                 |ContainerLoader               :106|I| Loaded container: delegator-container
2026-06-04 00:23:24,359 |main                 |ContainerLoader               :103|I| Loading container: service-container
2026-06-04 00:23:24,360 |main                 |ContainerLoader               :106|I| Loaded container: service-container
2026-06-04 00:23:24,360 |main                 |ContainerLoader               :103|I| Loading container: catalina-container
2026-06-04 00:23:24,414 |main                 |CatalinaContainer             :454|I| Tomcat Connector["ajp-nio-127.0.0.1-8009"]: set scheme=http
2026-06-04 00:23:24,415 |main                 |CatalinaContainer             :454|I| Tomcat Connector["ajp-nio-127.0.0.1-8009"]: set secure=false
2026-06-04 00:23:24,417 |main                 |CatalinaContainer             :454|I| Tomcat Connector["ajp-nio-127.0.0.1-8009"]: set URIEncoding=UTF-8
2026-06-04 00:23:24,417 |main                 |CatalinaContainer             :454|I| Tomcat Connector["ajp-nio-127.0.0.1-8009"]: set xpoweredBy=false
2026-06-04 00:23:24,417 |main                 |CatalinaContainer             :454|I| Tomcat Connector["ajp-nio-127.0.0.1-8009"]: set secretRequired=false
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :438|I| Tomcat Connector["http-nio-8080"]: enabled HTTP/2
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :454|I| Tomcat Connector["http-nio-8080"]: set scheme=http
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :454|I| Tomcat Connector["http-nio-8080"]: set secure=false
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :454|I| Tomcat Connector["http-nio-8080"]: set URIEncoding=UTF-8
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :454|I| Tomcat Connector["http-nio-8080"]: set xpoweredBy=false
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :454|I| Tomcat Connector["http-nio-8080"]: set compression=on
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :454|I| Tomcat Connector["http-nio-8080"]: set compressibleMimeType=text/html,text/xml,text/plain,text/css,text/javascript,application/json
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :438|I| Tomcat Connector["http-nio-8443"]: enabled HTTP/2
2026-06-04 00:23:24,422 |main                 |CatalinaContainer             :454|I| Tomcat Connector["http-nio-8443"]: set scheme=https
2026-06-04 00:23:24,423 |main                 |CatalinaContainer             :454|I| Tomcat Connector["http-nio-8443"]: set secure=true
2026-06-04 00:23:24,423 |main                 |CatalinaContainer             :454|I| Tomcat Connector["https-jsse-nio-8443"]: set SSLEnabled=true
2026-06-04 00:23:24,423 |main                 |CatalinaContainer             :454|I| Tomcat Connector["https-jsse-nio-8443"]: set URIEncoding=UTF-8
2026-06-04 00:23:24,423 |main                 |CatalinaContainer             :454|I| Tomcat Connector["https-jsse-nio-8443"]: set xpoweredBy=false
2026-06-04 00:23:24,423 |main                 |CatalinaContainer             :454|I| Tomcat Connector["https-jsse-nio-8443"]: set compression=on
2026-06-04 00:23:24,424 |main                 |CatalinaContainer             :454|I| Tomcat Connector["https-jsse-nio-8443"]: set compressibleMimeType=text/html,text/xml,text/plain,text/css,text/javascript,application/json
