### PR TITLE
Fix Party CSV import failure caused by trailing commas. (OFBIZ-13435)

### DIFF
--- a/applications/party/src/main/java/org/apache/ofbiz/party/party/PartyServices.java
+++ b/applications/party/src/main/java/org/apache/ofbiz/party/party/PartyServices.java
@@ -2296,7 +2296,7 @@ public class PartyServices {
         ByteBuffer fileBytes = (ByteBuffer) context.get("uploadedFile");
         String encoding = System.getProperty("file.encoding");
         String csvString = Charset.forName(encoding).decode(fileBytes).toString();
-        Builder csvFormatBuilder = Builder.create().setHeader();
+        Builder csvFormatBuilder = Builder.create().setHeader().setAllowMissingColumnNames(true);
         CSVFormat fmt = csvFormatBuilder.get();
         List<String> errMsgs = new LinkedList<>();
         List<String> newErrMsgs = new LinkedList<>();


### PR DESCRIPTION
Fixed: IllegalArgumentException on importing CSVs with trailing commas in PartyServices.
(OFBIZ-13435)

Thanks @ratneshup for your contribution.
