### PR TITLE
Fixed : Child communication event sorting. (OFBIZ-8152)

### DIFF
--- a/applications/order/widget/ordermgr/CustRequestForms.xml
+++ b/applications/order/widget/ordermgr/CustRequestForms.xml
@@ -107,7 +107,7 @@ under the License.
             <service service-name="performFind" result-map="result" result-map-list="listIt">
                 <field-map field-name="inputFields" from-field="parameters"/>
                 <field-map field-name="entityName" from-field="entityName"/>
-                <field-map field-name="orderBy" from-field="parameters.sortField"/>
+                <field-map field-name="orderBy" from-field="parameters.custRequestSortField"/>
                 <field-map field-name="viewIndex" from-field="viewIndex"/>
                 <field-map field-name="viewSize" from-field="viewSize"/>
             </service>

--- a/applications/party/widget/partymgr/CommunicationEventScreens.xml
+++ b/applications/party/widget/partymgr/CommunicationEventScreens.xml
@@ -463,8 +463,10 @@ under the License.
                     </screenlet>
                     <section>
                         <actions>
-                            <entity-and entity-name="CommunicationEvent" list="commEvents">
+                            <set field="parameters.sortField" from-field="parameters.sortField" default-value="-entryDate"/>
+                            <entity-and entity-name="CommunicationEventAndRole" list="commEvents">
                                 <field-map field-name="parentCommEventId" from-field="parameters.communicationEventId"/>
+                                <order-by field-name="${parameters.sortField}"/>
                             </entity-and>
                         </actions>
                         <widgets>


### PR DESCRIPTION
Fixed: Child communication event sorting
(OFBIZ-8152)

Explanation: The child-event sort parameter was incorrectly reused by the Customer Request List. Additionally, the child-event query used CommunicationEvent, while the form contains sortable fields from CommunicationEventAndRole.

Thanks:
Ravi Lodhi for reporting the issue.