### PR TITLE
Fixed: correct content of the 'View Shipment Receipts' screenlet in the ViewShipment screen (OFBIZ-13433)

### DIFF
--- a/applications/product/widget/facility/ShipmentScreens.xml
+++ b/applications/product/widget/facility/ShipmentScreens.xml
@@ -183,9 +183,7 @@ under the License.
                                     </platform-specific>
                                 </screenlet>
                                 <screenlet id="shipmentReceiptPanel" title="${uiLabelMap.PageTitleViewShipmentReceipts}" initially-collapsed="true">
-                                    <platform-specific>
-                                        <html><html-template location="component://product/template/shipment/ViewShipmentRouteInfo.ftl"/></html>
-                                    </platform-specific>
+                                    <include-grid name="ShipmentReceipts" location="component://product/widget/facility/ShipmentForms.xml"/>
                                 </screenlet>
                             </decorator-section>
                         </decorator-screen>


### PR DESCRIPTION
As described in [OFBIZ-13433](https://issues.apache.org/jira/browse/OFBIZ-13433), in the 'View Shipment' screen, the 'View Shipment Receipts' screenlet erroneously displays route information instead of shipment receipt information.

This PR solves the issue by including in the 'shipmentReceiptPanel' screenlet the 'ShipmentReceipts' grid defined in 'ShipmentForms.xml', instead of the wrong 'ViewShipmentRouteInfo.ftl' template.

