### PR TITLE
Fixed: Entity import dir causes problems because of ECAs (OFBIZ-5259)

### DIFF
--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/util/EntitySaxReader.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/util/EntitySaxReader.java
@@ -225,6 +225,19 @@ public class EntitySaxReader extends DefaultHandler {
         this.currentAction = action;
     }
 
+    private boolean isSequenceValueItemRegression(GenericValue value) throws GenericEntityException {
+        if (!"SequenceValueItem".equals(value.getEntityName())) {
+            return false;
+        }
+        GenericValue existing = delegator.findOne("SequenceValueItem", false, "seqName", value.get("seqName"));
+        if (existing == null) {
+            return false;
+        }
+        Long incomingSeqId = value.getLong("seqId");
+        Long existingSeqId = existing.getLong("seqId");
+        return incomingSeqId != null && existingSeqId != null && incomingSeqId < existingSeqId;
+    }
+
     /**
      * Parse long.
      * @param content the content
@@ -484,6 +497,12 @@ public class EntitySaxReader extends DefaultHandler {
                         } else if (Action.DELETE == currentAction && !exist) {
                             skip = true;
                         }
+                    }
+                    if (!skip && !this.checkDataOnly && Action.DELETE != currentAction && isSequenceValueItemRegression(currentValue)) {
+                        skip = true;
+                        Debug.logWarning("Skipping import of " + currentValue.getEntityName() + " [" + currentValue.get("seqName")
+                                + "]: imported seqId=" + currentValue.getLong("seqId")
+                                + " would move the sequence counter backward, keeping the current higher value", MODULE);
                     }
                     if (!skip) {
                         if (this.useTryInsertMethod && !this.checkDataOnly) {

--- a/framework/webtools/config/WebtoolsUiLabels.xml
+++ b/framework/webtools/config/WebtoolsUiLabels.xml
@@ -1665,6 +1665,12 @@
         <value xml:lang="en">Use instead</value>
         <value xml:lang="fr">Utilisez en remplacement</value>
     </property>
+    <property key="WebtoolsDisableEeca">
+        <value xml:lang="en">Disable ECAs</value>
+    </property>
+    <property key="WebtoolsDisableEecaWarning">
+        <value xml:lang="en">Disabling ECAs prevents entity-change-triggered services (e.g. order status updates) from firing while this data is loaded. Use this for full-instance snapshot restores; leave it unchecked for partial or incremental imports that rely on those side effects.</value>
+    </property>
     <property key="WebtoolsDispatcherName">
         <value xml:lang="de">Dispatcher-Name</value>
         <value xml:lang="en">Dispatcher Name</value>

--- a/framework/webtools/servicedef/services.xml
+++ b/framework/webtools/servicedef/services.xml
@@ -37,6 +37,7 @@ under the License.
         <attribute name="txTimeout" type="Integer" mode="IN" optional="true"/>
         <attribute name="createDummyFks" type="String" mode="IN" optional="true"/>
         <attribute name="checkDataOnly" type="String" mode="IN" optional="true"/>
+        <attribute name="disableEeca" type="String" mode="IN" optional="true"/>
         <attribute name="placeholderValues" type="java.util.Map" mode="IN" optional="true"/>
         <attribute name="rowProcessed" type="Long" mode="OUT" optional="false"/>
     </service>
@@ -52,6 +53,7 @@ under the License.
         <attribute name="maintainTimeStamps" type="String" mode="IN" optional="true"/>
         <attribute name="createDummyFks" type="String" mode="IN" optional="true"/>
         <attribute name="checkDataOnly" type="String" mode="IN" optional="true"/>
+        <attribute name="disableEeca" type="String" mode="IN" optional="true"/>
         <attribute name="txTimeout" type="Integer" mode="IN" optional="true"/>
         <attribute name="placeholderValues" type="java.util.Map" mode="IN" optional="true"/>
         <attribute name="messages" type="List" mode="OUT" optional="false"/>
@@ -65,6 +67,7 @@ under the License.
         <attribute name="maintainTimeStamps" type="String" mode="IN" optional="true"/>
         <attribute name="createDummyFks" type="String" mode="IN" optional="true"/>
         <attribute name="checkDataOnly" type="String" mode="IN" optional="true"/>
+        <attribute name="disableEeca" type="String" mode="IN" optional="true"/>
         <attribute name="deleteFiles" type="String" mode="IN" optional="true"/>
         <attribute name="txTimeout" type="Integer" mode="IN" optional="true"/>
         <attribute name="filePause" type="Long" mode="IN" optional="true"/>

--- a/framework/webtools/src/main/java/org/apache/ofbiz/webtools/WebToolsServices.java
+++ b/framework/webtools/src/main/java/org/apache/ofbiz/webtools/WebToolsServices.java
@@ -122,6 +122,7 @@ public class WebToolsServices {
         String maintainTimeStamps = (String) context.get("maintainTimeStamps");
         String createDummyFks = (String) context.get("createDummyFks");
         String checkDataOnly = (String) context.get("checkDataOnly");
+        String disableEeca = (String) context.get("disableEeca");
         Map<String, Object> placeholderValues = UtilGenerics.cast(context.get("placeholderValues"));
 
         Integer txTimeout = (Integer) context.get("txTimeout");
@@ -212,6 +213,7 @@ public class WebToolsServices {
                 Map<String, Object> inputMap = UtilMisc.toMap("onlyInserts", onlyInserts,
                         "createDummyFks", createDummyFks,
                         "checkDataOnly", checkDataOnly,
+                        "disableEeca", disableEeca,
                         "maintainTimeStamps", maintainTimeStamps,
                         "txTimeout", txTimeout,
                         "placeholderValues", placeholderValues,
@@ -253,6 +255,7 @@ public class WebToolsServices {
         String onlyInserts = (String) context.get("onlyInserts");
         String maintainTimeStamps = (String) context.get("maintainTimeStamps");
         String createDummyFks = (String) context.get("createDummyFks");
+        String disableEeca = (String) context.get("disableEeca");
         boolean deleteFiles = (String) context.get("deleteFiles") != null;
         String checkDataOnly = (String) context.get("checkDataOnly");
         Map<String, Object> placeholderValues = UtilGenerics.cast(context.get("placeholderValues"));
@@ -296,6 +299,7 @@ public class WebToolsServices {
                         Map<String, Object> parseEntityXmlFileArgs = UtilMisc.toMap("onlyInserts", onlyInserts,
                                 "createDummyFks", createDummyFks,
                                 "checkDataOnly", checkDataOnly,
+                                "disableEeca", disableEeca,
                                 "maintainTimeStamps", maintainTimeStamps,
                                 "txTimeout", txTimeout,
                                 "placeholderValues", placeholderValues,
@@ -479,6 +483,7 @@ public class WebToolsServices {
         boolean maintainTimeStamps = (String) context.get("maintainTimeStamps") != null;
         boolean createDummyFks = (String) context.get("createDummyFks") != null;
         boolean checkDataOnly = (String) context.get("checkDataOnly") != null;
+        boolean disableEeca = (String) context.get("disableEeca") != null;
         Integer txTimeout = (Integer) context.get("txTimeout");
         Map<String, Object> placeholderValues = UtilGenerics.cast(context.get("placeholderValues"));
 
@@ -495,6 +500,9 @@ public class WebToolsServices {
             reader.setCreateDummyFks(createDummyFks);
             reader.setCheckDataOnly(checkDataOnly);
             reader.setPlaceholderValues(placeholderValues);
+            if (disableEeca) {
+                reader.setDisableEeca(true);
+            }
 
             long numberRead = (url != null ? reader.parse(url) : reader.parse(xmltext));
             rowProcessed = numberRead;

--- a/framework/webtools/template/entity/EntityImport.ftl
+++ b/framework/webtools/template/entity/EntityImport.ftl
@@ -54,6 +54,7 @@ under the License.
                     <label><input type="checkbox" name="maintainTimeStamps" <#if keepStamps??>checked="checked"</#if>/>${uiLabelMap.WebtoolsMaintainTimestamps}</label>
                     <label><input type="checkbox" name="createDummyFks" <#if createDummyFks??>checked="checked"</#if>/>${uiLabelMap.WebtoolsCreateDummyFks}</label>
                     <label><input type="checkbox" name="checkDataOnly" <#if checkDataOnly??>checked="checked"</#if>/>${uiLabelMap.WebtoolsCheckDataOnly}</label>
+                    <label><input type="checkbox" name="disableEeca" <#if disableEeca??>checked="checked"</#if>/>${uiLabelMap.WebtoolsDisableEeca}</label><span class="tooltip">${uiLabelMap.WebtoolsDisableEecaWarning}</span>
                 </td>
             </tr>
             <tr>

--- a/framework/webtools/template/entity/EntityImportDir.ftl
+++ b/framework/webtools/template/entity/EntityImportDir.ftl
@@ -46,6 +46,7 @@ under the License.
                     <label><input type="checkbox" name="createDummyFks" <#if createDummyFks??>checked="checked"</#if>/>${uiLabelMap.WebtoolsCreateDummyFks}</label>
                     <label><input type="checkbox" name="deleteFiles" <#if (deleteFiles??)>checked="checked"</#if>/>${uiLabelMap.WebtoolsDeleteFiles}</label>
                     <label><input type="checkbox" name="checkDataOnly" <#if checkDataOnly??>checked="checked"</#if>/>${uiLabelMap.WebtoolsCheckDataOnly}</label>
+                    <label><input type="checkbox" name="disableEeca" <#if disableEeca??>checked="checked"</#if>/>${uiLabelMap.WebtoolsDisableEeca}</label><span class="tooltip">${uiLabelMap.WebtoolsDisableEecaWarning}</span>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
Fixed: Entity import dir causes problems because of ECAs
(OFBIZ-5259)

- Add optional `disableEeca` attribute to `parseEntityXmlFile`/`entityImport`/`entityImportDir` (default off), wired to the existing `EntitySaxReader.setDisableEeca`, with a checkbox + tooltip on the import screens — lets operators skip ECA side effects during full-instance restores.
- Harden `EntitySaxReader` so importing a `SequenceValueItem` can never move its `seqId` backward, closing the actual corruption path regardless of ECA state.

Thanks: Skip Dever for reporting.
