### PR TITLE
OFBIZ-13461 : Avoid async RequirementStatus FK race after createRequirement

### DIFF
--- a/applications/order/servicedef/secas.xml
+++ b/applications/order/servicedef/secas.xml
@@ -349,11 +349,11 @@ under the License.
         <condition field-name="custRequestItemSeqId" operator="is-not-empty"/>
         <action service="createRequirementCustRequest" mode="sync"/>
     </eca>
-    <eca service="createRequirement" event="commit" run-on-error="false">
+    <eca service="createRequirement" event="global-commit-post-run" run-on-error="false">
         <condition field-name="statusId" operator="is-not-empty" />
         <action service="createRequirementStatus" mode="async"/>
     </eca>
-    <eca service="updateRequirement" event="commit" run-on-error="false">
+    <eca service="updateRequirement" event="global-commit" run-on-error="false">
         <condition-field field-name="statusId" operator="not-equals" to-field-name="oldStatusId"/>
         <action service="createRequirementStatus" mode="async"/>
     </eca>

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/RequirementStatusEcaTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/RequirementStatusEcaTests.groovy
@@ -79,9 +79,9 @@ class RequirementStatusEcaTests extends OFBizTestCase {
         GenericValue userLogin = from('UserLogin').where('userLoginId', userLoginId).queryOne()
         if (userLogin == null) {
             userLogin = delegator.makeValue('UserLogin', [
-                userLoginId : userLoginId,
+                userLoginId: userLoginId,
                 userFullName: 'MRP Requirement Status Test User',
-                enabled     : 'Y'
+                enabled: 'Y'
             ])
             delegator.create(userLogin)
         }
@@ -92,24 +92,25 @@ class RequirementStatusEcaTests extends OFBizTestCase {
         if (from('RequirementType').where('requirementTypeId', 'CUSTOMER_REQUIREMENT').queryOne() == null) {
             delegator.create(delegator.makeValue('RequirementType', [
                 requirementTypeId: 'CUSTOMER_REQUIREMENT',
-                hasTable         : 'N',
-                description      : 'Customer Requirement'
+                hasTable: 'N',
+                description: 'Customer Requirement'
             ]))
         }
         if (from('StatusType').where('statusTypeId', 'REQUIREMENT_STATUS').queryOne() == null) {
             delegator.create(delegator.makeValue('StatusType', [
                 statusTypeId: 'REQUIREMENT_STATUS',
-                description : 'Requirement Status'
+                description: 'Requirement Status'
             ]))
         }
         if (from('StatusItem').where('statusId', 'REQ_PROPOSED').queryOne() == null) {
             delegator.create(delegator.makeValue('StatusItem', [
-                statusId    : 'REQ_PROPOSED',
+                statusId: 'REQ_PROPOSED',
                 statusTypeId: 'REQUIREMENT_STATUS',
-                statusCode  : 'PROPOSED',
-                sequenceId  : '01',
-                description : 'Proposed'
+                statusCode: 'PROPOSED',
+                sequenceId: '01',
+                description: 'Proposed'
             ]))
         }
     }
+
 }

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/RequirementStatusEcaTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/RequirementStatusEcaTests.groovy
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ofbiz.order.order.test
+
+import org.apache.ofbiz.entity.GenericValue
+import org.apache.ofbiz.entity.transaction.TransactionUtil
+import org.apache.ofbiz.service.ServiceUtil
+import org.apache.ofbiz.service.testtools.OFBizTestCase
+
+class RequirementStatusEcaTests extends OFBizTestCase {
+
+    RequirementStatusEcaTests(String name) {
+        super(name)
+    }
+
+    void testCreateRequirementStatusAfterOuterTransactionCommit() {
+        ensureRequirementReferenceData()
+        GenericValue userLogin = ensureUserLogin('mrpRequirementStatusTest')
+        assert userLogin
+
+        boolean beganTransaction = false
+        String requirementId = null
+
+        try {
+            beganTransaction = TransactionUtil.begin()
+            Map serviceCtx = [
+                requirementTypeId: 'CUSTOMER_REQUIREMENT',
+                statusId: 'REQ_PROPOSED',
+                userLogin: userLogin
+            ]
+            Map serviceResult = dispatcher.runSync('createRequirement', serviceCtx)
+            assert ServiceUtil.isSuccess(serviceResult)
+
+            requirementId = serviceResult.requirementId
+            assert requirementId
+            assert from('Requirement').where('requirementId', requirementId).queryCount() == 1
+
+            sleep(500L)
+            assert from('RequirementStatus').where('requirementId', requirementId, 'statusId', 'REQ_PROPOSED').queryCount() == 0
+
+            TransactionUtil.commit(beganTransaction)
+            beganTransaction = false
+        } finally {
+            if (beganTransaction) {
+                TransactionUtil.rollback(beganTransaction, 'Rolling back unfinished requirement status ECA test transaction', null)
+            }
+        }
+
+        assert waitForRequirementStatus(requirementId, 'REQ_PROPOSED')
+    }
+
+    private boolean waitForRequirementStatus(String requirementId, String statusId) {
+        for (int attempt = 0; attempt < 20; attempt++) {
+            if (from('RequirementStatus').where('requirementId', requirementId, 'statusId', statusId).queryCount() == 1) {
+                return true
+            }
+            sleep(100L)
+        }
+        return false
+    }
+
+    private GenericValue ensureUserLogin(String userLoginId) {
+        GenericValue userLogin = from('UserLogin').where('userLoginId', userLoginId).queryOne()
+        if (userLogin == null) {
+            userLogin = delegator.makeValue('UserLogin', [
+                userLoginId : userLoginId,
+                userFullName: 'MRP Requirement Status Test User',
+                enabled     : 'Y'
+            ])
+            delegator.create(userLogin)
+        }
+        return userLogin
+    }
+
+    private void ensureRequirementReferenceData() {
+        if (from('RequirementType').where('requirementTypeId', 'CUSTOMER_REQUIREMENT').queryOne() == null) {
+            delegator.create(delegator.makeValue('RequirementType', [
+                requirementTypeId: 'CUSTOMER_REQUIREMENT',
+                hasTable         : 'N',
+                description      : 'Customer Requirement'
+            ]))
+        }
+        if (from('StatusType').where('statusTypeId', 'REQUIREMENT_STATUS').queryOne() == null) {
+            delegator.create(delegator.makeValue('StatusType', [
+                statusTypeId: 'REQUIREMENT_STATUS',
+                description : 'Requirement Status'
+            ]))
+        }
+        if (from('StatusItem').where('statusId', 'REQ_PROPOSED').queryOne() == null) {
+            delegator.create(delegator.makeValue('StatusItem', [
+                statusId    : 'REQ_PROPOSED',
+                statusTypeId: 'REQUIREMENT_STATUS',
+                statusCode  : 'PROPOSED',
+                sequenceId  : '01',
+                description : 'Proposed'
+            ]))
+        }
+    }
+}

--- a/applications/order/testdef/OrderTest.xml
+++ b/applications/order/testdef/OrderTest.xml
@@ -42,4 +42,7 @@ under the License.
     <test-case case-name="order-requirement-tests">
         <junit-test-suite class-name="org.apache.ofbiz.order.order.test.OrderRequirementTests"/>
     </test-case>
+    <test-case case-name="requirement-status-eca-tests">
+        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.RequirementStatusEcaTests"/>
+    </test-case>
 </test-suite>


### PR DESCRIPTION
## Jira ticket:

https://issues.apache.org/jira/browse/OFBIZ-13461

## Summary

This fixes a timing-dependent foreign-key failure during requirement status creation.

When `createRequirement` runs inside a larger transaction, its async SECA can invoke `createRequirementStatus` before the enclosing transaction has fully committed. In that window, the new `Requirement` row is not yet visible, and the `RequirementStatus` insert can fail with:

`REQ_STTS_REQ: OFBIZ.REQUIREMENT_STATUS FOREIGN KEY(REQUIREMENT_ID) REFERENCES OFBIZ.REQUIREMENT(REQUIREMENT_ID)`

This was observed from the Manufacturing `Run MRP` flow, but the underlying bug is in the order-side requirement status SECA behavior.

## Root Cause

The existing `createRequirement` SECA used `event="commit"` with `mode="async"`.

That is not a safe boundary when `createRequirement` participates in an outer transaction. The async follow-up may run before the outer transaction is committed and globally visible.

This is a race condition rather than a deterministic logic error.

## Changes

- changed the `createRequirement` status SECA to `global-commit-post-run`
- changed the `updateRequirement` status SECA to `global-commit`
- added a focused order-side regression test for the outer-transaction scenario
- registered the regression test in the order test suite

## Why `global-commit-post-run`

`createRequirementStatus` needs the generated `requirementId`.

`global-commit-post-run` ensures:
- the enclosing transaction has committed
- the generated service output is still available to the follow-up async action

## Tests

Added a focused regression test for the outer-transaction timing case:

- `RequirementStatusEcaTests.testCreateRequirementStatusAfterOuterTransactionCommit`

This verifies that:

- `createRequirement` can run inside an outer transaction
- `RequirementStatus` is not created before commit
- `RequirementStatus` is created successfully after commit


