### PR TITLE
Fixed: Gradle build failure in a linked git worktree (OFBIZ-13470)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,6 +288,10 @@ checkstyle {
     showViolations = true
 }
 gitHooks {
+    // Resolve the real .git dir so this also works from a linked worktree,
+    // where "$rootDir/.git" (the plugin's default) is a gitlink file, not a directory.
+    def gitCommonDir = "git -C ${rootDir} rev-parse --git-common-dir".execute().text.trim()
+    hooksDirectory.set(new File(rootDir, gitCommonDir).toPath().resolve('hooks').toFile())
     hooks = ['pre-push': 'checkstyleMain codenarcMain codenarcTest']
 }
 


### PR DESCRIPTION
Fixed: Gradle build failure in a linked git worktree (OFBIZ-13470)

`./gradlew` failed in a linked git worktree because the git-hooks plugin
assumed `$rootDir/.git/hooks` was a directory. In a worktree, `.git` is a
gitlink file instead, so `Files.createDirectories()` threw. Now resolves
the hooks directory via `git rev-parse --git-common-dir`, which correctly
points to the shared `.git/hooks` in both a normal checkout and a
worktree.

Backport of #1517.