### PR TITLE
Fixed: Remove leftover references from deleted shipping carrier integrations (OFBIZ-7935)

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/order/OrderView.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/order/OrderView.groovy
@@ -532,10 +532,6 @@ if (orderItems) {
     context.orderItem = orderItem
 }
 
-// getting online ship estimates corresponding to this Order from UPS when "Hold" button will be clicked, when user packs from weight package screen.
-// This case comes when order's shipping amount is  more then or less than default percentage (defined in shipment.properties)
-// of online UPS shipping amount.
-
 shipments = from('Shipment').where('primaryOrderId', orderId, 'statusId', 'SHIPMENT_PICKED').queryList()
 if (shipments) {
     pickedShipmentId = EntityUtil.getFirst(shipments).shipmentId

--- a/applications/order/template/entry/order/OrderHeaderInfo.ftl
+++ b/applications/order/template/entry/order/OrderHeaderInfo.ftl
@@ -101,7 +101,6 @@ under the License.
                 </td>
                 <td width="5">&nbsp;</td>
                 <td valign="top" width="80%">
-                    <#-- TODO: add links to UPS/FEDEX/etc based on carrier partyId  -->
                     <div>${trackingNumber}</div>
                 </td>
             </tr>

--- a/applications/order/template/order/OrderShippingInfo.ftl
+++ b/applications/order/template/order/OrderShippingInfo.ftl
@@ -555,7 +555,6 @@ under the License.
                 <span class="label">&nbsp;${uiLabelMap.OrderTrackingNumber}</span>
               </td>
               <td>
-                <#-- TODO: add links to UPS/FEDEX/etc based on carrier partyId  -->
                 <#if shipGroup.trackingNumber?has_content>
                   ${shipGroup.trackingNumber}
                 </#if>

--- a/applications/order/template/return/ReturnLinks.ftl
+++ b/applications/order/template/return/ReturnLinks.ftl
@@ -43,21 +43,6 @@ under the License.
           <#assign partyId = "${(returnHeader.fromPartyId)!}"/>
           <li><a href="<@ofbizUrl>setOrderCurrencyAgreementShipDates?partyId=${partyId!}&amp;originOrderId=${orderId!}</@ofbizUrl>" class="buttontext">${uiLabelMap.OrderCreateExchangeOrder} ${uiLabelMap.CommonFor} ${orderId!}</a></li>
         </#if>
-        <#if returnHeader.statusId?has_content && "RETURN_ACCEPTED" == returnHeader.statusId>
-          <#assign returnItems = EntityQuery.use(delegator).from("ReturnItem").where("returnId", returnId!).queryList()!/>
-          <#if returnItems?has_content>
-            <#assign orderId = (Static["org.apache.ofbiz.entity.util.EntityUtil"].getFirst(returnItems)).getString("orderId")/>
-            <#assign shipGroupAssoc = EntityQuery.use(delegator).from("OrderItemShipGroupAssoc").where("orderId", orderId!).queryFirst()!/>
-            <#assign shipGroup = delegator.findOne("OrderItemShipGroup", {"orderId" : orderId, "shipGroupSeqId" : shipGroupAssoc.shipGroupSeqId}, false)>
-            <#if shipGroup?? && shipGroup.shipmentMethodTypeId != "NO_SHIPPING">
-              <#assign shipGroupShipment = EntityQuery.use(delegator).from("Shipment").where("primaryOrderId", shipGroup.orderId!, "primaryShipGroupSeqId", shipGroup.shipGroupSeqId!).queryFirst()! />
-                <#if shipGroupShipment??>
-                <#assign shipmentRouteSegment = EntityQuery.use(delegator).from("ShipmentRouteSegment").where("shipmentId", shipGroupShipment.shipmentId!).queryFirst()!>
-                </#if>
-              </#if>
-            </#if>
-          </#if>
-        </#if>
       </#if>
           </ul>
         </li>


### PR DESCRIPTION
Fixed: Remove leftover references from deleted shipping carrier integrations
(OFBIZ-7935)

Follow-up cleanup after PR #1335 removed DHL, FedEx, UPS, and USPS shipping carrier integrations. Removes:
- Orphaned </#if> in ReturnLinks.ftl caused by incomplete UPS block removal
- Stale UPS comment in OrderView.groovy
- Stale TODO comments referencing UPS/FedEx in OrderShippingInfo.ftl and OrderHeaderInfo.ftl