### PR TITLE
Fixed: Gift card purchase copyMe (BCC purchaser) can never work (OFBIZ-13464)

### DIFF
--- a/applications/accounting/src/main/java/org/apache/ofbiz/accounting/payment/GiftCertificateServices.java
+++ b/applications/accounting/src/main/java/org/apache/ofbiz/accounting/payment/GiftCertificateServices.java
@@ -813,7 +813,12 @@ public class GiftCertificateServices {
                 }
                 if (question != null) {
                     String desc = question.getString("description");
-                    String ans = answer.getString("textResponse");  // only support text response types for now
+                    String ans;
+                    if ("BOOLEAN".equals(question.getString("surveyQuestionTypeId"))) {
+                        ans = "Y".equalsIgnoreCase(answer.getString("booleanResponse")) ? "true" : "false";
+                    } else {
+                        ans = answer.getString("textResponse");  // only support text response types otherwise
+                    }
                     answerMap.put(desc, ans);
                 }
             }
@@ -892,7 +897,8 @@ public class GiftCertificateServices {
                 Debug.logError(e, "Unable to get product store email setting for gift card purchase", MODULE);
             }
             if (productStoreEmail == null) {
-                Debug.logError("No gift card purchase email setting found for this store; cannot send gift card information", MODULE);
+                Debug.logError("No ProductStoreEmailSetting for productStoreId [" + productStoreId + "] emailType [" + emailType
+                        + "]; gift card activation email for orderId [" + orderId + "] was NOT sent", MODULE);
             } else {
                 answerMap.put("locale", locale);
 


### PR DESCRIPTION
Fixed: Gift card purchase copyMe (BCC purchaser) can never work
(OFBIZ-13464)

Survey answers were read via textResponse only, so a BOOLEAN-type answer (stored in booleanResponse) could never satisfy the "true".equalsIgnoreCase(copyMeResp) check used to decide whether to BCC the purchaser on the gift card activation email. This made the feature impossible to enable for any store, regardless of configuration. Also make the missing-ProductStoreEmailSetting log line include productStoreId/orderId so a silently skipped email is diagnosable.