### PR TITLE
Fixed: Fix FindGeneric on view entity

### DIFF
--- a/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/FindGeneric.groovy
+++ b/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/FindGeneric.groovy
@@ -162,9 +162,9 @@ if (modelEntity) {
 static Set<String> getFieldsToSelect(ModelEntity modelEntity) {
     if (modelEntity instanceof ModelViewEntity) {
         List groupByFields = modelEntity.getAliasesCopy()
-                .find { it.getGroupBy() }*.getName()
+                .find { it.getGroupBy() }*.getName() ?: []
         List functionFields = modelEntity.getAliasesCopy()
-                .find { it.getFunction() }*.getName()
+                .find { it.getFunction() }*.getName() ?: []
         return [*groupByFields, *functionFields] as Set
     }
     return [] as Set


### PR DESCRIPTION
When you display a ViewEntity that not contains group by or function, the EntityQuery failed to resolve selected fields I introduced this regression after a groovy reformat (adefd159d2) where this empty case would not well manage
