### PR TITLE
OFBIZ-13437 Change 'Remove' action to 'Reject' on the Find Requirement screen

### DIFF
--- a/applications/order/webapp/ordermgr/WEB-INF/controller.xml
+++ b/applications/order/webapp/ordermgr/WEB-INF/controller.xml
@@ -1207,10 +1207,11 @@ under the License.
         <event type="service" invoke="updateRequirement"/>
         <response name="success" type="view" value="EditRequirement"/>
     </request-map>
-    <request-map uri="deleteRequirement">
+    <request-map uri="rejectRequirement">
         <security https="true" auth="true"/>
-        <event type="service" invoke="deleteRequirementAndRelated"/>
+        <event type="service" invoke="updateRequirement"/>
         <response name="success" type="view" value="FindRequirements"/>
+        <response name="error" type="view" value="FindRequirements"/>
     </request-map>
     <request-map uri="removeRequirementRole">
         <security https="true" auth="true"/>

--- a/applications/order/widget/ordermgr/RequirementForms.xml
+++ b/applications/order/widget/ordermgr/RequirementForms.xml
@@ -104,9 +104,10 @@ under the License.
                 <parameter param-name="requirementId"/>
             </hyperlink>
         </field>
-        <field name="deleteLink" widget-style="buttontext" title=" ">
-            <hyperlink description="${uiLabelMap.CommonRemove}" target="deleteRequirement">
+        <field name="rejectLink" widget-style="buttontext" title=" ">
+            <hyperlink description="${uiLabelMap.FormFieldTitle_rejectButton}" target="rejectRequirement">
                 <parameter param-name="requirementId"/>
+                <parameter param-name="statusId" value="REQ_REJECTED"/>
             </hyperlink>
         </field>
     </form>


### PR DESCRIPTION
## Summary
- Replaces the hard-delete 'Remove' button on the Find Requirement screen with a 'Reject' action that soft-deletes by setting `statusId = REQ_REJECTED`
- The `REQ_REJECTED` status and all valid transitions already exist in seed data; the existing SECA auto-logs a `RequirementStatus` history entry on every `statusId` change via `updateRequirement`
- Preserves the full audit trail instead of cascading hard-deleting the requirement and its related records

## Changes
- `RequirementForms.xml`: replaced `deleteLink`/`CommonRemove`/`deleteRequirement` with `rejectLink`/`FormFieldTitle_rejectButton`/`rejectRequirement`, passing `statusId=REQ_REJECTED` as a fixed parameter
- `controller.xml`: replaced `deleteRequirement` request-map (invoked `deleteRequirementAndRelated`) with `rejectRequirement` (invokes existing `updateRequirement`)

## Test Plan
- [ ] Navigate to Order Manager → Requirements → Find Requirements
- [ ] Confirm the 'Remove' button is replaced by a 'Reject' button
- [ ] Click 'Reject' on a requirement and verify its status changes to 'Rejected' without deleting the record
- [ ] Verify the `RequirementStatus` history entry is created automatically