### PR TITLE
Handle trailing empty CSV headers in invoice import and fix Accounting ImportExport menu navigation.(OFBIZ-12089)

### DIFF
--- a/applications/accounting/src/main/java/org/apache/ofbiz/accounting/invoice/InvoiceServices.java
+++ b/applications/accounting/src/main/java/org/apache/ofbiz/accounting/invoice/InvoiceServices.java
@@ -3673,7 +3673,7 @@ public class InvoiceServices {
         String organizationPartyId = (String) context.get("organizationPartyId");
         String encoding = System.getProperty("file.encoding");
         String csvString = Charset.forName(encoding).decode(fileBytes).toString();
-        Builder csvFormatBuilder = Builder.create().setHeader();
+        Builder csvFormatBuilder = Builder.create().setHeader().setAllowMissingColumnNames(true);
         CSVFormat fmt = csvFormatBuilder.get();
         List<String> errMsgs = new LinkedList<>();
         List<String> newErrMsgs;

--- a/applications/accounting/widget/AccountingMenus.xml
+++ b/applications/accounting/widget/AccountingMenus.xml
@@ -114,6 +114,7 @@ under the License.
             </condition>
             <link target="EditFinAccount"/>
         </menu-item>
+        <menu-item name="ImportExport" title="${uiLabelMap.CommonImportExport}"><link target="ImportExport"/></menu-item>
     </menu>
 
     <menu name="AccountingShortcutAppBar" title="${uiLabelMap.AccountingManager}">

--- a/applications/accounting/widget/GlSetupScreens.xml
+++ b/applications/accounting/widget/GlSetupScreens.xml
@@ -103,6 +103,7 @@ under the License.
         <section>
             <actions>
                 <set field="titleProperty" value="CommonImportExport"/>
+                <set field="headerItem" value="invoices"/>
                 <entity-one entity-name="PartyGroup" value-field="partyGroup">
                     <field-map field-name="partyId" value="${groovy:parameters.get('ApplicationDecorator|organizationPartyId')}"/>
                 </entity-one>


### PR DESCRIPTION
Fixed:  Invoice import is not visible from UI and not working (OFBIZ- 12089) (#1332)

Prevented IllegalArgumentException and NullPointerException during CSV imports when uploaded templates contain trailing empty column headers (trailing commas). Also fixed Accounting Import/Export menu visibility and navigation.
