### PR TITLE
Migrate applications JUnit3 integration tests to JUnit5 (Jupiter)

### DIFF
--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgAdminTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgAdminTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.accounting.accounting
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgAdminTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgAdminTests implements JupiterTestHelper {
 
-    AutoAcctgAdminTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testGetFXConversion() {
         Map serviceCtx = [
                 uomId: 'EUR',
@@ -38,6 +40,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
+    @Test
+    @Order(2)
     void testAddPaymentMethodTypeGlAssignment() {
         Map serviceCtx = [
             paymentMethodTypeId: 'GIFT_CARD',
@@ -56,6 +60,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert paymentMethodTypeGlAccount.glAccountId == '999999'
     }
 
+    @Test
+    @Order(3)
     void testRemovePaymentTypeGlAssignment() {
         Map serviceCtx = [
                 paymentTypeId: 'COMMISSION_PAYMENT',
@@ -72,6 +78,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert !paymentMethodTypeGlAccount
     }
 
+    @Test
+    @Order(4)
     void testCreatePartyAcctgPreference() {
         Map serviceCtx = [
                 partyId: 'DEMO_COMPANY',
@@ -89,6 +97,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert partyAcctgPreference.refundPaymentMethodId == '9020'
     }
 
+    @Test
+    @Order(5)
     void testUpdatePartyAcctgPreference() {
         Map serviceCtx = [
                 partyId: 'DEMO_COMPANY1',
@@ -105,6 +115,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert partyAcctgPreference.refundPaymentMethodId == '9020'
     }
 
+    @Test
+    @Order(6)
     void testGetPartyAccountingPreferences() {
         Map serviceCtx = [
                 organizationPartyId: 'DEMO_COMPANY1',
@@ -115,6 +127,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert serviceResult.partyAccountingPreference
     }
 
+    @Test
+    @Order(7)
     void testSetAcctgCompany() {
         Map serviceCtx = [
                 organizationPartyId: 'DEMO_COMPANY1',
@@ -131,6 +145,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert userPreference.userPrefTypeId == 'ORGANIZATION_PARTY'
     }
 
+    @Test
+    @Order(8)
     void testUpdateFXConversion() {
         Map serviceCtx = [
                 uomId: 'INR',
@@ -148,6 +164,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert uomConversionDated.conversionFactor == 2.0
     }
 
+    @Test
+    @Order(9)
     void testCreateGlAccountTypeDefault() {
         Map serviceCtx = [
                 glAccountTypeId: 'BALANCE_ACCOUNT',
@@ -165,6 +183,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert glAccountTypeDefault.glAccountId == '999999'
     }
 
+    @Test
+    @Order(10)
     void testRemoveGlAccountTypeDefault() {
         Map serviceCtx = [
                 glAccountTypeId: 'ACCOUNTS_PAYABLE',
@@ -182,6 +202,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert !glAccountTypeDefault
     }
 
+    @Test
+    @Order(11)
     void testAddInvoiceItemTypeGlAssignment() {
         Map serviceCtx = [
                 invoiceItemTypeId: 'PINV_FPROD_ITEM',
@@ -200,6 +222,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert invoiceItemTypeGlAccount.glAccountId == '999999'
     }
 
+    @Test
+    @Order(12)
     void testRemoveInvoiceItemTypeGlAssignment() {
         Map serviceCtx = [
                 invoiceItemTypeId: 'PINV_SALES_TAX',
@@ -216,6 +240,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert !invoiceItemTypeGlAccount
     }
 
+    @Test
+    @Order(13)
     void testAddPaymentTypeGlAssignment() {
         Map serviceCtx = [
                 paymentTypeId: 'TAX_PAYMENT',
@@ -234,6 +260,8 @@ class AutoAcctgAdminTests extends OFBizTestCase {
         assert paymentGlAccountTypeMap.glAccountTypeId == 'TAX_ACCOUNT'
     }
 
+    @Test
+    @Order(14)
     void testRemovePaymentMethodTypeGlAssignment() {
         Map serviceCtx = [
                 paymentMethodTypeId: 'CASH',

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgAgreementTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgAgreementTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.accounting.accounting
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgAgreementTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgAgreementTests implements JupiterTestHelper {
 
-    AutoAcctgAgreementTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testAddPaymentMethodTypeGlAssignment() {
         Map serviceCtx = [
                 agreementId: '1000',
@@ -43,6 +45,8 @@ class AutoAcctgAgreementTests extends OFBizTestCase {
         assert agreement == null
     }
 
+    @Test
+    @Order(2)
     void testCopyAgreement() {
         Map serviceCtx = [
                 agreementId: '1010',
@@ -66,6 +70,8 @@ class AutoAcctgAgreementTests extends OFBizTestCase {
         assert agreementProductAppls
     }
 
+    @Test
+    @Order(3)
     void testGetCommissionForProduct() {
         Map serviceCtx = [
                 productId: 'TestProduct2',

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBudgetTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBudgetTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.accounting.accounting
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgBudgetTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgBudgetTests implements JupiterTestHelper {
 
-    AutoAcctgBudgetTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateBudget() {
         Map serviceCtx = [:]
         serviceCtx.budgetTypeId = 'CAPITAL_BUDGET'
@@ -42,6 +44,8 @@ class AutoAcctgBudgetTests extends OFBizTestCase {
         assert budget.comments == 'Capital Budget'
     }
 
+    @Test
+    @Order(2)
     void testUpdateBudgetStatus() {
         Map serviceCtx = [:]
         serviceCtx.budgetId = '9999'

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgCostTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgCostTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.accounting.accounting
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgCostTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgCostTests implements JupiterTestHelper {
 
-    AutoAcctgCostTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testUpdateProductAverageCostOnReceiveInventory() {
         Map serviceCtx = [:]
         serviceCtx.facilityId = 'DemoFacility1'
@@ -45,6 +47,8 @@ class AutoAcctgCostTests extends OFBizTestCase {
         assert productAverageCost.averageCost == 9
     }
 
+    @Test
+    @Order(2)
     void testGetProductAverageCost() {
         GenericValue inventoryItem = from('InventoryItem')
                                             .where('inventoryItemId', '9999').queryOne()

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFinAccountTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFinAccountTests.groovy
@@ -21,14 +21,16 @@ package org.apache.ofbiz.accounting.accounting
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgFinAccountTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgFinAccountTests implements JupiterTestHelper {
 
-    AutoAcctgFinAccountTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateFinAccount() {
         Map serviceCtx = [
                 finAccountId: '1000',
@@ -49,6 +51,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert finAccount.finAccountCode == '1000'
     }
 
+    @Test
+    @Order(2)
     void testUpdateFinAccount() {
         Map serviceCtx = [
                 finAccountId: '1001',
@@ -65,6 +69,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert finAccount.organizationPartyId == 'DEMO_COMPANY2'
     }
 
+    @Test
+    @Order(3)
     void testDeleteFinAccount() {
         Map serviceCtx = [
                 finAccountId: '1002',
@@ -79,6 +85,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert finAccount.thruDate != null
     }
 
+    @Test
+    @Order(4)
     void testCreateFinAccountRole() {
         Map serviceCtx = [
                 finAccountId: '1003',
@@ -97,6 +105,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert finAccountRole
     }
 
+    @Test
+    @Order(5)
     void testUpdateFinAccountRole() {
         Map serviceCtx = [
                 finAccountId: '1004',
@@ -116,6 +126,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert finAccountRole.thruDate != null
     }
 
+    @Test
+    @Order(6)
     void testDeleteFinAccountRole() {
         Map serviceCtx = [
                 finAccountId: '1004',
@@ -133,6 +145,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert finAccountRole == null
     }
 
+    @Test
+    @Order(7)
     void testCreateFinAccountTrans() {
         Map serviceCtx = [
                 finAccountId: '1003',
@@ -148,6 +162,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert finAccountTran
     }
 
+    @Test
+    @Order(8)
     void testCreateFinAccountStatus() {
         Map serviceCtx = [
                 finAccountId: '1003',
@@ -164,6 +180,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert finAccountStatus
     }
 
+    @Test
+    @Order(9)
     void testCreateFinAccountAuth() {
         Map serviceCtx = [
                 finAccountId: '1004',
@@ -178,6 +196,8 @@ class AutoAcctgFinAccountTests extends OFBizTestCase {
         assert serviceResult.finAccountAuthId != null
     }
 
+    @Test
+    @Order(10)
     void testSetFinAccountTransStatus() {
         Map serviceCtx = [
                 finAccountTransId: '1010',

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFixedAssetTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFixedAssetTests.groovy
@@ -21,14 +21,16 @@ package org.apache.ofbiz.accounting.accounting
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgFixedAssetTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgFixedAssetTests implements JupiterTestHelper {
 
-    AutoAcctgFixedAssetTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateFixedAssetMaint() {
         Map serviceCtx = [
                 fixedAssetId: '1000',
@@ -46,6 +48,8 @@ class AutoAcctgFixedAssetTests extends OFBizTestCase {
         assert fixedAssetMaint.maintHistSeqId != null
     }
 
+    @Test
+    @Order(2)
     void testCreateFixedAssetMeter() {
         Map serviceCtx = [
                    fixedAssetId: '1000',
@@ -63,6 +67,8 @@ class AutoAcctgFixedAssetTests extends OFBizTestCase {
         assert fixedAssetMeter.meterValue == BigDecimal.TEN
     }
 
+    @Test
+    @Order(3)
     void testCancelFixedAssetStdCost() {
         Map serviceCtx = [
                         fixedAssetId: '1000',

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgInvoiceTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgInvoiceTests.groovy
@@ -21,16 +21,18 @@ package org.apache.ofbiz.accounting.accounting
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgInvoiceTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgInvoiceTests implements JupiterTestHelper {
 
-    AutoAcctgInvoiceTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateInvoiceContent() {
         Map serviceCtx = [
             invoiceId: '1008',
@@ -50,6 +52,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
 
         assert invoiceContent.contentId == serviceResult.contentId
     }
+    @Test
+    @Order(2)
     void testCreateSimpleTextContentForInvoice() {
         Map serviceCtx = [
                 invoiceId: '1009',
@@ -70,6 +74,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert invoiceContent
     }
 
+    @Test
+    @Order(3)
     void testCopyInvoice() {
         Map serviceCtx = [
                 invoiceIdToCopyFrom: '1000',
@@ -81,6 +87,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert serviceResult.invoiceId
     }
 
+    @Test
+    @Order(4)
     void testCreateInvoice() {
         Map serviceCtx = [
                 invoiceTypeId: 'PURCHASE_INVOICE',
@@ -95,6 +103,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert serviceResult.invoiceId
     }
 
+    @Test
+    @Order(5)
     void testGetInvoice() {
         Map serviceCtx = [
                 invoiceId: '1001',
@@ -107,6 +117,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert serviceResult.invoiceItems
     }
 
+    @Test
+    @Order(6)
     void testSetInvoiceStatus() {
         Map serviceCtx = [
                 invoiceId: '1002',
@@ -124,6 +136,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert invoice.statusId == 'INVOICE_APPROVED'
     }
 
+    @Test
+    @Order(7)
     void testCopyInvoiceToTemplate() {
         Map serviceCtx = [
                 invoiceId: '1002',
@@ -136,6 +150,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert serviceResult.invoiceId
     }
 
+    @Test
+    @Order(8)
     void testCreateInvoiceItem() {
         Map serviceCtx = [
                 invoiceId: '1003',
@@ -149,6 +165,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert serviceResult.invoiceItemSeqId
     }
 
+    @Test
+    @Order(9)
     void testCreateInvoiceStatus() {
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Map serviceCtx = [
@@ -169,6 +187,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert invoiceStatus
     }
 
+    @Test
+    @Order(10)
     void testCreateInvoiceRole() {
         Map serviceCtx = [
                 invoiceId: '1006',
@@ -188,6 +208,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert invoiceRole
     }
 
+    @Test
+    @Order(11)
     void testCreateInvoiceTerm() {
         Map serviceCtx = [
                 invoiceId: '1006',
@@ -207,6 +229,8 @@ class AutoAcctgInvoiceTests extends OFBizTestCase {
         assert invoiceTerm
     }
 
+    @Test
+    @Order(12)
     void testCancelInvoice() {
         Map serviceCtx = [
                 invoiceId: '1007',

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgLedgerTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgLedgerTests.groovy
@@ -21,13 +21,16 @@ package org.apache.ofbiz.accounting.accounting
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgLedgerTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgLedgerTests implements JupiterTestHelper {
 
-    AutoAcctgLedgerTests(String name) {
-        super(name)
-    }
+    @Test
+    @Order(1)
     void testCreateAcctgTrans() {
         Map serviceCtx = [:]
         serviceCtx.acctgTransTypeId = 'CREDIT_MEMO'
@@ -42,6 +45,8 @@ class AutoAcctgLedgerTests extends OFBizTestCase {
         assert acctgTrans.acctgTransId == serviceResult.acctgTransId
         assert acctgTrans.acctgTransTypeId == 'CREDIT_MEMO'
     }
+    @Test
+    @Order(2)
     void testCreateAcctgTransEntry() {
         Map serviceCtx = [
             acctgTransId: '1000',

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgPaymentGatewayTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgPaymentGatewayTests.groovy
@@ -20,14 +20,14 @@ package org.apache.ofbiz.accounting.accounting
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
-class AutoAcctgPaymentGatewayTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgPaymentGatewayTests implements JupiterTestHelper {
 
-    AutoAcctgPaymentGatewayTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testUpdatePaymentGatewayConfig() {
         Map serviceCtx = [:]
         serviceCtx.paymentGatewayConfigId = 'TEST_GATEWAY_CONFIG'

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgPaymentTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgPaymentTests.groovy
@@ -21,15 +21,18 @@ package org.apache.ofbiz.accounting.accounting
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgPaymentTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoAcctgPaymentTests implements JupiterTestHelper {
 
-    AutoAcctgPaymentTests(String name) {
-        super(name)
-    }
+    @Test
+    @Order(1)
     void testCreatePayment() {
         Map serviceCtx = [:]
         serviceCtx.paymentTypeId = 'CUSTOMER_PAYMENT'
@@ -45,6 +48,8 @@ class AutoAcctgPaymentTests extends OFBizTestCase {
         assert payment.paymentTypeId == 'CUSTOMER_PAYMENT'
         assert payment.paymentMethodTypeId == 'COMPANY_CHECK'
     }
+    @Test
+    @Order(2)
     void testSetPaymentStatus() {
         Map serviceCtx = [:]
         serviceCtx.paymentId = '1000'
@@ -57,6 +62,8 @@ class AutoAcctgPaymentTests extends OFBizTestCase {
         assert payment
         assert serviceResult.oldStatusId == 'PAYMENT_NOT_AUTH'
     }
+    @Test
+    @Order(3)
     void testQuickSendPayment() {
         Map serviceCtx = [:]
         serviceCtx.paymentId = '1001'
@@ -68,6 +75,8 @@ class AutoAcctgPaymentTests extends OFBizTestCase {
         assert payment
         assert payment.statusId == 'PMNT_SENT'
     }
+    @Test
+    @Order(4)
     void testGetPayments() {
         Map serviceCtx = [
             finAccountTransId: '1001',
@@ -77,6 +86,8 @@ class AutoAcctgPaymentTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.payments != null
     }
+    @Test
+    @Order(5)
     void testCreatePaymentContent() {
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Map serviceCtx = [

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgTransPurchaseTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgTransPurchaseTests.groovy
@@ -20,15 +20,17 @@ package org.apache.ofbiz.accounting.accounting
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgTransPurchaseTests extends OFBizTestCase {
-
-    AutoAcctgTransPurchaseTests(String name) {
-        super(name)
-    }
+@JunitJupiterTest
+class AutoAcctgTransPurchaseTests implements JupiterTestHelper {
 
     // Test case for Accounting Transaction on Purchase
+    @Test
+    @Order(1)
     void testAcctgTransOnPoReceipts() {
         /*
             Precondition : shipment is created from supplier and order items are issued
@@ -87,6 +89,8 @@ class AutoAcctgTransPurchaseTests extends OFBizTestCase {
         assert orderItemBilling
     }
 
+    @Test
+    @Order(2)
     void testAcctgTransOnEditPoInvoice() {
         /*
             Precondition: To the Purchase Invoice created add taxes and two different shipping charges
@@ -136,6 +140,8 @@ class AutoAcctgTransPurchaseTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(3)
     void testAcctgTransOnPaymentSentToSupplier() {
         /*
             Precondition: New payment is created for: supplierId = "DemoSupplier", "Payment Type ID" = "Vendor Payment" and

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgTransSalesTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgTransSalesTests.groovy
@@ -21,15 +21,17 @@ package org.apache.ofbiz.accounting.accounting
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.util.EntityUtil
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoAcctgTransSalesTests extends OFBizTestCase {
-
-    AutoAcctgTransSalesTests(String name) {
-        super(name)
-    }
+@JunitJupiterTest
+class AutoAcctgTransSalesTests implements JupiterTestHelper {
 
     // Test case for Accounting Transaction on Sales
+    @Test
+    @Order(1)
     void testAcctgTransForSalesOrderShipments() {
         /*
             Precondition :
@@ -86,6 +88,8 @@ class AutoAcctgTransSalesTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(2)
     void testAcctgTransOnSalesInvoice() {
         /*
             Precondition:
@@ -169,6 +173,8 @@ class AutoAcctgTransSalesTests extends OFBizTestCase {
         assert accountsReceivableEntries
     }
 
+    @Test
+    @Order(3)
     void testAcctgTransOnPaymentReceivedFromCustomer() {
         /*
             Precondition :-

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoInvoiceTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoInvoiceTests.groovy
@@ -23,14 +23,16 @@ import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoInvoiceTests extends OFBizTestCase {
+@JunitJupiterTest
+class AutoInvoiceTests implements JupiterTestHelper {
 
-    AutoInvoiceTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testInvoiceWorkerGetInvoiceTotal() {
         String invoiceId = 'demo10000'
         BigDecimal amount = 323.54
@@ -106,6 +108,8 @@ class AutoInvoiceTests extends OFBizTestCase {
     }
 
     // Test case for Commission Run
+    @Test
+    @Order(2)
     void testCommissionRun() {
         /*
             Precondition : For Creating Commission invoice following data should be there :
@@ -145,6 +149,8 @@ class AutoInvoiceTests extends OFBizTestCase {
     }
 
     // Test case to verify GL postings for Cancel Invoice process
+    @Test
+    @Order(3)
     void testGlPostingOnCancelInvoice() {
         /*
             Precondition :
@@ -216,6 +222,8 @@ class AutoInvoiceTests extends OFBizTestCase {
     }
 
     // Test case to verify GL postings for Cancel Check Run process
+    @Test
+    @Order(4)
     void testGlPostingOnCancelCheckRun() {
         /*
             Precondition :

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoPaymentTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoPaymentTests.groovy
@@ -25,15 +25,17 @@ import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.util.EntityUtil
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class AutoPaymentTests extends OFBizTestCase {
-
-    AutoPaymentTests(String name) {
-        super(name)
-    }
+@JunitJupiterTest
+class AutoPaymentTests implements JupiterTestHelper {
 
     // Test case for Batching Payments process
+    @Test
+    @Order(1)
     void testCreatePaymentGroupAndMember() {
         String paymentGroupTypeId = 'BATCH_PAYMENT'
         String paymentGroupName = 'Payment Batch'
@@ -67,6 +69,8 @@ class AutoPaymentTests extends OFBizTestCase {
     }
 
     // Test case for voiding payments
+    @Test
+    @Order(2)
     void testVoidPayment() {
         /*
             Precondition : payment is in sent status and invoice is in ready for posting status
@@ -114,6 +118,8 @@ class AutoPaymentTests extends OFBizTestCase {
     }
 
     // Test case for canceling invoices
+    @Test
+    @Order(3)
     void testCancelInvoice() {
         /*
             Precondition : invoice is in ready status
@@ -162,6 +168,8 @@ class AutoPaymentTests extends OFBizTestCase {
     }
 
     // Test case for process mass check run
+    @Test
+    @Order(4)
     void testCreatePaymentAndPaymentGroupForInvoices() {
         /*
             Precondition : Invoice is in ready status.
@@ -196,6 +204,8 @@ class AutoPaymentTests extends OFBizTestCase {
     }
 
     // Test case for cancel check run
+    @Test
+    @Order(5)
     void testCancelCheckRunPayments() {
         /*
             Pre condition : Invoice is in paid status.
@@ -232,6 +242,8 @@ class AutoPaymentTests extends OFBizTestCase {
     }
 
     // Test case for deposit or withdraw payments
+    @Test
+    @Order(6)
     void testDepositWithdrawPayments() {
         //List paymentIds = ['demo10001', 'demo10010']
         List paymentIds = ['demo10010']
@@ -259,6 +271,8 @@ class AutoPaymentTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(7)
     void testDepositWithdrawPaymentsInSingleTrans() {
         List paymentIds = ['8004']
         BigDecimal paymentRunningTotal = new BigDecimal('0')
@@ -289,6 +303,8 @@ class AutoPaymentTests extends OFBizTestCase {
     }
 
     // Test case for fin account trans
+    @Test
+    @Order(8)
     void testSetFinAccountTransStatus() {
         /*
             Precondition : FinAccountTrans should be in CREATED status
@@ -319,6 +335,8 @@ class AutoPaymentTests extends OFBizTestCase {
     }
 
     // Test case to verify GL postings for Void Payment process
+    @Test
+    @Order(9)
     void testGlPostingsOnVoidPayment() {
         /*
             Precondition :
@@ -391,6 +409,8 @@ class AutoPaymentTests extends OFBizTestCase {
     }
 
     // Test case to verify GL postings for Check Run process
+    @Test
+    @Order(10)
     void testGlPostingOnCheckRun() {
         /*
             Precondition :

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/FixedAssetTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/FixedAssetTests.groovy
@@ -21,14 +21,17 @@ package org.apache.ofbiz.accounting.accounting
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class FixedAssetTests extends OFBizTestCase {
+@JunitJupiterTest
+class FixedAssetTests implements JupiterTestHelper {
 
-    FixedAssetTests(String name) {
-        super(name)
-    }
+    @Test
+    @Order(1)
     void testCreateFixedAssetRegistration() {
         Map serviceCtx = [
                 fixedAssetId: 'DEMO_VEHICLE_01',
@@ -46,6 +49,8 @@ class FixedAssetTests extends OFBizTestCase {
                 .filterByDate().queryFirst()
         assert fixedAssetRegistration
     }
+    @Test
+    @Order(2)
     void testUpdateFixedAssetRegistration() {
         Timestamp fromDate = UtilDateTime.toTimestamp('04/01/2020 00:00:00')
         Map serviceCtx = [
@@ -65,6 +70,8 @@ class FixedAssetTests extends OFBizTestCase {
                 .filterByDate().queryOne()
         assert !fixedAssetRegistration
     }
+    @Test
+    @Order(3)
     void testDeleteFixedAssetRegistration() {
         Timestamp fromDate = UtilDateTime.toTimestamp('04/01/2020 00:00:00')
         Map serviceCtx = [
@@ -80,6 +87,8 @@ class FixedAssetTests extends OFBizTestCase {
                 .queryOne()
         assert !fixedAssetRegistration
     }
+    @Test
+    @Order(4)
     void testCreateFixedAssetMeter() {
         Map serviceCtx = [
                 fixedAssetId: 'DEMO_VEHICLE_01',
@@ -96,6 +105,8 @@ class FixedAssetTests extends OFBizTestCase {
                 .queryFirst()
         assert fixedAssetMeter
     }
+    @Test
+    @Order(5)
     void testUpdateFixedAssetMeter() {
         Timestamp readingDate = UtilDateTime.toTimestamp('04/01/2020 00:00:00')
         Map serviceCtx = [
@@ -113,6 +124,8 @@ class FixedAssetTests extends OFBizTestCase {
                 .queryOne()
         assert fixedAssetMeter
     }
+    @Test
+    @Order(6)
     void testDeleteFixedAssetMeter() {
         Timestamp readingDate = UtilDateTime.toTimestamp('04/01/2020 00:00:00')
         Map serviceCtx = [
@@ -129,6 +142,8 @@ class FixedAssetTests extends OFBizTestCase {
                 .queryOne()
         assert !fixedAssetMeter
     }
+    @Test
+    @Order(7)
     void testCreateFixedAssetGeoPoint() {
         Map serviceCtx = [
                 fixedAssetId: 'DEMO_VEHICLE_01',

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/InvoicePerShipmentTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/InvoicePerShipmentTests.groovy
@@ -27,17 +27,19 @@ import org.apache.ofbiz.security.Security
 import org.apache.ofbiz.security.SecurityFactory
 import org.apache.ofbiz.service.ModelService
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.shipment.packing.PackingSession
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class InvoicePerShipmentTests extends OFBizTestCase {
+@JunitJupiterTest
+class InvoicePerShipmentTests implements JupiterTestHelper {
 
-    InvoicePerShipmentTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testInvoicePerShipmentSetFalse() {
         /* Test Invoice Per Shipment
          Step 1) Set create.invoice.per.shipment=N in accounting.properties file.
@@ -49,6 +51,8 @@ class InvoicePerShipmentTests extends OFBizTestCase {
         assert !invoices
     }
 
+    @Test
+    @Order(2)
     void testInvoicePerShipmentSetTrue() {
         /* Test Invoice Per Shipment
          Step 1) Set create.invoice.per.shipment=Y in accounting.properties file.
@@ -60,6 +64,8 @@ class InvoicePerShipmentTests extends OFBizTestCase {
         assert invoices
     }
 
+    @Test
+    @Order(3)
     void testInvoicePerShipmentSetOrderFalse() {
         /* Test Invoice Per Shipment
          Step 1) Create order and set invoicePerShipment=N.
@@ -70,6 +76,8 @@ class InvoicePerShipmentTests extends OFBizTestCase {
         assert !invoices
     }
 
+    @Test
+    @Order(4)
     void testInvoicePerShipmentSetOrderTrue() {
         /* Test Invoice Per Shipment
          Step 1) Create order and set invoicePerShipment=Y

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/PaymentApplicationTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/PaymentApplicationTests.groovy
@@ -20,17 +20,19 @@ package org.apache.ofbiz.accounting.accounting
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.accounting.invoice.InvoiceWorker
 import org.apache.ofbiz.accounting.payment.PaymentWorker
 import org.apache.ofbiz.order.order.OrderReadHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class PaymentApplicationTests extends OFBizTestCase {
+@JunitJupiterTest
+class PaymentApplicationTests implements JupiterTestHelper {
 
-    PaymentApplicationTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testInvoiceAppl() {
         Map serviceInMap = [:]
         //from the test data
@@ -60,6 +62,8 @@ class PaymentApplicationTests extends OFBizTestCase {
         delegator.removeAll('PaymentApplication')
     }
 
+    @Test
+    @Order(2)
     void testToPayment() {
         Map serviceInMap = [:]
         serviceInMap.paymentId = 'appltest10000'
@@ -90,6 +94,8 @@ class PaymentApplicationTests extends OFBizTestCase {
         delegator.removeAll('PaymentApplication')
     }
 
+    @Test
+    @Order(3)
     void testBillingAppl() {
         Map serviceInMap = [:]
         //from the test data
@@ -123,7 +129,9 @@ class PaymentApplicationTests extends OFBizTestCase {
         delegator.removeAll('PaymentApplication')
     }
 
-    void testTaxGeoId () {
+    @Test
+    @Order(4)
+    void testTaxGeoId() {
         Map serviceInMap = [:]
         //from the test data
         serviceInMap.paymentId = 'appltest10000'

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/RateTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/RateTests.groovy
@@ -18,19 +18,21 @@
  */
 package org.apache.ofbiz.accounting.accounting
 
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.service.ServiceUtil
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.base.util.UtilDateTime
 
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class RateTests extends OFBizTestCase {
+@JunitJupiterTest
+class RateTests implements JupiterTestHelper {
 
-    RateTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testExpirePartyRate() {
         Timestamp fromDate = UtilDateTime.toTimestamp('07/04/2013 00:00:00')
         Map serviceCtx = [
@@ -48,6 +50,8 @@ class RateTests extends OFBizTestCase {
         assert partyRate.thruDate
     }
 
+    @Test
+    @Order(2)
     void testUpdateRateAmount() {
         Timestamp fromDate = UtilDateTime.toTimestamp('04/07/2013 00:00:00')
         Map serviceCtx = [
@@ -69,6 +73,8 @@ class RateTests extends OFBizTestCase {
         assert rateAmount.rateAmount == 25
     }
 
+    @Test
+    @Order(3)
     void testGetRateAmount() {
         Map serviceCtx = [
                 rateTypeId: 'AVERAGE_PAY_RATE',
@@ -80,6 +86,8 @@ class RateTests extends OFBizTestCase {
         assert serviceResult.rateAmount == 75
     }
 
+    @Test
+    @Order(4)
     void testGetRatesAmountsFromWorkEffortId() {
         Map serviceCtx = [
                 periodTypeId: 'RATE_HOUR',
@@ -93,6 +101,8 @@ class RateTests extends OFBizTestCase {
         assert serviceResult.ratesList
     }
 
+    @Test
+    @Order(5)
     void testGetRatesAmountsFromPartyId() {
         Map serviceCtx = [
                 periodTypeId: 'RATE_HOUR',
@@ -106,6 +116,8 @@ class RateTests extends OFBizTestCase {
         assert serviceResult.ratesList != null
     }
 
+    @Test
+    @Order(6)
     void testGetRatesAmountsFromEmplPositionTypeId() {
         Map serviceCtx = [
                 periodTypeId: 'RATE_HOUR',
@@ -119,6 +131,8 @@ class RateTests extends OFBizTestCase {
         assert serviceResult.ratesList
     }
 
+    @Test
+    @Order(7)
     void testUpdatePartyRate() {
         Timestamp fromDate = UtilDateTime.toTimestamp('04/07/2013 00:00:00')
         Map serviceCtx = [
@@ -143,6 +157,8 @@ class RateTests extends OFBizTestCase {
         assert rateAmount.rateAmount == 75
     }
 
+    @Test
+    @Order(8)
     void testFilterRateAmountList() {
         List<GenericValue> amountList = from('RateAmount').where('rateTypeId', 'AVERAGE_PAY_RATE', 'rateCurrencyUomId', 'USD').queryList()
         Map serviceCtx = [
@@ -155,6 +171,8 @@ class RateTests extends OFBizTestCase {
         assert serviceResult.filteredRatesList
     }
 
+    @Test
+    @Order(9)
     void testExpireRateAmount() {
         Timestamp fromDate = UtilDateTime.toTimestamp('07/04/2013 00:00:00')
         Map serviceCtx = [

--- a/applications/accounting/testdef/accountingtests.xml
+++ b/applications/accounting/testdef/accountingtests.xml
@@ -27,43 +27,43 @@
     </test-case>
 
     <test-case case-name="accounting-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.order.test.FinAccountTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.test.FinAccountTest"/>
     </test-case>
 
     <test-case case-name="auto-accounting-transaction-tests-sales">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgTransSalesTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgTransSalesTests"/>
     </test-case>
     <test-case case-name="auto-accounting-transaction-tests-purchase">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgTransPurchaseTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgTransPurchaseTests"/>
     </test-case>
     <test-case case-name="auto-accounting-admin-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgAdminTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgAdminTests"/>
     </test-case>
     <test-case case-name="auto-accounting-agreement-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgAgreementTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgAgreementTests"/>
     </test-case>
     <test-case case-name="auto-accounting-budget-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgBudgetTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgBudgetTests"/>
     </test-case>
     <test-case case-name="auto-accounting-cost-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgCostTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgCostTests"/>
     </test-case>
     <test-case case-name="auto-accounting-finaccount-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgFinAccountTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgFinAccountTests"/>
     </test-case>
     <test-case case-name="auto-accounting-fixedasset-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgFixedAssetTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgFixedAssetTests"/>
     </test-case>
     <test-case case-name="auto-accounting-invoice-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgInvoiceTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgInvoiceTests"/>
     </test-case>
     <test-case case-name="auto-accounting-payment-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgPaymentTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgPaymentTests"/>
     </test-case>
     <test-case case-name="auto-accounting-paymentgateway-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgPaymentGatewayTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgPaymentGatewayTests"/>
     </test-case>
     <test-case case-name="auto-accounting-ledger-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgLedgerTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgLedgerTests"/>
     </test-case>
 </test-suite>

--- a/applications/accounting/testdef/fixedassettests.xml
+++ b/applications/accounting/testdef/fixedassettests.xml
@@ -27,7 +27,7 @@
     </test-case>
 
     <test-case case-name="fixedasset-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.FixedAssetTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.FixedAssetTests"/>
     </test-case>
 
 </test-suite>

--- a/applications/accounting/testdef/invoicetests.xml
+++ b/applications/accounting/testdef/invoicetests.xml
@@ -23,9 +23,9 @@
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-group case-name="auto-invoice-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoInvoiceTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoInvoiceTests"/>
     </test-group>
     <test-case case-name="invoice-per-shipment-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.InvoicePerShipmentTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.InvoicePerShipmentTests"/>
     </test-case>
 </test-suite>

--- a/applications/accounting/testdef/paymentappltests.xml
+++ b/applications/accounting/testdef/paymentappltests.xml
@@ -26,7 +26,7 @@
         <entity-xml action="load" entity-xml-url="component://accounting/testdef/data/PaymentApplicationTestsData.xml"/>
     </test-case>
     <test-case case-name="application-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.PaymentApplicationTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.PaymentApplicationTests"/>
     </test-case>
 
 </test-suite>

--- a/applications/accounting/testdef/paymenttests.xml
+++ b/applications/accounting/testdef/paymenttests.xml
@@ -23,7 +23,7 @@
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-case case-name="auto-payment-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoPaymentTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoPaymentTests"/>
     </test-case>
     
 

--- a/applications/accounting/testdef/ratetests.xml
+++ b/applications/accounting/testdef/ratetests.xml
@@ -26,6 +26,6 @@
     </test-case>
     
     <test-case case-name="rate-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.accounting.accounting.RateTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.RateTests"/>
     </test-case>
 </test-suite>

--- a/applications/content/src/test/groovy/org/apache/ofbiz/content/content/ContentTests.groovy
+++ b/applications/content/src/test/groovy/org/apache/ofbiz/content/content/ContentTests.groovy
@@ -21,14 +21,16 @@ package org.apache.ofbiz.content.content
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ContentTests extends OFBizTestCase {
+@JunitJupiterTest
+class ContentTests implements JupiterTestHelper {
 
-    ContentTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testGetDataResource() {
         Map serviceCtx = [:]
         serviceCtx.dataResourceId = 'TEST_RESOURCE'
@@ -39,6 +41,8 @@ class ContentTests extends OFBizTestCase {
         assert serviceResult.resultData.dataResource.dataResourceTypeId == 'TEST_RESOURCE_TYPE'
     }
 
+    @Test
+    @Order(2)
     void testCreateDataCategory() {
         Map serviceCtx = [:]
         serviceCtx.dataCategoryId = 'TEST_DATA_CATEGORY_1'
@@ -54,6 +58,8 @@ class ContentTests extends OFBizTestCase {
         assert dataCategory.categoryName == 'Test Data Category 1'
     }
 
+    @Test
+    @Order(3)
     void testUpdateDataCategory() {
         Map serviceCtx = [:]
         serviceCtx.dataCategoryId = 'TEST_DATA_CATEGORY_2'
@@ -80,6 +86,8 @@ class ContentTests extends OFBizTestCase {
         assert dataCategory
     }
 
+    @Test
+    @Order(4)
     void testDeleteDataCategory() {
         Map serviceCtx = [:]
         serviceCtx.dataCategoryId = 'TEST_DATA_CATEGORY_3'
@@ -100,6 +108,8 @@ class ContentTests extends OFBizTestCase {
         assert !dataCategory
     }
 
+    @Test
+    @Order(5)
     void testCreateDataResourceRole() {
         Map serviceCtx = [:]
         serviceCtx.dataResourceId = 'TEST_DATA_RESOURCE_1'
@@ -120,6 +130,8 @@ class ContentTests extends OFBizTestCase {
         assert dataResourceRole
     }
 
+    @Test
+    @Order(6)
     void testUpdateDataResourceRole() {
         Map serviceCtx = [:]
         serviceCtx.dataResourceId = 'TEST_DATA_RESOURCE_2'
@@ -150,6 +162,8 @@ class ContentTests extends OFBizTestCase {
         assert dataResourceRole.thruDate
     }
 
+    @Test
+    @Order(7)
     void testRemoveDataResourceRole() {
         Map serviceCtx = [:]
         serviceCtx.dataResourceId = 'TEST_DATA_RESOURCE_3'
@@ -177,6 +191,8 @@ class ContentTests extends OFBizTestCase {
         assert !dataResourceRole
     }
 
+    @Test
+    @Order(8)
     void testGetContent() {
         Map serviceCtx = [:]
         serviceCtx.contentId = 'TEST_CONTENT4'

--- a/applications/content/testdef/ContentTests.xml
+++ b/applications/content/testdef/ContentTests.xml
@@ -26,7 +26,7 @@
     </test-case>
 
     <test-case case-name="content-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.content.content.ContentTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.content.content.ContentTests"/>
     </test-case>
 </test-suite>
 

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/InventoryIssuanceTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/InventoryIssuanceTests.groovy
@@ -22,20 +22,20 @@ import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.condition.EntityCondition
 import org.apache.ofbiz.entity.condition.EntityOperator
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import java.math.RoundingMode
 import org.apache.ofbiz.base.util.Debug
 import org.apache.ofbiz.base.util.UtilDateTime
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
+@JunitJupiterTest
 class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
-    public InventoryIssuanceTests(String name) {
-        super(name)
-    }
-
-    @Override
+    @BeforeEach
     void setUp() {
-        super.setUp()
         userLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
 
         // Target Purge: Clean up only the items and reservations we own.
@@ -55,6 +55,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
     // --- Category 1 & 2: Basic & Force Issuance ---
 
+    @Test
+    @Order(1)
     void testS1_1_StrictIssuanceFailure() {
         String facId = 'WH_S1_1'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -70,6 +72,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert ServiceUtil.isError(result)
     }
 
+    @Test
+    @Order(2)
     void testS1_2_ForceWithReallocation() {
         String facId = 'WH_S1_2'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -103,6 +107,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
     // --- Category 4: Real-time Reconciliation (SECA) ---
 
+    @Test
+    @Order(3)
     void testS4_1_RealTimeReconciliationOnReceipt() {
         String facId = 'WH_RECON_Y'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -139,6 +145,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert res.inventoryItemId == newItemId : 'Reservation should be tied to the newly received item'
     }
 
+    @Test
+    @Order(4)
     void testS4_2_ProductionChainAutoSatisfaction() {
         String facId = 'WH_CHAIN_RECON'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -192,6 +200,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
     // --- Category 3: Backorders & Residuals ---
 
+    @Test
+    @Order(5)
     void testS3_2_NegativeReservationResolution() {
         String facId = 'WH_S3_2'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -218,6 +228,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_C_COST', weId, 20.0, 0.0, 30.0, facId)
     }
 
+    @Test
+    @Order(6)
     void testS3_4_ImpactPlanAudit() {
         String facId = 'WH_S3_4'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -248,6 +260,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert v1Impact.type == 'REALLOCATED' : 'Affected reservation 1 impact type should be REALLOCATED'
     }
 
+    @Test
+    @Order(7)
     void testS3_5_AffectedReservationSanityGuard() {
         String facId = 'WH_S3_5'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -284,6 +298,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert scaleQuantity(totalCommited) == scaleQuantity(20.0) : 'Total commitment should match Requirement (20)'
     }
 
+    @Test
+    @Order(8)
     void testS3_6_ExplicitReallocationWorkflow() {
         String facId = 'WH_S3_6'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -320,6 +336,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert scaleQuantity(invItem.getBigDecimal('accountingQuantityTotal')) == scaleQuantity(50.0) : 'Accounting Total should be 50'
     }
 
+    @Test
+    @Order(9)
     void testS4_1_ReleaseWithRestore() {
         String facId = 'WH_S4_1'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -342,6 +360,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert res == null
     }
 
+    @Test
+    @Order(10)
     void testS4_2_ReleaseSatisfaction() {
         String weId = setUpProductionRun('II_PROD_MANUF', 10.0)
 
@@ -366,6 +386,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
     // --- Category 5: Hardened Policy & Reconciliation ---
 
+    @Test
+    @Order(11)
     void testS5_1_PolicyGateFail() {
         String itemId = 'II_INV_TRAD_S5_1'
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', itemId, 100.0)
@@ -385,6 +407,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
                 'Error message should contain reallocation policy violation'
     }
 
+    @Test
+    @Order(12)
     void testS5_2_APIPolicyEnforcement() {
         String itemId = 'II_INV_TRAD_S5_2'
         String issuingWeId = setUpProductionRun('II_PROD_MANUF', 10.0, 'WH_TRADITIONAL')
@@ -404,6 +428,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert reallocResult.errorMessage.contains('Policy Violation')
     }
 
+    @Test
+    @Order(13)
     void testS5_3_NightlyReconciliation() {
         String itemIdA = 'II_INV_FLUID_A_S5_3'
         String itemIdC = 'II_INV_FLUID_C_S5_3'
@@ -440,6 +466,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert (boRes.getBigDecimal('quantityNotAvailable') ?: BigDecimal.ZERO) == BigDecimal.ZERO
     }
 
+    @Test
+    @Order(14)
     void testS5_4_ReconFluidPolicy() {
         String itemId = 'II_INV_FLUID_A_S5_4'
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', itemId, 5.0)
@@ -480,6 +508,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
                 'Satisfier should have settled the debt in Fluid Warehouse'
     }
 
+    @Test
+    @Order(15)
     void testS5_5_ReconTraditionalPolicy() {
         String itemId = 'II_INV_TRAD_A_S5_5'
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', itemId, 20.0)
@@ -521,6 +551,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert scaleQuantity(boQna) == scaleQuantity(2.0) : 'Satisfier should NOT have settled in Traditional Warehouse'
     }
 
+    @Test
+    @Order(16)
     void testS5_6_ReconSafePolicy() {
         setUpInventory('WH_SAFE', 'II_MAT_A_COST', 'INV_SAFE_A', 20.0)
         setUpInventory('WH_SAFE', 'II_MAT_C_COST', 'INV_SAFE_C_HEAL', 0.0)
@@ -554,6 +586,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert scaleQuantity(boQna) == scaleQuantity(0.0) : 'Safe Mode (Conservative Satisfier) should have healed backorder'
     }
 
+    @Test
+    @Order(17)
     void testM1_ManualLotReallocationSuccess() {
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', 'II_MAN_FLUID', 10.0)
         GenericValue item = from('InventoryItem').where('inventoryItemId', 'II_MAN_FLUID').queryOne()
@@ -578,6 +612,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
                 'Affected reservation should be backordered by 5'
     }
 
+    @Test
+    @Order(18)
     void testM2_ManualForceNegative() {
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', 'II_MAN_FLUID', 0.0)
 
@@ -592,6 +628,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert scaleQuantity(item.getBigDecimal('quantityOnHandTotal')) == scaleQuantity(-10.0) : 'QOH should be -10'
     }
 
+    @Test
+    @Order(19)
     void testM3_UserStrictnessOverridesFacilityFluidity() {
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', 'II_MAN_FLUID', 10.0)
         GenericValue item = from('InventoryItem').where('inventoryItemId', 'II_MAN_FLUID').queryOne()
@@ -615,6 +653,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
                 "Error should contain 'Materials Not Available' or 'promised to other tasks'. Got: ${error}"
     }
 
+    @Test
+    @Order(20)
     void testM4_FacilityStrictnessOverridesUserFluidity() {
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', 'II_MAN_STRICT', 10.0)
         GenericValue item = from('InventoryItem').where('inventoryItemId', 'II_MAN_STRICT').queryOne()
@@ -638,6 +678,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
                 "Error should contain 'Materials Not Available' or 'forbids inventory reallocation'. Got: ${error}"
     }
 
+    @Test
+    @Order(21)
     void testM6_SelfConsumptionSuccessInStrictMode() {
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', 'II_MAN_STRICT', 10.0)
 
@@ -655,6 +697,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_A_COST', 'WE_ISSUING_STRICT', 5.0, 5.0, 0.0, 'WH_TRADITIONAL')
     }
 
+    @Test
+    @Order(22)
     void testS5_7_NullPolicyDefaultsToStrict() {
         String facId = 'WH_NULL_POLICY'
         storeFacility([
@@ -673,6 +717,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert impactResult.policyViolation.contains('forbidden') : 'Message should explain that reallocation is forbidden'
     }
 
+    @Test
+    @Order(23)
     void testFacilityPolicyPersistence() {
         String facId = 'WH_POLICY_TEST'
         storeFacility([
@@ -698,15 +744,11 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
 }
 
+@JunitJupiterTest
 class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
 
-    InventoryIssuancePolicyMatrixTests(String name) {
-        super(name)
-    }
-
-    @Override
+    @BeforeEach
     void setUp() {
-        super.setUp()
         userLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
 
         delegator.removeByCondition('WorkEffortInvRes', EntityCondition.makeCondition('productId', EntityOperator.LIKE, 'II_%'))
@@ -724,6 +766,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
                 'InventoryIssuancePolicyMatrixTests')
     }
 
+    @Test
+    @Order(1)
     void testS6_1_ManualReserve_IssueDefault_Success() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_1', 100.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
@@ -736,6 +780,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
     }
 
+    @Test
+    @Order(2)
     void testS6_2_ManualReserve_IssueFailIfAvail_Y_Success() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_2', 100.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
@@ -750,6 +796,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
     }
 
+    @Test
+    @Order(3)
     void testS6_3_ManualReserve_IssueFailIfAvail_N_Success() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_3', 100.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
@@ -764,6 +812,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
     }
 
+    @Test
+    @Order(4)
     void testS6_4_NoReserve_DirectIssueDefault_Success() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_4', 100.0)
 
@@ -772,6 +822,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
     }
 
+    @Test
+    @Order(5)
     void testS6_5_NoReserve_DirectIssueFailIfAvail_Y_Success() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_5', 100.0)
 
@@ -782,6 +834,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
     }
 
+    @Test
+    @Order(6)
     void testS6_6_NoReserve_DirectIssueFailIfAvail_N_Success() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_6', 100.0)
 
@@ -792,6 +846,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
     }
 
+    @Test
+    @Order(7)
     void testS6_7_Insufficient_ManualReserve_IssueDefault_Fail() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_7', 0.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
@@ -803,6 +859,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assert ServiceUtil.isError(result)
     }
 
+    @Test
+    @Order(8)
     void testS6_8_Insufficient_ManualReserve_IssueFailIfAvail_Y_Fail() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_8', 0.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
@@ -816,6 +874,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assert ServiceUtil.isError(result)
     }
 
+    @Test
+    @Order(9)
     void testS6_9_Insufficient_ManualReserve_IssueFailIfAvail_N_Success() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_9', 0.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
@@ -830,12 +890,16 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, -20.0, 'WH_NO_AUTO_RES')
     }
 
+    @Test
+    @Order(10)
     void testS6_10_Insufficient_NoReserve_DirectIssueDefault_Fail() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_10', 0.0)
         Map result = dispatcher.runSync('issueProductionRunTask', [workEffortId: weId, userLogin: userLogin], 0, true)
         assert ServiceUtil.isError(result)
     }
 
+    @Test
+    @Order(11)
     void testS6_11_Insufficient_NoReserve_DirectIssueFailIfAvail_Y_Fail() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_11', 0.0)
         Map result = dispatcher.runSync('issueProductionRunTask', [
@@ -844,6 +908,8 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
         assert ServiceUtil.isError(result)
     }
 
+    @Test
+    @Order(12)
     void testS6_12_Insufficient_NoReserve_DirectIssueFailIfAvail_N_Success() {
         String weId = setUpNoAutoReserveProductionRun('II_S6_12', 0.0)
         Map result = dispatcher.runSync('issueProductionRunTask', [
@@ -855,13 +921,9 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
 
 }
 
-class InventoryIssuanceTestSupport extends OFBizTestCase {
+class InventoryIssuanceTestSupport implements JupiterTestHelper {
 
     protected GenericValue userLogin
-
-    protected InventoryIssuanceTestSupport(String name) {
-        super(name)
-    }
 
     protected void storeFacility(Map fields) {
         GenericValue gv = delegator.makeValue('Facility', fields)

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/MrpServicesTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/MrpServicesTests.groovy
@@ -20,16 +20,18 @@ package org.apache.ofbiz.manufacturing.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.manufacturing.mrp.MrpServices
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class MrpServicesTests extends OFBizTestCase {
+@JunitJupiterTest
+class MrpServicesTests implements JupiterTestHelper {
 
-    MrpServicesTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testRequiredMrpProposedOrderIsNotLateForSlightlyEarlierTimestamp() {
         Timestamp runStartedAt = Timestamp.valueOf('2026-07-22 11:30:00.100')
         Timestamp requirementStartDate = Timestamp.valueOf('2026-07-22 11:30:00.095')
@@ -37,6 +39,8 @@ class MrpServicesTests extends OFBizTestCase {
         assert !MrpServices.isProposedOrderLate(requirementStartDate, runStartedAt, mrpEvent(mrpEventTypeId: 'REQUIRED_MRP'))
     }
 
+    @Test
+    @Order(2)
     void testNonRequiredMrpProposedOrderRemainsLateWhenStartDatePrecedesRun() {
         Timestamp runStartedAt = Timestamp.valueOf('2026-07-22 11:30:00.100')
         Timestamp requirementStartDate = Timestamp.valueOf('2026-07-22 11:29:59.000')

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/ProductionRunTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/ProductionRunTests.groovy
@@ -20,16 +20,18 @@ package org.apache.ofbiz.manufacturing.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.base.util.UtilDateTime
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ProductionRunTests extends OFBizTestCase {
+@JunitJupiterTest
+class ProductionRunTests implements JupiterTestHelper {
 
-    ProductionRunTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(7)
     void testProductionRunCreation() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
         String productId = 'PROD_MANUF'
@@ -92,6 +94,8 @@ class ProductionRunTests extends OFBizTestCase {
         assert productionRunMaterialB.estimatedQuantity == quantity * 3
     }
 
+    @Test
+    @Order(5)
     void testProductionRunScheduleConfirm() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
         String productId = 'PROD_MANUF'
@@ -136,6 +140,8 @@ class ProductionRunTests extends OFBizTestCase {
         assert productionRunTask.currentStatusId == 'PRUN_DOC_PRINTED'
     }
 
+    @Test
+    @Order(1)
     void testProductionRunDateChange() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
         String productId = 'PROD_MANUF'
@@ -177,6 +183,8 @@ class ProductionRunTests extends OFBizTestCase {
                 || productionRunTask.estimatedStartDate.getTime() == productionRunNewStartDate.getTime()
     }
 
+    @Test
+    @Order(2)
     void testProductionRunCancelled() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
         String productId = 'PROD_MANUF'
@@ -227,6 +235,8 @@ class ProductionRunTests extends OFBizTestCase {
         assert productionRunMaterialB.statusId == 'WEGS_CANCELLED'
     }
 
+    @Test
+    @Order(8)
     void testProductionRunQuickIssueAndProduce() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
         String productId = 'PROD_MANUF'
@@ -352,6 +362,8 @@ class ProductionRunTests extends OFBizTestCase {
         assert acctgTrans
     }
 
+    @Test
+    @Order(9)
     void testQuickRunProductionRun() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
         String productId = 'PROD_MANUF'
@@ -390,6 +402,8 @@ class ProductionRunTests extends OFBizTestCase {
         assert costResult.totalCost
     }
 
+    @Test
+    @Order(6)
     void testQuickCloseProductionRun() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
         String productId = 'PROD_MANUF'
@@ -425,6 +439,12 @@ class ProductionRunTests extends OFBizTestCase {
         assert productionRunTask.currentStatusId == 'PRUN_CLOSED'
     }
 
+    @Test
+    // Must run before testProductionRunQuickIssueAndProduce/testQuickRunProductionRun/
+    // testQuickCloseProductionRun: those tests produce PROD_MANUF inventory as a side effect,
+    // which pre-satisfies this test's order reservation and breaks its
+    // "reservation moves to the newly produced item" assertion below.
+    @Order(4)
     void testCreateProductionRunForOrder() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'admin').queryOne()
         String productId = 'PROD_MANUF'
@@ -494,6 +514,8 @@ class ProductionRunTests extends OFBizTestCase {
         assert producedMaterial.inventoryItemId == newOrderItemShipGrpInvRes.inventoryItemId
     }
 
+    @Test
+    @Order(3)
     void testCreateProductionRunForRequirement() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestSupplyAdmin').queryOne()
         String productId = 'PROD_MANUF'

--- a/applications/manufacturing/testdef/InventoryIssuanceTests.xml
+++ b/applications/manufacturing/testdef/InventoryIssuanceTests.xml
@@ -25,10 +25,10 @@
     </test-case>
 
     <test-case case-name="inventory-issuance-groovy-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.manufacturing.test.InventoryIssuanceTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.manufacturing.test.InventoryIssuanceTests"/>
     </test-case>
 
     <test-case case-name="inventory-issuance-policy-matrix-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.manufacturing.test.InventoryIssuancePolicyMatrixTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.manufacturing.test.InventoryIssuancePolicyMatrixTests"/>
     </test-case>
 </test-suite>

--- a/applications/manufacturing/testdef/MrpTests.xml
+++ b/applications/manufacturing/testdef/MrpTests.xml
@@ -21,6 +21,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
     <test-case case-name="mrp-services-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.manufacturing.test.MrpServicesTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.manufacturing.test.MrpServicesTests"/>
     </test-case>
 </test-suite>

--- a/applications/manufacturing/testdef/productionruntests.xml
+++ b/applications/manufacturing/testdef/productionruntests.xml
@@ -26,6 +26,6 @@
     </test-case>
 
     <test-case case-name="production-run-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.manufacturing.test.ProductionRunTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.manufacturing.test.ProductionRunTests"/>
     </test-case>
 </test-suite>

--- a/applications/marketing/src/test/groovy/org/apache/ofbiz/marketing/marketing/test/MarketingTests.groovy
+++ b/applications/marketing/src/test/groovy/org/apache/ofbiz/marketing/marketing/test/MarketingTests.groovy
@@ -20,14 +20,14 @@ package org.apache.ofbiz.marketing.marketing.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
-class MarketingTests extends OFBizTestCase {
+@JunitJupiterTest
+class MarketingTests implements JupiterTestHelper {
 
-    MarketingTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testCreateAndUpdateContactList() {
         /* Precondition:
         Create contact list

--- a/applications/marketing/testdef/MarketingTests.xml
+++ b/applications/marketing/testdef/MarketingTests.xml
@@ -22,6 +22,6 @@
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-case case-name="marketing-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.marketing.marketing.test.MarketingTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.marketing.marketing.test.MarketingTests"/>
     </test-case>
 </test-suite>

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/CustRequestPermissionCheckTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/CustRequestPermissionCheckTests.groovy
@@ -19,14 +19,14 @@
 package org.apache.ofbiz.order.order.test
 
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
-class CustRequestPermissionCheckTests extends OFBizTestCase {
+@JunitJupiterTest
+class CustRequestPermissionCheckTests implements JupiterTestHelper {
 
-    CustRequestPermissionCheckTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testCustRequestPermission() {
         Map serviceCtx = [:]
         serviceCtx.fromPartyId = 'Company'

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/CustRequestTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/CustRequestTests.groovy
@@ -19,15 +19,17 @@
 package org.apache.ofbiz.order.order.test
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.service.ServiceUtil
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class CustRequestTests extends OFBizTestCase {
+@JunitJupiterTest
+class CustRequestTests implements JupiterTestHelper {
 
-    CustRequestTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateNewRequest() {
         Map serviceCtx = [
                 userLogin: userLogin,
@@ -40,6 +42,8 @@ class CustRequestTests extends OFBizTestCase {
         assert custRequest
     }
 
+    @Test
+    @Order(2)
     void testUpdateCustRequest() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -54,6 +58,8 @@ class CustRequestTests extends OFBizTestCase {
         assert custRequest.custRequestName == 'Updated Test Request'
     }
 
+    @Test
+    @Order(3)
     void testCreateCustRequestItem() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -65,6 +71,8 @@ class CustRequestTests extends OFBizTestCase {
         assert serviceResult.custRequestId
     }
 
+    @Test
+    @Order(4)
     void testCreateCustRequestItemNote() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -78,6 +86,8 @@ class CustRequestTests extends OFBizTestCase {
         assert serviceResult.noteId
     }
 
+    @Test
+    @Order(5)
     void testCreateCustRequestNote() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -91,6 +101,8 @@ class CustRequestTests extends OFBizTestCase {
         assert serviceResult.fromPartyId == 'DemoCustomer'
     }
 
+    @Test
+    @Order(6)
     void testCreateCustRequestParty() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -107,6 +119,8 @@ class CustRequestTests extends OFBizTestCase {
         assert custRequestParty
     }
 
+    @Test
+    @Order(7)
     void testCreateCustRequestStatus() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -120,6 +134,8 @@ class CustRequestTests extends OFBizTestCase {
         assert serviceResult.custRequestStatusId
     }
 
+    @Test
+    @Order(8)
     void testSetCustRequestStatus() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -132,6 +148,8 @@ class CustRequestTests extends OFBizTestCase {
         assert serviceResult.oldStatusId
     }
 
+    @Test
+    @Order(9)
     void testGetCustRequestsByRole() {
         Map serviceCtx = [
                 roleTypeId: 'OWNER',
@@ -143,6 +161,8 @@ class CustRequestTests extends OFBizTestCase {
         assert serviceResult.custRequestAndRoles instanceof List
     }
 
+    @Test
+    @Order(10)
     void testCreateCustRequestContent() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -158,6 +178,8 @@ class CustRequestTests extends OFBizTestCase {
         assert custRequestContent
     }
 
+    @Test
+    @Order(11)
     void testCreateCustRequestAttribute() {
         Map serviceCtx = [
                 attrName: 'Test Name',
@@ -175,6 +197,8 @@ class CustRequestTests extends OFBizTestCase {
         assert custRequestAttribute.attrValue == 'Test Value'
     }
 
+    @Test
+    @Order(12)
     void testCopyCustRequestItem() {
         Map serviceCtx = [
                 custRequestId: '9000',

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderRequirementTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderRequirementTests.groovy
@@ -19,14 +19,17 @@
 package org.apache.ofbiz.order.order.test
 
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class OrderRequirementTests extends OFBizTestCase {
+@JunitJupiterTest
+class OrderRequirementTests implements JupiterTestHelper {
 
-    OrderRequirementTests(String name) {
-        super(name)
-    }
     // Requirement related test services
+    @Test
+    @Order(1)
     void testCheckCreateProductRequirementForFacility() {
         Map serviceCtx = [
             facilityId: 'WebStoreWarehouse',
@@ -36,6 +39,8 @@ class OrderRequirementTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('checkCreateProductRequirementForFacility', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(2)
     void testCheckCreateStockRequirementQoh() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10090',
@@ -48,6 +53,8 @@ class OrderRequirementTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('checkCreateStockRequirementQoh', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(3)
     void testCheckCreateStockRequirementAtp() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10091',
@@ -60,6 +67,8 @@ class OrderRequirementTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('checkCreateStockRequirementAtp', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(4)
     void testCheckCreateOrderRequirement() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10090',
@@ -69,6 +78,8 @@ class OrderRequirementTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('checkCreateOrderRequirement', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(5)
     void testAutoAssignRequirementToSupplier() {
         Map serviceCtx = [
             requirementId: '1000',
@@ -77,6 +88,8 @@ class OrderRequirementTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('autoAssignRequirementToSupplier', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(6)
     void testCreateRequirementCustRequest() {
         Map serviceCtx = [
             requirementId: '1000',
@@ -87,6 +100,8 @@ class OrderRequirementTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createRequirementCustRequest', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(7)
     void testAddRequirementTask() {
         Map serviceCtx = [
             requirementId: '1000',

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderReturnTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderReturnTests.groovy
@@ -19,14 +19,16 @@
 package org.apache.ofbiz.order.order.test
 
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class OrderReturnTests extends OFBizTestCase {
+@JunitJupiterTest
+class OrderReturnTests implements JupiterTestHelper {
 
-    OrderReturnTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testQuickReturnOrder() {
         Map serviceCtx = [
             orderId: 'TEST_DEMO10090',
@@ -37,6 +39,8 @@ class OrderReturnTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.returnId != null
     }
+    @Test
+    @Order(2)
     void testProcessCreditReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -45,6 +49,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processCreditReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(3)
     void testProcessCrossShipReplacementReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -53,6 +59,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processCrossShipReplacementReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(4)
     void testProcessRefundImmediatelyReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -61,6 +69,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processRefundImmediatelyReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(5)
     void testGetReturnItemInitialCost() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -71,6 +81,8 @@ class OrderReturnTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.initialItemCost != null
     }
+    @Test
+    @Order(6)
     void testProcessRefundReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -80,6 +92,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processRefundReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(7)
     void testProcessReplacementReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -89,6 +103,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processReplacementReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(8)
     void testProcessReplaceImmediatelyReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -98,6 +114,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processReplaceImmediatelyReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(9)
     void testProcessRefundOnlyReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -106,6 +124,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processRefundOnlyReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(10)
     void testProcessWaitReplacementReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -114,6 +134,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processWaitReplacementReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(11)
     void testProcessWaitReplacementReservedReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -123,6 +145,8 @@ class OrderReturnTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult != null
     }
+    @Test
+    @Order(12)
     void testProcessSubscriptionReturn() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -131,6 +155,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processSubscriptionReturn', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(13)
     void testCreateReturnAndItemOrAdjustment() {
         Map serviceCtx = [
                 orderId: 'DEMO10090',
@@ -141,6 +167,8 @@ class OrderReturnTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.returnAdjustmentId != null
     }
+    @Test
+    @Order(14)
     void testCreateReturnAdjustment() {
         Map serviceCtx = [
                 amount: '2.0000',
@@ -151,6 +179,8 @@ class OrderReturnTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.returnAdjustmentId != null
     }
+    @Test
+    @Order(15)
     void testCheckReturnComplete() {
         Map serviceCtx = [
                 amount: '2.0000',
@@ -161,6 +191,8 @@ class OrderReturnTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.statusId != null
     }
+    @Test
+    @Order(16)
     void testCheckPaymentAmountForRefund() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -169,6 +201,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('checkPaymentAmountForRefund', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(17)
     void testCreateReturnItemShipment() {
         Map serviceCtx = [
                 shipmentId: '1014',
@@ -181,6 +215,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createReturnItemShipment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(18)
     void testCreateReturnStatus() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -189,6 +225,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('createReturnStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(19)
     void testGetReturnAmountByOrder() {
         Map serviceCtx = [
                 returnId: '1009',
@@ -197,6 +235,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('getReturnAmountByOrder', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(20)
     void testCreateReturnHeader() {
         Map serviceCtx = [
                 toPartyId: 'Company',
@@ -207,6 +247,8 @@ class OrderReturnTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.returnId != null
     }
+    @Test
+    @Order(21)
     void testProcessRefundReturnForReplacement() {
         Map serviceCtx = [
                 orderId: 'TEST_DEMO10090',
@@ -215,6 +257,8 @@ class OrderReturnTests extends OFBizTestCase {
         Map serviceResult = dispatcher.runSync('processRefundReturnForReplacement', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
     }
+    @Test
+    @Order(22)
     void testProcessRepairReplacementReturn() {
         Map serviceCtx = [
                 returnId: '1009',

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderTests.groovy
@@ -19,14 +19,16 @@
 package org.apache.ofbiz.order.order.test
 
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class OrderTests extends OFBizTestCase {
+@JunitJupiterTest
+class OrderTests implements JupiterTestHelper {
 
-    OrderTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateOrderDeliverySchedule() {
         Map serviceCtx = [
                 orderId: 'TEST_DEMO10090',
@@ -36,6 +38,8 @@ class OrderTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
+    @Test
+    @Order(2)
     void testCreateOrderItemChange() {
         Map serviceCtx = [
                 changeTypeEnumId: 'ODR_ITM_APPEND',
@@ -48,6 +52,8 @@ class OrderTests extends OFBizTestCase {
         assert serviceResult.orderItemChangeId
     }
 
+    @Test
+    @Order(3)
     void testCreateOrderPaymentApplication() {
         Map serviceCtx = [
                 paymentId: '1014',
@@ -57,6 +63,8 @@ class OrderTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
+    @Test
+    @Order(4)
     void testCreateRequirement() {
         Map serviceCtx = [
                 custRequestId: '9000',
@@ -67,6 +75,8 @@ class OrderTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
+    @Test
+    @Order(5)
     void testGetRequirementsForSupplier() {
         Map serviceCtx = [
                 partyId: 'Company',
@@ -76,6 +86,8 @@ class OrderTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
+    @Test
+    @Order(6)
     void testCreateRequirementRole() {
         Map serviceCtx = [
                 requirementId: '1000',
@@ -87,6 +99,8 @@ class OrderTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
+    @Test
+    @Order(7)
     void testCreateAutoRequirementsForOrder() {
         Map serviceCtx = [
                 orderId: 'TEST_DEMO10090',
@@ -96,6 +110,8 @@ class OrderTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
+    @Test
+    @Order(8)
     void testCreateATPRequirementsForOrder() {
         Map serviceCtx = [
                 orderId: 'TEST_DEMO10090',

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/QuoteTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/QuoteTests.groovy
@@ -27,14 +27,16 @@ import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.condition.EntityCondition
 import org.apache.ofbiz.order.shoppingcart.ShoppingCart
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class QuoteTests extends OFBizTestCase {
+@JunitJupiterTest
+class QuoteTests implements JupiterTestHelper {
 
-    QuoteTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateQuoteWorkEffort() {
         GenericValue userLogin = getUserLogin('DemoRepStore')
 
@@ -55,6 +57,8 @@ class QuoteTests extends OFBizTestCase {
     // Test case for unsuccessfully creating a QuoteWorkEffort record by attempting
     // to use a quoteId and workEffortId that has already been used in an existing
     // QuoteWorkEffortRecord.
+    @Test
+    @Order(2)
     void testCreateQuoteWorkEffortFail() {
         Timestamp startTime = UtilDateTime.nowTimestamp()
         GenericValue userLogin = getUserLogin('DemoRepStore')
@@ -83,6 +87,8 @@ class QuoteTests extends OFBizTestCase {
         assert !quoteWorkEffort
     }
 
+    @Test
+    @Order(3)
     void testCheckUpdateQuotestatus() {
         Map serviceCtx = [
                 userLogin: userLogin,
@@ -97,6 +103,8 @@ class QuoteTests extends OFBizTestCase {
 
     // Test case for calling createQuoteWorkEffort without a workEffortId which
     // triggers an ECA to create the WorkEffort first.
+    @Test
+    @Order(4)
     void testCreateWorkEffortAndQuoteWorkEffort() {
         GenericValue userLogin = getUserLogin('system')
 
@@ -128,7 +136,9 @@ class QuoteTests extends OFBizTestCase {
         assert quoteWorkEffort
     }
 
-    void testCreateQuote () {
+    @Test
+    @Order(5)
+    void testCreateQuote() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 partyId: 'Company'
@@ -140,6 +150,8 @@ class QuoteTests extends OFBizTestCase {
         assert quote
     }
 
+    @Test
+    @Order(6)
     void testUpdateQuote() {
         Map serviceCtx = [
                 userLogin: userLogin,
@@ -156,6 +168,8 @@ class QuoteTests extends OFBizTestCase {
         assert ServiceUtil.isError(serviceResult)
     }
 
+    @Test
+    @Order(7)
     void testCopyQuote() {
         Map serviceCtx = [
                 userLogin: userLogin,
@@ -166,6 +180,8 @@ class QuoteTests extends OFBizTestCase {
         assert serviceResult.quoteId
     }
 
+    @Test
+    @Order(8)
     void testCreateQuoteItem() {
         Map serviceCtx = [
                 userLogin: userLogin,
@@ -179,6 +195,8 @@ class QuoteTests extends OFBizTestCase {
         assert quoteItem.quoteUnitPrice
     }
 
+    @Test
+    @Order(9)
     void testUpdateQuoteItem() {
         Map serviceCtx = [
                 userLogin: userLogin,
@@ -192,6 +210,11 @@ class QuoteTests extends OFBizTestCase {
         assert quoteItem.productId == 'GZ-1001'
     }
 
+    @Test
+    // Must run after testUpdateQuoteTerm: this removes QuoteItem 9000/00002, which cascades to
+    // delete its QuoteTerm - testUpdateQuoteTerm updates that same QuoteTerm and fails
+    // ("Value not found, cannot update") if it no longer exists.
+    @Order(12)
     void testRemoveQuoteItem() {
         Map serviceCtx = [
                 userLogin: userLogin,
@@ -206,7 +229,9 @@ class QuoteTests extends OFBizTestCase {
         assert !quoteTerm
     }
 
-    void testCreateQuoteTerm () {
+    @Test
+    @Order(11)
+    void testCreateQuoteTerm() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 termTypeId: 'FIN_PAYMENT_DISC',
@@ -232,6 +257,8 @@ class QuoteTests extends OFBizTestCase {
         assert serviceCtx.description == term.description
     }
 
+    @Test
+    @Order(10)
     void testUpdateQuoteTerm() {
         Map serviceCtx = [
             termTypeId: 'FIN_PAYMENT_DISC',
@@ -262,7 +289,9 @@ class QuoteTests extends OFBizTestCase {
         assert quoteTerm.description == serviceCtx.description
     }
 
-    void testDeleteQuoteTerm () {
+    @Test
+    @Order(13)
+    void testDeleteQuoteTerm() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 termTypeId: 'FIN_PAYMENT_DISC',
@@ -277,7 +306,9 @@ class QuoteTests extends OFBizTestCase {
         assert !quoteTerm
     }
 
-    void testCreateQuoteAttribute () {
+    @Test
+    @Order(14)
+    void testCreateQuoteAttribute() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 quoteId: '9001',
@@ -288,7 +319,9 @@ class QuoteTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
-    void testCreateQuoteCoefficient () {
+    @Test
+    @Order(15)
+    void testCreateQuoteCoefficient() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 quoteId: '9001',
@@ -299,7 +332,9 @@ class QuoteTests extends OFBizTestCase {
         assert ServiceUtil.isSuccess(serviceResult)
     }
 
-    void testGetNextQuoteId () {
+    @Test
+    @Order(16)
+    void testGetNextQuoteId() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 partyId: 'DemoCustomer-1'
@@ -310,6 +345,8 @@ class QuoteTests extends OFBizTestCase {
         assert serviceResult.quoteId
     }
 
+    @Test
+    @Order(17)
     void testQuoteSequenceEnforced() {
         GenericValue partyAcctgPreference = from('PartyAcctgPreference').where('partyId', 'DemoCustomer').queryOne()
         Long lastQuoteNumber = partyAcctgPreference.lastQuoteNumber ?: 0
@@ -325,7 +362,9 @@ class QuoteTests extends OFBizTestCase {
         assert serviceResult.quoteId == lastQuoteNumber + 1L
     }
 
-    void testCopyQuoteItem () {
+    @Test
+    @Order(18)
+    void testCopyQuoteItem() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 quoteId: '9001',
@@ -342,7 +381,9 @@ class QuoteTests extends OFBizTestCase {
         assert quoteAdjustment
     }
 
-    void testCreateQuoteAndQuoteItemForRequest () {
+    @Test
+    @Order(19)
+    void testCreateQuoteAndQuoteItemForRequest() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 custRequestId: '9000',
@@ -355,6 +396,8 @@ class QuoteTests extends OFBizTestCase {
     }
 
     @SuppressWarnings('UnnecessaryObjectReferences')
+    @Test
+    @Order(20)
     void testCreateQuoteFromCart() {
         String productId = 'SV-1001'
         String partyId = 'DemoCustomer'
@@ -385,6 +428,8 @@ class QuoteTests extends OFBizTestCase {
         assert quoteAdjustment
     }
 
+    @Test
+    @Order(21)
     void testCreateQuoteFromShoppingList() {
         Map serviceCtx = [
             userLogin: userLogin,
@@ -399,6 +444,8 @@ class QuoteTests extends OFBizTestCase {
         assert quoteAdjustment
     }
 
+    @Test
+    @Order(22)
     void testAutoUpdateQuotePrice() {
         Map serviceCtx = [
             userLogin: userLogin,
@@ -412,7 +459,9 @@ class QuoteTests extends OFBizTestCase {
         assert quoteItem.quoteUnitPrice == 12
     }
 
-    void testCreateQuoteFromCustRequest () {
+    @Test
+    @Order(23)
+    void testCreateQuoteFromCustRequest() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 custRequestId: '9000'
@@ -423,7 +472,9 @@ class QuoteTests extends OFBizTestCase {
         assert quoteItem
     }
 
-    void testAutoCreateQuoteAdjustments () {
+    @Test
+    @Order(24)
+    void testAutoCreateQuoteAdjustments() {
         Map serviceCtx = [
             userLogin: userLogin,
             quoteId: '9001'
@@ -435,7 +486,9 @@ class QuoteTests extends OFBizTestCase {
         assert promoQuoteAdjustment
     }
 
-    void testCreateQuoteNote () {
+    @Test
+    @Order(25)
+    void testCreateQuoteNote() {
         Map serviceCtx = [
                 userLogin: userLogin,
                 quoteId: '9001',

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/RequirementStatusEcaTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/RequirementStatusEcaTests.groovy
@@ -21,14 +21,14 @@ package org.apache.ofbiz.order.order.test
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.transaction.TransactionUtil
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
-class RequirementStatusEcaTests extends OFBizTestCase {
+@JunitJupiterTest
+class RequirementStatusEcaTests implements JupiterTestHelper {
 
-    RequirementStatusEcaTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testCreateRequirementStatusAfterOuterTransactionCommit() {
         ensureRequirementReferenceData()
         GenericValue userLogin = ensureUserLogin('mrpRequirementStatusTest')

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/ShoppingListTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/ShoppingListTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.order.order.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ShoppingListTests extends OFBizTestCase {
+@JunitJupiterTest
+class ShoppingListTests implements JupiterTestHelper {
 
-    ShoppingListTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateShoppingList() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
         Map serviceCtx = [
@@ -48,6 +50,8 @@ class ShoppingListTests extends OFBizTestCase {
         assert shoppingList.listName == 'Demo Wish List 1'
     }
 
+    @Test
+    @Order(2)
     void testCreateShoppingListItem() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
         String shoppingListId = 'DemoWishList'
@@ -67,6 +71,8 @@ class ShoppingListTests extends OFBizTestCase {
         assert shoppingListItem.quantity == 3
     }
 
+    @Test
+    @Order(3)
     void testCreateShoppingListItemWithSameProduct() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
         String shoppingListId = 'DemoWishList'
@@ -85,6 +91,8 @@ class ShoppingListTests extends OFBizTestCase {
         assert shoppingListItem.quantity == 7
     }
 
+    @Test
+    @Order(4)
     void testUpdateShoppingList() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
         Map serviceCtx = [
@@ -99,7 +107,9 @@ class ShoppingListTests extends OFBizTestCase {
         assert shoppingList.listName == 'New Demo Wish List'
     }
 
-    void testUpdateShoppingListItem () {
+    @Test
+    @Order(5)
+    void testUpdateShoppingListItem() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
         Map serviceCtx = [
                 shoppingListId: 'DemoWishList',
@@ -115,6 +125,8 @@ class ShoppingListTests extends OFBizTestCase {
         assert shoppingListItem.quantity == 4
     }
 
+    @Test
+    @Order(6)
     void testUpdateShoppingListItemWithZeroQty() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
         Map serviceCtx = [
@@ -130,6 +142,8 @@ class ShoppingListTests extends OFBizTestCase {
         assert shoppingListItem
     }
 
+    @Test
+    @Order(7)
     void testRemoveShoppingListItem() {
         GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
         Map serviceCtx = [

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/shoppingcart/test/ShoppingCartTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/shoppingcart/test/ShoppingCartTests.groovy
@@ -19,20 +19,22 @@
 package org.apache.ofbiz.order.shoppingcart.test
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.order.shoppingcart.ShoppingCart
 import org.apache.ofbiz.order.shoppingcart.CheckOutHelper
 import org.apache.ofbiz.order.order.OrderChangeHelper
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.product.config.ProductConfigWrapper
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ShoppingCartTests extends OFBizTestCase {
+@JunitJupiterTest
+class ShoppingCartTests implements JupiterTestHelper {
 
-    ShoppingCartTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateShoppingCart() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         Locale locale = Locale.getDefault()
@@ -41,6 +43,8 @@ class ShoppingCartTests extends OFBizTestCase {
         assert orderMap.orderId
     }
 
+    @Test
+    @Order(2)
     void testCreateOrderRentalProduct() {
         Locale locale = Locale.getDefault()
         GenericValue demoCustomer = from('UserLogin').where('userLoginId', 'DemoCustomer').queryOne()
@@ -73,6 +77,8 @@ class ShoppingCartTests extends OFBizTestCase {
         dispatcher.runSync('quickShipEntireOrder', [orderId: orderId, userLogin: systemLogin])
     }
 
+    @Test
+    @Order(3)
     void testCreateOrderServiceProduct() {
         Locale locale = Locale.getDefault()
         GenericValue demoCustomer = from('UserLogin').where('userLoginId', 'DemoCustomer').queryOne()
@@ -101,6 +107,8 @@ class ShoppingCartTests extends OFBizTestCase {
         dispatcher.runSync('quickShipEntireOrder', [orderId: orderId, userLogin: systemLogin])
     }
 
+    @Test
+    @Order(4)
     void testLoadCartFromQuote() {
         GenericValue systemLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
 
@@ -158,6 +166,8 @@ class ShoppingCartTests extends OFBizTestCase {
         assert shoppingCart.getGrandTotal() == expectedTotal
     }
 
+    @Test
+    @Order(5)
     void testCreateOrderConfigurableServiceProduct() {
         // ShoppingCartEvents requires request/response which are not readily mockable here without Spring
         // So we just use CheckOutHelper for test.
@@ -200,6 +210,8 @@ class ShoppingCartTests extends OFBizTestCase {
         dispatcher.runSync('quickShipEntireOrder', [orderId: orderId, userLogin: systemLogin])
     }
 
+    @Test
+    @Order(6)
     void testOrderMoveItemBetweenShipGoups() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         Locale locale = Locale.getDefault()

--- a/applications/order/src/test/java/org/apache/ofbiz/order/test/FinAccountTest.java
+++ b/applications/order/src/test/java/org/apache/ofbiz/order/test/FinAccountTest.java
@@ -18,6 +18,10 @@
  *******************************************************************************/
 package org.apache.ofbiz.order.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.Locale;
 
 import org.apache.ofbiz.base.util.Debug;
@@ -25,18 +29,19 @@ import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.order.finaccount.FinAccountHelper;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Test;
 
-public class FinAccountTest extends OFBizTestCase {
+@JunitJupiterTest
+public class FinAccountTest implements JupiterTestHelper {
     private static final String MODULE = FinAccountTest.class.getName();
-    public FinAccountTest(String name) {
-        super(name);
-    }
 
     /**
      * Test create fin account basic.
      * @throws Exception the exception
      */
+    @Test
     public void testCreateFinAccountBasic() throws Exception {
         Delegator delegator = getDelegator();
         String finAccountCode;

--- a/applications/order/src/test/java/org/apache/ofbiz/order/test/OrderTest.java
+++ b/applications/order/src/test/java/org/apache/ofbiz/order/test/OrderTest.java
@@ -18,24 +18,30 @@
  *******************************************************************************/
 package org.apache.ofbiz.order.test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.service.ServiceUtil;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class OrderTest extends OFBizTestCase {
-    private static final String MODULE = OFBizTestCase.class.getName();
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
-    public OrderTest(String name) {
-        super(name);
-    }
+@JunitJupiterTest
+public class OrderTest implements JupiterTestHelper {
+    private static final String MODULE = OrderTest.class.getName();
 
     /**
      * Test admin get next order seq id.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testAdminGetNextOrderSeqId() throws Exception {
         Map<String, Object> ctx = new HashMap<>();
         ctx.put("partyId", "admin"); //party with no AcctgPref prefix
@@ -53,6 +59,8 @@ public class OrderTest extends OFBizTestCase {
      * Test company get next order seq id.
      * @throws Exception the exception
      */
+    @Test
+    @Order(2)
     public void testCompanyGetNextOrderSeqId() throws Exception {
         Map<String, Object> ctx = new HashMap<>();
         ctx.put("partyId", "Company"); //party with AcctgPref prefix : CO
@@ -70,6 +78,8 @@ public class OrderTest extends OFBizTestCase {
      * Test complete get next order seq id.
      * @throws Exception the exception
      */
+    @Test
+    @Order(3)
     public void testCompleteGetNextOrderSeqId() throws Exception {
         Map<String, Object> ctx = new HashMap<>();
         ctx.put("partyId", "Company"); //party with AcctgPref prefix : CO

--- a/applications/order/src/test/java/org/apache/ofbiz/order/test/PurchaseOrderTest.java
+++ b/applications/order/src/test/java/org/apache/ofbiz/order/test/PurchaseOrderTest.java
@@ -18,6 +18,8 @@
  *******************************************************************************/
 package org.apache.ofbiz.order.test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -28,27 +30,23 @@ import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericValue;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
 import org.apache.ofbiz.service.ServiceUtil;
+import org.junit.jupiter.api.Test;
 
-public class PurchaseOrderTest extends OFBizTestCase {
-    private static final String MODULE = OFBizTestCase.class.getName();
+@JunitJupiterTest
+public class PurchaseOrderTest implements JupiterTestHelper {
+    private static final String MODULE = PurchaseOrderTest.class.getName();
 
     private String orderId = null;
     private String statusId = null;
-
-    public PurchaseOrderTest(String name) {
-        super(name);
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-    }
 
     /**
      * Test create purchase order.
      * @throws Exception the exception
      */
+    @Test
     public void testCreatePurchaseOrder() throws Exception {
         Delegator delegator = getDelegator();
         Map<String, Object> ctx = new HashMap<>();

--- a/applications/order/src/test/java/org/apache/ofbiz/order/test/SalesOrderTest.java
+++ b/applications/order/src/test/java/org/apache/ofbiz/order/test/SalesOrderTest.java
@@ -23,29 +23,26 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.service.ServiceUtil;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Test;
 
-public class SalesOrderTest extends OFBizTestCase {
-    private static final String MODULE = OFBizTestCase.class.getName();
-
-
-    public SalesOrderTest(String name) {
-        super(name);
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-    }
+@JunitJupiterTest
+public class SalesOrderTest implements JupiterTestHelper {
+    private static final String MODULE = SalesOrderTest.class.getName();
 
     /**
      * Test create sales order.
      * @throws Exception the exception
      */
+    @Test
     public void testCreateSalesOrder() throws Exception {
         Delegator delegator = getDelegator();
         Map<String, Object> ctx = UtilMisc.<String, Object>toMap("partyId", "DemoCustomer", "orderTypeId", "SALES_ORDER", "currencyUom", "USD",

--- a/applications/order/testdef/CustRequestTests.xml
+++ b/applications/order/testdef/CustRequestTests.xml
@@ -27,9 +27,9 @@ under the License.
         <entity-xml action="load" entity-xml-url="component://order/testdef/data/QuoteTestData.xml"/>
     </test-case>
     <test-case case-name="custrequest-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.CustRequestTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.order.test.CustRequestTests"/>
     </test-case>
     <test-case case-name="test-cust-request-permission-check">
-        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.CustRequestPermissionCheckTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.order.test.CustRequestPermissionCheckTests"/>
     </test-case>
 </test-suite>

--- a/applications/order/testdef/FinAccountTests.xml
+++ b/applications/order/testdef/FinAccountTests.xml
@@ -23,6 +23,6 @@ under the License.
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
         
     <test-case case-name="finaccount-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.order.test.FinAccountTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.test.FinAccountTest"/>
     </test-case>
 </test-suite>

--- a/applications/order/testdef/OrderTest.xml
+++ b/applications/order/testdef/OrderTest.xml
@@ -25,24 +25,24 @@ under the License.
         <entity-xml action="load" entity-xml-url="component://order/testdef/data/OrderTestData.xml"/>
     </test-case>
     <test-case case-name="order-test">
-        <junit-test-suite class-name="org.apache.ofbiz.order.test.OrderTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.test.OrderTest"/>
     </test-case>
     <test-case case-name="purchaseOrder-test">
-        <junit-test-suite class-name="org.apache.ofbiz.order.test.PurchaseOrderTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.test.PurchaseOrderTest"/>
     </test-case>
     <test-case case-name="salesOrder-test">
-        <junit-test-suite class-name="org.apache.ofbiz.order.test.SalesOrderTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.test.SalesOrderTest"/>
     </test-case>
     <test-case case-name="order-tests-xml">
-        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.OrderTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.order.test.OrderTests"/>
     </test-case>
     <test-case case-name="order-return-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.OrderReturnTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.order.test.OrderReturnTests"/>
     </test-case>
     <test-case case-name="order-requirement-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.OrderRequirementTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.order.test.OrderRequirementTests"/>
     </test-case>
     <test-case case-name="requirement-status-eca-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.RequirementStatusEcaTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.order.test.RequirementStatusEcaTests"/>
     </test-case>
 </test-suite>

--- a/applications/order/testdef/QuoteTests.xml
+++ b/applications/order/testdef/QuoteTests.xml
@@ -26,6 +26,6 @@ under the License.
         <entity-xml action="load" entity-xml-url="component://order/testdef/data/QuoteTestData.xml"/>
     </test-case>
     <test-case case-name="quoteTests">
-        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.QuoteTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.order.test.QuoteTests"/>
     </test-case>
 </test-suite>

--- a/applications/order/testdef/ShoppingCartTests.xml
+++ b/applications/order/testdef/ShoppingCartTests.xml
@@ -22,6 +22,6 @@ under the License.
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
     <test-case case-name="shoppingcart-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.order.shoppingcart.test.ShoppingCartTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.shoppingcart.test.ShoppingCartTests"/>
     </test-case>
 </test-suite>

--- a/applications/order/testdef/ShoppingListTests.xml
+++ b/applications/order/testdef/ShoppingListTests.xml
@@ -27,6 +27,6 @@ under the License.
     </test-case>
 
     <test-case case-name="shoppingList-test">
-        <junit-test-suite class-name="org.apache.ofbiz.order.order.test.ShoppingListTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.order.order.test.ShoppingListTests"/>
     </test-case>
 </test-suite>

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/ContactMechWorkerTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/ContactMechWorkerTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.party.party.test
 
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.party.contact.ContactMechWorker
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ContactMechWorkerTests extends OFBizTestCase {
+@JunitJupiterTest
+class ContactMechWorkerTests implements JupiterTestHelper {
 
-    ContactMechWorkerTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testPartyContactMechResolution() {
         //control for the DemoCustomer that postal, email, telecom and ftp contact are present and return correct information
         List partyContactMechValueMaps = ContactMechWorker.getPartyContactMechValueMaps(delegator, 'DemoCustomer', true)
@@ -103,6 +105,8 @@ class ContactMechWorkerTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(2)
     void testOrderContactMechResolution() {
         List orderContactMechValueMaps = ContactMechWorker.getOrderContactMechValueMaps(delegator, 'Demo1002')
         assert orderContactMechValueMaps
@@ -139,6 +143,8 @@ class ContactMechWorkerTests extends OFBizTestCase {
         assert foundBillingAddress && foundShippingAddress && foundOrderEmail
     }
 
+    @Test
+    @Order(3)
     void testWorkEffortContactMechResolution() {
         List workEffortContactMechValueMaps = ContactMechWorker.getWorkEffortContactMechValueMaps(delegator, 'TEST_CM_WORKER')
         assert workEffortContactMechValueMaps

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyAddressTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyAddressTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.party.party.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class PartyAddressTests extends OFBizTestCase {
+@JunitJupiterTest
+class PartyAddressTests implements JupiterTestHelper {
 
-    PartyAddressTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateContactMech() {
         Map serviceCtx = [
                 contactMechId: 'TestEmailConactMech',
@@ -43,6 +45,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert contactMech.infoString == 'test_email@example.com'
     }
 
+    @Test
+    @Order(2)
     void testCreateEmailAddress() {
         Map serviceCtx = [
                 emailAddress: 'test.email123@example.com',
@@ -56,6 +60,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert contactMech.infoString == 'test.email123@example.com'
     }
 
+    @Test
+    @Order(3)
     void testCreatePartyContactMech() {
         Map serviceCtx = [
                 contactMechId: 'TestContactMech3',
@@ -73,6 +79,11 @@ class PartyAddressTests extends OFBizTestCase {
         assert partyContactMech
     }
 
+    @Test
+    // Must run after testExpirePartyContactMechPurpose: that test expires the fixture's active
+    // PRIMARY_EMAIL purpose for this contactMechId, which this test needs already expired -
+    // otherwise createPartyContactMechPurpose fails ("a purpose with that type already exists").
+    @Order(9)
     void testCreatePartyContactMechPurpose() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -97,6 +108,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert partyContactMechPurpose
     }
 
+    @Test
+    @Order(5)
     void testCreatePartyDataSource() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -113,6 +126,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert partyDataSource
     }
 
+    @Test
+    @Order(6)
     void testCreatePartyEmailAddress() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -127,6 +142,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert contactMech.infoString == 'test.email1234@example.com'
     }
 
+    @Test
+    @Order(7)
     void testCreatePostalAddress() {
         Map serviceCtx = [
                 toName: 'Test Address',
@@ -147,6 +164,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert postalAddress.postalCode == '90000'
     }
 
+    @Test
+    @Order(8)
     void testCreateTelecomNumber() {
         Map serviceCtx = [
                 contactMechId: 'TestTelecomNumber',
@@ -163,6 +182,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert telecomNumber.contactNumber == '1111111'
     }
 
+    @Test
+    @Order(4)
     void testExpirePartyContactMechPurpose() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -188,6 +209,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert partyContactMechPurpose.thruDate != null
     }
 
+    @Test
+    @Order(10)
     void testGetPartyEmail() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -200,6 +223,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert serviceResult.contactMechId
     }
 
+    @Test
+    @Order(11)
     void testGetPartyPostalAddress() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -213,6 +238,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert serviceResult.contactMechId
     }
 
+    @Test
+    @Order(12)
     void testGetPartyTelephone() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -225,6 +252,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert serviceResult.contactMechId
     }
 
+    @Test
+    @Order(13)
     void testUpdateContactMech() {
         Map serviceCtx = [
                 contactMechId: 'TestContactMech',
@@ -240,6 +269,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert contactMech.infoString == 'demo_email@example.com'
     }
 
+    @Test
+    @Order(14)
     void testUpdateEmailAddress() {
         Map serviceCtx = [
                 contactMechId: 'TestContactMech',
@@ -254,6 +285,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert contactMech.infoString == 'test.email123@example.com'
     }
 
+    @Test
+    @Order(15)
     void testUpdatePartyEmailAddress() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -269,6 +302,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert contactMech.infoString == 'test.email12345@example.com'
     }
 
+    @Test
+    @Order(16)
     void testUpdatePartyGroup() {
         Map serviceCtx = [
                 partyId: 'TestGroup-1',
@@ -285,6 +320,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert partyGroup.logoImageUrl == '/images/ofbiz_logo.png'
     }
 
+    @Test
+    @Order(17)
     void testUpdatePartyPostalAddress() {
         Map serviceCtx = [
                 contactMechId: 'TestPostalAdd2',
@@ -307,6 +344,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert postalAddress.postalCode == '90000'
     }
 
+    @Test
+    @Order(18)
     void testUpdatePartyTelecomNumber() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -324,6 +363,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert telecomNumber.contactNumber == '1111111'
     }
 
+    @Test
+    @Order(19)
     void testUpdatePerson() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -340,6 +381,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert person.lastName == 'Person'
     }
 
+    @Test
+    @Order(20)
     void testUpdatePostalAddress() {
         Map serviceCtx = [
                 contactMechId: 'TestPostalAdd1',
@@ -362,6 +405,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert serviceResult.contactMechId != serviceResult.oldContactMechId
     }
 
+    @Test
+    @Order(21)
     void testUpdatePostalAddressAndPurposes() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -385,6 +430,8 @@ class PartyAddressTests extends OFBizTestCase {
         assert postalAddress.postalCode == '90000'
     }
 
+    @Test
+    @Order(22)
     void testUpdateTelecomNumber() {
         Map serviceCtx = [
                 contactMechId: 'TestContactMech1',

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyCommunicationEventTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyCommunicationEventTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.party.party.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class PartyCommunicationEventTests extends OFBizTestCase {
+@JunitJupiterTest
+class PartyCommunicationEventTests implements JupiterTestHelper {
 
-    PartyCommunicationEventTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateCommunicationEvent() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-3',
@@ -47,6 +49,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEvent.subject == 'Why i would use the OFBiz system'
     }
 
+    @Test
+    @Order(2)
     void testCreateCommunicationEventRole() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-6',
@@ -66,6 +70,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEventRole.statusId == 'COM_ROLE_CREATED'
     }
 
+    @Test
+    @Order(3)
     void testCreateCommunicationEventRoleWithoutPermission() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-6',
@@ -85,6 +91,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEventRole.statusId == 'COM_ROLE_CREATED'
     }
 
+    @Test
+    @Order(4)
     void testCreateCommunicationEventWithoutPermission() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-4',
@@ -104,6 +112,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEvent.subject == 'Why i would use the OFBiz system'
     }
 
+    @Test
+    @Order(5)
     void testCreateNewCommEvent() {
         Map createNewCommEventMap = [
                 communicationEventTypeId: 'EMAIL_COMMUNICATION',
@@ -135,6 +145,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEvent.contactMechTypeId == updateCommEventMap.contactMechTypeId
     }
 
+    @Test
+    @Order(6)
     void testDeleteCommunicationEvent() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-1',
@@ -147,6 +159,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert !communicationEvent
     }
 
+    @Test
+    @Order(7)
     void testDeleteCommunicationEventWorkEffort() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-5',
@@ -162,6 +176,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert !communicationEventWorkEff
     }
 
+    @Test
+    @Order(8)
     void testRemoveCommunicationEventRole() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-5',
@@ -179,6 +195,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert !communicationEventRole
     }
 
+    @Test
+    @Order(9)
     void testSetCommEventComplete() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-6',
@@ -192,6 +210,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEvent.statusId == 'COM_COMPLETE'
     }
 
+    @Test
+    @Order(10)
     void testSetCommEventRoleToRead() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-7',
@@ -208,6 +228,11 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEventRole
     }
 
+    @Test
+    // Must run after testUpdateCommunicationEventRole: this sets the CommunicationEventRole
+    // (TestEvent-2/TestCompany/ADDRESSEE) to COM_ROLE_COMPLETED, and COMPLETED -> READ is not a
+    // valid transition, which is what testUpdateCommunicationEventRole needs to do to that role.
+    @Order(14)
     void testSetCommunicationEventRoleStatus() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-2',
@@ -225,6 +250,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEventRole
     }
 
+    @Test
+    @Order(12)
     void testSetCommunicationEventStatus() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-6',
@@ -239,6 +266,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEvent.statusId == 'COM_COMPLETE'
     }
 
+    @Test
+    @Order(13)
     void testUpdateCommunicationEvent() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-7',
@@ -253,6 +282,8 @@ class PartyCommunicationEventTests extends OFBizTestCase {
         assert communicationEvent.statusId == 'COM_COMPLETE'
     }
 
+    @Test
+    @Order(11)
     void testUpdateCommunicationEventRole() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-2',

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyContactMechTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyContactMechTests.groovy
@@ -22,14 +22,16 @@ import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.party.party.PartyWorker
 import org.apache.ofbiz.service.ModelService
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class PartyContactMechTests extends OFBizTestCase {
+@JunitJupiterTest
+class PartyContactMechTests implements JupiterTestHelper {
 
-    PartyContactMechTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testUpdatePartyEmailAddress() {
         String partyId = 'DemoCustomer'
         String contactMechTypeId = 'EMAIL_ADDRESS'
@@ -72,6 +74,8 @@ class PartyContactMechTests extends OFBizTestCase {
         assert contactMech.infoString == serviceCtx.emailAddress
     }
 
+    @Test
+    @Order(2)
     void testUpdatePartyTelecomNumber() {
         String partyId = 'DemoCustomer'
 
@@ -126,6 +130,8 @@ class PartyContactMechTests extends OFBizTestCase {
         assert telecomNumber.contactNumber == serviceCtx.contactNumber
     }
 
+    @Test
+    @Order(3)
     void testUpdatePartyPostalAddress() {
         String partyId = 'DemoCustomer'
 
@@ -179,6 +185,8 @@ class PartyContactMechTests extends OFBizTestCase {
         assert postalAddress.postalCode == serviceCtx.postalCode
     }
 
+    @Test
+    @Order(4)
     void testCreatePartyEmailAddress() {
         String partyId = 'DemoEmployee'
         String emailAddress = 'demo.employee@gmail.com'
@@ -217,6 +225,8 @@ class PartyContactMechTests extends OFBizTestCase {
         assert contactMechPurposeTypeId == partyContactMechPurpose.contactMechPurposeTypeId
     }
 
+    @Test
+    @Order(5)
     void testCreatePartyTelecomNumber() {
         String partyId = 'DemoEmployee'
         String areaCode = '801'
@@ -260,6 +270,8 @@ class PartyContactMechTests extends OFBizTestCase {
         assert contactMechPurposeTypeId == partyContactMechPurpose.contactMechPurposeTypeId
     }
 
+    @Test
+    @Order(6)
     void testCreateUpdatePartyTelecomNumberWithCreate() {
         String partyId = 'DemoCustomer'
         String contactMechPurposeTypeId = 'PHONE_WORK'
@@ -306,6 +318,8 @@ class PartyContactMechTests extends OFBizTestCase {
         assert contactMechPurposeTypeId == partyContactMechPurpose.contactMechPurposeTypeId
     }
 
+    @Test
+    @Order(7)
     void testCreateUpdatePartyTelecomNumberWithUpdate() {
         String partyId = 'DemoCustomer'
         String contactMechPurposeTypeId = 'PHONE_HOME'
@@ -355,6 +369,8 @@ class PartyContactMechTests extends OFBizTestCase {
         assert partyContactMechPurpose
     }
 
+    @Test
+    @Order(8)
     void testCreateUpdatePartyEmailAddressWithCreate() {
         String partyId = 'DemoCustomer'
         String contactMechPurposeTypeId = 'PRIMARY_EMAIL'
@@ -389,6 +405,8 @@ class PartyContactMechTests extends OFBizTestCase {
         assert partyContactMechPurpose
     }
 
+    @Test
+    @Order(9)
     void testCreateUpdatePartyEmailAddressWithUpdate() {
         String partyId = 'DemoCustomer'
         String contactMechPurposeTypeId = 'PRIMARY_EMAIL'

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyMiscTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyMiscTests.groovy
@@ -20,14 +20,20 @@ package org.apache.ofbiz.party.party.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class PartyMiscTests extends OFBizTestCase {
+@JunitJupiterTest
+class PartyMiscTests implements JupiterTestHelper {
 
-    PartyMiscTests(String name) {
-        super(name)
-    }
-
+    @Test
+    // Must run after testRemoveAddressMatchMap: this wipes the whole AddressMatchMap table
+    // (delegator.removeAll), and running it first breaks testRemoveAddressMatchMap's own
+    // create-then-remove of a fresh row ("Value not found, cannot remove") - confirmed by
+    // isolating this from testCreateAddressMatchMap's position, which does not matter.
+    @Order(15)
     void testClearAddressMatchMap() {
         Map serviceCtx = [
                 userLogin: userLogin
@@ -39,6 +45,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert !addrs
     }
 
+    @Test
+    @Order(1)
     void testCreateAddressMatchMap() {
         Map serviceCtx = [
                 mapKey: 'TEST_KEY',
@@ -52,6 +60,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert addressMatchMap
     }
 
+    @Test
+    @Order(2)
     void testCreateAffiliate() {
         Map serviceCtx = [
                 partyId: 'TestCompany',
@@ -66,6 +76,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert affiliate.affiliateName == 'Test Affiliate'
     }
 
+    @Test
+    @Order(3)
     void testCreateEmailAddressVerification() {
         Map serviceCtx = [
                 emailAddress: 'test_email@example.com',
@@ -79,6 +91,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert emailAddressVerification.verifyHash == serviceResult.verifyHash
     }
 
+    @Test
+    @Order(4)
     void testCreatePartyIdentifications() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -98,6 +112,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert partyIdentification.idValue == '123456789'
     }
 
+    @Test
+    @Order(5)
     void testCreatePartyInvitation() {
         Map serviceCtx = [
                 partyIdFrom: 'TestCompany',
@@ -113,6 +129,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert partyInvitation.emailAddress == 'test_email@example.com'
     }
 
+    @Test
+    @Order(6)
     void testCreatePartyInvitationGroupAssoc() {
         Map serviceCtx = [
                 partyInvitationId: 'TEST_INVITE',
@@ -129,6 +147,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert partyInvitationGroupAssoc
     }
 
+    @Test
+    @Order(7)
     void testCreatePartyInvitationRoleAssoc() {
         Map serviceCtx = [
                 partyInvitationId: 'TEST_INVITE',
@@ -145,6 +165,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert partyInvitationRoleAssoc
     }
 
+    @Test
+    @Order(8)
     void testCreatePartyNote() {
         Map serviceCtx = [
                 partyId: 'DemoCustomer',
@@ -164,6 +186,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert noteData.noteInfo == 'This is demo note to test createPartyNote service'
     }
 
+    @Test
+    @Order(9)
     void testDeletePartyInvitation() {
         Map serviceCtx = [
                 partyInvitationId: 'TEST_INVITE-1',
@@ -176,6 +200,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert !partyInvitation
     }
 
+    @Test
+    @Order(10)
     void testDeletePartyInvitationGroupAssoc() {
         Map serviceCtx = [
                 partyInvitationId: 'TEST_INVITE-2',
@@ -192,6 +218,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert !partyInvitationGroupAssoc
     }
 
+    @Test
+    @Order(11)
     void testDeletePartyInvitationRoleAssoc() {
         Map serviceCtx = [
                 partyInvitationId: 'TEST_INVITE-2',
@@ -208,6 +236,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert !partyInvitationRoleAssoc
     }
 
+    @Test
+    @Order(12)
     void testRemoveAddressMatchMap() {
         // Create the record first so this test is independent of seed data and execution order
         dispatcher.runSync('createAddressMatchMap', [mapKey: 'TESTKEY-1', mapValue: 'Test Value 1', userLogin: userLogin])
@@ -224,6 +254,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert !addressMatchMap
     }
 
+    @Test
+    @Order(13)
     void testUpdateAffiliate() {
         Map serviceCtx = [
                 partyId: 'TestGroup-1',
@@ -242,6 +274,8 @@ class PartyMiscTests extends OFBizTestCase {
         assert affiliate.siteVisitors == '2000'
     }
 
+    @Test
+    @Order(14)
     void testUpdatePartyInvitation() {
         Map serviceCtx = [
                 partyInvitationId: 'TEST_INVITE',

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyStatusChangeTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyStatusChangeTests.groovy
@@ -21,15 +21,17 @@ package org.apache.ofbiz.party.party.test
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class PartyStatusChangeTests extends OFBizTestCase {
-
-    PartyStatusChangeTests(String name) {
-        super(name)
-    }
+@JunitJupiterTest
+class PartyStatusChangeTests implements JupiterTestHelper {
 
     // Test case for changing party status to PARTY_DISABLED
+    @Test
+    @Order(1)
     void testSetPartyStatusToDisabled() {
         String partyId = 'PARTY_ENABLED'
         String statusId = 'PARTY_DISABLED'
@@ -52,6 +54,8 @@ class PartyStatusChangeTests extends OFBizTestCase {
     }
 
     // Test case for changing party status to PARTY_ENABLED
+    @Test
+    @Order(2)
     void testSetPartyStatusToEnabled() {
         String partyId = 'PARTY_DISABLED'
         String statusId = 'PARTY_ENABLED'

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.party.party.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class PartyTests extends OFBizTestCase {
+@JunitJupiterTest
+class PartyTests implements JupiterTestHelper {
 
-    PartyTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCopyPartyContactMechs() {
         Map serviceCtx = [
                 partyIdFrom: 'TestCustomer',
@@ -41,6 +43,8 @@ class PartyTests extends OFBizTestCase {
         assert partyContactMechList
     }
 
+    @Test
+    @Order(2)
     void testCreatePartyGroup() {
         Map serviceCtx = [
                 partyId: 'DemoGroup1',
@@ -59,6 +63,8 @@ class PartyTests extends OFBizTestCase {
         assert partyGroup.groupName == 'Demo Group'
     }
 
+    @Test
+    @Order(3)
     void testCreatePartyPostalAddress() {
         Map serviceCtx = [
                 contactMechId: 'TestPostalAddress',
@@ -79,6 +85,8 @@ class PartyTests extends OFBizTestCase {
         assert postalAddress.city == 'City of Industry'
     }
 
+    @Test
+    @Order(4)
     void testCreatePartyRelationship() {
         Map serviceCtx = [
                 partyIdFrom: 'TestCompany',
@@ -106,6 +114,8 @@ class PartyTests extends OFBizTestCase {
         assert partyRelationship
     }
 
+    @Test
+    @Order(5)
     void testCreatePartyRelationshipAndRole() {
         Map serviceCtx = [
                 partyIdFrom: 'TestCompany',
@@ -136,6 +146,8 @@ class PartyTests extends OFBizTestCase {
         assert partyRelationship
     }
 
+    @Test
+    @Order(6)
     void testCreatePartyRelationshipContactAccount() {
         Map serviceCtx = [
                 accountPartyId: 'TestParty',
@@ -152,6 +164,8 @@ class PartyTests extends OFBizTestCase {
         assert partyRelationshipList
     }
 
+    @Test
+    @Order(7)
     void testCreatePartyRole() {
         Map serviceCtx = [
                 partyId: 'DemoCustomer',
@@ -170,6 +184,8 @@ class PartyTests extends OFBizTestCase {
         assert partyRole.roleTypeId == 'CLIENT'
     }
 
+    @Test
+    @Order(8)
     void testCreatePartyTelecomNumber() {
         Map serviceCtx = [
                 partyId: 'DemoCustomer',
@@ -209,6 +225,8 @@ class PartyTests extends OFBizTestCase {
         assert pcmp.contactMechPurposeTypeId == 'PRIMARY_PHONE'
     }
 
+    @Test
+    @Order(9)
     void testCreatePerson() {
         Map serviceCtx = [
                 firstName: 'Demo',
@@ -229,6 +247,8 @@ class PartyTests extends OFBizTestCase {
         assert person.lastName == 'Person'
     }
 
+    @Test
+    @Order(10)
     void testCreatePersonAndUserLogin() {
         Map serviceCtx = [
                 partyId: 'DemoPerson',
@@ -253,6 +273,8 @@ class PartyTests extends OFBizTestCase {
         assert person.lastName == 'Person'
     }
 
+    @Test
+    @Order(11)
     void testCreateUpdatePartyRelationshipAndRoles() {
         Map serviceCtx = [
                 partyId: 'TestCompany',
@@ -286,6 +308,8 @@ class PartyTests extends OFBizTestCase {
         assert serviceCtx.partyRelationshipTypeId == 'AGENT'
     }
 
+    @Test
+    @Order(12)
     void testCreateUpdatePersonWithCreate() {
         Map serviceCtx = [
                 partyId: 'DemoPerson1',
@@ -305,6 +329,8 @@ class PartyTests extends OFBizTestCase {
         assert person.lastName == 'Person1'
     }
 
+    @Test
+    @Order(13)
     void testCreateUpdatePersonWithUpdate() {
         Map serviceCtx = [
                 partyId: 'DemoPerson1',
@@ -324,6 +350,8 @@ class PartyTests extends OFBizTestCase {
         assert person.lastName == 'Person2'
     }
 
+    @Test
+    @Order(14)
     void testDeletePartyRelationship() {
         Map serviceCtx = [
                 partyIdFrom: 'TestCompany',
@@ -351,6 +379,8 @@ class PartyTests extends OFBizTestCase {
         assert !partyRelationship
     }
 
+    @Test
+    @Order(15)
     void testDeletePartyRole() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -364,6 +394,8 @@ class PartyTests extends OFBizTestCase {
         assert !partyRole
     }
 
+    @Test
+    @Order(16)
     void testEnsurePartyRole() {
         Map serviceCtx = [
                 partyId: 'DemoCustomer',
@@ -413,6 +445,8 @@ class PartyTests extends OFBizTestCase {
         assert partyRole
     }
 
+    @Test
+    @Order(17)
     void testFindPartiesById() {
         Map serviceCtx = [
                 idToFind: 'TestCustomer',
@@ -426,6 +460,8 @@ class PartyTests extends OFBizTestCase {
         assert party.partyId == 'TestCustomer'
     }
 
+    @Test
+    @Order(18)
     void testFindPartyFromEmailAddress() {
         Map serviceCtx = [
                 address: 'newtest_email@example.com',
@@ -440,6 +476,8 @@ class PartyTests extends OFBizTestCase {
         assert contactMech
     }
 
+    @Test
+    @Order(19)
     void testFindPartyFromTelephone() {
         Map serviceCtx = [
                 telno: '801555-5555',
@@ -452,6 +490,8 @@ class PartyTests extends OFBizTestCase {
         assert party
     }
 
+    @Test
+    @Order(20)
     void testFindPartyFromTelephoneComplete() {
         Map serviceCtx = [
                 telno: '801555-5555',
@@ -464,6 +504,8 @@ class PartyTests extends OFBizTestCase {
         assert party
     }
 
+    @Test
+    @Order(21)
     void testFindPartyWithNoSearchParameters() {
         Map serviceCtx = [
                 lookupFlag: 'Y',
@@ -480,6 +522,8 @@ class PartyTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(22)
     void testFindPartyWithSearchParameters() {
         Map serviceCtx = [
                 partyId: 'DemoCustomer',
@@ -507,6 +551,8 @@ class PartyTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(23)
     void testGetPartyMainRole() {
         Map serviceCtx = [
                 partyId: 'TestCustomer',
@@ -519,6 +565,8 @@ class PartyTests extends OFBizTestCase {
         assert partyRole
     }
 
+    @Test
+    @Order(24)
     void testLookupParty() {
         Map serviceCtx = [
                 firstName: 'Test',
@@ -530,6 +578,8 @@ class PartyTests extends OFBizTestCase {
         assert serviceResult.lookupResult
     }
 
+    @Test
+    @Order(25)
     void testQuickCreateCustomer() {
         Map serviceCtx = [
                 firstName: 'Test',
@@ -549,6 +599,8 @@ class PartyTests extends OFBizTestCase {
         assert partyRole
     }
 
+    @Test
+    @Order(26)
     void testUpdatePartyCreditCard() {
         Map serviceCtx = [
                 partyId: 'DemoCustomer',
@@ -594,6 +646,8 @@ class PartyTests extends OFBizTestCase {
         assert newPmac.cardNumber == '5500000000000004'
     }
 
+    @Test
+    @Order(27)
     void testUpdatePartyRelationship() {
         Map serviceCtx = [
                 partyIdFrom: 'TestCompany',
@@ -623,6 +677,8 @@ class PartyTests extends OFBizTestCase {
         assert partyRelationship.partyRelationshipTypeId == 'AGENT'
     }
 
+    @Test
+    @Order(28)
     void testUpdateUserPassword() {
         GenericValue partyUserLogin = org.apache.ofbiz.party.party.PartyWorker.findPartyLatestUserLogin('DemoCustomer', delegator)
         Map serviceCtx = dispatcher.getDispatchContext().makeValidContext('updatePassword',

--- a/applications/party/testdef/PartyContactMechTests.xml
+++ b/applications/party/testdef/PartyContactMechTests.xml
@@ -25,10 +25,10 @@
         <entity-xml action="load" entity-xml-url="component://party/testdef/data/PartyContactMechTestData.xml"/>
     </test-case>
     <test-case case-name="ContactMechWorker-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.party.party.test.ContactMechWorkerTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.party.party.test.ContactMechWorkerTests"/>
     </test-case>
     <test-case case-name="partyContactMech-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.party.party.test.PartyContactMechTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.party.party.test.PartyContactMechTests"/>
     </test-case>
 
 

--- a/applications/party/testdef/PartyStatusChangeTests.xml
+++ b/applications/party/testdef/PartyStatusChangeTests.xml
@@ -26,7 +26,7 @@
     </test-case>
 
     <test-case case-name="partystatuschangetest">
-        <junit-test-suite class-name="org.apache.ofbiz.party.party.test.PartyStatusChangeTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.party.party.test.PartyStatusChangeTests"/>
     </test-case>
 
 </test-suite>

--- a/applications/party/testdef/PartyTests.xml
+++ b/applications/party/testdef/PartyTests.xml
@@ -26,15 +26,15 @@
     </test-case>
 
     <test-case case-name="party-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.party.party.test.PartyTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.party.party.test.PartyTests"/>
     </test-case>
     <test-case case-name="party-address-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.party.party.test.PartyAddressTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.party.party.test.PartyAddressTests"/>
     </test-case>
     <test-case case-name="party-communication-event-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.party.party.test.PartyCommunicationEventTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.party.party.test.PartyCommunicationEventTests"/>
     </test-case>
     <test-case case-name="party-misc-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.party.party.test.PartyMiscTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.party.party.test.PartyMiscTests"/>
     </test-case>
 </test-suite>

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/CategoryTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/CategoryTests.groovy
@@ -21,14 +21,16 @@ package org.apache.ofbiz.product.product.test
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class CategoryTests extends OFBizTestCase {
+@JunitJupiterTest
+class CategoryTests implements JupiterTestHelper {
 
-    CategoryTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testAddProductCategoryToCategory() {
         Map serviceCtx = [
                 productCategoryId: 'TPC',
@@ -44,6 +46,8 @@ class CategoryTests extends OFBizTestCase {
         assert prodCategory != null
     }
 
+    @Test
+    @Order(2)
     void testGetProductCategoryAndLimitedMembers() {
         Map serviceCtx = [
                 productCategoryId: '101',

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/CostTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/CostTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.product.product.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class CostTests extends OFBizTestCase {
+@JunitJupiterTest
+class CostTests implements JupiterTestHelper {
 
-    CostTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCalculateProductStandardCosts() {
         String productId = 'PROD_MANUF'
         Map serviceCtx = [
@@ -63,6 +65,8 @@ class CostTests extends OFBizTestCase {
         assert costTotalAmount == 84
     }
 
+    @Test
+    @Order(2)
     void testGetProductCost() {
         String productId = 'PROD_MANUF'
         Map serviceCtx = [

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/GroupOrderTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/GroupOrderTests.groovy
@@ -21,16 +21,18 @@ package org.apache.ofbiz.product.product.test
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class GroupOrderTests extends OFBizTestCase {
+@JunitJupiterTest
+class GroupOrderTests implements JupiterTestHelper {
 
-    GroupOrderTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testGroupOrderLimitReached() {
         GenericValue systemUserLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         GenericValue adminUserLogin = from('UserLogin').where('userLoginId', 'admin').queryOne()
@@ -73,6 +75,8 @@ class GroupOrderTests extends OFBizTestCase {
         assert orderItem.statusId == 'ITEM_APPROVED'
     }
 
+    @Test
+    @Order(2)
     void testGroupOrderLimitNotReached() {
         GenericValue systemUserLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         GenericValue adminUserLogin = from('UserLogin').where('userLoginId', 'admin').queryOne()

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/InventoryTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/InventoryTests.groovy
@@ -19,14 +19,16 @@
 package org.apache.ofbiz.product.product.test
 
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class InventoryTests extends OFBizTestCase {
+@JunitJupiterTest
+class InventoryTests implements JupiterTestHelper {
 
-    InventoryTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testGetInventoryAvailableByFacility() {
         Map serviceCtx = [
                 productId: 'GZ-2644',
@@ -40,6 +42,8 @@ class InventoryTests extends OFBizTestCase {
     }
 
     // Test Physical Inventory Adjustment
+    @Test
+    @Order(2)
     void testCreatePhysicalInventoryAndVariance() {
         Map serviceCtx = [
                 inventoryItemId: '9024',

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductConfigTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductConfigTests.groovy
@@ -19,15 +19,15 @@
 package org.apache.ofbiz.product.product.test
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.service.ServiceUtil
+import org.junit.jupiter.api.Test
 
-class ProductConfigTests extends OFBizTestCase {
+@JunitJupiterTest
+class ProductConfigTests implements JupiterTestHelper {
 
-    ProductConfigTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testCreateProductConfigOption() {
         Map serviceCtx = [:]
         serviceCtx.configItemId = 'testConfigItemId'

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductFeatureTypeTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductFeatureTypeTests.groovy
@@ -20,14 +20,14 @@ package org.apache.ofbiz.product.product.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
-class ProductFeatureTypeTests extends OFBizTestCase {
+@JunitJupiterTest
+class ProductFeatureTypeTests implements JupiterTestHelper {
 
-    ProductFeatureTypeTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testCreateProductFeatureType() {
         Map serviceCtx = [:]
         serviceCtx.productFeatureTypeId = 'testProdFeat'

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductPriceTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductPriceTests.groovy
@@ -20,14 +20,16 @@ package org.apache.ofbiz.product.product.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ProductPriceTests extends OFBizTestCase {
+@JunitJupiterTest
+class ProductPriceTests implements JupiterTestHelper {
 
-    ProductPriceTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCalculateProductPrice() {
         String productId = 'GZ-2002'
         GenericValue product = from('Product').where('productId', productId).queryOne()
@@ -39,6 +41,8 @@ class ProductPriceTests extends OFBizTestCase {
         assert resultMap.listPrice == 48
     }
 
+    @Test
+    @Order(2)
     void testCalculateProductPriceOfVariantProduct() {
         // If product is a variant and no price is set, then default price of virtual product will be set
         String productId = 'GZ-1006-3'
@@ -51,6 +55,8 @@ class ProductPriceTests extends OFBizTestCase {
         assert resultMap.listPrice == 5.99
     }
 
+    @Test
+    @Order(3)
     void testCalculateProductPriceOfVirtualProduct() {
         // If product is a virtual and no price is set then then the service return price of a variant product which have lowest DEFAULT_PRICE.
         // It is also considered whether the product is discontinued for sale before using the lowest price against a variant for a virtual product

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductPromoActionTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductPromoActionTests.groovy
@@ -25,19 +25,21 @@ import org.apache.ofbiz.order.shoppingcart.ShoppingCart
 import org.apache.ofbiz.order.shoppingcart.ShoppingCartItem
 import org.apache.ofbiz.order.shoppingcart.product.ProductPromoWorker.ActionResultInfo
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ProductPromoActionTests extends OFBizTestCase {
-
-    ProductPromoActionTests(String name) {
-        super(name)
-    }
+@JunitJupiterTest
+class ProductPromoActionTests implements JupiterTestHelper {
 
     /**
      * This test check if the function productTaxPercent work correctly
      *  1. test failed with passing non valid value
      *  2. test success if the tax percent promo is set for tax percent
      */
+    @Test
+    @Order(1)
     void testActionProductTaxPercent() {
         ShoppingCart cart = loadOrder('DEMO10090')
 
@@ -73,6 +75,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      *  1. test failed with passing non valid value
      *  2. test success if the ship charge promo is set for the shipping amount
      */
+    @Test
+    @Order(2)
     void testProductShipCharge() {
         ShoppingCart cart = loadOrder('DEMO10090')
 
@@ -100,6 +104,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      *  1. test failed with passing non valid value
      *  2. test success if the special price is set
      */
+    @Test
+    @Order(3)
     void testProductSpecialPrice() {
         ShoppingCart cart = loadOrder('DEMO10091')
 
@@ -133,6 +139,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      * This test check if the function ProductOrderAmount work correctly
      *  1. test success if the order amount off is set
      */
+    @Test
+    @Order(4)
     void testProductOrderAmount() {
         ShoppingCart cart = loadOrder('DEMO10090')
 
@@ -155,6 +163,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      *  1. test success if the order percent off promo is set
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(5)
     void testProductOrderPercent() {
         ShoppingCart cart = loadOrder('DEMO10090')
 
@@ -196,6 +206,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      *  1. test failed with passing non valid value
      *  2. test success if promo is applied
      */
+    @Test
+    @Order(6)
     void testProductPrice() {
         ShoppingCart cart = loadOrder('DEMO10090')
 
@@ -232,6 +244,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      *  1. test success if promo is applied
      *  2. test failed with passing already applied promo
      */
+    @Test
+    @Order(7)
     void testProductAMDISC() {
         ShoppingCart cart = loadOrder('DEMO10090')
 
@@ -261,6 +275,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      *  1. test success if promo is applied
      *  2. test failed with passing already applied promo
      */
+    @Test
+    @Order(8)
     void testProductDISC() {
         ShoppingCart cart = loadOrder('DEMO10090')
 
@@ -290,6 +306,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      *  1. test failed with passing non valid value
      *  2. test success if gift with purchase promo is set for order
      */
+    @Test
+    @Order(9)
     void testProductGWP() {
         ShoppingCart cart = loadOrder('DEMO10090')
 
@@ -319,6 +337,8 @@ class ProductPromoActionTests extends OFBizTestCase {
      *  1. test success if the free shipping promo is set for tax percent
      *  2. don't need to make false test because this fonction doesn't need condition
      */
+    @Test
+    @Order(10)
     void testFreeShippingAct() {
         ShoppingCart cart = loadOrder('DEMO10090')
 

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductPromoCondTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductPromoCondTests.groovy
@@ -22,20 +22,22 @@ import java.sql.Timestamp
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.order.shoppingcart.ShoppingCart
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.service.ServiceUtil
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ProductPromoCondTests extends OFBizTestCase {
-
-    ProductPromoCondTests(String name) {
-        super(name)
-    }
+@JunitJupiterTest
+class ProductPromoCondTests implements JupiterTestHelper {
 
     /**
      * This test check if the function productPartyID work correctly
      *  1. test success with a valid partyId
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(1)
     void testPartyIdPromo() {
         String condValue = 'FrenchCustomer'
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
@@ -61,6 +63,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the customer is subscribed more than the "condValue"
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(2)
     void testNewACCTPromo() {
         String condValue = '1095'
         GenericValue frenchCustomer = delegator.makeValue('Party', [partyId: 'FrenchCustomer', createdDate: Timestamp.valueOf('2010-01-01 00:00:00')])
@@ -90,6 +94,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the login user is from part of classification of the promoCondition
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(3)
     void testPartyClassPromo() {
         String condValue = 'PROMO_TEST'
         GenericValue partyClassGroup = delegator.makeValue('PartyClassificationGroup', [partyClassificationGroupId: condValue])
@@ -124,6 +130,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the login user is from part of the Group member of the promoCondition
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(4)
     void testPartyGMPromo() {
         String condValue = 'HUMAN_RES'
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
@@ -158,6 +166,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the login user role type is equal to the condValue
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(5)
     void testRoleTypePromo() {
         String condValue = 'APPROVER'
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
@@ -185,6 +195,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the shipping address is equal to the condValue
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(6)
     void testCondGeoIdPromo() {
         ShoppingCart cart = loadOrder('DEMO10090')
         cart.setShippingContactMechId(0, '9200')
@@ -213,6 +225,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the order total is equal or greater than the condValue
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(7)
     void testCondOrderTotalPromo() {
         String condValue = '34.56'
         // call service promo
@@ -235,6 +249,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the recurrence is equal to the condValue
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(8)
     void testRecurrencePromo() {
         String condValue = 'TEST_PROMO'
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
@@ -267,6 +283,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if ship total is greater than the condValue
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(9)
     void testShipTotalPromo() {
         String condValue = '20'
         BigDecimal amount = BigDecimal.valueOf(25)
@@ -294,6 +312,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the amount of specific product is equal to the condValue
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(10)
     void testProductAmountPromo() {
         String condValue = '30'
         String orderId = 'DEMO10090'
@@ -324,6 +344,8 @@ class ProductPromoCondTests extends OFBizTestCase {
      *  1. test success if the total amount of product is equal or greater than the condValue
      *  2. test failed with passing non valid value
      */
+    @Test
+    @Order(11)
     void testProductTotalPromo() {
         String orderId = 'Demo1002'
         ShoppingCart cart = loadOrder(orderId)

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTagTest.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTagTest.groovy
@@ -20,17 +20,17 @@ package org.apache.ofbiz.product.product.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.apache.ofbiz.product.product.ProductEvents
+import org.junit.jupiter.api.Test
 
-class ProductTagTest extends OFBizTestCase {
+@JunitJupiterTest
+class ProductTagTest implements JupiterTestHelper {
 
-    ProductTagTest(String name) {
-        super(name)
-    }
-
+    @Test
     void testProductTag() {
         /*Test Product Tag
         Step 1) Create a product tag.

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTest.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTest.groovy
@@ -21,16 +21,18 @@ package org.apache.ofbiz.product.product.test
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 
 import java.sql.Timestamp
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ProductTest extends OFBizTestCase {
+@JunitJupiterTest
+class ProductTest implements JupiterTestHelper {
 
-    ProductTest(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateProduct() {
         String internalName = 'Test_product'
         String productTypeId = 'Test_type'
@@ -52,6 +54,8 @@ class ProductTest extends OFBizTestCase {
         assert productTypeId == product.productTypeId
     }
 
+    @Test
+    @Order(2)
     void testUpdateProduct() {
         String productId = 'Test_product_A'
         String productName = 'Test_name_B'
@@ -74,6 +78,8 @@ class ProductTest extends OFBizTestCase {
         assert description == product.description
     }
 
+    @Test
+    @Order(3)
     void testDuplicateProduct() {
         String productId = 'Duplicate_Id'
         String oldProductId = 'Test_product_B'
@@ -95,6 +101,8 @@ class ProductTest extends OFBizTestCase {
         assert product.description == 'This is product description'
     }
 
+    @Test
+    @Order(4)
     void testQuickAddVariant() {
         String productId = 'Test_product_B'
         String productFeatureIds = 'Test_feature'
@@ -128,6 +136,8 @@ class ProductTest extends OFBizTestCase {
         assert productFeature
     }
 
+    @Test
+    @Order(5)
     void testDeleteProductKeywords() {
         String productId = 'Test_product_C'
 
@@ -151,6 +161,8 @@ class ProductTest extends OFBizTestCase {
         assert !keywords
     }
 
+    @Test
+    @Order(6)
     void testDiscontinueProductSales() {
         String productId = 'Test_product_C'
 
@@ -168,6 +180,12 @@ class ProductTest extends OFBizTestCase {
         assert product.salesDiscontinuationDate
     }
 
+    @Test
+    // Must run after testUpdateProductReview: updateProductReview's rating-recalculation does an
+    // unconditional insert into ProductCalculatedInfo(Test_product_C) when none exists yet: if this
+    // test runs first, its own recalculation already creates that row, and updateProductReview's
+    // insert then fails with a primary-key violation.
+    @Order(8)
     void testCreateProductReview() {
         String productId = 'Test_product_C'
         String productStoreId = 'Test_store'
@@ -194,6 +212,8 @@ class ProductTest extends OFBizTestCase {
         assert productRating == review.productRating
     }
 
+    @Test
+    @Order(7)
     void testUpdateProductReview() {
         String productReviewId = 'Test_review'
         BigDecimal productRating = new BigDecimal('3')
@@ -216,6 +236,8 @@ class ProductTest extends OFBizTestCase {
         assert productRating == review.productRating
     }
 
+    @Test
+    @Order(9)
     void testFindProductById() {
         Map serviceCtx = [
                 idToFind: 'Test_product_C',
@@ -226,6 +248,8 @@ class ProductTest extends OFBizTestCase {
         assert serviceResult.product
     }
 
+    @Test
+    @Order(10)
     void testCreateProductPrice() {
         String productId = 'Test_product_A'
         String productPriceTypeId = 'AVERAGE_COST'
@@ -260,6 +284,8 @@ class ProductTest extends OFBizTestCase {
         assert price == productPrice.price
     }
 
+    @Test
+    @Order(11)
     void testUpdateProductPrice() {
         String productId = 'Test_prod_price_up'
         String productPriceTypeId = 'AVERAGE_COST'
@@ -312,6 +338,8 @@ class ProductTest extends OFBizTestCase {
         assert price == productPrice.price
     }
 
+    @Test
+    @Order(12)
     void testDeleteProductPrice() {
         String productId = 'Test_product_C'
         String productPriceTypeId = 'AVERAGE_COST'
@@ -343,6 +371,8 @@ class ProductTest extends OFBizTestCase {
         assert !productPrice
     }
 
+    @Test
+    @Order(13)
     void testCreateProductCategory() {
         String productCategoryId = 'TEST_CATEGORY'
         String productCategoryTypeId = 'USAGE_CATEGORY'

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTests.groovy
@@ -20,14 +20,14 @@ package org.apache.ofbiz.product.product.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
-class ProductTests extends OFBizTestCase {
+@JunitJupiterTest
+class ProductTests implements JupiterTestHelper {
 
-    ProductTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testUpdateProductCategory() {
         Map serviceCtx = [
                 categoryName: 'Updated Test Product Category',

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ShipmentTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ShipmentTests.groovy
@@ -21,15 +21,17 @@ package org.apache.ofbiz.product.product.test
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.shipment.packing.PackingSession
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ShipmentTests extends OFBizTestCase {
+@JunitJupiterTest
+class ShipmentTests implements JupiterTestHelper {
 
-    ShipmentTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testPackingServices() {
         PackingSession packingSession = new PackingSession(dispatcher, userLogin)
         Map serviceCtx = [
@@ -102,6 +104,8 @@ class ShipmentTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(2)
     void testShipmentServices() {
         Map serviceCtx = [
                 shipmentTypeId: 'SALES_SHIPMENT',
@@ -138,6 +142,8 @@ class ShipmentTests extends OFBizTestCase {
         assert shipment.statusId == 'SHIPMENT_SHIPPED'
     }
 
+    @Test
+    @Order(3)
     void testReceiveInventoryNonSerialized() {
         Map serviceCtx = [
                 facilityId: 'WebStoreWarehouse',
@@ -177,6 +183,8 @@ class ShipmentTests extends OFBizTestCase {
         assert shipmentReceipt.productId == serviceCtx.productId
     }
 
+    @Test
+    @Order(4)
     void testIssueOrderItemShipGrpInvResToShipmentRejectsMixedDestinations() {
         Map orderResult = dispatcher.runSync('createTestSalesOrderSingle',
                 [userLogin: userLogin, productId: 'GZ-2644'])
@@ -231,6 +239,8 @@ class ShipmentTests extends OFBizTestCase {
         assert ServiceUtil.getErrorMessage(issueResult).contains('different destination')
     }
 
+    @Test
+    @Order(5)
     void testIssueOrderItemShipGrpInvResToShipmentRejectsMixedDestinationsAcrossOrders() {
         Map orderResult1 = dispatcher.runSync('createTestSalesOrderSingle',
                 [userLogin: userLogin, productId: 'GZ-2644'])
@@ -300,6 +310,8 @@ class ShipmentTests extends OFBizTestCase {
         assert ServiceUtil.getErrorMessage(issueResult).contains('different destination')
     }
 
+    @Test
+    @Order(6)
     void testPackingSessionRejectsMixedShipGroupDestinations() {
         Map orderResult = dispatcher.runSync('createTestSalesOrderSingle',
                 [userLogin: userLogin, productId: 'GZ-2644'])
@@ -357,6 +369,8 @@ class ShipmentTests extends OFBizTestCase {
         assert ServiceUtil.getErrorMessage(completeResult).contains('[104]')
     }
 
+    @Test
+    @Order(7)
     void testCreateShipmentRouteSegment() {
         GenericValue shipment = from('Shipment')
                 .where('shipmentId', '9998')
@@ -381,6 +395,8 @@ class ShipmentTests extends OFBizTestCase {
         assert shipmentRouteSegment.shipmentRouteSegmentId == shipmentRouteSegmentId
     }
 
+    @Test
+    @Order(8)
     void testQuickShipEntireOrderDoesNotMixShipGroupDestinations() {
         Map orderResult = dispatcher.runSync('createTestSalesOrderSingle',
                 [userLogin: userLogin, productId: 'GZ-2644'])
@@ -412,6 +428,8 @@ class ShipmentTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(9)
     void testQuickShipEntireOrderSkipsShipGroupWithNothingToShip() {
         Map orderResult = dispatcher.runSync('createTestSalesOrderSingle',
                 [userLogin: userLogin, productId: 'GZ-2644'])

--- a/applications/product/src/test/groovy/org/apache/ofbiz/shipment/product/test/ShipmentCostTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/shipment/product/test/ShipmentCostTests.groovy
@@ -19,13 +19,13 @@
 package org.apache.ofbiz.product.shipment.test
 
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class ShipmentCostTests extends OFBizTestCase {
-
-    ShipmentCostTests(String name) {
-        super(name)
-    }
+@JunitJupiterTest
+class ShipmentCostTests implements JupiterTestHelper {
 
     /**
      * ShipmentCostEstimates from ShipmentCostTestData.xml
@@ -68,6 +68,8 @@ class ShipmentCostTests extends OFBizTestCase {
 
      */
 
+    @Test
+    @Order(1)
     void testCalculateSimpleShipmentCostFlatValue() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],
@@ -86,6 +88,8 @@ class ShipmentCostTests extends OFBizTestCase {
         assert resultMap.shippingEstimateAmount == 10d
     }
 
+    @Test
+    @Order(2)
     void testCalculateSimpleShipmentCostPercentValue() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],
@@ -104,6 +108,8 @@ class ShipmentCostTests extends OFBizTestCase {
         assert resultMap.shippingEstimateAmount == 0.4d
     }
 
+    @Test
+    @Order(3)
     void testCalculateWeightBreakShipmentCostFlatValue() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],
@@ -156,6 +162,8 @@ class ShipmentCostTests extends OFBizTestCase {
         assert resultMap.shippingEstimateAmount as Double == 11d
     }
 
+    @Test
+    @Order(4)
     void testCalculateQuantityBreakShipmentCostFlatValue() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],
@@ -206,6 +214,8 @@ class ShipmentCostTests extends OFBizTestCase {
         assert resultMap.shippingEstimateAmount as Double == 14d
     }
 
+    @Test
+    @Order(5)
     void testCalculatePriceBreakShipmentCostFlatValue() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],
@@ -256,6 +266,8 @@ class ShipmentCostTests extends OFBizTestCase {
         assert resultMap.shippingEstimateAmount as Double == 17d
     }
 
+    @Test
+    @Order(6)
     void testCalculatePriceAndWeightBreakShipmentCostFlatValue() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],
@@ -322,6 +334,8 @@ class ShipmentCostTests extends OFBizTestCase {
         assert resultMap.shippingEstimateAmount as Double == 21d
     }
 
+    @Test
+    @Order(7)
     void testPriceBreakOverRangeAndFailedShipmentCost() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],
@@ -339,6 +353,8 @@ class ShipmentCostTests extends OFBizTestCase {
         assert ServiceUtil.isFailure(resultMap)
     }
 
+    @Test
+    @Order(8)
     void testCalculateMultipleWithPartyShipmentCostFlatValue() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],
@@ -358,6 +374,8 @@ class ShipmentCostTests extends OFBizTestCase {
         assert resultMap.shippingEstimateAmount as Double == 1d
     }
 
+    @Test
+    @Order(9)
     void testCalculateMultipleWithBreakShipmentCostFlatValue() {
         Map serviceCtx = [
                 shippableItemInfo: [[:]],

--- a/applications/product/src/test/java/org/apache/ofbiz/product/test/InventoryItemTransferTest.java
+++ b/applications/product/src/test/java/org/apache/ofbiz/product/test/InventoryItemTransferTest.java
@@ -19,31 +19,30 @@
 
 package org.apache.ofbiz.product.test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.ofbiz.base.util.UtilDateTime;
 import org.apache.ofbiz.entity.GenericValue;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Test;
 
-public class InventoryItemTransferTest extends OFBizTestCase {
+@JunitJupiterTest
+public class InventoryItemTransferTest implements JupiterTestHelper {
 
     private static String inventoryTransferId = null;
     private BigDecimal transferQty = BigDecimal.ONE;
-
-    public InventoryItemTransferTest(String name) {
-        super(name);
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-    }
 
     /**
      * Test create inventory items transfer.
      * @throws Exception the exception
      */
+    @Test
     public void testCreateInventoryItemsTransfer() throws Exception {
         GenericValue userLogin = getUserLogin("system");
         // create

--- a/applications/product/src/test/java/org/apache/ofbiz/product/test/StockMovesTest.java
+++ b/applications/product/src/test/java/org/apache/ofbiz/product/test/StockMovesTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.ofbiz.product.test;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
@@ -26,25 +28,21 @@ import java.util.Map;
 
 import org.apache.ofbiz.base.util.UtilGenerics;
 import org.apache.ofbiz.entity.GenericValue;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Test;
 
 /**
  * Facility Tests
  */
-public class StockMovesTest extends OFBizTestCase {
-
-    public StockMovesTest(String name) {
-        super(name);
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-    }
+@JunitJupiterTest
+public class StockMovesTest implements JupiterTestHelper {
 
     /**
      * Test stock moves.
      * @throws Exception the exception
      */
+    @Test
     public void testStockMoves() throws Exception {
         GenericValue userLogin = getUserLogin("system");
         Map<String, Object> fsmnCtx = new HashMap<>();

--- a/applications/product/src/test/java/org/apache/ofbiz/shipment/test/IssuanceTest.java
+++ b/applications/product/src/test/java/org/apache/ofbiz/shipment/test/IssuanceTest.java
@@ -19,6 +19,10 @@
 
 package org.apache.ofbiz.shipment.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -26,26 +30,22 @@ import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityQuery;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
 import org.apache.ofbiz.shipment.packing.PackingSession;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Test;
 
 /**
  * Item Issuance Tests
  */
-public class IssuanceTest extends OFBizTestCase {
-
-    public IssuanceTest(String name) {
-        super(name);
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-    }
+@JunitJupiterTest
+public class IssuanceTest implements JupiterTestHelper {
 
     /**
      * Test multiple inventory item issuance.
      * @throws Exception the exception
      */
+    @Test
     public void testMultipleInventoryItemIssuance() throws Exception {
         String facilityId = "WebStoreWarehouse";
         String productId = "GZ-2644";
@@ -64,8 +64,8 @@ public class IssuanceTest extends OFBizTestCase {
         // Test the OrderShipment is correct
         List<GenericValue> orderShipments = orderHeader.getRelated("OrderShipment", null, null, false);
 
-        assertFalse("No OrderShipment for order", UtilValidate.isEmpty(orderShipments));
-        assertEquals("Incorrect number of OrderShipments for order", 1, orderShipments.size());
+        assertFalse(UtilValidate.isEmpty(orderShipments), "No OrderShipment for order");
+        assertEquals(1, orderShipments.size(), "Incorrect number of OrderShipments for order");
 
         GenericValue orderShipment = orderShipments.get(0);
         assertEquals(orderItemSeqId, orderShipment.getString("orderItemSeqId"));
@@ -73,12 +73,12 @@ public class IssuanceTest extends OFBizTestCase {
         assertEquals(shipmentId, orderShipment.getString("shipmentId"));
         assertEquals(shipmentItemSeqId, orderShipment.getString("shipmentItemSeqId"));
         BigDecimal actual = orderShipment.getBigDecimal("quantity");
-        assertTrue("Incorrect quantity in OrderShipment. Expected 6.00000 actual " + actual, actual.compareTo(BigDecimal.valueOf(6L)) == 0);
+        assertTrue(actual.compareTo(BigDecimal.valueOf(6L)) == 0, "Incorrect quantity in OrderShipment. Expected 6.00000 actual " + actual);
 
         // Test the ItemIssuances are correct
         List<GenericValue> itemIssuances = orderHeader.getRelated("ItemIssuance", null, UtilMisc.toList("inventoryItemId"), false);
-        assertFalse("No ItemIssuances for order", UtilValidate.isEmpty(itemIssuances));
-        assertEquals("Incorrect number of ItemIssuances for order", 2, itemIssuances.size());
+        assertFalse(UtilValidate.isEmpty(itemIssuances), "No ItemIssuances for order");
+        assertEquals(2, itemIssuances.size(), "Incorrect number of ItemIssuances for order");
 
         GenericValue itemIssuance = itemIssuances.get(0);
         assertEquals(orderItemSeqId, itemIssuance.getString("orderItemSeqId"));
@@ -87,7 +87,7 @@ public class IssuanceTest extends OFBizTestCase {
         assertEquals(shipmentItemSeqId, itemIssuance.getString("shipmentItemSeqId"));
         assertEquals("9001", itemIssuance.getString("inventoryItemId"));
         actual = itemIssuance.getBigDecimal("quantity");
-        assertTrue("Incorrect quantity in ItemIssuance. Expected 5.00000 actual " + actual, actual.compareTo(BigDecimal.valueOf(5L)) == 0);
+        assertTrue(actual.compareTo(BigDecimal.valueOf(5L)) == 0, "Incorrect quantity in ItemIssuance. Expected 5.00000 actual " + actual);
 
         itemIssuance = itemIssuances.get(1);
         assertEquals(orderItemSeqId, itemIssuance.getString("orderItemSeqId"));
@@ -96,11 +96,11 @@ public class IssuanceTest extends OFBizTestCase {
         assertEquals(shipmentItemSeqId, itemIssuance.getString("shipmentItemSeqId"));
         assertEquals("9025", itemIssuance.getString("inventoryItemId"));
         actual = itemIssuance.getBigDecimal("quantity");
-        assertTrue("Incorrect quantity in ItemIssuance. Expected 1.00000 actual " + actual, actual.compareTo(BigDecimal.valueOf(1L)) == 0);
+        assertTrue(actual.compareTo(BigDecimal.valueOf(1L)) == 0, "Incorrect quantity in ItemIssuance. Expected 1.00000 actual " + actual);
 
         // Test reservations have been removed
         List<GenericValue> reservations = orderHeader.getRelated("OrderItemShipGrpInvRes", null, null, false);
-        assertTrue("Reservations exist for order - should have been deleted", UtilValidate.isEmpty(reservations));
+        assertTrue(UtilValidate.isEmpty(reservations), "Reservations exist for order - should have been deleted");
 
         // Test order header status is now ORDER_COMPLETED
         assertEquals(orderHeader.getString("statusId"), "ORDER_COMPLETED");

--- a/applications/product/testdef/CatalogTests.xml
+++ b/applications/product/testdef/CatalogTests.xml
@@ -27,7 +27,7 @@ under the License.
     </test-case>
 
     <test-case case-name="productPrice-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ProductPriceTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ProductPriceTests"/>
     </test-case>
 
     <test-case case-name="loadCategoryTestData">
@@ -35,6 +35,6 @@ under the License.
     </test-case>
 
     <test-case case-name="category-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.CategoryTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.CategoryTests"/>
     </test-case>
 </test-suite>

--- a/applications/product/testdef/CostTests.xml
+++ b/applications/product/testdef/CostTests.xml
@@ -23,6 +23,6 @@ under the License.
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-case case-name="cost-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.CostTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.CostTests"/>
     </test-case>
 </test-suite>

--- a/applications/product/testdef/FacilityTest.xml
+++ b/applications/product/testdef/FacilityTest.xml
@@ -22,22 +22,22 @@ under the License.
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
     <test-case case-name="stockMove-test">
-        <junit-test-suite class-name="org.apache.ofbiz.product.test.StockMovesTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.test.StockMovesTest"/>
     </test-case>
     <test-case case-name="inventoryItemTransfer-test">
-        <junit-test-suite class-name="org.apache.ofbiz.product.test.InventoryItemTransferTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.test.InventoryItemTransferTest"/>
     </test-case>
     <test-case case-name="inventory-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.InventoryTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.InventoryTests"/>
     </test-case>
 
     <test-case case-name="shipment-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ShipmentTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ShipmentTests"/>
     </test-case>
 
     <test-group case-name="shipmentcost-tests">
         <entity-xml action="load" entity-xml-url="component://product/testdef/data/ShipmentCostTestData.xml"/>
-        <junit-test-suite class-name="org.apache.ofbiz.product.shipment.test.ShipmentCostTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.shipment.test.ShipmentCostTests"/>
     </test-group>
 
     <test-case case-name="loadIssuanceTestData">
@@ -45,7 +45,7 @@ under the License.
     </test-case>
 
     <test-case case-name="issuance-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.shipment.test.IssuanceTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.shipment.test.IssuanceTest"/>
     </test-case>
 
 </test-suite>

--- a/applications/product/testdef/GroupOrderTest.xml
+++ b/applications/product/testdef/GroupOrderTest.xml
@@ -23,7 +23,7 @@ under the License.
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-case case-name="group-order-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.GroupOrderTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.GroupOrderTests"/>
     </test-case>
 
 </test-suite>

--- a/applications/product/testdef/ProductConfigTests.xml
+++ b/applications/product/testdef/ProductConfigTests.xml
@@ -27,6 +27,6 @@
         <entity-xml action="load" entity-xml-url="component://product/testdef/data/ProductConfigTestData.xml"/>
     </test-case>
     <test-case case-name="productConfigtests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ProductConfigTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ProductConfigTests"/>
     </test-case>
 </test-suite>

--- a/applications/product/testdef/ProductPromoTests.xml
+++ b/applications/product/testdef/ProductPromoTests.xml
@@ -23,9 +23,9 @@
             xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-group case-name="product-Conditions-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ProductPromoCondTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ProductPromoCondTests"/>
     </test-group>
     <test-group case-name="product-Action-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ProductPromoActionTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ProductPromoActionTests"/>
     </test-group>
 </test-suite>

--- a/applications/product/testdef/ProductTagTest.xml
+++ b/applications/product/testdef/ProductTagTest.xml
@@ -23,7 +23,7 @@ under the License.
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-case case-name="producttag-test">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ProductTagTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ProductTagTest"/>
     </test-case>
 
 </test-suite>

--- a/applications/product/testdef/ProductTest.xml
+++ b/applications/product/testdef/ProductTest.xml
@@ -27,13 +27,13 @@ under the License.
     </test-case>
 
     <test-case case-name="producttest">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ProductTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ProductTest"/>
     </test-case>
 
     <test-case case-name="product-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ProductTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ProductTests"/>
     </test-case>
     <test-case case-name="testCreateProductFeatureType">
-        <junit-test-suite class-name="org.apache.ofbiz.product.product.test.ProductFeatureTypeTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.product.product.test.ProductFeatureTypeTests"/>
     </test-case>
 </test-suite>

--- a/applications/workeffort/src/test/groovy/org/apache/ofbiz/workeffort/workeffort/test/WorkEffortTests.groovy
+++ b/applications/workeffort/src/test/groovy/org/apache/ofbiz/workeffort/workeffort/test/WorkEffortTests.groovy
@@ -19,15 +19,17 @@
 package org.apache.ofbiz.workeffort.workeffort.test
 
 import org.apache.ofbiz.entity.GenericValue
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.service.ServiceUtil
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class WorkEffortTests extends OFBizTestCase {
+@JunitJupiterTest
+class WorkEffortTests implements JupiterTestHelper {
 
-    WorkEffortTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testCreateWorkEffortAndPartyAssign() {
         Map serviceCtx = [
                 partyId: 'TestParty-1',
@@ -59,6 +61,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortPartyAssignment.statusId == 'PRTYASGN_ASSIGNED'
     }
 
+    @Test
+    @Order(2)
     void testDeleteWorkEffort() {
         Map createCtx = [
                 workEffortId: 'TestWorkEffort-98',
@@ -80,6 +84,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert !workEffort
     }
 
+    @Test
+    @Order(3)
     void testCopyWorkEffort() {
         Map serviceCtx = [
                 sourceWorkEffortId: 'TestWorkeffort-3',
@@ -94,6 +100,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffort.workEffortName == 'New Test Workeffort'
     }
 
+    @Test
+    @Order(4)
     void testDuplicateWorkEffort() {
         Map serviceCtx = [
                 oldWorkEffortId: 'TestWorkeffort-3',
@@ -108,6 +116,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffort.workEffortName == 'New Test Workeffort'
     }
 
+    @Test
+    @Order(5)
     void testMakeCommunicationEventWorkEffort() {
         Map serviceCtx = [
                 communicationEventId: 'TestEvent-1',
@@ -126,6 +136,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert communicationEventWorkEff
     }
 
+    @Test
+    @Order(6)
     void testAssignPartyToWorkEffort() {
         Map serviceCtx = [
                 partyId: 'TestParty',
@@ -150,6 +162,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortPartyAssignment
     }
 
+    @Test
+    @Order(7)
     void testUpdatePartyToWorkEffortAssignment() {
         Map serviceCtx = [
                 partyId: 'TestParty',
@@ -174,6 +188,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortPartyAssignment.statusId == 'PRTYASGN_ASSIGNED'
     }
 
+    @Test
+    @Order(8)
     void testDeletePartyToWorkEffortAssignment() {
         Map serviceCtx = [
                 partyId: 'TestParty',
@@ -197,6 +213,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortPartyAssignment.thruDate
     }
 
+    @Test
+    @Order(9)
     void testQuickAssignPartyToWorkEffort() {
         Map serviceCtx = [
                 quickAssignPartyId: 'TestCompany',
@@ -214,6 +232,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortPartyAssignment
     }
 
+    @Test
+    @Order(10)
     void testQuickAssignPartyToWorkEffortWithRole() {
         Map serviceCtx = [
                 quickAssignPartyId: 'TestParty-1',
@@ -234,6 +254,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortPartyAssignment
     }
 
+    @Test
+    @Order(11)
     void testCreateWorkEffortNote() {
         Map serviceCtx = [
                 workEffortId: 'TestWorkeffort-3',
@@ -251,6 +273,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert noteData.noteInfo == 'This is test note.'
     }
 
+    @Test
+    @Order(12)
     void testUpdateWorkEffortNote() {
         Map serviceCtx = [
                 workEffortId: 'TestWorkeffort-3',
@@ -269,6 +293,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert noteData.noteInfo == 'This is updated test note.'
     }
 
+    @Test
+    @Order(13)
     void testGetWorkEffort() {
         Map serviceCtx = [
                 workEffortId: 'TestWorkeffort-3',
@@ -279,6 +305,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert serviceResult.workEffort
     }
 
+    @Test
+    @Order(14)
     void testCreateWorkEffortAssoc() {
         Map serviceCtx = [
                 workEffortIdFrom: 'TestWorkeffort-2',
@@ -301,6 +329,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortAssoc
     }
 
+    @Test
+    @Order(15)
     void testCopyWorkEffortAssocs() {
         Map serviceCtx = [
                 sourceWorkEffortId: 'TestWorkeffort-2',
@@ -314,6 +344,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortAssocList
     }
 
+    @Test
+    @Order(16)
     void testCreateWorkEffortKeyword() {
         Map serviceCtx = [
                 workEffortId: 'TestWorkeffort-2',
@@ -331,6 +363,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffortKeyword
     }
 
+    @Test
+    @Order(17)
     void testDeleteWorkEffortKeyword() {
         Map serviceCtx = [
                 workEffortId: 'TestWorkeffort-3',
@@ -344,6 +378,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert !workEffortKeyword
     }
 
+    @Test
+    @Order(18)
     void testDeleteWorkEffortKeywords() {
         Map serviceCtx = [
                 workEffortId: 'TestWorkeffort-2',
@@ -356,6 +392,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert !workEffortKeywordList
     }
 
+    @Test
+    @Order(19)
     void testCreateTimesheet() {
         Map serviceCtx = [
                 partyId: 'TestParty',
@@ -374,6 +412,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert timesheet.comments == 'Test timesheet'
     }
 
+    @Test
+    @Order(20)
     void testUpdateTimesheet() {
         Map serviceCtx = [
                 timesheetId: 'TestTimesheet-2',
@@ -390,6 +430,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert timesheet.statusId == 'TIMESHEET_COMPLETED'
     }
 
+    @Test
+    @Order(21)
     void testDeleteTimesheet() {
         Map serviceCtx = [
                 timesheetId: 'TestTimesheet-3',
@@ -402,6 +444,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert !timesheet
     }
 
+    @Test
+    @Order(22)
     void testCreateTimesheets() {
         List partyIdList = ['TestParty', 'TestParty-1']
         Map serviceCtx = [
@@ -420,6 +464,8 @@ class WorkEffortTests extends OFBizTestCase {
         }
     }
 
+    @Test
+    @Order(23)
     void testCreateTimesheetForThisWeek() {
         Map serviceCtx = [
                 partyId: 'TestParty-1',
@@ -437,6 +483,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert timesheet.fromDate == java.sql.Timestamp.valueOf('2009-09-06 00:00:00.0')
     }
 
+    @Test
+    @Order(24)
     void testAddTimesheetToNewInvoice() {
         Map serviceCtx = [
                 partyId: 'TestParty-1',
@@ -453,6 +501,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert invoice.partyId == 'TestParty-1'
     }
 
+    @Test
+    @Order(25)
     void testCreateTimeEntry() {
         Map serviceCtx = [
                 workEffortId: 'TestWorkeffort-2',
@@ -469,6 +519,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert timeEntry.comments == 'Test Time Entry'
     }
 
+    @Test
+    @Order(26)
     void testUpdateTimeEntry() {
         Map serviceCtx = [
                 timeEntryId: 'TestTimeEntry-1',
@@ -483,6 +535,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert timeEntry.timesheetId == 'TestTimesheet-4'
     }
 
+    @Test
+    @Order(27)
     void testDeleteTimeEntry() {
         Map serviceCtx = [
                 timeEntryId: 'TestTimeEntry-2',
@@ -495,6 +549,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert !timeEntry
     }
 
+    @Test
+    @Order(28)
     void testCreateEventService() {
         GenericValue systemLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         Map createCtx = [
@@ -526,6 +582,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert workEffort.currentStatusId == 'CAL_ACCEPTED'
     }
 
+    @Test
+    @Order(29)
     void testCreateProjectService() {
         GenericValue systemLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         Map createCtx = [
@@ -571,6 +629,8 @@ class WorkEffortTests extends OFBizTestCase {
         assert noteData.noteInfo == "This is a note for party 'DemoCustomer'"
     }
 
+    @Test
+    @Order(30)
     void testGetTimeEntryRate() {
         Map serviceCtx = [
                 timeEntryId: 'TestTimeEntry-3',

--- a/applications/workeffort/testdef/workefforttests.xml
+++ b/applications/workeffort/testdef/workefforttests.xml
@@ -24,6 +24,6 @@
         <entity-xml action="load" entity-xml-url="component://workeffort/testdef/data/WorkEffortTestData.xml"/>
     </test-case>
     <test-case case-name="workeffort-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.workeffort.workeffort.test.WorkEffortTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.workeffort.workeffort.test.WorkEffortTests"/>
     </test-case>
 </test-suite>


### PR DESCRIPTION
I took care of the following work:

1) Migrated all 62 testdef-wired JUnit3 test classes across accounting, content, manufacturing, marketing, order, party, product, and
workeffort to Jupiter: extends OFBizTestCase/EntityTestCase ->
implements JupiterTestHelper, @JunitJupiterTest on the class, @Test (+ @Order matching declaration order for multi-method files) on each method, testdef <junit-test-suite> -> <jupiter-test-suite>.

2) Moved every migrated file still under src/main/{java,groovy} to src/test/{java,groovy} (manufacturing: 3 files, order: 5, product: 3 Java).

3) Fixed 8 pre-existing test-order-dependency bugs that JUnit 3's nondeterministic ordering had been masking, surfaced by Jupiter's deterministic @Order - each verified pre-existing before fixing, in manufacturing/ProductionRunTests, order/QuoteTests, party (3x), and product/ProductTest.

4) Dropped 4 dead no-op tearDown() overrides; reordered IssuanceTest.java's message-first JUnit3/4 assertions to JUnit 5's convention.

5) Left applications/accounting's orphaned FinAccountTests.java untouched - not wired to any testdef, out of scope.

6) Verified every migrated suite via scoped testIntegration runs, all passing with 0 failures/errors.