### PR TITLE
Bump fast-xml-parser to 5.10.1 and dompurify to 3.4.12

### DIFF
--- a/framework/rest-api/package-lock.json
+++ b/framework/rest-api/package-lock.json
@@ -44,9 +44,9 @@
             "license": "MIT"
         },
         "node_modules/@nodable/entities": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-            "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+            "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
             "funding": [
                 {
                     "type": "github",
@@ -317,9 +317,9 @@
             "integrity": "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ=="
         },
         "node_modules/dompurify": {
-            "version": "3.4.11",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-            "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -381,9 +381,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
-            "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+            "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
             "funding": [
                 {
                     "type": "github",
@@ -392,15 +392,30 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@nodable/entities": "^2.2.0",
+                "@nodable/entities": "^3.0.0",
                 "fast-xml-builder": "^1.2.0",
-                "is-unsafe": "^1.0.1",
-                "path-expression-matcher": "^1.5.0",
+                "is-unsafe": "^2.0.0",
+                "path-expression-matcher": "^1.6.2",
                 "strnum": "^2.4.1",
-                "xml-naming": "^0.1.0"
+                "xml-naming": "^0.3.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/fast-xml-parser/node_modules/xml-naming": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+            "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/foreach": {
@@ -447,9 +462,9 @@
             }
         },
         "node_modules/is-unsafe": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
-            "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+            "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
             "funding": [
                 {
                     "type": "github",
@@ -763,9 +778,9 @@
             "license": "MIT"
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
-            "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+            "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
             "funding": [
                 {
                     "type": "github",

--- a/framework/rest-api/package.json
+++ b/framework/rest-api/package.json
@@ -9,6 +9,8 @@
     },
     "overrides": {
         "js-yaml": "4.3.0",
-        "brace-expansion": "2.1.2"
+        "brace-expansion": "2.1.2",
+        "fast-xml-parser": "5.10.1",
+        "dompurify": "3.4.12"
     }
 }


### PR DESCRIPTION
These are transitive dependencies introduced via redoc 2.5.3. The upgrade fixes 2 security alerts by Dependabot.