### PR TITLE
Fixed: Updated ShoppingCartEvents.destroyCart() to invoke clearCart() after removing session attributes (OFBIZ-6805)

### DIFF
--- a/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/ShoppingCartEvents.java
+++ b/applications/order/src/main/java/org/apache/ofbiz/order/shoppingcart/ShoppingCartEvents.java
@@ -955,12 +955,13 @@ public class ShoppingCartEvents {
     /** Totally wipe out the cart, removes all stored info. */
     public static String destroyCart(HttpServletRequest request, HttpServletResponse response) {
         HttpSession session = request.getSession();
-        clearCart(request, response);
         session.removeAttribute("shoppingCart");
         session.removeAttribute("orderPartyId");
         session.removeAttribute("orderMode");
         session.removeAttribute("productStoreId");
         session.removeAttribute("CURRENT_CATALOG_ID");
+        // Call clearCart at the end as if user is anonymous then it will throw session already invalidated error on removeAttribute method.
+        clearCart(request, response);
         return "success";
     }
 


### PR DESCRIPTION
Previously, clearCart() could invalidate the session for anonymous users before destroyCart() attempted to remove additional session attributes, resulting in a Session already invalidated exception.

Thanks Ankush for your contribution!!
