### PR TITLE
Fixed: duplicate QuoteRole insertion error in copyQuote service (OFBIZ-13436)

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/quote/QuoteServicesScript.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/quote/QuoteServicesScript.groovy
@@ -242,11 +242,16 @@ Map copyQuote() {
         List quoteRoles = quote.getRelated('QuoteRole', null, null, false)
         for (GenericValue quoteRole : quoteRoles) {
             if (quoteRole.roleTypeId != 'REQ_TAKER') {
-                Map serviceContext = dctx.makeValidContext('createQuoteRole', ModelService.IN_PARAM,
-                        [*: quoteRole, quoteId: quoteIdTo, userLogin: userLogin])
-                serviceResult = dispatcher.runSync('createQuoteRole', serviceContext)
-                if (ServiceUtil.isError(serviceResult)) {
-                    return serviceResult
+                GenericValue existingQuoteRole = from('QuoteRole')
+                        .where(quoteId: quoteIdTo, partyId: quoteRole.partyId, roleTypeId: quoteRole.roleTypeId)
+                        .queryOne()
+                if (!existingQuoteRole) {
+                    Map serviceContext = dctx.makeValidContext('createQuoteRole', ModelService.IN_PARAM,
+                            [*: quoteRole, quoteId: quoteIdTo, userLogin: userLogin])
+                    serviceResult = dispatcher.runSync('createQuoteRole', serviceContext)
+                    if (ServiceUtil.isError(serviceResult)) {
+                        return serviceResult
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixed: Fix duplicate QuoteRole insertion error in copyQuote service, avoid duplicate key constraints when copying quote roles by checking if a role already exists for the new quote before creating it.
(OFBIZ-13436)
