### PR TITLE
Fixed: correct content of the 'View Shipment Receipts' screenlet in the ViewShipment screen

### DIFF
--- a/applications/product/widget/facility/ShipmentScreens.xml
+++ b/applications/product/widget/facility/ShipmentScreens.xml
@@ -183,9 +183,7 @@ under the License.
                                     </platform-specific>
                                 </screenlet>
                                 <screenlet id="shipmentReceiptPanel" title="${uiLabelMap.PageTitleViewShipmentReceipts}" initially-collapsed="true">
-                                    <platform-specific>
-                                        <html><html-template location="component://product/template/shipment/ViewShipmentRouteInfo.ftl"/></html>
-                                    </platform-specific>
+                                    <include-grid name="ShipmentReceipts" location="component://product/widget/facility/ShipmentForms.xml"/>
                                 </screenlet>
                             </decorator-section>
                         </decorator-screen>


### PR DESCRIPTION
This PR backports PR #1333. 

(cherry picked from commit 9f3d7d06e06c6501723453df92731bb1c162fcba)