### PR TITLE
Fixed: EntityExpr no longer hardcodes the "default" delegator when validating condition types (OFBIZ-5100)

### DIFF
--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityCondition.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityCondition.java
@@ -270,6 +270,20 @@ public interface EntityCondition extends IsEmpty, Serializable {
             Datasource datasourceInfo);
 
     /**
+     * Dumps the corresponding SQL string, using {@code delegator} (when available) to validate
+     * field/value type compatibility instead of assuming the {@code "default"} delegator.
+     * @param modelEntity the model of the entity
+     * @param entityConditionParams the effective parameters used to substitute '?' parameters
+     * @param datasourceInfo the model of the data source interpreting the SQL
+     * @param delegator the delegator actually being used to run this query, or {@code null} if unavailable
+     * @return the corresponding SQL string
+     */
+    default String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams,
+            Datasource datasourceInfo, Delegator delegator) {
+        return makeWhereString(modelEntity, entityConditionParams, datasourceInfo);
+    }
+
+    /**
      * Verifies that this condition expression is valid.
      * @param modelEntity the model of the entity
      * @throws GenericModelException when this condition expression is not valid

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityConditionBuilder.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityConditionBuilder.java
@@ -51,7 +51,13 @@ public class EntityConditionBuilder extends BuilderSupport {
 
         @Override
         public String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams, Datasource datasourceInfo) {
-            return condition.makeWhereString(modelEntity, entityConditionParams, datasourceInfo);
+            return makeWhereString(modelEntity, entityConditionParams, datasourceInfo, null);
+        }
+
+        @Override
+        public String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams,
+                Datasource datasourceInfo, Delegator delegator) {
+            return condition.makeWhereString(modelEntity, entityConditionParams, datasourceInfo, delegator);
         }
 
         @Override

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityConditionListBase.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityConditionListBase.java
@@ -76,8 +76,14 @@ abstract class EntityConditionListBase<T extends EntityCondition> implements Ent
 
     @Override
     public String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams, Datasource datasourceInfo) {
+        return makeWhereString(modelEntity, entityConditionParams, datasourceInfo, null);
+    }
+
+    @Override
+    public String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams,
+            Datasource datasourceInfo, Delegator delegator) {
         StringBuilder sql = new StringBuilder();
-        operator.addSqlValue(sql, modelEntity, entityConditionParams, conditions, datasourceInfo);
+        operator.addSqlValue(sql, modelEntity, entityConditionParams, conditions, datasourceInfo, delegator);
         return sql.toString();
     }
 

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityExpr.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityExpr.java
@@ -27,7 +27,6 @@ import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.ObjectType;
 import org.apache.ofbiz.base.util.UtilGenerics;
 import org.apache.ofbiz.entity.Delegator;
-import org.apache.ofbiz.entity.DelegatorFactory;
 import org.apache.ofbiz.entity.GenericEntity;
 import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericModelException;
@@ -136,7 +135,13 @@ public final class EntityExpr implements EntityCondition {
     @Override
     public String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams,
             Datasource datasourceInfo) {
-        checkRhsType(modelEntity, null);
+        return makeWhereString(modelEntity, entityConditionParams, datasourceInfo, null);
+    }
+
+    @Override
+    public String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams,
+            Datasource datasourceInfo, Delegator delegator) {
+        checkRhsType(modelEntity, delegator);
         StringBuilder sql = new StringBuilder();
         operator.addSqlValue(sql, modelEntity, entityConditionParams, true, lhs, rhs, datasourceInfo);
         return sql.toString();
@@ -174,7 +179,7 @@ public final class EntityExpr implements EntityCondition {
      * @param delegator the delegator used to check the condition expression
      */
     public void checkRhsType(ModelEntity modelEntity, Delegator delegator) {
-        if (EntityExpr.isNullField(rhs) || modelEntity == null) {
+        if (EntityExpr.isNullField(rhs) || modelEntity == null || delegator == null) {
             return;
         }
 
@@ -194,9 +199,7 @@ public final class EntityExpr implements EntityCondition {
             }
         }
 
-        // This will be the common case for now as the delegator isn't available where we want to do this
-        // we'll cheat a little here and assume the default delegator.
-        Delegator deleg = (delegator == null) ? DelegatorFactory.getDelegator("default") : delegator;
+        Delegator deleg = delegator;
 
         String fieldName = null;
         ModelField curField;

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityJoinOperator.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityJoinOperator.java
@@ -65,6 +65,20 @@ public class EntityJoinOperator extends EntityOperator<EntityCondition, EntityCo
      */
     public void addSqlValue(StringBuilder sql, ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams,
                             List<? extends EntityCondition> conditionList, Datasource datasourceInfo) {
+        addSqlValue(sql, modelEntity, entityConditionParams, conditionList, datasourceInfo, null);
+    }
+
+    /**
+     * Add sql value.
+     * @param sql the sql
+     * @param modelEntity the model entity
+     * @param entityConditionParams the entity condition params
+     * @param conditionList the condition list
+     * @param datasourceInfo the datasource info
+     * @param delegator the delegator actually being used to run this query, or {@code null} if unavailable
+     */
+    public void addSqlValue(StringBuilder sql, ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams,
+                            List<? extends EntityCondition> conditionList, Datasource datasourceInfo, Delegator delegator) {
         if (UtilValidate.isNotEmpty(conditionList)) {
             boolean hadSomething = false;
             Iterator<? extends EntityCondition> conditionIter = conditionList.iterator();
@@ -81,7 +95,7 @@ public class EntityJoinOperator extends EntityOperator<EntityCondition, EntityCo
                     hadSomething = true;
                     sql.append('(');
                 }
-                sql.append(condition.makeWhereString(modelEntity, entityConditionParams, datasourceInfo));
+                sql.append(condition.makeWhereString(modelEntity, entityConditionParams, datasourceInfo, delegator));
             }
             if (hadSomething) {
                 sql.append(')');

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityNotCondition.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityNotCondition.java
@@ -66,9 +66,15 @@ public class EntityNotCondition implements EntityCondition {
 
     @Override
     public String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams, Datasource datasourceInfo) {
+        return makeWhereString(modelEntity, entityConditionParams, datasourceInfo, null);
+    }
+
+    @Override
+    public String makeWhereString(ModelEntity modelEntity, List<EntityConditionParam> entityConditionParams,
+            Datasource datasourceInfo, Delegator delegator) {
         return new StringBuilder()
                 .append("NOT(")
-                .append(condition.makeWhereString(modelEntity, entityConditionParams, datasourceInfo))
+                .append(condition.makeWhereString(modelEntity, entityConditionParams, datasourceInfo, delegator))
                 .append(')')
                 .toString();
     }

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/datasource/GenericDAO.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/datasource/GenericDAO.java
@@ -355,7 +355,7 @@ public class GenericDAO {
                 params.add(new EntityConditionParam(field, entry.getValue()));
             }
         }
-        sql.append(" WHERE ").append(condition.makeWhereString(modelEntity, params, this.datasource));
+        sql.append(" WHERE ").append(condition.makeWhereString(modelEntity, params, this.datasource, sqlP.getDelegator()));
 
         sqlP.prepareStatement(sql.toString());
         for (EntityConditionParam param : params) {
@@ -773,7 +773,7 @@ public class GenericDAO {
 
         // WHERE clause
         List<EntityConditionParam> whereEntityConditionParams = new LinkedList<>();
-        makeConditionWhereString(sqlBuffer, " WHERE ", modelEntity, whereEntityCondition, viewWhereConditions, whereEntityConditionParams);
+        makeConditionWhereString(sqlBuffer, " WHERE ", modelEntity, whereEntityCondition, viewWhereConditions, whereEntityConditionParams, delegator);
 
         // GROUP BY clause for view-entity
         if (modelViewEntity != null) {
@@ -782,7 +782,8 @@ public class GenericDAO {
 
         // HAVING clause
         List<EntityConditionParam> havingEntityConditionParams = new LinkedList<>();
-        makeConditionHavingString(sqlBuffer, " HAVING ", modelEntity, havingEntityCondition, viewHavingConditions, havingEntityConditionParams);
+        makeConditionHavingString(sqlBuffer, " HAVING ", modelEntity, havingEntityCondition, viewHavingConditions,
+                havingEntityConditionParams, delegator);
 
         // ORDER BY clause
         List<String> orderByExpanded = new LinkedList<>();
@@ -859,7 +860,8 @@ public class GenericDAO {
     protected StringBuilder makeConditionWhereString(ModelEntity modelEntity, EntityCondition whereEntityCondition,
                                                      List<EntityCondition> viewWhereConditions,
                                                      List<EntityConditionParam> whereEntityConditionParams) throws GenericEntityException {
-        return makeConditionWhereString(new StringBuilder(), "", modelEntity, whereEntityCondition, viewWhereConditions, whereEntityConditionParams);
+        return makeConditionWhereString(new StringBuilder(), "", modelEntity, whereEntityCondition, viewWhereConditions,
+                whereEntityConditionParams, null);
     }
 
     /**
@@ -870,12 +872,14 @@ public class GenericDAO {
      * @param whereEntityCondition the where entity condition
      * @param viewWhereConditions the view where conditions
      * @param whereEntityConditionParams the where entity condition params
+     * @param delegator the delegator actually being used to run this query, or {@code null} if unavailable
      * @return the string builder
      * @throws GenericEntityException the generic entity exception
      */
     protected StringBuilder makeConditionWhereString(StringBuilder whereString, String prefix, ModelEntity modelEntity,
                                                      EntityCondition whereEntityCondition, List<EntityCondition> viewWhereConditions,
-                                                     List<EntityConditionParam> whereEntityConditionParams) throws GenericEntityException {
+                                                     List<EntityConditionParam> whereEntityConditionParams, Delegator delegator)
+            throws GenericEntityException {
         ModelViewEntity modelViewEntity = null;
         if (modelEntity instanceof ModelViewEntity) {
             modelViewEntity = (ModelViewEntity) modelEntity;
@@ -902,7 +906,7 @@ public class GenericDAO {
         if (!conditions.isEmpty()) {
             whereString.append(prefix);
             whereString.append(EntityCondition.makeCondition(conditions, EntityOperator.AND).makeWhereString(modelEntity,
-                    whereEntityConditionParams, this.datasource));
+                    whereEntityConditionParams, this.datasource, delegator));
         }
 
         return whereString;
@@ -922,7 +926,7 @@ public class GenericDAO {
                                                       List<EntityCondition> viewHavingConditions,
                                                       List<EntityConditionParam> havingEntityConditionParams) throws GenericEntityException {
         return makeConditionHavingString(new StringBuilder(), "", modelEntity, havingEntityCondition, viewHavingConditions,
-                havingEntityConditionParams);
+                havingEntityConditionParams, null);
     }
 
     /**
@@ -933,12 +937,14 @@ public class GenericDAO {
      * @param havingEntityCondition the having entity condition
      * @param viewHavingConditions the view having conditions
      * @param havingEntityConditionParams the having entity condition params
+     * @param delegator the delegator actually being used to run this query, or {@code null} if unavailable
      * @return the string builder
      * @throws GenericEntityException the generic entity exception
      */
     protected StringBuilder makeConditionHavingString(StringBuilder havingString, String prefix, ModelEntity modelEntity,
                                                       EntityCondition havingEntityCondition, List<EntityCondition> viewHavingConditions,
-                                                      List<EntityConditionParam> havingEntityConditionParams) throws GenericEntityException {
+                                                      List<EntityConditionParam> havingEntityConditionParams, Delegator delegator)
+            throws GenericEntityException {
         ModelViewEntity modelViewEntity = null;
         if (modelEntity instanceof ModelViewEntity) {
             modelViewEntity = (ModelViewEntity) modelEntity;
@@ -946,14 +952,14 @@ public class GenericDAO {
 
         String entityCondHavingString = "";
         if (havingEntityCondition != null) {
-            entityCondHavingString = havingEntityCondition.makeWhereString(modelEntity, havingEntityConditionParams, this.datasource);
+            entityCondHavingString = havingEntityCondition.makeWhereString(modelEntity, havingEntityConditionParams, this.datasource, delegator);
         }
 
         String viewEntityCondHavingString = null;
         if (modelViewEntity != null) {
             EntityCondition viewHavingEntityCondition = EntityCondition.makeCondition(viewHavingConditions);
             viewEntityCondHavingString = viewHavingEntityCondition.makeWhereString(modelEntity,
-                    havingEntityConditionParams, this.datasource);
+                    havingEntityConditionParams, this.datasource, delegator);
         }
 
         if (UtilValidate.isNotEmpty(entityCondHavingString) || UtilValidate.isNotEmpty(viewEntityCondHavingString)) {
@@ -1228,7 +1234,7 @@ public class GenericDAO {
 
         // WHERE clause
         List<EntityConditionParam> whereEntityConditionParams = new LinkedList<>();
-        makeConditionWhereString(sqlBuffer, " WHERE ", modelEntity, whereEntityCondition, viewWhereConditions, whereEntityConditionParams);
+        makeConditionWhereString(sqlBuffer, " WHERE ", modelEntity, whereEntityCondition, viewWhereConditions, whereEntityConditionParams, delegator);
 
         // GROUP BY clause for view-entity
         if (isGroupBy) {
@@ -1237,7 +1243,8 @@ public class GenericDAO {
 
         // HAVING clause
         List<EntityConditionParam> havingEntityConditionParams = new LinkedList<>();
-        makeConditionHavingString(sqlBuffer, " HAVING ", modelEntity, havingEntityCondition, viewHavingConditions, havingEntityConditionParams);
+        makeConditionHavingString(sqlBuffer, " HAVING ", modelEntity, havingEntityCondition, viewHavingConditions,
+                havingEntityConditionParams, delegator);
 
         if (isGroupBy) {
             sqlBuffer.append(") TEMP_NAME");
@@ -1368,7 +1375,7 @@ public class GenericDAO {
 
         StringBuilder sql = new StringBuilder("DELETE FROM ").append(modelEntity.getTableName(this.datasource));
 
-        String whereCondition = condition.makeWhereString(modelEntity, null, this.datasource);
+        String whereCondition = condition.makeWhereString(modelEntity, null, this.datasource, sqlP.getDelegator());
         if (UtilValidate.isNotEmpty(whereCondition)) {
             sql.append(" WHERE ").append(whereCondition);
         }


### PR DESCRIPTION
Fixed: EntityExpr no longer hardcodes the "default" delegator when validating condition types
(OFBIZ-5100)

EntityExpr.checkRhsType() always resolved DelegatorFactory.getDelegator("default") instead of using the delegator actually running the query, so any setup using a non-"default"-named delegator could throw GenericEntityException when building a WHERE clause. The real delegator was already available at every call site in GenericDAO; it just wasn't being passed down.

Threads the real Delegator through EntityCondition.makeWhereString(...) as a new backward-compatible default method, and forwards it through every condition type that wraps or combines other conditions (EntityConditionList, EntityFieldMap, EntityNotCondition, EntityConditionBuilder) down to EntityExpr.checkRhsType(), which now skips RHS type validation instead of guessing at "default" when no delegator is available.

Thanks: Tarun Kumar for reporting the issue.