### PR TITLE
Fixed: OFBizTestCase-based integration tests never run on release24.09 (OFBIZ-13469)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,14 +253,14 @@ sourceSets {
         java {
             srcDirs = getDirectoryInActiveComponentsIfExists('src/test/java')
         }
-        // Groovy tests often fail, because JUNIT does not have access to the ofbiz enviroment.
-        // If a groovy test is supposed to be tested this way, it can be added here.
+        // All groovy tests are compiled here so OFBizTestCase-based integration
+        // tests are on the classpath for 'ofbiz --test' (see createOfbizCommandTask).
+        // Most of them extend OFBizTestCase -> junit.framework.TestCase and would
+        // otherwise be auto-discovered and run directly by the 'test' task below,
+        // which fails because JUnit does not have access to the ofbiz environment.
+        // See the 'test' task's include list for which ones are safe to run that way.
         groovy {
             srcDirs = getDirectoryInActiveComponentsIfExists('src/test/groovy')
-            include 'org/apache/ofbiz/service/ModelServiceTest.groovy'
-            include 'org/apache/ofbiz/test/TestServices.groovy'
-            include 'org/apache/ofbiz/base/util/string/FlexibleStringExpanderBaseCodeTests.groovy'
-            include 'org/apache/ofbiz/base/util/FileUtilTests.groovy'
         }
         resources {
             srcDirs = getDirectoryInActiveComponentsIfExists('src/test/resources')
@@ -326,6 +326,13 @@ tasks.eclipse.dependsOn(cleanEclipse)
 
 test {
     useJUnit()
+    // Only run the plain JUnit tests here; OFBizTestCase-based integration tests
+    // are compiled (see sourceSets.test.groovy above) but must run via
+    // 'ofbiz --test', since they need the ofbiz environment JUnit doesn't provide.
+    include 'org/apache/ofbiz/service/ModelServiceTest.class'
+    include 'org/apache/ofbiz/test/TestServices.class'
+    include 'org/apache/ofbiz/base/util/string/FlexibleStringExpanderBaseCodeTests.class'
+    include 'org/apache/ofbiz/base/util/FileUtilTests.class'
     jvmArgs "-javaagent:${classpath.find { it.name.contains('jmockit') }.absolutePath}"
 }
 
@@ -990,12 +997,14 @@ tasks.addRule('Pattern: ofbizBackground <Commands>: Execute OFBiz startup comman
 def createOfbizCommandTask(taskName, arguments) {
     task(type: JavaExec, dependsOn: classes, taskName) {
         jvmArgs(application.applicationDefaultJvmArgs)
-        classpath = sourceSets.main.runtimeClasspath
+        if (taskName ==~ /^ofbiz.*(--test|-t).*/) {
+            classpath = sourceSets.main.runtimeClasspath + sourceSets.test.runtimeClasspath
+            finalizedBy(createTestReports)
+        } else {
+            classpath = sourceSets.main.runtimeClasspath
+        }
         mainClass = application.mainClass
         args arguments
-        if (taskName ==~ /^ofbiz.*(--test|-t).*/) {
-            finalizedBy(createTestReports)
-        }
     }
 }
 


### PR DESCRIPTION
Fixed: OFBizTestCase-based integration tests never run on release24.09 (OFBIZ-13469)

- `ofbiz --test`/`-t` tasks' classpath was unconditionally `sourceSets.main.runtimeClasspath`, so the ~52 `OFBizTestCase`-based Groovy tests under `src/test/groovy` (relocated there by OFBIZ-13402) were never on the classpath `ModelTestSuite` uses, causing `ClassNotFoundException` per class. `testIntegration` logged and skipped these instead of failing, so the build reported success while silently running only a fraction of the suite.
- Restores the conditional classpath for `--test` tasks and drops the sourceSet's stale 4-file `include` whitelist so those classes compile. Since this branch is still on JUnit 4 (unlike trunk's Jupiter-only setup), also adds a matching `include` filter to the `test` task itself, so `./gradlew test`/`build` doesn't try to auto-execute these classes outside the ofbiz environment.