### PR TITLE
Fixed: Escape possibility to override serviceName at vcard import

### DIFF
--- a/applications/marketing/servicedef/services.xml
+++ b/applications/marketing/servicedef/services.xml
@@ -576,13 +576,28 @@ under the License.
     </service>
 
     <!-- VCard services -->
-    <service name="importVCard" engine="java" location="org.apache.ofbiz.sfa.vcard.VCard" invoke="importVCard" transaction-timeout="7200">
-        <attribute name="infile" type="java.nio.ByteBuffer" mode="IN" optional="false"/>
+    <service name="importVCard" engine="interface">
+        <attribute name="infile" type="java.nio.ByteBuffer" mode="IN"/>
         <attribute name="partyType" type="String" mode="IN" optional="true"/>
         <attribute name="serviceContext" type="Map" mode="IN" optional="true"/>
-        <attribute name="serviceName" type="String" mode="IN" optional="false"/>
-        <attribute name="partiesCreated" type="List" mode="OUT" optional="false"/>
+        <attribute name="partiesCreated" type="List" mode="OUT"/>
         <attribute name="partiesExist" type="List" mode="OUT" optional="true"/>
+    </service>
+    <service name="createPartyFromVCard" engine="java"
+             location="org.apache.ofbiz.sfa.vcard.VCard" invoke="importVCard"
+             auth="true" transaction-timeout="7200">
+        <implements service="importVCard"/>
+        <attribute name="serviceName" type="String" mode="IN"/>
+    </service>
+    <service name="createPartyLeadFromVCard" engine="groovy"
+             location="component://marketing/src/main/groovy/org/apache/ofbiz/marketing/sfa/lead/LeadServices.groovy" invoke="createPartyLeadFromVCard"
+             auth="true" transaction-timeout="7200">
+        <implements service="importVCard"/>
+    </service>
+    <service name="createPartyContactFromVCard" engine="groovy"
+             location="component://marketing/src/main/groovy/org/apache/ofbiz/marketing/sfa/lead/LeadServices.groovy" invoke="createPartyContactFromVCard"
+             auth="true" transaction-timeout="7200">
+        <implements service="importVCard"/>
     </service>
     <service name="exportVCard" engine="java" location="org.apache.ofbiz.sfa.vcard.VCard" invoke="exportVCard">
         <attribute name="partyId" type="String" mode="IN" optional="false"/>

--- a/applications/marketing/src/main/groovy/org/apache/ofbiz/marketing/sfa/lead/LeadServices.groovy
+++ b/applications/marketing/src/main/groovy/org/apache/ofbiz/marketing/sfa/lead/LeadServices.groovy
@@ -200,3 +200,13 @@ Map resolvePartyProcessMap() {
     }
     return resultMap
 }
+
+Map createPartyLeadFromVCard() {
+    return (run service: 'createPartyFromVCard', with: [*: parameters,
+                                                        serviceName: 'createLead'])
+}
+
+Map createPartyContactFromVCard() {
+    return (run service: 'createPartyFromVCard', with: [*: parameters,
+                                                        serviceName: 'createContact'])
+}

--- a/applications/marketing/src/main/java/org/apache/ofbiz/sfa/vcard/VCard.java
+++ b/applications/marketing/src/main/java/org/apache/ofbiz/sfa/vcard/VCard.java
@@ -201,10 +201,9 @@ public class VCard {
                 String serviceName = (String) context.get("serviceName");
                 Map<String, Object> serviceContext = UtilGenerics.cast(context.get("serviceContext"));
                 if (UtilValidate.isNotEmpty(serviceContext)) {
-                    for (Map.Entry<String, Object> entry : serviceContext.entrySet()) {
-                        serviceCtx.put(entry.getKey(), entry.getValue());
-                    }
+                    serviceCtx.putAll(serviceContext);
                 }
+                serviceCtx = dctx.makeValidContext(serviceName, "IN", serviceCtx);
                 Map<String, Object> resp = dispatcher.runSync(serviceName, serviceCtx);
                 if (ServiceUtil.isError(resp)) {
                     return ServiceUtil.returnError(ServiceUtil.getErrorMessage(resp));

--- a/applications/marketing/webapp/sfa/WEB-INF/controller.xml
+++ b/applications/marketing/webapp/sfa/WEB-INF/controller.xml
@@ -145,7 +145,7 @@ under the License.
     </request-map>
     <request-map uri="createLeadFromVCard">
         <security https="true" auth="true"/>
-        <event type="service" invoke="importVCard"/>
+        <event type="service" invoke="createPartyLeadFromVCard"/>
         <response name="success" type="view" value="ViewPartiesCreatedByVCard"/>
         <response name="error" type="view" value="NewLeadFromVCard"/>
     </request-map>
@@ -205,7 +205,7 @@ under the License.
     </request-map>
     <request-map uri="createContactFromVCard">
         <security https="true" auth="true"/>
-        <event type="service" invoke="importVCard"/>
+        <event type="service" invoke="createPartyContactFromVCard"/>
         <response name="success" type="view" value="ViewPartiesCreatedByVCard"/>
         <response name="error" type="view" value="NewContactFromVCard"/>
     </request-map>

--- a/applications/marketing/widget/sfa/forms/ContactForms.xml
+++ b/applications/marketing/widget/sfa/forms/ContactForms.xml
@@ -172,7 +172,6 @@ under the License.
 
     <form name="NewContactFromVCard" type="upload" target="createContactFromVCard" header-row-style="header-row" default-table-style="basic-table">
         <field name="infile" title="${uiLabelMap.SfaUploadVCard}"><file/></field>
-        <field name="serviceName"><hidden value="createContact"/></field>
         <field name="submitButton" title="${uiLabelMap.CommonUpload}" widget-style="smallSubmit"><submit button-type="button"/></field>
     </form>
 

--- a/applications/marketing/widget/sfa/forms/LeadForms.xml
+++ b/applications/marketing/widget/sfa/forms/LeadForms.xml
@@ -115,8 +115,7 @@ under the License.
 
     <form name="NewLeadFromVCard" type="upload" target="createLeadFromVCard" header-row-style="header-row" default-table-style="basic-table">
         <field name="infile" title="${uiLabelMap.SfaUploadVCard}"><file/></field>
-        <field name="serviceName"><hidden value="createLead"/></field>
-        <field name="submitButton" title="${uiLabelMap.CommonUpload}" widget-style="smallSubmit"><submit button-type="button"/></field>
+        <field name="submitButton" title="${uiLabelMap.CommonUpload}" widget-style="smallSubmit"><submit/></field>
     </form>
 
     <form name="QuickAddLead" type="single" target="quickAddLead">


### PR DESCRIPTION
When you import a party from Vcard, the service to call was hardcoded on form and can be override by user.

We change it to create dedicate service for each case that prepare the call for the generic importVCard service.
