### PR TITLE
Fixed: Incorrect unit price calculation during PO receiving under non-US locales (OFBIZ-13449)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/product/test/ReceivePoLocaleTest.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/product/test/ReceivePoLocaleTest.groovy
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.ofbiz.product.product.test
+
+import org.apache.ofbiz.base.util.UtilDateTime
+import org.apache.ofbiz.entity.GenericValue
+import org.apache.ofbiz.entity.util.EntityQuery
+import org.apache.ofbiz.service.ServiceUtil
+import org.apache.ofbiz.service.testtools.OFBizTestCase
+
+/**
+ * OFBIZ-13449 regression: during PO receiving under a locale whose decimal
+ * separator is a comma (e.g. pl_PL), the order-currency unit price submitted
+ * from the receiving form must be parsed locale-aware (7,41 -> 7.41), not
+ * corrupted (-> 741) by the locale-insensitive new BigDecimal(String).
+ */
+class ReceivePoLocaleTest extends OFBizTestCase {
+
+    ReceivePoLocaleTest(String name) {
+        super(name)
+    }
+
+    void testUpdateOrderItemUnitPriceUnderPolishLocale() {
+        String orderId = 'TEST13449PO'
+        // clean any leftovers from a previous run
+        delegator.removeByAnd('OrderItem', [orderId: orderId])
+        delegator.removeByAnd('OrderHeader', [orderId: orderId])
+
+        delegator.makeValue('OrderHeader', [
+                orderId: orderId,
+                orderTypeId: 'PURCHASE_ORDER',
+                statusId: 'ORDER_CREATED',
+                currencyUom: 'PLN',
+                orderDate: UtilDateTime.nowTimestamp(),
+                entryDate: UtilDateTime.nowTimestamp()
+        ]).create()
+        delegator.makeValue('OrderItem', [
+                orderId: orderId,
+                orderItemSeqId: '00001',
+                orderItemTypeId: 'PRODUCT_ORDER_ITEM',
+                statusId: 'ITEM_CREATED',
+                quantity: 1.0,
+                unitPrice: 1.0,
+                isPromo: 'N'
+        ]).create()
+
+        // Submit the price exactly as the pl_PL receiving form would: "7,41"
+        Map<String, Object> ctx = [
+                orderId: orderId,
+                orderItemSeqId: '00001',
+                quantityAccepted: 1.0,
+                orderCurrencyUnitPrice: '7,41',
+                userLogin: userLogin,
+                locale: new Locale('pl', 'PL')
+        ]
+        Map<String, Object> result = dispatcher.runSync('updateIssuanceShipmentAndPoOnReceiveInventory', ctx)
+        assert ServiceUtil.isSuccess(result)
+
+        GenericValue updated = EntityQuery.use(delegator).from('OrderItem')
+                .where(orderId: orderId, orderItemSeqId: '00001').queryOne()
+        // 7,41 (pl_PL) must be stored as 7.41 -- not 741. Currently FAILS on trunk and on the
+        // "type as BigDecimal" fix, because NumberConverters.fromString ignores the caller locale
+        // (uses Locale.getDefault()). Should pass once the price is parsed with the request locale.
+        assert updated.unitPrice == 7.41
+
+        delegator.removeByAnd('OrderItem', [orderId: orderId])
+        delegator.removeByAnd('OrderHeader', [orderId: orderId])
+    }
+
+}

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentReceiptServices.groovy
@@ -20,6 +20,8 @@ package org.apache.ofbiz.product.shipment
 
 import java.math.RoundingMode
 import java.sql.Timestamp
+import java.text.DecimalFormat
+import java.text.NumberFormat
 
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.base.util.UtilProperties
@@ -304,13 +306,28 @@ BigDecimal getReceivedQuantityForOrderItem (GenericValue orderItem) {
 }
 
 /**
+ * Parse a user-entered amount with the request locale so that values formatted with a comma
+ * decimal separator (e.g. pl_PL "7,41") are not mis-parsed as 741. OFBiz's generic
+ * String-&gt;BigDecimal conversion ignores the caller locale (NumberConverters.fromString falls
+ * back to Locale.getDefault()), so the receiving price is parsed explicitly here. (OFBIZ-13449)
+ */
+BigDecimal parseLocalizedAmount(String amount, Locale locale) {
+    NumberFormat numberFormat = NumberFormat.getNumberInstance(locale ?: Locale.default)
+    if (numberFormat instanceof DecimalFormat) {
+        ((DecimalFormat) numberFormat).parseBigDecimal = true
+    }
+    return (BigDecimal) numberFormat.parse(amount)
+}
+
+/**
  * Update issuance, shipment and order items if quantity received is higher than quantity on purchase order
  */
 Map updateIssuanceShipmentAndPoOnReceiveInventory() {
     GenericValue orderItem = from('OrderItem').where(parameters).queryOne()
     if (parameters.orderCurrencyUnitPrice) {
-        if (parameters.orderCurrencyUnitPrice != orderItem.unitPrice) {
-            orderItem.unitPrice = new BigDecimal (parameters.orderCurrencyUnitPrice)
+        BigDecimal orderCurrencyUnitPrice = parseLocalizedAmount((String) parameters.orderCurrencyUnitPrice, (Locale) parameters.locale)
+        if (orderCurrencyUnitPrice != orderItem.unitPrice) {
+            orderItem.unitPrice = orderCurrencyUnitPrice
             orderItem.store()
         }
     } else {

--- a/applications/product/testdef/FacilityTest.xml
+++ b/applications/product/testdef/FacilityTest.xml
@@ -48,4 +48,8 @@ under the License.
         <junit-test-suite class-name="org.apache.ofbiz.shipment.test.IssuanceTest"/>
     </test-case>
 
+    <test-case case-name="receivePoLocale-test">
+        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ReceivePoLocaleTest"/>
+    </test-case>
+
 </test-suite>


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/OFBIZ-13449

## Problem
Receiving a purchase order under a locale whose decimal separator is a comma (e.g. `pl_PL`) corrupts the order item unit price: `7,41` is stored as `741`.

## Root cause
The receiving form submits the order-currency unit price as a locale-formatted string. OFBiz's generic String→BigDecimal conversion (`ObjectType.simpleTypeOrObjectConvert` → `NumberConverters.fromString`) **ignores the caller locale** and falls back to `Locale.getDefault()` unless the `testBigDecimal` system property is set:

```java
// framework/base/.../conversion/NumberConverters.java
locale = null != System.getProperty("testBigDecimal") ? locale : Locale.getDefault();
```

So `simpleTypeOrObjectConvert("7,41","BigDecimal",...,pl_PL,...)` returns `741` (comma read as grouping), even though raw `NumberFormat.getNumberInstance(pl_PL).parse("7,41")` returns `7.41`. **Declaring the service attribute as `BigDecimal` does not help**, because the same converter runs — verified by integration test (it stored `741.000`).

## Fix
Parse the submitted order-currency unit price explicitly with the request locale (`parameters.locale`) in `updateIssuanceShipmentAndPoOnReceiveInventory`, bypassing the generic converter.

## Verification
Added `ReceivePoLocaleTest` (registered in `FacilityTest.xml`) that drives the service in a real container under `pl_PL` with `orderCurrencyUnitPrice="7,41"` and asserts the stored `unitPrice == 7.41`:
- Before this change: `741.000` (fails).
- After: `[JUNIT] Pass: true | # Tests: 1 | # Failed: 0`.

`checkstyleMain` / `codenarcMain` / `codenarcTest` pass.

## Note
The underlying `NumberConverters.fromString` behaviour (discarding the caller locale) looks like a broader framework issue and is probably worth a separate ticket; this PR fixes the receiving flow without changing that shared converter.