### PR TITLE
Implemented: Add new decorator FilteredListDecorator

### DIFF
--- a/applications/workeffort/widget/CommonScreens.xml
+++ b/applications/workeffort/widget/CommonScreens.xml
@@ -213,6 +213,24 @@ under the License.
         </section>
     </screen>
 
+    <screen name="FilteredListDecorator">
+        <section>
+            <actions>
+                <property-map resource="WorkEffortUiLabels" map-name="uiLabelMap" global="true"/>
+                <property-map resource="OrderUiLabels" map-name="uiLabelMap" global="true"/>
+                <property-map resource="PartyUiLabels" map-name="uiLabelMap" global="true"/>
+                <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
+                <property-map resource="ContentUiLabels" map-name="uiLabelMap" global="true"/>
+                <property-map resource="ProductUiLabels" map-name="uiLabelMap" global="true"/>
+                <property-map resource="AccountingUiLabels" map-name="uiLabelMap" global="true"/>
+                <property-map resource="TemporalExpressionUiLabels" map-name="uiLabelMap" global="true"/>
+            </actions>
+            <widgets>
+                <include-screen name="FilteredListDecorator" location="component://common/widget/CommonScreens.xml"/>
+            </widgets>
+        </section>
+    </screen>
+
     <screen name="main">
         <section>
             <actions>

--- a/applications/workeffort/widget/workeffort/WorkEffortPartyAssignCpd.xml
+++ b/applications/workeffort/widget/workeffort/WorkEffortPartyAssignCpd.xml
@@ -25,22 +25,22 @@ under the License.
                   xsi:noNamespaceSchemaLocation="../../../../framework/widget/dtd/compound-widgets.xsd">
 
     <sc:site-conf>
-        <sc:request-map uri="WorkEffortPartyAssigns/List"><sc:security https="true" auth="true"/><sc:response name="success" type="view" value="WorkEffortPartyAssigns/List"/></sc:request-map>
-        <sc:request-map uri="WorkEffortPartyAssigns/Edit"><sc:security https="true" auth="true"/><sc:response name="success" type="view" value="WorkEffortPartyAssigns/Edit"/></sc:request-map>
+        <sc:request-map uri="WorkEffortPartyAssigns/List"><sc:security/><sc:response name="success" type="view" value="WorkEffortPartyAssigns/List"/></sc:request-map>
+        <sc:request-map uri="WorkEffortPartyAssigns/Edit"><sc:security/><sc:response name="success" type="view" value="WorkEffortPartyAssigns/Edit"/></sc:request-map>
         <sc:request-map uri="WorkEffortPartyAssigns/create">
-            <sc:security https="true" auth="true"/>
+            <sc:security/>
             <sc:event type="service" invoke="assignPartyToWorkEffort"/>
             <sc:response name="success" type="request" value="json"/>
             <sc:response name="error" type="request" value="json"/>
         </sc:request-map>
         <sc:request-map uri="WorkEffortPartyAssigns/update">
-            <sc:security https="true" auth="true"/>
+            <sc:security/>
             <sc:event type="service" invoke="updatePartyToWorkEffortAssignment"/>
             <sc:response name="success" type="request" value="json"/>
             <sc:response name="error" type="request" value="json"/>
         </sc:request-map>
         <sc:request-map uri="WorkEffortPartyAssigns/delete">
-            <sc:security https="true" auth="true"/>
+            <sc:security/>
             <sc:event type="service" invoke="expireWorkEffortPartyAssignment"/>
             <sc:response name="success" type="request" value="json"/>
             <sc:response name="error" type="request" value="json"/>
@@ -58,11 +58,14 @@ under the License.
                     <ws:set field="workEffortId" from-field="workEffort.workEffortId"/>
                 </ws:actions>
                 <ws:widgets>
-                    <ws:decorator-screen name="CommonEmbeddedDecorator" location="component://workeffort/widget/CommonScreens.xml">
-                        <ws:decorator-section name="actions">
+                    <ws:decorator-screen name="FilteredListDecorator" location="component://workeffort/widget/CommonScreens.xml">
+                        <ws:decorator-section name="menu-bar">
                             <ws:include-menu name="WorkEffortPartyAssignTabBar" location="component://workeffort/widget/workeffort/WorkEffortPartyAssignCpd.xml"/>
                         </ws:decorator-section>
-                        <ws:decorator-section name="list">
+                        <ws:decorator-section name="filter-options">
+                            <ws:include-form name="FilterListWorkEffortPartyAssigns" location="component://workeffort/widget/workeffort/WorkEffortPartyAssignCpd.xml"/>
+                        </ws:decorator-section>
+                        <ws:decorator-section name="filtered-results">
                             <ws:include-grid name="ListWorkEffortPartyAssigns" location="component://workeffort/widget/workeffort/WorkEffortPartyAssignCpd.xml"/>
                         </ws:decorator-section>
                     </ws:decorator-screen>
@@ -117,11 +120,35 @@ under the License.
     </wm:menus>
 
     <wf:forms>
+        <wf:form name="FilterListWorkEffortPartyAssigns" target="WorkEffortPartyAssigns/List"
+                 extends="CommonDynamicSingle" extends-resource="component://common/widget/CommonForms.xml">
+            <wf:field name="workEffortId"><wf:hidden value="${workEffort.workEffortId}"/></wf:field>
+            <wf:field name="statusId">
+                <wf:drop-down allow-empty="true">
+                    <wf:entity-options entity-name="StatusItem">
+                        <wf:entity-constraint name="statusTypeId" value="PRTYASGN_STATUS"/>
+                        <wf:entity-order-by field-name="description"/>
+                    </wf:entity-options>
+                </wf:drop-down>
+            </wf:field>
+            <wf:field name="roleTypeId" title="${uiLabelMap.PartyRoleType}">
+                <wf:drop-down allow-empty="true">
+                    <wf:entity-options entity-name="RoleType">
+                        <wf:entity-order-by field-name="description"/>
+                    </wf:entity-options>
+                </wf:drop-down>
+            </wf:field>
+            <wf:field name="filterButton"><wf:submit/></wf:field>
+        </wf:form>
         <wf:grid name="ListWorkEffortPartyAssigns" target="WorkEffortPartyAssigns/update" paginate-target="WorkEffortPartyAssigns/List"
                  extends="CommonDynamicGrid" extends-resource="component://common/widget/CommonForms.xml">
             <wf:actions>
                 <wf:entity-condition entity-name="WorkEffortPartyAssignment">
-                    <wf:condition-expr field-name="workEffortId" from-field="workEffortId"/>
+                    <wf:condition-list>
+                        <wf:condition-expr field-name="workEffortId" from-field="workEffortId"/>
+                        <wf:condition-expr field-name="roleTypeId" from-field="parameters.roleTypeId" ignore-if-empty="true"/>
+                        <wf:condition-expr field-name="statusId" from-field="parameters.statusId" ignore-if-empty="true"/>
+                    </wf:condition-list>
                     <wf:order-by field-name="roleTypeId"/>
                 </wf:entity-condition>
             </wf:actions>

--- a/framework/common/config/CommonUiLabels.xml
+++ b/framework/common/config/CommonUiLabels.xml
@@ -14565,6 +14565,25 @@
         <value xml:lang="zh">开始日期</value>
         <value xml:lang="zh-TW">開始日期</value>
     </property>
+    <property key="FormFieldTitle_filterButton">
+        <value xml:lang="ar">مصفاة</value>
+        <value xml:lang="cs">Filtr</value>
+        <value xml:lang="de">Filter</value>
+        <value xml:lang="en">Filter</value>
+        <value xml:lang="es">Filtro</value>
+        <value xml:lang="fr">Filtrer</value>
+        <value xml:lang="hi-IN">फ़िल्टर</value>
+        <value xml:lang="it">Filtra</value>
+        <value xml:lang="ja">フィルタ</value>
+        <value xml:lang="pt">Filtrar</value>
+        <value xml:lang="pt-BR">Filtro</value>
+        <value xml:lang="ro">Filtreaza</value>
+        <value xml:lang="ru">Фильтр</value>
+        <value xml:lang="th">Filter</value>
+        <value xml:lang="vi">Bộ lọc</value>
+        <value xml:lang="zh">过滤器</value>
+        <value xml:lang="zh-TW">篩選器</value>
+    </property>
     <property key="FormFieldTitle_hasTable">
         <value xml:lang="ar">يحوز على جدول</value>
         <value xml:lang="cs">Má tabulku</value>

--- a/framework/common/widget/CommonScreens.xml
+++ b/framework/common/widget/CommonScreens.xml
@@ -329,6 +329,21 @@ under the License.
         </section>
     </screen>
 
+    <!--FilteredListDecorator: Sub Screen to display a list link to a filter form.
+        contains sections :
+          * menu-bar
+          * filter-options: option for filter on the list
+          * filtered-results: result displayed after apply filter
+          -->
+    <screen name="FilteredListDecorator">
+        <section>
+            <widgets>
+                <include-screen name="MinimalActions" />
+                <include-screen name="FilteredListDecorator" location="${groovy:commonScreenLocations.FilteredListDecorator?commonScreenLocations.FilteredListDecorator:commonDecoratorLocation}"/>
+            </widgets>
+        </section>
+    </screen>
+
     <!--DetailScreenDecorator: Sub Screen to show a sum up of
         an object and its related data. Composed in six sections :
           * menu-bar

--- a/themes/common-theme/widget/CommonScreens.xml
+++ b/themes/common-theme/widget/CommonScreens.xml
@@ -734,6 +734,30 @@ under the License.
         </section>
     </screen>
 
+    <screen name="FilteredListDecorator">
+        <section>
+            <widgets>
+                <container id="${screen:id(screenStack)}">
+                    <decorator-section-include name="menu-bar"/>
+                    <container style="clear"/>
+                    <section>
+                        <condition>
+                            <not><if-empty-section section-name="filter-options"/></not>
+                        </condition>
+                        <widgets>
+                            <container id="filter-options">
+                                <decorator-section-include name="filter-options" />
+                            </container>
+                        </widgets>
+                    </section>
+                    <container id="filtered-results">
+                        <decorator-section-include name="filtered-results"/>
+                    </container>
+                </container>
+            </widgets>
+        </section>
+    </screen>
+
     <screen name="DetailScreenDecorator">
         <section>
             <actions>

--- a/themes/common-theme/widget/Theme.xml
+++ b/themes/common-theme/widget/Theme.xml
@@ -128,14 +128,15 @@ under the License.
             <screen name="LookupDecorator"/>
             <screen name="ShortcutDecorator"/>
             <screen name="SimpleDecorator"/>
-            <screen name="EmbeddedDecorator"/>
             <screen name="FoReportDecorator"/>
             <screen name="GlobalFoDecorator"/>
             <screen name="LookupHelpDecorator" location="component://common-theme/widget/HelpScreens.xml"/>
         </root-decorator>
         <subtype-decorator default-location="component://common-theme/widget/CommonScreens.xml">
-            <screen name="FindScreenDecorator"/>
             <screen name="DetailScreenDecorator"/>
+            <screen name="FindScreenDecorator"/>
+            <screen name="FilteredListDecorator"/>
+            <screen name="EmbeddedDecorator"/>
         </subtype-decorator>
         <generic-screen default-location="component://common-theme/widget/CommonScreens.xml">
             <screen name="geoChart"/>


### PR DESCRIPTION
A new type of decorator has been added to handle searches at the top of lists.

Currently, we have the FindScreenDecorator, which allows us to define a page structure for searching, comprising a search form and a results form. This new decorator offers the same functionality but is designed to be more compact. It therefore enables a compact search form linked to a list, acting as a filter. The decorator’s structure allows for direct management of dynamic refreshing.

This new structure is particularly useful in sub-screen lists, enabling lightweight searches.

An example has been added to the WorkEffort compounds, where, in the party tab linked to a WorkEffort, you can quickly filter by status or role.

<img width="900" height="522" alt="Capture d’écran du 2026-06-13 16-39-40" src="https://github.com/user-attachments/assets/356d3b1d-0774-499c-be89-08093f1f5ceb" />
<img width="926" height="527" alt="Capture d’écran du 2026-06-13 16-39-58" src="https://github.com/user-attachments/assets/2e48e532-ffb7-4ec1-a1f9-8be781f51825" />

