### PR TITLE
Fixed: E-commerce search and product detail no longer leak products across catalogs (OFBIZ-4755)

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/entry/catalog/KeywordSearch.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/entry/catalog/KeywordSearch.groovy
@@ -29,9 +29,11 @@ import org.apache.ofbiz.product.product.ProductSearchSession
 module = 'KeywordSearch.groovy'
 
 // note: this can be run multiple times in the same request without causing problems, will check to see on its own if it has run again
+prodCatalogId = CatalogWorker.getCurrentCatalogId(request)
+// without this, a catalog with no PCCT_VIEW_ALLW category configured searches every catalog
+parameters.SEARCH_CATALOG_ID = parameters.SEARCH_CATALOG_ID ?: prodCatalogId
 request.getSession().setAttribute('dispatcher', dispatcher)
 ProductSearchSession.processSearchParameters(parameters, request)
-prodCatalogId = CatalogWorker.getCurrentCatalogId(request)
 result = ProductSearchSession.getProductSearchResult(request, delegator, prodCatalogId)
 
 context << [

--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/entry/catalog/Product.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/entry/catalog/Product.groovy
@@ -26,6 +26,7 @@ import org.apache.ofbiz.product.category.CategoryContentWrapper
 import org.apache.ofbiz.product.category.CategoryWorker
 import org.apache.ofbiz.product.product.ProductContentWrapper
 import org.apache.ofbiz.product.product.ProductWorker
+import org.apache.ofbiz.product.store.ProductStoreWorker
 
 contentPathPrefix = CatalogWorker.getContentPathPrefix(request)
 catalogName = CatalogWorker.getCatalogName(request)
@@ -85,6 +86,29 @@ if (productId) {
             if (!CategoryWorker.isProductInCategory(delegator, productId, viewProductCategoryId)) {
                 // a view allow productCategoryId was found, but the product is not in the category, axe it...
                 product = null
+            }
+        } else {
+            // no View-Allow category configured: fall back to scoping by the whole store's catalogs
+            // (not just currentCatalogId) so products shared across a store's own catalogs still work,
+            // while products that only exist in an unrelated store's catalog get excluded
+            productStoreId = ProductStoreWorker.getProductStoreId(request)
+            if (productStoreId) {
+                storeCatalogCategoryIds = [] as Set
+                CatalogWorker.getStoreCatalogs(delegator, productStoreId)?.each { storeCatalog ->
+                    topCategoryId = CatalogWorker.getCatalogTopCategoryId(delegator, storeCatalog.prodCatalogId)
+                    if (topCategoryId) {
+                        storeCatalogCategoryIds << topCategoryId
+                        CategoryWorker.getRelatedCategoriesRet(delegator, 'topLevelList', topCategoryId, true, false, true).each {
+                            storeCatalogCategoryIds << it.productCategoryId
+                        }
+                    }
+                }
+                productCategoryIds = from('ProductCategoryMember').where('productId', productId).filterByDate()
+                        .queryList()*.productCategoryId as Set
+                if (storeCatalogCategoryIds.disjoint(productCategoryIds)) {
+                    // product isn't reachable from any catalog belonging to the current store, axe it...
+                    product = null
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed: E-commerce search and product detail no longer leak products across catalogs
(OFBIZ-4755)

KeywordSearch.groovy now sets SEARCH_CATALOG_ID from the current catalog before processSearchParameters runs, so a catalog with no PCCT_VIEW_ALLW category configured no longer defaults to searching every catalog in the system.

Product.groovy applies the same idea to product-detail viewing: when no View-Allow category is configured, a product is only shown if it belongs to some catalog of the current product store, preventing direct links to products that exist solely in an unrelated store's catalog while leaving legitimate cross-catalog sharing within a store untouched.

Thanks: Jeremy Olmstead for reporting the issue.