### PR TITLE
Fixed: Add missing license header

### DIFF
--- a/framework/rest-api/webapp/docs/swagger-ui.html
+++ b/framework/rest-api/webapp/docs/swagger-ui.html
@@ -1,3 +1,21 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Added a license header to address the "Unapproved Licenses" issue reported in the RAT report.