### PR TITLE
Fixed: Time zones always displayed using their daylight savings display name (OFBIZ-12731)

### DIFF
--- a/themes/common-theme/template/includes/ListTimezones.ftl
+++ b/themes/common-theme/template/includes/ListTimezones.ftl
@@ -26,13 +26,12 @@ under the License.
   </div>
   <table cellspacing="0" class="basic-table hover-bar">
     <#assign altRow = true>
-    <#assign displayStyle = Static["java.util.TimeZone"].LONG>
     <#assign availableTimeZones = Static["org.apache.ofbiz.base.util.UtilDateTime"].availableTimeZones()/>
     <#list availableTimeZones as availableTz>
       <#assign altRow = !altRow>
       <tr<#if altRow> class="alternate-row"</#if>>
         <td>
-          <a href="<@ofbizUrl>setSessionTimeZone</@ofbizUrl>?tzId=${availableTz.getID()}">${availableTz.getDisplayName(availableTz.useDaylightTime(), displayStyle, locale)} (${availableTz.getID()})</a>
+          <a href="<@ofbizUrl>setSessionTimeZone</@ofbizUrl>?tzId=${availableTz.getID()}">${availableTz.toZoneId().getDisplayName(Static["java.time.format.TextStyle"].FULL_STANDALONE, locale)} (${availableTz.getID()})</a>
         </td>
       </tr>
     </#list>


### PR DESCRIPTION
[OFBIZ-12731](https://issues.apache.org/jira/browse/OFBIZ-12731)

The time zone lookup list (`partymgr/control/ListTimezones`) builds its display names with `TimeZone#getDisplayName(useDaylightTime(), LONG, locale)`. `useDaylightTime()` answers whether the zone *has* DST rules at all, not whether DST is currently in effect, so every DST-observing zone is permanently shown with its summer name — e.g. "British Summer Time" in December, or "Australian Eastern Daylight Time" during the southern winter. This is the remaining part of OFBIZ-12731 that Daniel noted after the footer was fixed.

This change uses the same `ZoneId#getDisplayName(TextStyle.FULL_STANDALONE, locale)` call the footer has used since OFBIZ-12721 (ca0433d0e4), so the list now shows the season-neutral generic name ("British Time", "Central European Time"). A nice side effect is that the list entries now match the name displayed in the footer — previously the footer name could not be found in the list, as Jacques noticed with "heure d'Europe centrale".

Verified on a local instance: the rendered page shows 631 zones with no "Summer Time"/"Daylight Time" variants remaining; Europe/London → "British Time", Australia/Sydney → "Eastern Australia Time" (the previous code shows "Australian Eastern Daylight Time" today, mid-southern-winter), Europe/Paris → "Central European Time".