### PR TITLE
Implemented: Add header screen for the screenlet

### DIFF
--- a/framework/webtools/config/WebtoolsUiLabels.xml
+++ b/framework/webtools/config/WebtoolsUiLabels.xml
@@ -3325,6 +3325,10 @@
         <value xml:lang="zh">布局演示</value>
         <value xml:lang="zh-TW">佈局演示</value>
     </property>
+    <property key="WebtoolsLayoutDemoSimpleGridHeaderInfo">
+        <value xml:lang="en">Demonstration of a complex header for a collapsed screenlet</value>
+        <value xml:lang="fr">Démonstration d'entête complexe pour screenlet repliée</value>
+    </property>
     <property key="WebtoolsLayoutDemoText">
         <value xml:lang="en">Demonstrate layout best practices and provide a visual theme test page (it's recommended to use HTML source code).</value>
         <value xml:lang="fr">Démontre les bonnes pratiques de mise en page et fournit un page de test pour les thèmes (il est recommandé d'utiliser le code source HTML).</value>

--- a/framework/webtools/widget/MiscScreens.xml
+++ b/framework/webtools/widget/MiscScreens.xml
@@ -201,6 +201,10 @@ under the License.
                                             <include-form name="LayoutDemoList" location="component://webtools/widget/MiscForms.xml"/>
                                             <include-form name="LayoutDemoForm" location="component://webtools/widget/MiscForms.xml"/>
                                         </screenlet>
+                                        <screenlet id="screenlet-demo-header" collapsible="true"
+                                                   screen-header-name="WebtoolsLayoutDemoSimpleGridResume">
+                                            <include-grid name="LayoutDemoSimpleGrid" location="component://webtools/widget/MiscForms.xml"/>
+                                        </screenlet>
                                     </widgets>
                                 </section>
                             </widgets>
@@ -210,6 +214,15 @@ under the License.
                         </section>
                     </decorator-section>
                 </decorator-screen>
+            </widgets>
+        </section>
+    </screen>
+    <screen name="WebtoolsLayoutDemoSimpleGridResume">
+        <section>
+            <widgets>
+                <label style="h2">${uiLabelMap.WebtoolsLayoutDemo}</label>
+                <horizontal-separator/>
+                <label>${uiLabelMap.CommonOther}</label>
             </widgets>
         </section>
     </screen>

--- a/framework/webtools/widget/MiscScreens.xml
+++ b/framework/webtools/widget/MiscScreens.xml
@@ -201,8 +201,8 @@ under the License.
                                             <include-form name="LayoutDemoList" location="component://webtools/widget/MiscForms.xml"/>
                                             <include-form name="LayoutDemoForm" location="component://webtools/widget/MiscForms.xml"/>
                                         </screenlet>
-                                        <screenlet id="screenlet-demo-header" collapsible="true"
-                                                   screen-header-name="WebtoolsLayoutDemoSimpleGridResume">
+                                        <screenlet id="screenlet-demo-header" collapsible="true" initially-collapsed="true"
+                                                   screen-header-name="WebtoolsLayoutDemoSimpleGridHeader">
                                             <include-grid name="LayoutDemoSimpleGrid" location="component://webtools/widget/MiscForms.xml"/>
                                         </screenlet>
                                     </widgets>
@@ -217,12 +217,12 @@ under the License.
             </widgets>
         </section>
     </screen>
-    <screen name="WebtoolsLayoutDemoSimpleGridResume">
+    <screen name="WebtoolsLayoutDemoSimpleGridHeader">
         <section>
             <widgets>
                 <label style="h2">${uiLabelMap.WebtoolsLayoutDemo}</label>
                 <horizontal-separator/>
-                <label>${uiLabelMap.CommonOther}</label>
+                <label>${uiLabelMap.WebtoolsLayoutDemoSimpleGridHeaderInfo}</label>
             </widgets>
         </section>
     </screen>

--- a/framework/widget/dtd/widget-screen.xsd
+++ b/framework/widget/dtd/widget-screen.xsd
@@ -312,6 +312,16 @@ under the License.
                     <xs:documentation>Name of the screenlet include-menu sub element that will be used for the screenlet tab bar.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute type="xs:string" name="screen-header-name">
+                <xs:annotation>
+                    <xs:documentation>The screen name to use if you when a complex screenlet header</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute type="xs:string" name="screen-header-location">
+                <xs:annotation>
+                    <xs:documentation>The screen location to use if you when a complex screenlet header, if empty use the same location of the screenlet's parent screen</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 

--- a/framework/widget/dtd/widget-screen.xsd
+++ b/framework/widget/dtd/widget-screen.xsd
@@ -314,12 +314,12 @@ under the License.
             </xs:attribute>
             <xs:attribute type="xs:string" name="screen-header-name">
                 <xs:annotation>
-                    <xs:documentation>Name of the screen to be used for the complex display of a screenlet’s header. When the screenlet is minimized, the header remains visible.</xs:documentation>
+                    <xs:documentation>Name of the screen to define advanced layouts for a screenlet’s header. When the screenlet is minimized, the header remains visible</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
             <xs:attribute type="xs:string" name="screen-header-location">
                 <xs:annotation>
-                    <xs:documentation>Location of the screen to be used for the detailed view of a screenlet’s header. If empty use the same location of the screenlet's parent screen</xs:documentation>
+                    <xs:documentation>Location of the screen to define advanced layouts for a screenlet’s header. If empty use the same location of the screenlet's parent screen.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
         </xs:complexType>

--- a/framework/widget/dtd/widget-screen.xsd
+++ b/framework/widget/dtd/widget-screen.xsd
@@ -314,12 +314,12 @@ under the License.
             </xs:attribute>
             <xs:attribute type="xs:string" name="screen-header-name">
                 <xs:annotation>
-                    <xs:documentation>The screen name to use if you when a complex screenlet header</xs:documentation>
+                    <xs:documentation>Name of the screen to be used for the complex display of a screenlet’s header. When the screenlet is minimized, the header remains visible.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
             <xs:attribute type="xs:string" name="screen-header-location">
                 <xs:annotation>
-                    <xs:documentation>The screen location to use if you when a complex screenlet header, if empty use the same location of the screenlet's parent screen</xs:documentation>
+                    <xs:documentation>Location of the screen to be used for the detailed view of a screenlet’s header. If empty use the same location of the screenlet's parent screen</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
         </xs:complexType>

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelScreenWidget.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/model/ModelScreenWidget.java
@@ -37,6 +37,7 @@ import org.apache.ofbiz.base.util.StringUtil;
 import org.apache.ofbiz.base.util.UtilCodec;
 import org.apache.ofbiz.base.util.UtilGenerics;
 import org.apache.ofbiz.base.util.UtilMisc;
+import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.base.util.UtilXml;
 import org.apache.ofbiz.base.util.collections.MapStack;
 import org.apache.ofbiz.base.util.string.FlexibleStringExpander;
@@ -542,6 +543,8 @@ public abstract class ModelScreenWidget extends ModelWidget {
         public static final String TAG_NAME = "screenlet";
         private final FlexibleStringExpander idExdr;
         private final FlexibleStringExpander titleExdr;
+        private final FlexibleStringExpander screenHeaderNameExpr;
+        private final FlexibleStringExpander screenHeaderLocationExpr;
         private final Menu navigationMenu;
         private final Menu tabMenu;
         private final Form navigationForm;
@@ -606,6 +609,11 @@ public abstract class ModelScreenWidget extends ModelWidget {
                     }
                 }
             }
+
+            this.screenHeaderNameExpr = FlexibleStringExpander.getInstance(
+                    screenletElement.getAttribute("screen-header-name"));
+            this.screenHeaderLocationExpr = FlexibleStringExpander.getInstance(
+                    screenletElement.getAttribute("screen-header-location"));
             this.subWidgets = Collections.unmodifiableList(subWidgets);
             this.navigationForm = navigationForm;
             this.padded = padded;
@@ -724,6 +732,18 @@ public abstract class ModelScreenWidget extends ModelWidget {
 
         public boolean getPadded() {
             return padded;
+        }
+
+        public String getScreenHeader(Map<String, Object> context) {
+            String screenHeaderName = this.screenHeaderNameExpr.expandString(context);
+            if (UtilValidate.isEmpty(screenHeaderName)) {
+                return null;
+            }
+            String screenHeaderLocation = this.screenHeaderLocationExpr.expandString(context);
+            if (UtilValidate.isEmpty(screenHeaderLocation)) {
+                screenHeaderLocation = this.getModelScreen().getSourceLocation();
+            }
+            return screenHeaderLocation + "#" + screenHeaderName;
         }
     }
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroScreenRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroScreenRenderer.java
@@ -42,6 +42,7 @@ import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilRandom;
 import org.apache.ofbiz.base.util.UtilValidate;
+import org.apache.ofbiz.base.util.collections.MapStack;
 import org.apache.ofbiz.base.util.template.FreeMarkerWorker;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericValue;
@@ -709,6 +710,15 @@ public class MacroScreenRenderer implements ScreenStringRenderer {
         parameters.put("showMore", showMore);
         parameters.put("collapsed", collapsed);
         parameters.put("javaScriptEnabled", javaScriptEnabled);
+        String screenHeader = screenlet.getScreenHeader(context);
+        if (UtilValidate.isNotEmpty(screenHeader)) {
+            try {
+                StringWriter localWriter = new StringWriter();
+                ScreenRenderer screenRenderer = new ScreenRenderer(localWriter, MapStack.create(context), this);
+                screenRenderer.render(screenHeader);
+                parameters.put("screenHeader", localWriter.getBuffer().toString());
+            } catch (GeneralException | ParserConfigurationException | SAXException ignored) { }
+        }
         executeMacro(writer, "renderScreenletBegin", parameters);
     }
 

--- a/themes/common-theme/template/macro/CsvScreenMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/CsvScreenMacroLibrary.ftl
@@ -48,7 +48,7 @@ under the License.
 <#macro renderImage src id style wid hgt border alt urlString></#macro>
 
 <#macro renderContentFrame fullUrl width height border></#macro>
-<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled></#macro>
+<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled title="" screenHeader=""></#macro>
 <#macro renderScreenletSubWidget></#macro>
 <#macro renderScreenletEnd></#macro>
 

--- a/themes/common-theme/template/macro/FoScreenMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/FoScreenMacroLibrary.ftl
@@ -72,7 +72,7 @@ under the License.
 <#macro renderImage src id style wid hgt border alt urlString><fo:block><fo:external-graphic id="${id}" src="${src}" content-width="${wid}" content-height="${hgt}" scaling="non-uniform"/></fo:block></#macro>
 
 <#macro renderContentFrame></#macro>
-<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled></#macro>
+<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled title="" screenHeader=""></#macro>
 <#macro renderScreenletSubWidget></#macro>
 <#macro renderScreenletEnd></#macro>
 

--- a/themes/common-theme/template/macro/HtmlScreenMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/HtmlScreenMacroLibrary.ftl
@@ -139,10 +139,11 @@ under the License.
 </#macro>
 
 <#macro renderContentFrame fullUrl width height border=""><iframe src="${fullUrl}" width="${width}" height="${height}" <#if border?has_content>border="${border}"</#if> /></#macro>
-<#macro renderScreenletBegin collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled id="" title="">
+<#macro renderScreenletBegin collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled id="" title="" screenHeader="">
 <div class="screenlet"<#if id?has_content> id="${id}"</#if>><#rt/>
 <#if showMore>
 <div class="screenlet-title-bar"><ul><#if title?has_content><li class="h3">${title}</li></#if>
+<#if screenHeader?has_content><li><div class="screenlet-header">${screenHeader}</div></li></#if>
 <#if collapsible>
 <li class="<#rt/>
 <#if collapsed>

--- a/themes/common-theme/template/macro/TextScreenMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/TextScreenMacroLibrary.ftl
@@ -50,7 +50,7 @@ under the License.
 <#macro renderImage src id style wid hgt border alt urlString></#macro>
 
 <#macro renderContentFrame fullUrl width height border></#macro>
-<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled></#macro>
+<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled title="" screenHeader=""></#macro>
 <#macro renderScreenletSubWidget></#macro>
 <#macro renderScreenletEnd></#macro>
 

--- a/themes/common-theme/template/macro/XlsScreenMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XlsScreenMacroLibrary.ftl
@@ -44,7 +44,7 @@ under the License.
 <#macro renderImage src id style wid hgt border alt urlString></#macro>
 
 <#macro renderContentFrame fullUrl width height border></#macro>
-<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled></#macro>
+<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled title="" screenHeader=""></#macro>
 <#macro renderScreenletSubWidget></#macro>
 <#macro renderScreenletEnd></#macro>
 

--- a/themes/common-theme/template/macro/XmlScreenMacroLibrary.ftl
+++ b/themes/common-theme/template/macro/XmlScreenMacroLibrary.ftl
@@ -58,7 +58,7 @@ under the License.
 </#macro>
 
 <#macro renderContentFrame fullUrl width height border></#macro>
-<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled>
+<#macro renderScreenletBegin id title collapsible saveCollapsed collapsibleAreaId expandToolTip collapseToolTip fullUrlString padded menuString showMore collapsed javaScriptEnabled title="" screenHeader="">
 </#macro>
 <#macro renderScreenletSubWidget></#macro>
 <#macro renderScreenletEnd></#macro>


### PR DESCRIPTION
The screenlet can receive a title to describe it content on the body, and you can collapse it to optimize the page.

If you want to display some complex case the title isn't enough so we improve it by added a header screen.

Like this you can prepare your screenlet like :
```xml
    <screen ...>...
        <screenlet screen-header-name="MyScreenletResume" collapsible="true">
            <include-grid name="ComplexeGrid" location=".../>
        </screenlet>
    </screen>
```

```xml
    <screen name="MyScreenletResume">
       <column-container>
           <column>
               <label>My Title</label>
               <label>My Desc</label>
           </column>
           <column>
               <label>${numberElement}</label>
               <label>${warnElement}</label>
           </column>
        </column-container>...
    </screen>
```

With this, you can use all powerful of screen without add big complexity on the framework to manage complex case.