### PR TITLE
Fixed: Incorrect unit price calculation during PO receiving under non-US locales (OFBIZ-13449)

### DIFF
--- a/applications/product/servicedef/services_shipment.xml
+++ b/applications/product/servicedef/services_shipment.xml
@@ -893,7 +893,7 @@ under the License.
         <attribute name="priorityOrderItemSeqId" type="String" mode="IN" optional="true"/>
         <attribute name="currentInventoryItemId" type="String" mode="IN" optional="true"><!-- allow this to be passed in to update an existing InventoryItem, and all else is the same; if not passed in a new one will be created --></attribute>
         <attribute name="inventoryItemId" type="String" mode="OUT" optional="true"></attribute>
-        <attribute name="orderCurrencyUnitPrice" type="String" mode="IN" optional="true"/>
+        <attribute name="orderCurrencyUnitPrice" type="BigDecimal" mode="IN" optional="true"/>
         <override name="quantityAccepted" optional="false"/>
         <override name="quantityRejected" optional="false"/>
         <override name="inventoryItemTypeId" optional="false"/>
@@ -1129,8 +1129,8 @@ under the License.
         </attribute>
         <attribute name="shipmentId" type="String" mode="IN" optional="true"/>
         <attribute name="shipmentItemSeqId" type="String" mode="IN" optional="true"/>
-        <attribute name="unitCost" type="String" mode="IN" optional="true"/>
-        <attribute name="orderCurrencyUnitPrice" type="String" mode="IN" optional="true"/>
+        <attribute name="unitCost" type="BigDecimal" mode="IN" optional="true"/>
+        <attribute name="orderCurrencyUnitPrice" type="BigDecimal" mode="IN" optional="true"/>
     </service>
     <service name="createCarrierShipmentBoxType" default-entity-name="CarrierShipmentBoxType" engine="entity-auto" invoke="create" auth="true">
         <description>Create a new Carrier Shipment Box Type Record</description>

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
@@ -310,7 +310,7 @@ Map updateIssuanceShipmentAndPoOnReceiveInventory() {
     GenericValue orderItem = from('OrderItem').where(parameters).queryOne()
     if (parameters.orderCurrencyUnitPrice) {
         if (parameters.orderCurrencyUnitPrice != orderItem.unitPrice) {
-            orderItem.unitPrice = new BigDecimal (parameters.orderCurrencyUnitPrice)
+            orderItem.unitPrice = parameters.orderCurrencyUnitPrice
             orderItem.store()
         }
     } else {


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/OFBIZ-13449

## Problem
During PO receiving under a locale that uses a comma decimal separator (e.g. `pl_PL`), the received order item's unit price is corrupted (the value is mis-scaled, e.g. `7,41` becomes `741`).

## Root cause
The receiving form (`ReceiveInventory.ftl`) submits the unit price as a locale-formatted string. The services that carry it — `receiveInventoryProduct` and `updateIssuanceShipmentAndPoOnReceiveInventory` — declared `orderCurrencyUnitPrice` and `unitCost` as `String`, so no locale-aware conversion happened at the service boundary. The Groovy implementation then parsed the raw string with the **locale-insensitive** `new BigDecimal(String)` constructor, corrupting the value.

## Fix
- Declare `orderCurrencyUnitPrice` / `unitCost` as `BigDecimal` on both services, so the service engine performs locale-aware conversion of the incoming value.
- Assign the already-converted parameter directly to `orderItem.unitPrice` instead of re-wrapping it in `new BigDecimal(...)`.

The second part matters: the originally proposed fix (changing only the service-def types) leaves the `new BigDecimal(parameters.orderCurrencyUnitPrice)` call in place. Once the parameter is a `BigDecimal`, Groovy resolves `new BigDecimal(aBigDecimal)` to the `BigDecimal(double)` constructor, which reintroduces a precision error:

```
new BigDecimal(7.41G) => 7.410000000000000142108547152020037174224853515625  (scale 48)
```

so the wrap must be removed.

## Verification
- `xmllint` confirms `services_shipment.xml` is well-formed.
- The Groovy file parses cleanly (CompilationUnit CONVERSION phase).
- `./gradlew compileJava` → BUILD SUCCESSFUL.

Note: not yet exercised end-to-end in a live `pl_PL` instance; happy to add that if desired.