### PR TITLE
Test cases fixes

### DIFF
--- a/applications/order/servicedef/services_quote.xml
+++ b/applications/order/servicedef/services_quote.xml
@@ -247,15 +247,12 @@ under the License.
         <auto-attributes include="pk" mode="IN" optional="true"/>
     </service>
 
-    <!--Duplicate the service createQuoteWorkEffort, the first inform the deprecation, the second override and work normally-->
     <service name="createQuoteWorkEffort" default-entity-name="QuoteWorkEffort" engine="entity-auto" invoke="create" auth="true">
+        <description>Create a new QuoteWorkEffort</description>
         <deprecated use-instead="ensureWorkEffortAndCreateQuoteWorkEffort" since="Release 18.12">
             use createQuoteWorkEffort to create a workeffort has been deprecated for best pratice naming reason, use ensureWorkEffortAndCreateQuoteWorkEffort instead.
             Now createQuoteWorkEffort work as a crud service on QuoteWorkEffort
         </deprecated>
-    </service>
-    <service name="createQuoteWorkEffort" default-entity-name="QuoteWorkEffort" engine="entity-auto" invoke="create" auth="true">
-        <description>Create a new QuoteWorkEffort</description>
         <required-permissions join-type="AND">
             <check-permission permission="ORDERMGR" action="_CREATE"/>
         </required-permissions>

--- a/applications/product/servicedef/services.xml
+++ b/applications/product/servicedef/services.xml
@@ -213,7 +213,7 @@ under the License.
         <attribute name="statusId" type="String" mode="IN" optional="false"/>
     </service>
 
-    <service name="findProductById" engine="java"  auth="true" export="true" action="GET"
+    <service name="findProductById" engine="java" auth="true" export="true"
         location="org.apache.ofbiz.product.product.ProductServices" invoke="findProductById">
         <description>Finds productId(s) corresponding to a product reference, productId or a GoodIdentification idValue</description>
         <attribute type="String" mode="IN" name="idToFind" optional="false"/>

--- a/framework/base/src/main/groovy/org/apache/ofbiz/base/test/uel/MiscUelTest.groovy
+++ b/framework/base/src/main/groovy/org/apache/ofbiz/base/test/uel/MiscUelTest.groovy
@@ -30,10 +30,9 @@ class MiscUelTest extends OFBizTestCase {
 
     MiscUelTest(String name) { super(name) }
 
-    void testSystemUel() { // codenarc-disable JUnitTestMethodWithoutAssert
-         // todo: Both are null, but mockito doesn't do system mock..
-        doUelSystemTest('${sys:getenv}', 'foo', { String prop -> UelFunctions.sysGetEnv(prop) })
-        doUelSystemTest('${sys:getProperty}', 'bar', { String prop -> UelFunctions.sysGetProp(prop) })
+    void testSystemUel() {
+        doUelSystemTest('${sys:getenv("foo")}', 'foo', { String prop -> UelFunctions.sysGetEnv(prop) })
+        doUelSystemTest('${sys:getProperty("bar")}', 'bar', { String prop -> UelFunctions.sysGetProp(prop) })
     }
 
     void testUtilSizeUel() {

--- a/framework/base/src/main/groovy/org/apache/ofbiz/base/test/uel/MiscUelTest.groovy
+++ b/framework/base/src/main/groovy/org/apache/ofbiz/base/test/uel/MiscUelTest.groovy
@@ -30,7 +30,7 @@ class MiscUelTest extends OFBizTestCase {
 
     MiscUelTest(String name) { super(name) }
 
-    void testSystemUel() {
+    void testSystemUel() { // codenarc-disable JUnitTestMethodWithoutAssert
         doUelSystemTest('${sys:getenv("foo")}', 'foo', { String prop -> UelFunctions.sysGetEnv(prop) })
         doUelSystemTest('${sys:getProperty("bar")}', 'bar', { String prop -> UelFunctions.sysGetProp(prop) })
     }

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/model/ModelViewEntity.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/model/ModelViewEntity.java
@@ -671,7 +671,7 @@ public class ModelViewEntity extends ModelEntity {
             ModelViewEntity.ModelAlias alias = it.next();
             if (alias.isComplexAlias()) {
                 // TODO: conversion for complex-alias needs to be implemented for cache and in-memory eval stuff to work correctly
-                Debug.logWarning("[" + this.getEntityName() + "]: Conversion for complex-alias needs to be implemented for cache and "
+                Debug.logVerbose("[" + this.getEntityName() + "]: Conversion for complex-alias needs to be implemented for cache and "
                         + "in-memory eval stuff to work correctly, will not work for alias: " + alias.getName(), MODULE);
             } else {
                 ModelConversion conversion = getOrCreateModelConversion(alias.getEntityAlias());

--- a/framework/service/src/main/java/org/apache/ofbiz/service/ServiceDispatcher.java
+++ b/framework/service/src/main/java/org/apache/ofbiz/service/ServiceDispatcher.java
@@ -278,6 +278,10 @@ public final class ServiceDispatcher {
         Map<String, Object> ecaContext = null;
         RunningService rs = null;
         DispatchContext ctx = getLocalContext(localName);
+        if (ctx == null) {
+            throw new GenericServiceException("Service container is not available (shutting down?) for context: " + localName
+                    + " — cannot run service: " + modelService.getName());
+        }
         GenericEngine engine = null;
         Transaction parentTransaction = null;
         boolean isFailure = false;

--- a/framework/service/src/main/java/org/apache/ofbiz/service/eca/ServiceEcaUtil.java
+++ b/framework/service/src/main/java/org/apache/ofbiz/service/eca/ServiceEcaUtil.java
@@ -148,7 +148,7 @@ public final class ServiceEcaUtil {
             //remove the old rule if found and keep the recent one
             //This will prevent duplicate rule execution along with enabled/disabled seca workflow
             if (rules.remove(rule)) {
-                Debug.logWarning("Duplicate Service ECA [" + serviceName + "] on [" + eventName + "] ", MODULE);
+                Debug.logVerbose("Duplicate Service ECA [" + serviceName + "] on [" + eventName + "] ", MODULE);
             }
             rules.add(rule);
         }

--- a/framework/service/testdef/servicetests.xml
+++ b/framework/service/testdef/servicetests.xml
@@ -37,7 +37,7 @@ under the License.
         <entity-xml action="assert" entity-xml-url="component://service/testdef/data/ServiceDeadLockRetryAssertData.xml"/>
     </test-case>
     <test-case case-name="engine-tracker-tests">
-        <junit-test-suite name="engine-tracker" class-name="org.apache.ofbiz.service.test.engine.TrackerEngineTest"/>
+        <junit-test-suite class-name="org.apache.ofbiz.service.test.engine.TrackerEngineTest"/>
     </test-case>
     <!-- this case is failing, so commenting out by default until an automatic fix can be found
     <test-case case-name="service-lock-wait-timeout-retry-test">


### PR DESCRIPTION
Fixes the following issues observed in the ./gradlew testIntegration command. 

1. ServiceDispatcher.java — null-guard for ctx after getLocalContext() prevents NPE when async SECA jobs fire after dispatcher shutdown

2. ModelViewEntity.java — logWarning → logVerbose for the long-standing TODO about complex-alias cache conversion (repeated on every startup, not actionable without major framework work)

3. ServiceEcaUtil.java — logWarning → logVerbose for duplicate ECA detection (false positives from concurrent dispatcher initialization during tests) 

4. applications/product/servicedef/services.xml — removed invalid action="GET" attribute from <service> element

5. framework/service/testdef/servicetests.xml — removed name="engine-tracker" from <junit-test-suite> (not in schema) 

6. applications/order/servicedef/services_quote.xml — merged two duplicate createQuoteWorkEffort definitions into one (eliminating the "defined more than once" warning) 

7. MiscUelTest.groovy — fixed ${sys:getenv} and ${sys:getProperty} to use proper EL function call syntax with arguments, eliminating ERROR log entries from FlexibleStringExpander