### PR TITLE
OFBIZ-13451: Apply supplier lead time to purchased MRP requirements

### DIFF
--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/mrp/MrpServices.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/mrp/MrpServices.java
@@ -548,7 +548,7 @@ public class MrpServices {
         EntityQuery supplierProductQuery = EntityQuery.use(delegator)
                 .from("SupplierProduct")
                 .where("productId", productId)
-                .orderBy("supplierPrefOrderId", "availableFromDate", "partyId");
+                .orderBy("availableFromDate", "supplierPrefOrderId", "partyId");
         if (effectiveDate != null) {
             supplierProductQuery.filterByDate(effectiveDate, "availableFromDate", "availableThruDate");
         } else {

--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/mrp/MrpServices.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/mrp/MrpServices.java
@@ -58,6 +58,7 @@ public class MrpServices {
 
     private static final String MODULE = MrpServices.class.getName();
     private static final String RESOURCE = "ManufacturingUiLabels";
+    private static final String MAIN_SUPPLIER_PREF_ORDER_ID = "10_MAIN_SUPPL";
 
     public static Map<String, Object> initMrpEvents(DispatchContext ctx, Map<String, ? extends Object> context) {
         Delegator delegator = ctx.getDelegator();
@@ -542,6 +543,41 @@ public class MrpServices {
         return ((BigDecimal) resultMap.get("quantityOnHandTotal"));
     }
 
+    private static int getSupplierProductLeadTimeDays(Delegator delegator, String productId, Timestamp effectiveDate)
+            throws GenericEntityException {
+        EntityQuery supplierProductQuery = EntityQuery.use(delegator)
+                .from("SupplierProduct")
+                .where("productId", productId)
+                .orderBy("supplierPrefOrderId", "availableFromDate", "partyId");
+        if (effectiveDate != null) {
+            supplierProductQuery.filterByDate(effectiveDate, "availableFromDate", "availableThruDate");
+        } else {
+            supplierProductQuery.filterByDate();
+        }
+
+        List<GenericValue> supplierProducts = supplierProductQuery.queryList();
+        if (UtilValidate.isEmpty(supplierProducts)) {
+            return 0;
+        }
+        GenericValue fallbackSupplierProduct = null;
+        for (GenericValue supplierProduct : supplierProducts) {
+            BigDecimal standardLeadTimeDays = supplierProduct.getBigDecimal("standardLeadTimeDays");
+            if (UtilValidate.isEmpty(standardLeadTimeDays)) {
+                continue;
+            }
+            if (MAIN_SUPPLIER_PREF_ORDER_ID.equals(supplierProduct.getString("supplierPrefOrderId"))) {
+                return standardLeadTimeDays.intValue();
+            }
+            if (fallbackSupplierProduct == null) {
+                fallbackSupplierProduct = supplierProduct;
+            }
+        }
+
+        return UtilValidate.isNotEmpty(fallbackSupplierProduct)
+                ? fallbackSupplierProduct.getBigDecimal("standardLeadTimeDays").intValue()
+                : 0;
+    }
+
     public static void logMrpError(String mrpId, String productId, String errorMessage, Delegator delegator) {
         logMrpError(mrpId, productId, UtilDateTime.nowTimestamp(), errorMessage, delegator);
     }
@@ -844,8 +880,19 @@ public class MrpServices {
                         }
                         // #####################################################
 
+                        int startDateOffsetDays = daysToShip;
+                        if (!isBuilt) {
+                            try {
+                                startDateOffsetDays = getSupplierProductLeadTimeDays(delegator, product.getString("productId"), eventDate);
+                            } catch (GenericEntityException e) {
+                                return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE, "ManufacturingMrpCannotFindProductForEvent",
+                                        locale));
+                            }
+                        }
+
                         // calculate the ProposedOrder requirementStartDate and update the requirementStartDate object property.
-                        Map<String, Object> routingTaskStartDate = proposedOrder.calculateStartDate(daysToShip, routing, delegator, dispatcher,
+                        Map<String, Object> routingTaskStartDate = proposedOrder.calculateStartDate(startDateOffsetDays, routing, delegator,
+                                dispatcher,
                                 userLogin);
                         if (isBuilt) {
                             // process the product components

--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/mrp/MrpServices.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/mrp/MrpServices.java
@@ -573,7 +573,7 @@ public class MrpServices {
             }
         }
 
-        return UtilValidate.isNotEmpty(fallbackSupplierProduct)
+        return fallbackSupplierProduct != null
                 ? fallbackSupplierProduct.getBigDecimal("standardLeadTimeDays").intValue()
                 : 0;
     }

--- a/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/mrp/ProposedOrder.java
+++ b/applications/manufacturing/src/main/java/org/apache/ofbiz/manufacturing/mrp/ProposedOrder.java
@@ -28,11 +28,13 @@ import java.util.ListIterator;
 import java.util.Map;
 
 import org.apache.ofbiz.base.util.Debug;
+import org.apache.ofbiz.base.util.UtilDateTime;
 import org.apache.ofbiz.base.util.UtilGenerics;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
+import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.entity.util.EntityUtil;
 import org.apache.ofbiz.manufacturing.bom.BOMNode;
 import org.apache.ofbiz.manufacturing.bom.BOMTree;
@@ -202,9 +204,15 @@ public class ProposedOrder {
             // the product is purchased
             // TODO: REVIEW this code
             try {
-                GenericValue techDataCalendar = product.getDelegator().findOne("TechDataCalendar", UtilMisc.toMap("calendarId",
-                        "SUPPLIER"), true);
-                startDate = TechDataServices.addBackward(techDataCalendar, endDate, timeToShip);
+                GenericValue techDataCalendar = EntityQuery.use(product.getDelegator())
+                        .from("TechDataCalendar")
+                        .where("calendarId", "SUPPLIER")
+                        .queryOne();
+                if (techDataCalendar != null) {
+                    startDate = TechDataServices.addBackward(techDataCalendar, endDate, timeToShip);
+                } else {
+                    startDate = UtilDateTime.addDaysToTimestamp(endDate, -daysToShip);
+                }
             } catch (GenericEntityException e) {
                 Debug.logError(e, "Error : reading SUPPLIER TechDataCalendar: " + e.getMessage(), MODULE);
             }


### PR DESCRIPTION
## Summary
- use active `SupplierProduct.standardLeadTimeDays` when calculating `requirementStartDate` for purchased MRP requirements
- prefer `supplierPrefOrderId = 10_MAIN_SUPPL`, otherwise fall back to another active supplier with lead time
- filter supplier records by effective date so expired or inactive `SupplierProduct` rows are not used
- preserve existing `SUPPLIER` `TechDataCalendar` backward scheduling when available
- fall back to direct date subtraction when no supplier calendar is defined

## Details
Previously, purchased requirements created by MRP did not use supplier procurement lead time to offset the start date. This change updates the purchased-item path to resolve lead time from active `SupplierProduct` records effective for the planning date.

The lead time is now passed into `ProposedOrder.calculateStartDate(...)` for purchased items, while manufactured-item routing behavior remains unchanged.

If a `SUPPLIER` `TechDataCalendar` exists, the purchased requirement still uses OFBiz calendar-based backward scheduling. If it does not exist, the code now falls back to subtracting the resolved lead time directly from the required date so purchased items still receive a procurement offset.

