### PR TITLE
Fixed: Time zones always displayed using their daylight savings display name (OFBIZ-12731)

### DIFF
--- a/themes/common-theme/template/UserProfile.ftl
+++ b/themes/common-theme/template/UserProfile.ftl
@@ -27,7 +27,6 @@ under the License.
 <#if !(selectedTimeZoneId?has_content) && timeZone??>
   <#assign selectedTimeZoneId = timeZone.getID()>
 </#if>
-<#assign displayStyle = Static["java.util.TimeZone"].LONG>
 <#assign availableLocales = Static["org.apache.ofbiz.base.util.UtilMisc"].availableLocales()>
 <#assign availableTimeZones = Static["org.apache.ofbiz.base.util.UtilDateTime"].availableTimeZones()>
 
@@ -40,7 +39,7 @@ under the License.
 <#assign lastTimeZoneDisplay = uiLabelMap.CommonNA>
 <#if lastTimeZoneId?has_content>
   <#assign lastTimeZone = Static["java.util.TimeZone"].getTimeZone(lastTimeZoneId)>
-  <#assign lastTimeZoneDisplay = lastTimeZone.getDisplayName(lastTimeZone.useDaylightTime(), displayStyle, locale) + " (" + lastTimeZone.getID() + ")">
+  <#assign lastTimeZoneDisplay = lastTimeZone.toZoneId().getDisplayName(Static["java.time.format.TextStyle"].FULL_STANDALONE, locale) + " (" + lastTimeZone.getID() + ")">
 </#if>
 
 <div class="screenlet">
@@ -113,7 +112,7 @@ under the License.
           <#list availableTimeZones as availableTz>
             <#assign availableTzId = availableTz.getID()>
             <option value="${availableTzId}"<#if availableTzId == selectedTimeZoneId!> selected="selected"</#if>>
-              ${availableTz.getDisplayName(availableTz.useDaylightTime(), displayStyle, locale)} (${availableTzId})
+              ${availableTz.toZoneId().getDisplayName(Static["java.time.format.TextStyle"].FULL_STANDALONE, locale)} (${availableTzId})
             </option>
           </#list>
         </select>

--- a/themes/common-theme/template/includes/ListTimezones.ftl
+++ b/themes/common-theme/template/includes/ListTimezones.ftl
@@ -26,13 +26,12 @@ under the License.
   </div>
   <table cellspacing="0" class="basic-table hover-bar">
     <#assign altRow = true>
-    <#assign displayStyle = Static["java.util.TimeZone"].LONG>
     <#assign availableTimeZones = Static["org.apache.ofbiz.base.util.UtilDateTime"].availableTimeZones()/>
     <#list availableTimeZones as availableTz>
       <#assign altRow = !altRow>
       <tr<#if altRow> class="alternate-row"</#if>>
         <td>
-          <a href="<@ofbizUrl>setSessionTimeZone</@ofbizUrl>?tzId=${availableTz.getID()}">${availableTz.getDisplayName(availableTz.useDaylightTime(), displayStyle, locale)} (${availableTz.getID()})</a>
+          <a href="<@ofbizUrl>setSessionTimeZone</@ofbizUrl>?tzId=${availableTz.getID()}">${availableTz.toZoneId().getDisplayName(Static["java.time.format.TextStyle"].FULL_STANDALONE, locale)} (${availableTz.getID()})</a>
         </td>
       </tr>
     </#list>


### PR DESCRIPTION
[OFBIZ-12731](https://issues.apache.org/jira/browse/OFBIZ-12731)

This builds directly on work already done on the ticket. Credit where it is due:

- **Daniel Watford** reported the issue, suggested the `ZoneId#getDisplayName` approach back in 2022, and — after the footer was fixed — tested trunk and pinpointed that the `ListTimezones` page was the remaining part ("only partially fixed and shouldn't be closed").
- **Eugen Stan** authored the footer fix for OFBIZ-12721 (ca0433d0e4), which this change follows exactly.
- **Jacques Le Roux** followed up on both issues over the years and noticed that the time zone name shown in the footer could not be found in the list.

### The remaining problem

The time zone lookup list (`partymgr/control/ListTimezones`) still built its display names with `TimeZone#getDisplayName(useDaylightTime(), LONG, locale)`. `useDaylightTime()` answers whether the zone *has* DST rules at all, not whether DST is currently in effect, so every DST-observing zone was permanently shown with its summer name — e.g. "British Summer Time" in December, or "Australian Eastern Daylight Time" during the southern winter.

### The change

Use the same `ZoneId#getDisplayName(TextStyle.FULL_STANDALONE, locale)` call the footer has used since Eugen's OFBIZ-12721 fix, so the list shows the season-neutral generic name ("British Time", "Central European Time"). This also makes the list entries match the footer name, addressing Jacques's observation ("heure d'Europe centrale" is now findable in the list).

### Verification

On a local instance the rendered page shows 631 zones with no "Summer Time"/"Daylight Time" variants remaining; Europe/London → "British Time" (what Daniel saw in the fixed footer), Australia/Sydney → "Eastern Australia Time" (the previous code shows "Australian Eastern Daylight Time" today, mid-southern-winter), Europe/Paris → "Central European Time".

Supersedes #1510 (same change; reopened to properly credit the prior work in the commit message).