### PR TITLE
Fixed: MissingMethodException thrown during the execution of the updateProductStore service when attempting to expire existing facilities. (OFBIZ-13472)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/product/store/ProductStoreServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/product/store/ProductStoreServices.groovy
@@ -109,7 +109,7 @@ Map updateProductStore() {
                 EQUALS(productStoreId: store.productStoreId)
                 LESS_THAN_EQUAL_TO(fromDate: nowTimestamp)
             }
-            delegator.storeByCondition('ProductStoreFacility', condition, [thruDate: nowTimestamp])
+            delegator.storeByCondition('ProductStoreFacility', [thruDate: nowTimestamp], condition)
         }
         // create the new entry
         makeValue('ProductStoreFacility', [


### PR DESCRIPTION
Fixed: MissingMethodException thrown during the execution of the updateProductStore service when attempting to expire existing facilities. (OFBIZ-13472)

Thanks Swapnil Shah for reporting.
