### PR TITLE
Fixed: StringToTimestamp now accepts ISO 8601 timestamps (OFBIZ-2139)

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/conversion/DateTimeConverters.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/conversion/DateTimeConverters.java
@@ -22,6 +22,8 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -669,6 +671,16 @@ public class DateTimeConverters implements ConverterLoader {
             String str = obj.trim();
             if (str.isEmpty()) {
                 return null;
+            }
+            // ISO 8601 format (e.g. 2009-01-15T00:00:00.000Z) produced by SOAP serialization
+            // and external integrations is rejected by the default yyyy-MM-dd HH:mm:ss.SSS parser.
+            // An ISO 8601 date-time always carries the 'T' separator at index 10, right after yyyy-MM-dd.
+            if (str.length() > 10 && str.charAt(10) == 'T') {
+                try {
+                    return Timestamp.from(Instant.parse(str));
+                } catch (DateTimeParseException e) {
+                    // not a valid ISO 8601 instant — fall through to existing logic
+                }
             }
             DateFormat df = null;
             if (UtilValidate.isEmpty(formatString)) {


### PR DESCRIPTION
## OFBIZ-2139

https://issues.apache.org/jira/browse/OFBIZ-2139

### Problem
`StringToTimestamp.convert()` in `DateTimeConverters.java` parses with the fixed
`yyyy-MM-dd HH:mm:ss.SSS` format (space separator, no zone). ISO 8601 timestamps
such as `2009-01-15T00:00:00.000Z` — which OFBiz's own SOAP serialization emits, and
which REST clients and external integrations commonly send — fail the parse and raise
a service validation error (`Type check failed ... expected type is [java.sql.Timestamp];
actual type is [java.lang.String]`). This breaks SOAP round-trips of a Timestamp value.

### Change
Adds an early-exit in `convert()`: when the input contains a `T`, try
`Instant.parse(str)` first and return `Timestamp.from(...)`. If it is not a valid ISO
instant, it falls through to the existing logic unchanged.

- No impact on any existing format — only `T`-containing strings take the new path, and
  only when they parse as an ISO instant.
- Scope note for reviewers: this covers ISO 8601 instants that carry an explicit zone
  (e.g. the trailing `Z`), which is the reported case. ISO local date-times without a
  zone (`...T00:00:00` with no `Z`/offset) still fall through. Happy to extend to
  `OffsetDateTime`/`LocalDateTime` if the community prefers full ISO 8601 coverage.

### Testing
Verified `2009-01-15T00:00:00.000Z` now converts, and existing
`yyyy-MM-dd HH:mm:ss.SSS` inputs are unaffected.

### Thanks:
Adil BEN EL KHATTAB for reporting the issue and outlining the fix
options, @adrian-crum for the analysis ruling out changing the SOAP output
format, @JacquesLeRoux  for triaging and isolating the export="true" SOAP
path, and Mike Fanning for identifying that the SOAP handler passes all
parameters as strings.
