### PR TITLE
Fixed: The port offset is being applied twice when loading WebSite properties (OFBIZ-13352)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/website/WebSiteProperties.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/website/WebSiteProperties.java
@@ -81,7 +81,11 @@ public final class WebSiteProperties {
         Assert.notNull("request", request);
         WebSiteProperties webSiteProps = (WebSiteProperties) request.getAttribute("_WEBSITE_PROPS_");
         if (webSiteProps == null) {
-            Boolean addPortoffset = true;
+            // The port offset is already applied when the properties are built from a WebSite
+            // entity value (see from(GenericValue)). Only apply it here when we fall back to the
+            // url.properties defaults, otherwise it would be added twice. (OFBIZ-13352)
+            boolean applyPortOffset = false;
+            boolean addHttpsOffset = true;
             Delegator delegator = (Delegator) request.getAttribute("delegator");
             if (delegator != null) {
                 String webSiteId = WebSiteWorker.getWebSiteId(request);
@@ -94,6 +98,7 @@ public final class WebSiteProperties {
             }
             if (webSiteProps == null) {
                 webSiteProps = new WebSiteProperties(delegator);
+                applyPortOffset = true;
             }
             if (webSiteProps.getHttpPort().isEmpty() && !request.isSecure()) {
                 webSiteProps = webSiteProps.updateHttpPort(String.valueOf(request.getServerPort()));
@@ -103,12 +108,14 @@ public final class WebSiteProperties {
             }
             if (webSiteProps.getHttpsPort().isEmpty() && request.isSecure()) {
                 webSiteProps = webSiteProps.updateHttpsPort(String.valueOf(request.getServerPort()));
-                addPortoffset = false; // We take the port from the request, don't add the portOffset
+                addHttpsOffset = false; // We take the port from the request, don't add the portOffset
             }
             if (webSiteProps.getHttpsHost().isEmpty()) {
                 webSiteProps = webSiteProps.updateHttpsHost(request.getServerName());
             }
-            webSiteProps = webSiteProps.addPortOffset(addPortoffset);
+            if (applyPortOffset) {
+                webSiteProps = webSiteProps.addPortOffset(addHttpsOffset);
+            }
             request.setAttribute("_WEBSITE_PROPS_", webSiteProps);
         }
         return webSiteProps;


### PR DESCRIPTION
**JIRA:** [OFBIZ-13352](https://issues.apache.org/jira/browse/OFBIZ-13352)

`WebSiteProperties.from(HttpServletRequest)` delegates to `from(GenericValue)` when the request resolves to a `WebSite` entity. `from(GenericValue)` already applies the configured port offset, but the request method then applied it a **second time**, so with a non-zero `portOffset` the generated http and https ports were offset twice.

This builds on the approach in #949 (thanks @Lukas-Finster). #949 fixes the **https** port; this change also covers the **http** port, which is still offset twice there because `addPortOffset(boolean addHttpsOffset)` offsets the http port *unconditionally* (the flag only guards the https part). Rather than toggling the flag, this skips the offset call entirely on the WebSite-entity path (where the offset is already applied), and keeps a separate `addHttpsOffset` flag for the "https port taken from the request" case.

### Verification

Ran OFBiz with `--portoffset=10000` and a `WebSite` entity present for the ecommerce webapp (`webSiteId=WebStore`), logging the ports `WebSiteProperties.from(request)` actually computes:

| | httpPort | httpsPort |
|---|---|---|
| trunk | 28080 | 28443 |
| #949 | 28080 | **18443** |
| this PR | **18080** | **18443** |

With this change the secure redirect lands on `https://localhost:18443/…` and non-secure full-path URLs use `:18080`, both matching the actual offset listeners. Behaviour is unchanged when `portOffset` is `0` (the default).

Also verified with `./gradlew compileJava` and `./gradlew checkstyleMain`.

> Note for reviewers: a `WebSite` entity must exist for the affected `webSiteId` to reproduce this — with a seed-only DB everything falls back to the default path and the bug doesn't surface.
