### PR TITLE
Fixed: Used correct signature of makeValidContext method to prepare context for running the sendMailFromScreen service. (OFBIZ-13388)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceServicesScript.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceServicesScript.groovy
@@ -328,7 +328,7 @@ Map cancelInvoice() {
  */
 Map sendInvoicePerEmail() {
     Map emailParams = dispatcher.getDispatchContext()
-            .makeValidContext([*: parameters,
+            .makeValidContext('sendMailFromScreen', 'IN', [*: parameters,
                                xslfoAttachScreenLocation: 'component://accounting/widget/AccountingPrintScreens.xml#InvoicePDF',
                                bodyParameters: [invoiceId: parameters.invoiceId,
                                                 userLogin: parameters.userLogin,


### PR DESCRIPTION
Fixed: Used the correct signature of the makeValidContext method to prepare the context for running the sendMailFromScreen service. (OFBIZ-13388)

Thanks Arashpreet Singh, for reporting the issue and providing the patch for the fix. I have improved the code-fix and removed unnecessary changes from the patch, and then committed it.