### PR TITLE
Migrate framework JUnit3 integration tests to JUnit5 (Jupiter)

### DIFF
--- a/framework/base/src/test/groovy/org/apache/ofbiz/base/test/SimpleTests.groovy
+++ b/framework/base/src/test/groovy/org/apache/ofbiz/base/test/SimpleTests.groovy
@@ -18,30 +18,38 @@
 */
 package org.apache.ofbiz.base.test
 
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Order
 
 /**
  * Class validating groovy scripts test engine.
  */
 
-class SimpleTests extends OFBizTestCase {
+@JunitJupiterTest
+class SimpleTests implements JupiterTestHelper {
 
-    SimpleTests(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testTrue() {
         assert 1 + 1 == 2
     }
 
+    @Test
+    @Order(2)
     void testDelegator() {
         assert delegator
     }
 
+    @Test
+    @Order(3)
     void testDispatcher() {
         assert dispatcher
     }
 
+    @Test
+    @Order(4)
     void testSecurity() {
         assert dispatcher.security
     }

--- a/framework/base/testdef/basetests.xml
+++ b/framework/base/testdef/basetests.xml
@@ -21,7 +21,7 @@
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:noNamespaceSchemaLocation="http://ofbiz.apache.org/dtds/test-suite.xsd">
     <test-case case-name="basesimpletests">
-        <junit-test-suite class-name="org.apache.ofbiz.base.test.SimpleTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.base.test.SimpleTests"/>
     </test-case>
 
 </test-suite>

--- a/framework/common/src/test/groovy/org/apache/ofbiz/common/test/UserLoginTests.groovy
+++ b/framework/common/src/test/groovy/org/apache/ofbiz/common/test/UserLoginTests.groovy
@@ -20,14 +20,14 @@ package org.apache.ofbiz.common.test
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
-class UserLoginTests extends OFBizTestCase {
+@JunitJupiterTest
+class UserLoginTests implements JupiterTestHelper {
 
-    UserLoginTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testCreateUserLogin() {
         String userLoginId = 'demo.person'
 

--- a/framework/common/src/test/java/org/apache/ofbiz/common/test/PerformFindTests.java
+++ b/framework/common/src/test/java/org/apache/ofbiz/common/test/PerformFindTests.java
@@ -18,6 +18,9 @@
  *******************************************************************************/
 package org.apache.ofbiz.common.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -34,15 +37,15 @@ import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityListIterator;
 import org.apache.ofbiz.service.LocalDispatcher;
 import org.apache.ofbiz.service.ServiceUtil;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
 import org.apache.ofbiz.entity.util.EntityQuery;
+import org.junit.jupiter.api.Test;
 
-public class PerformFindTests extends OFBizTestCase {
+@JunitJupiterTest
+public class PerformFindTests implements JupiterTestHelper {
 
     private static final String MODULE = PerformFindTests.class.getName();
-    public PerformFindTests(String name) {
-        super(name);
-    }
 
     private static List<GenericValue> getCompleteList(Map<String, Object> context) {
         List<GenericValue> foundElements = new LinkedList<>();
@@ -118,6 +121,7 @@ public class PerformFindTests extends OFBizTestCase {
      * See the issue OFBIZ-6218 Unit tests throw exception in DBCP for more details
      * @throws Exception
      */
+    @Test
     public void testPerformFind() throws Exception {
         performFindConditionFieldEquals();
         performFindConditionFieldLike();
@@ -140,14 +144,14 @@ public class PerformFindTests extends OFBizTestCase {
         Map<String, Object> result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         List<GenericValue> foundElements = getCompleteList(result);
-        assertTrue("performFind search without condition ", UtilValidate.isEmpty(foundElements));
+        assertTrue(UtilValidate.isEmpty(foundElements), "performFind search without condition ");
 
         //second test without condition and noConditionFind to Y
         performFindMap = UtilMisc.toMap("userLogin", userLogin, "entityName", "Testing", "inputFields", inputFields, "noConditionFind", "Y");
         result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         foundElements = getCompleteList(result);
-        assertEquals("performFind search without condition with noConditionFind Y", 10, foundElements.size());
+        assertEquals(10, foundElements.size(), "performFind search without condition with noConditionFind Y");
 
         //third test with equals condition on testingTypeId
         inputFields = UtilMisc.toMap("testingTypeId", "PERFOMFINDTEST");
@@ -159,7 +163,7 @@ public class PerformFindTests extends OFBizTestCase {
                 .from("Testing")
                 .where("testingTypeId", "PERFOMFINDTEST")
                 .queryList();
-        assertEquals("performFind search without condition with equals on testingTypeId", testingElements.size(), foundElements.size());
+        assertEquals(testingElements.size(), foundElements.size(), "performFind search without condition with equals on testingTypeId");
 
         //fourth test with equals condition on testingId
         inputFields = UtilMisc.toMap("testingId", "PERF_TEST_1");
@@ -167,7 +171,7 @@ public class PerformFindTests extends OFBizTestCase {
         result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         foundElements = getCompleteList(result);
-        assertEquals("performFind search without condition with equals on testingId", 1, foundElements.size());
+        assertEquals(1, foundElements.size(), "performFind search without condition with equals on testingId");
     }
 
     private void performFindConditionFieldLike() throws Exception {
@@ -181,7 +185,7 @@ public class PerformFindTests extends OFBizTestCase {
         Map<String, Object> result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         List<GenericValue> foundElements = getCompleteList(result);
-        assertEquals("performFind search with like nice% condition", 4, foundElements.size());
+        assertEquals(4, foundElements.size(), "performFind search with like nice% condition");
 
         //second test contains condition
         inputFields = UtilMisc.toMap("testingName", "name", "testingName_op", "contains");
@@ -189,7 +193,7 @@ public class PerformFindTests extends OFBizTestCase {
         result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         foundElements = getCompleteList(result);
-        assertEquals("performFind search with like %name% condition", 5, foundElements.size());
+        assertEquals(5, foundElements.size(), "performFind search with like %name% condition");
 
         //third test not-like condition
         inputFields = UtilMisc.toMap("testingName", "bad", "testingName_op", "not-like");
@@ -197,7 +201,7 @@ public class PerformFindTests extends OFBizTestCase {
         result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         foundElements = getCompleteList(result);
-        assertEquals("performFind search with not like bad% condition", 5, foundElements.size());
+        assertEquals(5, foundElements.size(), "performFind search with not like bad% condition");
 
         //fourth test not-contains condition
         inputFields = UtilMisc.toMap("testingName", "name", "testingName_op", "not-contains");
@@ -205,7 +209,7 @@ public class PerformFindTests extends OFBizTestCase {
         result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         foundElements = getCompleteList(result);
-        assertEquals("performFind search with not like %name% condition", 1, foundElements.size());
+        assertEquals(1, foundElements.size(), "performFind search with not like %name% condition");
     }
 
     private void performFindConditionDistinct() throws Exception {
@@ -221,7 +225,7 @@ public class PerformFindTests extends OFBizTestCase {
         Map<String, Object> result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         List<GenericValue> foundElements = getCompleteList(result);
-        assertEquals("performFind search with distinct N", 9, foundElements.size());
+        assertEquals(9, foundElements.size(), "performFind search with distinct N");
 
         //second test with distinct condition
         performFindMap = UtilMisc.toMap("userLogin", userLogin, "entityName", "Testing", "inputFields", inputFields,
@@ -229,7 +233,7 @@ public class PerformFindTests extends OFBizTestCase {
         result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         foundElements = getCompleteList(result);
-        assertEquals("performFind search with distinct Y", 6, foundElements.size());
+        assertEquals(6, foundElements.size(), "performFind search with distinct Y");
     }
 
     private void performFindFilterByDate() throws Exception {
@@ -244,7 +248,7 @@ public class PerformFindTests extends OFBizTestCase {
         Map<String, Object> result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         List<GenericValue> foundElements = getCompleteList(result);
-        assertEquals("performFind search with filterDate N", 5, foundElements.size());
+        assertEquals(5, foundElements.size(), "performFind search with filterDate N");
 
         //second test with filterDate condition
         performFindMap = UtilMisc.toMap("userLogin", userLogin, "entityName", "TestingNodeMember", "inputFields",
@@ -252,7 +256,7 @@ public class PerformFindTests extends OFBizTestCase {
         result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         foundElements = getCompleteList(result);
-        assertEquals("performFind search with filterDate Y", 3, foundElements.size());
+        assertEquals(3, foundElements.size(), "performFind search with filterDate Y");
     }
 
     /*
@@ -276,7 +280,7 @@ public class PerformFindTests extends OFBizTestCase {
         Map<String, Object> result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         List<GenericValue> foundElements = getCompleteList(result);
-        assertEquals("performFind search with group condition", 2, foundElements.size());
+        assertEquals(2, foundElements.size(), "performFind search with group condition");
         assertTrue(foundElements.stream().allMatch(genericValue ->
                 List.of("PERF_TEST_1", "PERF_TEST_10").contains(genericValue.getString("testingId"))));
     }
@@ -301,7 +305,7 @@ public class PerformFindTests extends OFBizTestCase {
         Map<String, Object> result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         List<GenericValue> foundElements = getCompleteList(result);
-        assertEquals("performFind search with group condition", 3, foundElements.size());
+        assertEquals(3, foundElements.size(), "performFind search with group condition");
     }
 
     private void performFindDateFindAndIgnoreCase() throws Exception {
@@ -321,7 +325,7 @@ public class PerformFindTests extends OFBizTestCase {
         Map<String, Object> result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         List<GenericValue> foundElements = getCompleteList(result);
-        assertEquals("performFind search with date-find widget condition", 2, foundElements.size());
+        assertEquals(2, foundElements.size(), "performFind search with date-find widget condition");
     }
 
     private void performFindFilterByDateWithDedicateDateField() throws Exception {
@@ -337,7 +341,7 @@ public class PerformFindTests extends OFBizTestCase {
         Map<String, Object> result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         List<GenericValue> foundElements = getCompleteList(result);
-        assertEquals("performFind search with filterDate N and specific date field name", 5, foundElements.size());
+        assertEquals(5, foundElements.size(), "performFind search with filterDate N and specific date field name");
 
         //second test with filterDate condition
         performFindMap = UtilMisc.toMap("userLogin", userLogin, "entityName", "TestingNodeMember", "inputFields", inputFields,
@@ -346,6 +350,6 @@ public class PerformFindTests extends OFBizTestCase {
         result = dispatcher.runSync("performFind", performFindMap);
         assertTrue(ServiceUtil.isSuccess(result));
         foundElements = getCompleteList(result);
-        assertEquals("performFind search with filterDate Y and specific date field name", 4, foundElements.size());
+        assertEquals(4, foundElements.size(), "performFind search with filterDate Y and specific date field name");
     }
 }

--- a/framework/common/testdef/PerformFindTests.xml
+++ b/framework/common/testdef/PerformFindTests.xml
@@ -23,7 +23,7 @@
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-case case-name="performfind-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.common.test.PerformFindTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.common.test.PerformFindTests"/>
     </test-case>
 
 </test-suite>

--- a/framework/common/testdef/UserLoginTests.xml
+++ b/framework/common/testdef/UserLoginTests.xml
@@ -22,6 +22,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
-    <test-case case-name="userlogin-tests"><junit-test-suite class-name="org.apache.ofbiz.common.test.UserLoginTests"/></test-case>
+    <test-case case-name="userlogin-tests"><jupiter-test-suite class-name="org.apache.ofbiz.common.test.UserLoginTests"/></test-case>
 
 </test-suite>

--- a/framework/entity/src/test/groovy/org/apache/ofbiz/entity/test/EntityUtilPropertiesTests.groovy
+++ b/framework/entity/src/test/groovy/org/apache/ofbiz/entity/test/EntityUtilPropertiesTests.groovy
@@ -19,14 +19,14 @@
 package org.apache.ofbiz.entity.test
 
 import org.apache.ofbiz.entity.util.EntityUtilProperties
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
-class EntityUtilPropertiesTests extends OFBizTestCase {
+@JunitJupiterTest
+class EntityUtilPropertiesTests implements JupiterTestHelper {
 
-    EntityUtilPropertiesTests(String name) {
-        super(name)
-    }
-
+    @Test
     void testGetGeneralProperties() {
         String currencyUomIdDefault = EntityUtilProperties.getPropertyValue('general', 'currency.uom.id.default', delegator)
         assert currencyUomIdDefault == 'USD'

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/test/EntityCryptoTestSuite.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/test/EntityCryptoTestSuite.java
@@ -18,6 +18,10 @@
  *******************************************************************************/
 package org.apache.ofbiz.entity.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.List;
 
 import org.apache.ofbiz.base.util.UtilMisc;
@@ -26,21 +30,24 @@ import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.condition.EntityCondition;
 import org.apache.ofbiz.entity.condition.EntityConditionSubSelect;
 import org.apache.ofbiz.entity.condition.EntityOperator;
-import org.apache.ofbiz.entity.testtools.EntityTestCase;
 import org.apache.ofbiz.entity.util.EntityQuery;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
 /**
  * The type EntityCryptoTestSuite.
  */
-public class EntityCryptoTestSuite extends EntityTestCase {
-    public EntityCryptoTestSuite(String name) {
-        super(name);
-    }
+@JunitJupiterTest
+public class EntityCryptoTestSuite implements JupiterTestHelper {
 
     /**
      * Test crypto.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testCrypto() throws Exception {
         String nanoTime = "" + System.nanoTime();
         getDelegator().removeByAnd("TestingCrypto", UtilMisc.toMap("testingCryptoTypeId", "BASIC"));
@@ -65,6 +72,8 @@ public class EntityCryptoTestSuite extends EntityTestCase {
      * Test crypto encryption.
      * @throws Exception the exception
      */
+    @Test
+    @Order(2)
     public void testCryptoEncryption() throws Exception {
         Delegator delegator = getDelegator();
         // clear out all values
@@ -127,6 +136,8 @@ public class EntityCryptoTestSuite extends EntityTestCase {
      * Test crypto lookup.
      * @throws Exception the exception
      */
+    @Test
+    @Order(3)
     public void testCryptoLookup() throws Exception {
         Delegator delegator = getDelegator();
         String nanoTime = "" + System.nanoTime();
@@ -176,6 +187,8 @@ public class EntityCryptoTestSuite extends EntityTestCase {
      * Test crypto sub select.
      * @throws Exception the exception
      */
+    @Test
+    @Order(4)
     public void testCryptoSubSelect() throws Exception {
         Delegator delegator = getDelegator();
         String nanoTime = "" + System.nanoTime();

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/test/EntityQueryTestSuite.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/test/EntityQueryTestSuite.java
@@ -18,6 +18,12 @@
  *******************************************************************************/
 package org.apache.ofbiz.entity.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.sql.Timestamp;
 import java.util.LinkedList;
 import java.util.List;
@@ -30,23 +36,25 @@ import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.condition.EntityCondition;
 import org.apache.ofbiz.entity.condition.EntityOperator;
-import org.apache.ofbiz.entity.testtools.EntityTestCase;
 import org.apache.ofbiz.entity.transaction.TransactionUtil;
 import org.apache.ofbiz.entity.util.EntityFindOptions;
 import org.apache.ofbiz.entity.util.EntityListIterator;
 import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.entity.util.EntityUtil;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
-public class EntityQueryTestSuite extends EntityTestCase {
-
-    public EntityQueryTestSuite(String name) {
-        super(name);
-    }
+@JunitJupiterTest
+public class EntityQueryTestSuite implements JupiterTestHelper {
 
     /**
      * queryCount(): This method returns number of records found for the particular query.
      * assert: Compared count of number of records found by Entity Engine method with count of number of records found by EntityQuery method.
      */
+    @Test
+    @Order(1)
     public void testQueryCount() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -58,7 +66,7 @@ public class EntityQueryTestSuite extends EntityTestCase {
         List<GenericValue> totalRecordsByEntityEngine = delegator.findList("TestingType", null, null, null, null, false);
         int numberOfRecordsByEntityQuery = (int) EntityQuery.use(delegator).from("TestingType").queryCount();
 
-        assertEquals("queryCount(): Total Number of Records matched", totalRecordsByEntityEngine.size(), numberOfRecordsByEntityQuery);
+        assertEquals(totalRecordsByEntityEngine.size(), numberOfRecordsByEntityQuery, "queryCount(): Total Number of Records matched");
     }
 
     /**
@@ -67,6 +75,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 2: Compared 'testingTypeId' field of first record fetched by Entity Engine method and by EntityQuery method.
      * assert 3: Compared 'description' field of first record fetched by Entity Engine method and by EntityQuery method.
      */
+    @Test
+    @Order(2)
     public void testWhere() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -80,12 +90,12 @@ public class EntityQueryTestSuite extends EntityTestCase {
         List<GenericValue> listByEntityQuery = EntityQuery.use(delegator).from("TestingType").where("description", "find me")
                 .orderBy("description").queryList();
 
-        assertEquals("where(): Number of records fetched by Entity Engine and by EntityQuery matched", listByEntityEngine.size(),
-                listByEntityQuery.size());
-        assertEquals("where(): Record matched = testingTypeId", listByEntityEngine.get(0).getString("testingTypeId"),
-                listByEntityQuery.get(0).getString("testingTypeId"));
-        assertEquals("where(): Record matched = description", listByEntityEngine.get(0).getString("description"),
-                listByEntityQuery.get(0).getString("description"));
+        assertEquals(listByEntityEngine.size(),
+                listByEntityQuery.size(), "where(): Number of records fetched by Entity Engine and by EntityQuery matched");
+        assertEquals(listByEntityEngine.get(0).getString("testingTypeId"),
+                listByEntityQuery.get(0).getString("testingTypeId"), "where(): Record matched = testingTypeId");
+        assertEquals(listByEntityEngine.get(0).getString("description"),
+                listByEntityQuery.get(0).getString("description"), "where(): Record matched = description");
     }
 
     /**
@@ -94,6 +104,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 2: Compared 'testingTypeId' field of first record fetched by Entity Engine method and by EntityQuery method.
      * assert 3: Compared 'description' field of first record fetched by Entity Engine method and by EntityQuery method.
      */
+    @Test
+    @Order(3)
     public void testQueryList() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -105,12 +117,12 @@ public class EntityQueryTestSuite extends EntityTestCase {
         List<GenericValue> listByEntityEngine = delegator.findList("TestingType", null, null, UtilMisc.toList("description"), null, false);
         List<GenericValue> listByEntityQuery = EntityQuery.use(delegator).from("TestingType").orderBy("description").queryList();
 
-        assertEquals("queryList(): Number of records fetched by Entity Engine and by EntityQuery matched", listByEntityEngine.size(),
-                listByEntityQuery.size());
-        assertEquals("queryList(): Record matched = testingTypeId", listByEntityEngine.get(0).getString("testingTypeId"),
-                listByEntityQuery.get(0).getString("testingTypeId"));
-        assertEquals("queryList(): Record matched = description", listByEntityEngine.get(0).getString("description"),
-                listByEntityQuery.get(0).getString("description"));
+        assertEquals(listByEntityEngine.size(),
+                listByEntityQuery.size(), "queryList(): Number of records fetched by Entity Engine and by EntityQuery matched");
+        assertEquals(listByEntityEngine.get(0).getString("testingTypeId"),
+                listByEntityQuery.get(0).getString("testingTypeId"), "queryList(): Record matched = testingTypeId");
+        assertEquals(listByEntityEngine.get(0).getString("description"),
+                listByEntityQuery.get(0).getString("description"), "queryList(): Record matched = description");
     }
 
     /**
@@ -118,6 +130,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 1: Compared 'testingTypeId' field of record fetched by Entity Engine method and by EntityQuery method.
      * assert 2: Compared 'description' field of first record fetched by Entity Engine method and by EntityQuery method.
      */
+    @Test
+    @Order(4)
     public void testQueryFirst() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -129,10 +143,10 @@ public class EntityQueryTestSuite extends EntityTestCase {
         GenericValue firstRecordByEntityEngine = EntityUtil.getFirst(delegator.findList("TestingType", null, null, null, null, false));
         GenericValue firstRecordByEntityQuery = EntityQuery.use(delegator).from("TestingType").queryFirst();
 
-        assertEquals("queryFirst(): Record matched = testingTypeId", firstRecordByEntityEngine.getString("testingTypeId"),
-                firstRecordByEntityQuery.getString("testingTypeId"));
-        assertEquals("queryFirst(): Record matched = description", firstRecordByEntityEngine.getString("description"),
-                firstRecordByEntityQuery.getString("description"));
+        assertEquals(firstRecordByEntityEngine.getString("testingTypeId"),
+                firstRecordByEntityQuery.getString("testingTypeId"), "queryFirst(): Record matched = testingTypeId");
+        assertEquals(firstRecordByEntityEngine.getString("description"),
+                firstRecordByEntityQuery.getString("description"), "queryFirst(): Record matched = description");
     }
 
     /**
@@ -140,6 +154,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 1: Compared 'testingTypeId' field of record fetched by Entity Engine method and by EntityQuery method.
      * assert 2: Compared 'description' field of first record fetched by Entity Engine method and by EntityQuery method.
      */
+    @Test
+    @Order(5)
     public void testQueryOne() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -151,10 +167,10 @@ public class EntityQueryTestSuite extends EntityTestCase {
         GenericValue findOneByEntityEngine = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "queryOne-2").queryOne();
         GenericValue queryOneByEntityQuery = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "queryOne-2").queryOne();
 
-        assertEquals("queryOne(): Record matched = testingTypeId", findOneByEntityEngine.getString("testingTypeId"),
-                queryOneByEntityQuery.getString("testingTypeId"));
-        assertEquals("queryOne(): Record matched = description", findOneByEntityEngine.getString("description"),
-                queryOneByEntityQuery.getString("description"));
+        assertEquals(findOneByEntityEngine.getString("testingTypeId"),
+                queryOneByEntityQuery.getString("testingTypeId"), "queryOne(): Record matched = testingTypeId");
+        assertEquals(findOneByEntityEngine.getString("description"),
+                queryOneByEntityQuery.getString("description"), "queryOne(): Record matched = description");
     }
 
     /**
@@ -162,6 +178,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 1: Check the TestingType entity queryOneMap-2 has been resolve
      * assert 2: Check the TestingType entity queryOneMap-3 has been resolve with the parameters map present in context
      */
+    @Test
+    @Order(6)
     public void testQueryOneWithContext() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -172,14 +190,14 @@ public class EntityQueryTestSuite extends EntityTestCase {
 
         Map<String, Object> context = UtilMisc.toMap("testingTypeId", "queryOneMap-2", "description", "query two by map", "otherField", "otherValue");
         GenericValue queryOneByEntityQueryAndContext = EntityQuery.use(delegator).from("TestingType").where(context).queryOne();
-        assertNotNull("queryOne() with context: Record found", queryOneByEntityQueryAndContext);
+        assertNotNull(queryOneByEntityQueryAndContext, "queryOne() with context: Record found");
 
         context = UtilMisc.toMap("description", "query two by map", "otherField", "otherValue",
                 "parameters", UtilMisc.toMap("testingTypeId", "queryOneMap-3", "description", "query three by map", "otherField", "otherValue"));
         GenericValue queryOneByEntityQueryAndParameters = EntityQuery.use(delegator).from("TestingType").where(context).queryOne();
-        assertNotNull("queryOne() with parameters: Record found", queryOneByEntityQueryAndParameters);
-        assertEquals("queryOne() with parameters: Record is queryOneMap-3 ", "queryOneMap-3",
-                queryOneByEntityQueryAndParameters.getString("testingTypeId"));
+        assertNotNull(queryOneByEntityQueryAndParameters, "queryOne() with parameters: Record found");
+        assertEquals("queryOneMap-3",
+                queryOneByEntityQueryAndParameters.getString("testingTypeId"), "queryOne() with parameters: Record is queryOneMap-3 ");
     }
 
     /**
@@ -187,6 +205,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 1: Compared value of first record of selected 'description' field by both EntityEngine method and EntityQuery method.
      * assert 2: Compared 'testingTypeId' field for null which is fetched by EntityQuery method.
      */
+    @Test
+    @Order(7)
     public void testSelect() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -200,8 +220,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
         List<GenericValue> selectByEntityQuery = EntityQuery.use(delegator).select("description").from("TestingType")
                 .orderBy("description").queryList();
 
-        assertEquals("select(): Record matched = description", selectByEntityEngine.get(0).getString("description"),
-                selectByEntityQuery.get(0).getString("description"));
+        assertEquals(selectByEntityEngine.get(0).getString("description"),
+                selectByEntityQuery.get(0).getString("description"), "select(): Record matched = description");
         assertNull(selectByEntityQuery.get(0).getString("testingTypeId"));
     }
 
@@ -212,6 +232,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 2: Compared value of first record of selected 'description' field by both EntityEngine method and EntityQuery method.
      * assert 3: Compared 'testingTypeId' field for null which is fetched by EntityQuery method.
      */
+    @Test
+    @Order(8)
     public void testDistinctAndSelect() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -227,10 +249,11 @@ public class EntityQueryTestSuite extends EntityTestCase {
         List<GenericValue> distinctByEntityQuery = EntityQuery.use(delegator).select("description").from("TestingType")
                 .distinct().orderBy("description").queryList();
 
-        assertEquals("distinct(): Number of records found by EntityEngine method are matching with records found by EntityQuery distinct method",
-                distinctByEntityEngine.size(), distinctByEntityQuery.size());
-        assertEquals("distinct(): Record matched = description", distinctByEntityEngine.get(0).getString("description"),
-                distinctByEntityQuery.get(0).getString("description"));
+        assertEquals(
+                distinctByEntityEngine.size(), distinctByEntityQuery.size(),
+                "distinct(): Number of records found by EntityEngine method are matching with records found by EntityQuery distinct method");
+        assertEquals(distinctByEntityEngine.get(0).getString("description"),
+                distinctByEntityQuery.get(0).getString("description"), "distinct(): Record matched = description");
         assertNull(distinctByEntityQuery.get(0).getString("testingTypeId"));
     }
 
@@ -240,6 +263,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 2: Compared 'testingTypeId' field of first record fetched by Entity Engine method and by EntityQuery method.
      * assert 3: Compared 'description' field of first record fetched by Entity Engine method and by EntityQuery method.
      */
+    @Test
+    @Order(9)
     public void testOrderBy() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -253,11 +278,11 @@ public class EntityQueryTestSuite extends EntityTestCase {
         List<GenericValue> orderedByEntityQuery = EntityQuery.use(delegator).from("TestingType").where(EntityCondition.makeCondition("testingTypeId",
                 EntityOperator.LIKE, "orderBy-%")).orderBy("description").queryList();
 
-        assertEquals("orderBy(): Number of records found by both the methods matched", orderedByEntityEngine.size(), orderedByEntityQuery.size());
-        assertEquals("orderBy(): Record matched = testingTypeId", orderedByEntityEngine.get(0).getString("testingTypeId"),
-                orderedByEntityQuery.get(0).getString("testingTypeId"));
-        assertEquals("orderBy(): Record matched = description", orderedByEntityEngine.get(0).getString("description"),
-                orderedByEntityQuery.get(0).getString("description"));
+        assertEquals(orderedByEntityEngine.size(), orderedByEntityQuery.size(), "orderBy(): Number of records found by both the methods matched");
+        assertEquals(orderedByEntityEngine.get(0).getString("testingTypeId"),
+                orderedByEntityQuery.get(0).getString("testingTypeId"), "orderBy(): Record matched = testingTypeId");
+        assertEquals(orderedByEntityEngine.get(0).getString("description"),
+                orderedByEntityQuery.get(0).getString("description"), "orderBy(): Record matched = description");
     }
 
     /**
@@ -268,6 +293,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 4: Compared 'fromDate' field of first record fetched by Entity Engine method and by EntityQuery method.
      * assert 5: Compared 'thruDate' field of first record fetched by Entity Engine method and by EntityQuery method.
      */
+    @Test
+    @Order(10)
     public void testFilterByDate() throws GenericEntityException {
         Delegator delegator = getDelegator();
         delegator.create("TestingType", "testingTypeId", "filterByDate-1", "description", "Filter BY Date");
@@ -296,16 +323,16 @@ public class EntityQueryTestSuite extends EntityTestCase {
         List<GenericValue> filteredByEntityQuery = EntityQuery.use(delegator).from("TestingNodeMember").filterByDate()
                 .orderBy("testingNodeId").queryList();
 
-        assertEquals("filterByDate(): Number of records found by both the methods matched", filteredByEntityUtil.size(),
-                filteredByEntityQuery.size());
-        assertEquals("filterByDate(): Record matched = testingNodeId", filteredByEntityUtil.get(0).getString("testingNodeId"),
-                filteredByEntityQuery.get(0).getString("testingNodeId"));
-        assertEquals("filterByDate(): Record matched = testingId", filteredByEntityUtil.get(0).getString("testingId"),
-                filteredByEntityQuery.get(0).getString("testingId"));
-        assertEquals("filterByDate(): Record matched = fromDate", filteredByEntityUtil.get(0).getString("fromDate"),
-                filteredByEntityQuery.get(0).getString("fromDate"));
-        assertEquals("filterByDate(): Record matched = thruDate", filteredByEntityUtil.get(0).getString("thruDate"),
-                filteredByEntityQuery.get(0).getString("thruDate"));
+        assertEquals(filteredByEntityUtil.size(),
+                filteredByEntityQuery.size(), "filterByDate(): Number of records found by both the methods matched");
+        assertEquals(filteredByEntityUtil.get(0).getString("testingNodeId"),
+                filteredByEntityQuery.get(0).getString("testingNodeId"), "filterByDate(): Record matched = testingNodeId");
+        assertEquals(filteredByEntityUtil.get(0).getString("testingId"),
+                filteredByEntityQuery.get(0).getString("testingId"), "filterByDate(): Record matched = testingId");
+        assertEquals(filteredByEntityUtil.get(0).getString("fromDate"),
+                filteredByEntityQuery.get(0).getString("fromDate"), "filterByDate(): Record matched = fromDate");
+        assertEquals(filteredByEntityUtil.get(0).getString("thruDate"),
+                filteredByEntityQuery.get(0).getString("thruDate"), "filterByDate(): Record matched = thruDate");
     }
 
     /**
@@ -314,6 +341,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 2: Compared 'testingTypeId' field of first record fetched by Entity Engine method and by EntityQuery method.
      * assert 3: Compared 'description' field of first record fetched by Entity Engine method and by EntityQuery method.
      */
+    @Test
+    @Order(11)
     public void testMaxRows() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -327,11 +356,11 @@ public class EntityQueryTestSuite extends EntityTestCase {
         List<GenericValue> maxRowsByEntityEngine = delegator.findList("TestingType", null, null, UtilMisc.toList("description"), findOptions, false);
         List<GenericValue> maxRowsByEntityQuery = EntityQuery.use(delegator).from("TestingType").maxRows(2).orderBy("description").queryList();
 
-        assertEquals("maxRows(): Number of records found by both the methods matched", maxRowsByEntityEngine.size(), maxRowsByEntityQuery.size());
-        assertEquals("maxRows(): Record matched = testingTypeId", maxRowsByEntityEngine.get(0).getString("testingTypeId"),
-                maxRowsByEntityQuery.get(0).getString("testingTypeId"));
-        assertEquals("maxRows(): Record matched = description", maxRowsByEntityEngine.get(0).getString("description"),
-                maxRowsByEntityQuery.get(0).getString("description"));
+        assertEquals(maxRowsByEntityEngine.size(), maxRowsByEntityQuery.size(), "maxRows(): Number of records found by both the methods matched");
+        assertEquals(maxRowsByEntityEngine.get(0).getString("testingTypeId"),
+                maxRowsByEntityQuery.get(0).getString("testingTypeId"), "maxRows(): Record matched = testingTypeId");
+        assertEquals(maxRowsByEntityEngine.get(0).getString("description"),
+                maxRowsByEntityQuery.get(0).getString("description"), "maxRows(): Record matched = description");
     }
 
     /**
@@ -340,6 +369,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert 2: Compared 'testingTypeId' field of first record fetched by Entity Engine method and by EntityQuery method.
      * assert 3: Compared 'description' field of first record fetched by Entity Engine method and by EntityQuery method.
      */
+    @Test
+    @Order(12)
     public void testFetchSize() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -354,18 +385,20 @@ public class EntityQueryTestSuite extends EntityTestCase {
                 UtilMisc.toList("description"), findOptions, false);
         List<GenericValue> fetchSizeByEntityQuery = EntityQuery.use(delegator).from("TestingType").fetchSize(2).orderBy("description").queryList();
 
-        assertEquals("fetchSize(): Number of records found by both the methods matched", fetchSizeByEntityEngine.size(),
-                fetchSizeByEntityQuery.size());
-        assertEquals("fetchSize(): Record matched = testingTypeId", fetchSizeByEntityEngine.get(0).getString("testingTypeId"),
-                fetchSizeByEntityQuery.get(0).getString("testingTypeId"));
-        assertEquals("fetchSize(): Record matched = description", fetchSizeByEntityEngine.get(0).getString("description"),
-                fetchSizeByEntityQuery.get(0).getString("description"));
+        assertEquals(fetchSizeByEntityEngine.size(),
+                fetchSizeByEntityQuery.size(), "fetchSize(): Number of records found by both the methods matched");
+        assertEquals(fetchSizeByEntityEngine.get(0).getString("testingTypeId"),
+                fetchSizeByEntityQuery.get(0).getString("testingTypeId"), "fetchSize(): Record matched = testingTypeId");
+        assertEquals(fetchSizeByEntityEngine.get(0).getString("description"),
+                fetchSizeByEntityQuery.get(0).getString("description"), "fetchSize(): Record matched = description");
     }
 
     /**
      * queryIterator(): This method is used to get iterator object over the entity.
      * assert: Compared first record of both the iterator.
      */
+    @Test
+    @Order(13)
     public void testQueryIterator() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -386,7 +419,7 @@ public class EntityQueryTestSuite extends EntityTestCase {
             GenericValue recordByEntityEngine = eliByEntityEngine.next();
             GenericValue recordByEntityQuery = eliByEntityQuery.next();
 
-            assertEquals("queryIterator(): Value of first record pointed by both iterators matched", recordByEntityEngine, recordByEntityQuery);
+            assertEquals(recordByEntityEngine, recordByEntityQuery, "queryIterator(): Value of first record pointed by both iterators matched");
             eliByEntityEngine.close();
             eliByEntityQuery.close();
 
@@ -400,6 +433,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * cursorForwardOnly(): Indicate that the ResultSet object's cursor may move only forward
      * assert: Compared first record found by both the iterator.
      */
+    @Test
+    @Order(14)
     public void testCursorForwardOnly() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -422,8 +457,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
             GenericValue nextRecordByEntityEngine = eliByEntityEngine.next();
             GenericValue nextRecordByEntityQuery = eliByEntityQuery.next();
 
-            assertEquals("cursorForwardOnly(): Value of first record pointed by both iterators matched", nextRecordByEntityEngine,
-                    nextRecordByEntityQuery);
+            assertEquals(nextRecordByEntityEngine,
+                    nextRecordByEntityQuery, "cursorForwardOnly(): Value of first record pointed by both iterators matched");
             eliByEntityEngine.close();
             eliByEntityQuery.close();
 
@@ -437,6 +472,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * cursorScrollSensitive(): ResultSet object's cursor is scrollable but generally sensitive to changes to the data that underlies the ResultSet.
      * assert: Compared first record found by both the iterators.
      */
+    @Test
+    @Order(15)
     public void testCursorScrollSensitive() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -459,8 +496,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
             GenericValue nextRecordByDelegator = eliByEntityEngine.next();
             GenericValue nextRecordByEntityQuery = eliByEntityQuery.next();
 
-            assertEquals("cursorScrollSensitive(): Records by delegator method and by EntityQuery method matched", nextRecordByDelegator,
-                    nextRecordByEntityQuery);
+            assertEquals(nextRecordByDelegator,
+                    nextRecordByEntityQuery, "cursorScrollSensitive(): Records by delegator method and by EntityQuery method matched");
             eliByEntityEngine.close();
             eliByEntityQuery.close();
 
@@ -475,6 +512,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * assert: Ensure that a request with a select or a date filter stored in cache is not retrieved by a query
      * without select nor date filter having the same condition.
      */
+    @Test
+    @Order(16)
     public void testCache() throws GenericEntityException {
         Timestamp now = UtilDateTime.nowTimestamp();
         Delegator delegator = getDelegator();
@@ -494,11 +533,11 @@ public class EntityQueryTestSuite extends EntityTestCase {
 
         List<GenericValue> cachedResultWithFilterByDate = EntityQuery.use(delegator).from("TestingNodeMember").filterByDate()
                 .where("testingId", "testingCache1").cache().queryList();
-        assertEquals("testCache(): Number of records found match", 1, cachedResultWithFilterByDate.size());
+        assertEquals(1, cachedResultWithFilterByDate.size(), "testCache(): Number of records found match");
 
         List<GenericValue> cachedResultWithoutFilterByDate = EntityQuery.use(delegator).from("TestingNodeMember")
                 .where("testingId", "testingCache1").queryList();
-        assertEquals("testCache(): Number of records found match", 2, cachedResultWithoutFilterByDate.size());
+        assertEquals(2, cachedResultWithoutFilterByDate.size(), "testCache(): Number of records found match");
 
         GenericValue firstCachedResultWithSelect = EntityQuery.use(delegator).select("testingTypeId").from("TestingType").cache().queryFirst();
         assertFalse(firstCachedResultWithSelect.containsKey("description"));
@@ -512,6 +551,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * underlies the ResultSet.
      * assert: Compared first record found by both the iterators.
      */
+    @Test
+    @Order(17)
     public void testCursorScrollInSensitive() throws GenericEntityException {
         Delegator delegator = getDelegator();
         List<GenericValue> testingTypes = new LinkedList<>();
@@ -534,8 +575,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
             GenericValue nextRecordByDelegator = eliByEntityEngine.next();
             GenericValue nextRecordByEntityQuery = eliByEntityQuery.next();
 
-            assertEquals("cursorScrollInSensitive(): Records by delegator method and by EntityQuery method matched",
-                    nextRecordByDelegator, nextRecordByEntityQuery);
+            assertEquals(nextRecordByDelegator, nextRecordByEntityQuery,
+                    "cursorScrollInSensitive(): Records by delegator method and by EntityQuery method matched");
             eliByEntityEngine.close();
             eliByEntityQuery.close();
 
@@ -549,6 +590,8 @@ public class EntityQueryTestSuite extends EntityTestCase {
      * Check that init function use() work well with a GenericValue that implements DelegatorProvider
      * assert: ensure delegator present on GV is the same that created and EntityQuery.use on GV not return null
      */
+    @Test
+    @Order(18)
     public void testUseFromDelegatorProvider() throws GenericEntityException {
         Delegator delegator = getDelegator();
         GenericValue testGv = delegator.makeValue("TestingType",

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/test/EntityTestSuite.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/test/EntityTestSuite.java
@@ -18,6 +18,13 @@
  *******************************************************************************/
 package org.apache.ofbiz.entity.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.Date;
@@ -55,15 +62,19 @@ import org.apache.ofbiz.entity.config.model.Datasource;
 import org.apache.ofbiz.entity.config.model.EntityConfig;
 import org.apache.ofbiz.entity.model.ModelEntity;
 import org.apache.ofbiz.entity.model.ModelField;
-import org.apache.ofbiz.entity.testtools.EntityTestCase;
 import org.apache.ofbiz.entity.transaction.GenericTransactionException;
 import org.apache.ofbiz.entity.transaction.TransactionUtil;
 import org.apache.ofbiz.entity.util.EntityListIterator;
 import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.entity.util.EntitySaxReader;
 import org.apache.ofbiz.entity.util.SequenceUtil;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
-public class EntityTestSuite extends EntityTestCase {
+@JunitJupiterTest
+public class EntityTestSuite implements JupiterTestHelper {
 
     private static final String MODULE = EntityTestSuite.class.getName();
     /*
@@ -75,39 +86,39 @@ public class EntityTestSuite extends EntityTestCase {
      */
     public static final long TEST_COUNT = 1000;
 
-    public EntityTestSuite(String name) {
-        super(name);
-    }
-
     private static final int LEVEL_1_MAX = 3;   // number of TestingNode entities to create
 
     /**
      * Test models.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testModels() throws Exception {
         ModelEntity modelEntity = getDelegator().getModelEntity("TestingType");
-        assertNotNull("TestingType entity model not null", modelEntity);
+        assertNotNull(modelEntity, "TestingType entity model not null");
         ModelField modelField = modelEntity.getField("description");
-        assertNotNull("TestingType.description field model not null", modelField);
+        assertNotNull(modelField, "TestingType.description field model not null");
         modelField = ModelField.create(modelEntity, null, "newDesc", modelField.getType(), "NEW_DESC", null,
                 null, false, false, false, false, false, null);
         modelEntity.addField(modelField);
         modelField = modelEntity.getField("newDesc");
-        assertNotNull("TestingType.newDesc field model not null", modelField);
+        assertNotNull(modelField, "TestingType.newDesc field model not null");
         modelEntity.removeField("newDesc");
         modelField = modelEntity.getField("newDesc");
-        assertNull("TestingType.newDesc field model is null", modelField);
+        assertNull(modelField, "TestingType.newDesc field model is null");
     }
 
     /**
      * Tests storing values with the delegator's .create, .makeValue, and .storeAll methods
      */
+    @Test
+    @Order(2)
     public void testMakeValue() throws Exception {
         // This method call directly stores a new value into the entity engine
         GenericValue createdValue = getDelegator().create("TestingType", "testingTypeId", "TEST-MAKE-1", "description", "Testing Type #Make-1");
-        assertTrue("Created value is mutable", createdValue.isMutable());
-        assertFalse("Observable has not changed", createdValue.hasChanged());
+        assertTrue(createdValue.isMutable(), "Created value is mutable");
+        assertFalse(createdValue.hasChanged(), "Observable has not changed");
 
         // This sequence creates the GenericValue entities first, puts them in a List, then calls the delegator to store them all
         List<GenericValue> newValues = new LinkedList<>();
@@ -123,52 +134,56 @@ public class EntityTestSuite extends EntityTestCase {
                                                            .where(EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-MAKE-%"))
                                                            .orderBy("testingTypeId")
                                                            .queryList();
-        assertEquals("4 TestingTypes(for make) found", 4, newlyCreatedValues.size());
+        assertEquals(4, newlyCreatedValues.size(), "4 TestingTypes(for make) found");
     }
 
     /**
      * Tests updating entities by doing a GenericValue .put(key, value) and .store()
      */
+    @Test
+    @Order(3)
     public void testUpdateValue() throws Exception {
         // retrieve a sample GenericValue, make sure it's correct
         getDelegator().removeByCondition("TestingType", EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-UPDATE-%"));
         GenericValue testValue = EntityQuery.use(getDelegator()).from("TestingType").where("testingTypeId", "TEST-UPDATE-1").queryOne();
-        assertNull("No pre-existing type value", testValue);
+        assertNull(testValue, "No pre-existing type value");
         getDelegator().create("TestingType", "testingTypeId", "TEST-UPDATE-1", "description", "Testing Type #Update-1");
         testValue = EntityQuery.use(getDelegator()).from("TestingType").where("testingTypeId", "TEST-UPDATE-1").queryOne();
-        assertEquals("Retrieved value has the correct description", "Testing Type #Update-1", testValue.getString("description"));
+        assertEquals("Testing Type #Update-1", testValue.getString("description"), "Retrieved value has the correct description");
         // Test Observable aspect
-        assertFalse("Observable has not changed", testValue.hasChanged());
+        assertFalse(testValue.hasChanged(), "Observable has not changed");
         TestObserver observer = new TestObserver();
         testValue.addObserver(observer);
         testValue.put("description", "New Testing Type #Update-1");
-        assertEquals("Observer called with original GenericValue field name", "description", observer.arg);
+        assertEquals("description", observer.arg, "Observer called with original GenericValue field name");
         GenericValue clonedValue = (GenericValue) testValue.clone();
         clonedValue.put("description", "New Testing Type #Update-1");
-        assertTrue("Cloned Observable has changed", clonedValue.hasChanged());
-        assertEquals("Observer called with cloned GenericValue field name", "description", observer.arg);
+        assertTrue(clonedValue.hasChanged(), "Cloned Observable has changed");
+        assertEquals("description", observer.arg, "Observer called with cloned GenericValue field name");
         // now store it
         testValue.store();
-        assertFalse("Observable has not changed", testValue.hasChanged());
+        assertFalse(testValue.hasChanged(), "Observable has not changed");
         // now retrieve it again and make sure that the updated value is correct
         testValue = EntityQuery.use(getDelegator()).from("TestingType").where("testingTypeId", "TEST-UPDATE-1").queryOne();
-        assertEquals("Retrieved value has the correct description", "New Testing Type #Update-1", testValue.getString("description"));
+        assertEquals("New Testing Type #Update-1", testValue.getString("description"), "Retrieved value has the correct description");
     }
 
     /**
      * Test remove value.
      * @throws Exception the exception
      */
+    @Test
+    @Order(4)
     public void testRemoveValue() throws Exception {
         // Retrieve a sample GenericValue, make sure it's correct
         getDelegator().removeByCondition("TestingType", EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-REMOVE-%"));
         GenericValue testValue = EntityQuery.use(getDelegator()).from("TestingType").where("testingTypeId", "TEST-REMOVE-1").queryOne();
-        assertNull("No pre-existing type value", testValue);
+        assertNull(testValue, "No pre-existing type value");
         getDelegator().create("TestingType", "testingTypeId", "TEST-REMOVE-1", "description", "Testing Type #Remove-1");
         testValue = EntityQuery.use(getDelegator()).from("TestingType").where("testingTypeId", "TEST-REMOVE-1").queryOne();
-        assertEquals("Retrieved value has the correct description", "Testing Type #Remove-1", testValue.getString("description"));
+        assertEquals("Testing Type #Remove-1", testValue.getString("description"), "Retrieved value has the correct description");
         testValue.remove();
-        assertFalse("Observable has not changed", testValue.hasChanged());
+        assertFalse(testValue.hasChanged(), "Observable has not changed");
         // Test immutable
         try {
             testValue.put("description", "New Testing Type #Remove-4");
@@ -181,13 +196,15 @@ public class EntityTestSuite extends EntityTestCase {
         } catch (UnsupportedOperationException e) {
         }
         testValue = EntityQuery.use(getDelegator()).from("TestingType").where("testingTypeId", "TEST-REMOVE-1").queryOne();
-        assertEquals("Finding removed value returns null", null, testValue);
+        assertEquals(null, testValue, "Finding removed value returns null");
     }
 
     /**
      * Test to load huge entity
      * @throws Exception the exception
      */
+    @Test
+    @Order(5)
     public void testCreateAllValues() throws Exception {
         List<GenericValue> testValues = new ArrayList<>(100);
         for (int i = 0; i < 100; i++) {
@@ -197,26 +214,30 @@ public class EntityTestSuite extends EntityTestCase {
             testValues.add(getDelegator().makeValue("Testing", "testingId", "TEST_CREATE_DIST" + i));
         }
         getDelegator().createAllByBatchProcess(testValues);
-        assertEquals("create all insert 100 elements", 100, getDelegator().findCountByCondition("TestingType",
-                EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST_CREATE_ALL%"), null, null));
-        assertEquals("create all insert 100 elements", 100, getDelegator().findCountByCondition("Testing",
-                EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "TEST_CREATE_DIST%"), null, null));
+        assertEquals(100, getDelegator().findCountByCondition("TestingType",
+                EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST_CREATE_ALL%"), null, null),
+                "create all insert 100 elements");
+        assertEquals(100, getDelegator().findCountByCondition("Testing",
+                EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "TEST_CREATE_DIST%"), null, null),
+                "create all insert 100 elements");
     }
 
     /**
      * Tests the entity cache
      * @throws Exception the exception
      */
+    @Test
+    @Order(6)
     public void testEntityCache() throws Exception {
         // Test primary key cache
         Delegator delegator = getDelegator();
         delegator.removeByCondition("TestingType", EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-CACHE-%"));
         delegator.removeByCondition("TestingSubtype", EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-CACHE-%"));
         GenericValue testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-CACHE-1").cache(true).queryOne();
-        assertNull("No pre-existing type value", testValue);
+        assertNull(testValue, "No pre-existing type value");
         delegator.create("TestingType", "testingTypeId", "TEST-CACHE-1", "description", "Testing Type #Cache-1");
         testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-CACHE-1").cache(true).queryOne();
-        assertEquals("Retrieved from cache value has the correct description", "Testing Type #Cache-1", testValue.getString("description"));
+        assertEquals("Testing Type #Cache-1", testValue.getString("description"), "Retrieved from cache value has the correct description");
         // Test immutable
         try {
             testValue.put("description", "New Testing Type #Cache-1");
@@ -233,49 +254,49 @@ public class EntityTestSuite extends EntityTestCase {
         int hashCode = testValue.hashCode();
         GenericValue originalValue = testValue;
         testValue = (GenericValue) testValue.clone();
-        assertTrue("Cloned GenericValue equals original GenericValue", originalValue.equals(testValue));
-        assertTrue("Cloned GenericValue has the same hash code", hashCode == testValue.hashCode());
+        assertTrue(originalValue.equals(testValue), "Cloned GenericValue equals original GenericValue");
+        assertTrue(hashCode == testValue.hashCode(), "Cloned GenericValue has the same hash code");
         testValue.put("description", "New Testing Type #Cache-1");
-        assertFalse("Modified GenericValue does not equal original GenericValue", originalValue.equals(testValue));
-        assertTrue("Modified GenericValue has a different hash code", hashCode != testValue.hashCode());
+        assertFalse(originalValue.equals(testValue), "Modified GenericValue does not equal original GenericValue");
+        assertTrue(hashCode != testValue.hashCode(), "Modified GenericValue has a different hash code");
         testValue.store();
         testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-CACHE-1").cache(true).queryOne();
-        assertEquals("Retrieved from cache value has the correct description", "New Testing Type #Cache-1", testValue.getString("description"));
+        assertEquals("New Testing Type #Cache-1", testValue.getString("description"), "Retrieved from cache value has the correct description");
         // Test storeByCondition updates the cache
         testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-CACHE-1").cache(true).queryFirst();
         EntityCondition storeByCondition = EntityCondition.makeCondition(UtilMisc.toMap("testingTypeId", "TEST-CACHE-1",
                 "lastUpdatedStamp", testValue.get("lastUpdatedStamp")));
         int qtyChanged = delegator.storeByCondition("TestingType", UtilMisc.toMap("description", "New Testing Type #Cache-0"), storeByCondition);
-        assertEquals("Delegator.storeByCondition updated one value", 1, qtyChanged);
+        assertEquals(1, qtyChanged, "Delegator.storeByCondition updated one value");
         testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-CACHE-1").cache(true).queryFirst();
 
-        assertEquals("Retrieved from cache value has the correct description", "New Testing Type #Cache-0", testValue.getString("description"));
+        assertEquals("New Testing Type #Cache-0", testValue.getString("description"), "Retrieved from cache value has the correct description");
         // Test removeByCondition updates the cache
         qtyChanged = delegator.removeByCondition("TestingType", storeByCondition);
-        assertEquals("Delegator.removeByCondition removed one value", 1, qtyChanged);
+        assertEquals(1, qtyChanged, "Delegator.removeByCondition removed one value");
         testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-CACHE-1").cache(true).queryFirst();
-        assertEquals("Retrieved from cache value is null", null, testValue);
+        assertEquals(null, testValue, "Retrieved from cache value is null");
         // Test entity value remove operation updates the cache
         testValue = delegator.create("TestingType", "testingTypeId", "TEST-CACHE-1", "description", "Testing Type #Cache-1");
         testValue.remove();
         testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-CACHE-1").cache(true).queryOne();
-        assertEquals("Retrieved from cache value is null", null, testValue);
+        assertEquals(null, testValue, "Retrieved from cache value is null");
         // Test entity condition cache
         List<GenericValue> testList = EntityQuery.use(delegator)
                                                  .from("TestingType")
                                                  .where(EntityCondition.makeCondition("description", EntityOperator.EQUALS, "Testing Type #Cache-2"))
                                                  .cache(true)
                                                  .queryList();
-        assertEquals("Delegator findList returned no values", 0, testList.size());
+        assertEquals(0, testList.size(), "Delegator findList returned no values");
         delegator.create("TestingType", "testingTypeId", "TEST-CACHE-2", "description", "Testing Type #Cache-2");
         testList = EntityQuery.use(delegator)
                               .from("TestingType")
                               .where(EntityCondition.makeCondition("description", EntityOperator.EQUALS, "Testing Type #Cache-2"))
                               .cache(true)
                               .queryList();
-        assertEquals("Delegator findList returned one value", 1, testList.size());
+        assertEquals(1, testList.size(), "Delegator findList returned one value");
         testValue = testList.get(0);
-        assertEquals("Retrieved from cache value has the correct description", "Testing Type #Cache-2", testValue.getString("description"));
+        assertEquals("Testing Type #Cache-2", testValue.getString("description"), "Retrieved from cache value has the correct description");
         // Test immutable
         try {
             testValue.put("description", "New Testing Type #2");
@@ -296,7 +317,7 @@ public class EntityTestSuite extends EntityTestCase {
                               .where(EntityCondition.makeCondition("description", EntityOperator.EQUALS, "Testing Type #Cache-2"))
                               .cache(true)
                               .queryList();
-        assertEquals("Delegator findList returned two values", 2, testList.size());
+        assertEquals(2, testList.size(), "Delegator findList returned two values");
         // Test entity value update operation updates the cache
         testValue.put("description", "New Testing Type #Cache-3");
         testValue.store();
@@ -305,7 +326,7 @@ public class EntityTestSuite extends EntityTestCase {
                               .where(EntityCondition.makeCondition("description", EntityOperator.EQUALS, "Testing Type #Cache-2"))
                               .cache(true)
                               .queryList();
-        assertEquals("Delegator findList returned one value", 1, testList.size());
+        assertEquals(1, testList.size(), "Delegator findList returned one value");
         // Test entity value remove operation updates the cache
         testValue = testList.get(0);
         testValue = (GenericValue) testValue.clone();
@@ -315,16 +336,16 @@ public class EntityTestSuite extends EntityTestCase {
                               .where(EntityCondition.makeCondition("description", EntityOperator.EQUALS, "Testing Type #Cache-2"))
                               .cache(true)
                               .queryList();
-        assertEquals("Delegator findList returned empty list", 0, testList.size());
+        assertEquals(0, testList.size(), "Delegator findList returned empty list");
         // Test view entities in the pk cache - updating an entity should clear pk caches for all view entities containing that entity.
         testValue = EntityQuery.use(delegator).from("TestingSubtype").where("testingTypeId", "TEST-CACHE-3").cache(true).queryOne();
-        assertNull("No pre-existing TestingSubtype", testValue);
+        assertNull(testValue, "No pre-existing TestingSubtype");
         testValue = delegator.create("TestingSubtype", "testingTypeId", "TEST-CACHE-3", "subtypeDescription", "Testing Subtype #Cache-3");
-        assertNotNull("TestingSubtype created", testValue);
+        assertNotNull(testValue, "TestingSubtype created");
         // Confirm member entity appears in the view
         testValue = EntityQuery.use(delegator).from("TestingViewPks").where("testingTypeId", "TEST-CACHE-3").cache(true).queryOne();
-        assertEquals("View retrieved from cache has the correct member description", "Testing Subtype #Cache-3",
-                testValue.getString("subtypeDescription"));
+        assertEquals("Testing Subtype #Cache-3", testValue.getString("subtypeDescription"),
+                "View retrieved from cache has the correct member description");
         testValue = EntityQuery.use(delegator).from("TestingSubtype").where("testingTypeId", "TEST-CACHE-3").cache(true).queryOne();
         // Modify member entity
         testValue = (GenericValue) testValue.clone();
@@ -332,14 +353,16 @@ public class EntityTestSuite extends EntityTestCase {
         testValue.store();
         // Check if cached view contains the modification
         testValue = EntityQuery.use(delegator).from("TestingViewPks").where("testingTypeId", "TEST-CACHE-3").cache(true).queryOne();
-        assertEquals("View retrieved from cache has the correct member description", "New Testing Subtype #Cache-3",
-                testValue.getString("subtypeDescription"));
+        assertEquals("New Testing Subtype #Cache-3", testValue.getString("subtypeDescription"),
+                "View retrieved from cache has the correct member description");
     }
 
     /**
      * Test xml serialization.
      * @throws Exception the exception
      */
+    @Test
+    @Order(7)
     public void testXmlSerialization() throws Exception {
         // Must use the default delegator because the deserialized GenericValue can't
         // find the randomized one.
@@ -347,14 +370,14 @@ public class EntityTestSuite extends EntityTestCase {
         boolean transBegin = TransactionUtil.begin();
         localDelegator.create("TestingType", "testingTypeId", "TEST-5", "description", "Testing Type #5");
         GenericValue testValue = EntityQuery.use(localDelegator).from("TestingType").where("testingTypeId", "TEST-5").queryOne();
-        assertEquals("Retrieved value has the correct description", "Testing Type #5", testValue.getString("description"));
+        assertEquals("Testing Type #5", testValue.getString("description"), "Retrieved value has the correct description");
         String newValueStr = UtilXml.toXml(testValue);
         GenericValue newValue = (GenericValue) UtilXml.fromXml(newValueStr);
-        assertEquals("Retrieved value has the correct description", "Testing Type #5", newValue.getString("description"));
+        assertEquals("Testing Type #5", newValue.getString("description"), "Retrieved value has the correct description");
         newValue.put("description", "XML Testing Type #5");
         newValue.store();
         newValue = EntityQuery.use(localDelegator).from("TestingType").where("testingTypeId", "TEST-5").queryOne();
-        assertEquals("Retrieved value has the correct description", "XML Testing Type #5", newValue.getString("description"));
+        assertEquals("XML Testing Type #5", newValue.getString("description"), "Retrieved value has the correct description");
         TransactionUtil.rollback(transBegin, null, null);
     }
 
@@ -389,6 +412,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * Tests storing data with the delegator's .create method.  Also tests .findCountByCondition and .getNextSeqId
      */
+    @Test
+    @Order(8)
     public void testCreateTree() throws Exception {
         Delegator delegator = getDelegator();
         // get how many child nodes did we have before creating the tree
@@ -398,17 +423,19 @@ public class EntityTestSuite extends EntityTestCase {
                                       .from("TestingNode")
                                       .where(EntityCondition.makeCondition("description", EntityOperator.LIKE, "create:%"))
                                       .queryCount();
-        assertEquals("Created/Stored Nodes", created, newlyStored);
+        assertEquals(created, newlyStored, "Created/Stored Nodes");
     }
 
     /**
      * More tests of storing data with .storeAll.  Also prepares data for testing view-entities (see below.)
      */
+    @Test
+    @Order(9)
     public void testAddMembersToTree() throws Exception {
         Delegator delegator = getDelegator();
         delegator.removeByCondition("TestingType", EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-TREE-%"));
         GenericValue testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-TREE-1").cache(true).queryOne();
-        assertNull("No pre-existing type value", testValue);
+        assertNull(testValue, "No pre-existing type value");
         delegator.create("TestingType", "testingTypeId", "TEST-TREE-1", "description", "Testing Type #Tree-1");
         // get the level1 nodes
         List<GenericValue> nodeLevel1 = EntityQuery.use(delegator)
@@ -441,7 +468,7 @@ public class EntityTestSuite extends EntityTestCase {
             newValues.add(member);
         }
         int n = delegator.storeAll(newValues);
-        assertEquals("Created/Stored Nodes", newValues.size(), n);
+        assertEquals(newValues.size(), n, "Created/Stored Nodes");
     }
 
     /**
@@ -491,6 +518,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * Tests findByCondition and tests searching on a view-entity
      */
+    @Test
+    @Order(10)
     public void testCountViews() throws Exception {
         Delegator delegator = getDelegator();
         delegator.removeByCondition("Testing", EntityCondition.makeCondition("testingTypeId", EntityOperator.EQUALS, "TEST-COUNT-VIEW"));
@@ -514,25 +543,27 @@ public class EntityTestSuite extends EntityTestCase {
             }
         }
         long testingcount = EntityQuery.use(delegator).from("Testing").where("testingTypeId", "TEST-COUNT-VIEW").queryCount();
-        assertEquals("Number of views should equal number of created entities in the test.", testingcount, nodeWithMembers.size());
+        assertEquals(testingcount, nodeWithMembers.size(), "Number of views should equal number of created entities in the test.");
     }
 
     /**
      * Tests findByCondition and a find by distinct
      */
+    @Test
+    @Order(11)
     public void testFindDistinct() throws Exception {
         Delegator delegator = getDelegator();
         delegator.removeByCondition("Testing", EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-DISTINCT-%"));
         List<GenericValue> testingDistinctList = EntityQuery.use(delegator).from("Testing")
                 .where(EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-DISTINCT-%")).queryList();
 
-        assertEquals("No existing Testing entities for distinct", 0, testingDistinctList.size());
+        assertEquals(0, testingDistinctList.size(), "No existing Testing entities for distinct");
         delegator.removeByCondition("TestingType", EntityCondition.makeCondition("testingTypeId", EntityOperator.LIKE, "TEST-DISTINCT-%"));
         GenericValue testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-DISTINCT-1").cache(true).queryOne();
-        assertNull("No pre-existing type value", testValue);
+        assertNull(testValue, "No pre-existing type value");
         delegator.create("TestingType", "testingTypeId", "TEST-DISTINCT-1", "description", "Testing Type #Distinct-1");
         testValue = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "TEST-DISTINCT-1").cache(true).queryOne();
-        assertNotNull("Found newly created type value", testValue);
+        assertNotNull(testValue, "Found newly created type value");
 
         delegator.create("Testing", "testingId", "TEST-DISTINCT-1", "testingTypeId", "TEST-DISTINCT-1", "testingSize", 10L,
                 "comments", "No-comments");
@@ -552,29 +583,33 @@ public class EntityTestSuite extends EntityTestCase {
                                                       .queryList();
         Debug.logInfo("testingSize10 is " + testingSize10.size(), MODULE);
 
-        assertEquals("There should only be 1 result found by findDistinct()", 1, testingSize10.size());
+        assertEquals(1, testingSize10.size(), "There should only be 1 result found by findDistinct()");
     }
 
     /**
      * Tests a findByCondition using not like
      */
+    @Test
+    @Order(12)
     public void testNotLike() throws Exception {
         List<GenericValue> nodes = EntityQuery.use(getDelegator())
                                               .from("TestingNode")
                                               .where(EntityCondition.makeCondition("description", EntityOperator.NOT_LIKE, "root%"))
                                               .queryList();
-        assertNotNull("Found nodes", nodes);
+        assertNotNull(nodes, "Found nodes");
 
         for (GenericValue product: nodes) {
             String nodeId = product.getString("description");
             Debug.logInfo("Testing name - " + nodeId, MODULE);
-            assertFalse("No nodes starting w/ root", nodeId.startsWith("root"));
+            assertFalse(nodeId.startsWith("root"), "No nodes starting w/ root");
         }
     }
 
     /**
      * Tests foreign key integrity by trying to remove an entity which has foreign-key dependencies.  Should cause an exception.
      */
+    @Test
+    @Order(13)
     public void testForeignKeyCreate() {
         try {
             String helperName = getDelegator().getEntityHelper("Testing").getHelperName();
@@ -592,13 +627,15 @@ public class EntityTestSuite extends EntityTestCase {
         } catch (GenericEntityException e) {
             caught = e;
         }
-        assertNotNull("Foreign key referential integrity is not observed for create (INSERT)", caught);
+        assertNotNull(caught, "Foreign key referential integrity is not observed for create (INSERT)");
         Debug.logInfo(caught.toString(), MODULE);
     }
 
     /**
      * Tests foreign key integrity by trying to remove an entity which has foreign-key dependencies.  Should cause an exception.
      */
+    @Test
+    @Order(14)
     public void testForeignKeyRemove() throws Exception {
         Delegator delegator = getDelegator();
         try {
@@ -626,13 +663,15 @@ public class EntityTestSuite extends EntityTestCase {
         } catch (GenericEntityException e) {
             caught = e;
         }
-        assertNotNull("Foreign key referential integrity is not observed for remove (DELETE)", caught);
+        assertNotNull(caught, "Foreign key referential integrity is not observed for remove (DELETE)");
         Debug.logInfo(caught.toString(), MODULE);
     }
 
     /**
      * Tests the .getRelatedOne method and removeAll for removing entities
      */
+    @Test
+    @Order(15)
     public void testRemoveNodeMemberAndTesting() throws Exception {
         Delegator delegator = getDelegator();
         flushAndRecreateTree("rnmat");
@@ -656,19 +695,21 @@ public class EntityTestSuite extends EntityTestCase {
                             .from("TestingNodeMember")
                             .where(EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "rnmat:%"))
                             .queryList();
-        assertEquals("No more Node Member entities", 0, values.size());
+        assertEquals(0, values.size(), "No more Node Member entities");
 
         delegator.removeAll(testings);
         values = EntityQuery.use(delegator)
                             .from("Testing")
                             .where(EntityCondition.makeCondition("description", EntityOperator.LIKE, "rnmat:%"))
                             .queryList();
-        assertEquals("No more Testing entities", 0, values.size());
+        assertEquals(0, values.size(), "No more Testing entities");
     }
 
     /**
      * Tests the storeByCondition operation
      */
+    @Test
+    @Order(16)
     public void testStoreByCondition() throws Exception {
         flushAndRecreateTree("store-by-condition-a");
         flushAndRecreateTree("store-by-condition-b");
@@ -678,12 +719,14 @@ public class EntityTestSuite extends EntityTestCase {
         getDelegator().storeByCondition("TestingNode", fieldsToSet, isLevel1);
         List<GenericValue> updatedNodes = EntityQuery.use(getDelegator()).from("TestingNode").where(fieldsToSet).queryList();
         int n = updatedNodes.size();
-        assertTrue("testStoreByCondition updated nodes > 0", n > 0);
+        assertTrue(n > 0, "testStoreByCondition updated nodes > 0");
     }
 
     /**
      * Tests the .removeByCondition method for removing entities directly
      */
+    @Test
+    @Order(17)
     public void testRemoveByCondition() throws Exception {
         flushAndRecreateTree("remove-by-condition-a");
         //
@@ -691,12 +734,14 @@ public class EntityTestSuite extends EntityTestCase {
         //
         EntityCondition isLevel1 = EntityCondition.makeCondition("description", EntityOperator.LIKE, "remove-by-condition-a:1:%");
         int n = getDelegator().removeByCondition("TestingNode", isLevel1);
-        assertTrue("testRemoveByCondition nodes > 0", n > 0);
+        assertTrue(n > 0, "testRemoveByCondition nodes > 0");
     }
 
     /**
      * Test the .removeByPrimaryKey by using findByCondition and then retrieving the GenericPk from a GenericValue
      */
+    @Test
+    @Order(18)
     public void testRemoveByPK() throws Exception {
         Delegator delegator = getDelegator();
         flushAndRecreateTree("remove-by-pk");
@@ -713,40 +758,44 @@ public class EntityTestSuite extends EntityTestCase {
         for (GenericValue value: rootValues) {
             GenericPK pk = value.getPrimaryKey();
             int del = delegator.removeByPrimaryKey(pk);
-            assertEquals("Removing Root by primary key", 1, del);
+            assertEquals(1, del, "Removing Root by primary key");
         }
 
         // no more TestingNode should be in the data base anymore.
 
         List<GenericValue> testingNodes = EntityQuery.use(delegator).from("TestingNode").where(isRoot).queryList();
-        assertEquals("No more TestingNode after removing the roots", 0, testingNodes.size());
+        assertEquals(0, testingNodes.size(), "No more TestingNode after removing the roots");
     }
 
     /**
      * Tests the .removeAll method only.
      */
+    @Test
+    @Order(19)
     public void testRemoveType() throws Exception {
         Delegator delegator = getDelegator();
         List<GenericValue> values = EntityQuery.use(delegator).from("TestingRemoveAll").queryList();
         delegator.removeAll(values);
         values = EntityQuery.use(delegator).from("TestingRemoveAll").queryList();
-        assertEquals("No more TestingRemoveAll: setup", 0, values.size());
+        assertEquals(0, values.size(), "No more TestingRemoveAll: setup");
         for (int i = 0; i < 10; i++) {
             delegator.create("TestingRemoveAll", "testingRemoveAllId", "prefix:" + i);
         }
         values = EntityQuery.use(delegator).from("TestingRemoveAll").queryList();
-        assertEquals("No more TestingRemoveAll: create", 10, values.size());
+        assertEquals(10, values.size(), "No more TestingRemoveAll: create");
 
         delegator.removeAll(values);
 
         // now make sure there are no more of these
         values = EntityQuery.use(delegator).from("TestingRemoveAll").queryList();
-        assertEquals("No more TestingRemoveAll: finish", 0, values.size());
+        assertEquals(0, values.size(), "No more TestingRemoveAll: finish");
     }
 
     /**
      * This test will create a large number of unique items and add them to the delegator at once
      */
+    @Test
+    @Order(20)
     public void testCreateManyAndStoreAtOnce() throws Exception {
         Delegator delegator = getDelegator();
         try {
@@ -760,7 +809,7 @@ public class EntityTestSuite extends EntityTestCase {
                                                                .where(EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "T1-%"))
                                                                .orderBy("testingId")
                                                                .queryList();
-            assertEquals("Test to create " + TEST_COUNT + " and store all at once", TEST_COUNT, newlyCreatedValues.size());
+            assertEquals(TEST_COUNT, newlyCreatedValues.size(), "Test to create " + TEST_COUNT + " and store all at once");
         } finally {
             List<GenericValue> newlyCreatedValues = EntityQuery.use(delegator)
                                                                .from("Testing")
@@ -774,6 +823,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * This test will create a large number of unique items and add them to the delegator at once
      */
+    @Test
+    @Order(21)
     public void testCreateManyAndStoreOneAtATime() throws Exception {
         Delegator delegator = getDelegator();
         try {
@@ -785,7 +836,7 @@ public class EntityTestSuite extends EntityTestCase {
                                                                .where(EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "T2-%"))
                                                                .orderBy("testingId")
                                                                .queryList();
-            assertEquals("Test to create " + TEST_COUNT + " and store one at a time: ", TEST_COUNT, newlyCreatedValues.size());
+            assertEquals(TEST_COUNT, newlyCreatedValues.size(), "Test to create " + TEST_COUNT + " and store one at a time: ");
         } finally {
             List<GenericValue> newlyCreatedValues = EntityQuery.use(delegator)
                                                                .from("Testing")
@@ -799,6 +850,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * This test will use the large number of unique items from above and test the EntityListIterator looping through the list
      */
+    @Test
+    @Order(22)
     public void testEntityListIterator() throws Exception {
         Delegator delegator = getDelegator();
         try {
@@ -812,7 +865,7 @@ public class EntityTestSuite extends EntityTestCase {
                                                                .where(EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "T3-%"))
                                                                .orderBy("testingId")
                                                                .queryList();
-            assertEquals("Test to create " + TEST_COUNT + " and store all at once", TEST_COUNT, newlyCreatedValues.size());
+            assertEquals(TEST_COUNT, newlyCreatedValues.size(), "Test to create " + TEST_COUNT + " and store all at once");
             boolean beganTransaction = false;
             try {
                 beganTransaction = TransactionUtil.begin();
@@ -821,20 +874,20 @@ public class EntityTestSuite extends EntityTestCase {
                                                          .where(EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "T3-%"))
                                                          .orderBy("testingId")
                                                          .queryIterator();
-                assertNotNull("Test if EntityListIterator was created: ", iterator);
+                assertNotNull(iterator, "Test if EntityListIterator was created: ");
 
                 int i = 0;
                 GenericValue item = iterator.next();
                 while (item != null) {
-                    assertEquals("Testing if iterated data matches test data (row " + i + "): ", getTestId("T3-", i), item.getString("testingId"));
+                    assertEquals(getTestId("T3-", i), item.getString("testingId"), "Testing if iterated data matches test data (row " + i + "): ");
                     item = iterator.next();
                     i++;
                 }
-                assertEquals("Test if EntitlyListIterator iterates exactly " + TEST_COUNT + " times: ", TEST_COUNT, i);
+                assertEquals(TEST_COUNT, i, "Test if EntitlyListIterator iterates exactly " + TEST_COUNT + " times: ");
                 iterator.close();
             } catch (GenericEntityException e) {
                 TransactionUtil.rollback(beganTransaction, "GenericEntityException occurred while iterating with EntityListIterator", e);
-                assertTrue("GenericEntityException:" + e.toString(), false);
+                assertTrue(false, "GenericEntityException:" + e.toString());
                 return;
             } finally {
                 TransactionUtil.commit(beganTransaction);
@@ -851,6 +904,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * This test will verify transaction rollbacks using TransactionUtil.
      */
+    @Test
+    @Order(23)
     public void testTransactionUtilRollback() throws Exception {
         Delegator delegator = getDelegator();
         GenericValue testValue = delegator.makeValue("Testing", "testingId", "rollback-test");
@@ -858,12 +913,14 @@ public class EntityTestSuite extends EntityTestCase {
         delegator.create(testValue);
         TransactionUtil.rollback(transBegin, null, null);
         GenericValue testValueOut = EntityQuery.use(delegator).from("Testing").where("testingId", "rollback-test").queryOne();
-        assertEquals("Test that transaction rollback removes value: ", null, testValueOut);
+        assertEquals(null, testValueOut, "Test that transaction rollback removes value: ");
     }
 
     /**
      * This test will verify that a transaction which takes longer than the pre-set timeout are rolled back.
      */
+    @Test
+    @Order(24)
     public void testTransactionUtilMoreThanTimeout() throws Exception {
         Delegator delegator = getDelegator();
         GenericTransactionException caught = null;
@@ -876,7 +933,7 @@ public class EntityTestSuite extends EntityTestCase {
         } catch (GenericTransactionException e) {
             caught = e;
         } finally {
-            assertNotNull("timeout thrown", caught);
+            assertNotNull(caught, "timeout thrown");
             delegator.removeByAnd("Testing", "testingId", "timeout-test");
         }
     }
@@ -884,6 +941,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * This test will verify that the same transaction transaction which takes less time than timeout will be committed.
      */
+    @Test
+    @Order(25)
     public void testTransactionUtilLessThanTimeout() throws Exception {
         Delegator delegator = getDelegator();
         try {
@@ -901,6 +960,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * Tests field types.
      */
+    @Test
+    @Order(26)
     public void testFieldTypes() throws Exception {
         Delegator delegator = getDelegator();
         String id = "testFieldTypes";
@@ -941,26 +1002,26 @@ public class EntityTestSuite extends EntityTestCase {
             testValue.set("clobField", clobStr);
             testValue.store();
             testValue = EntityQuery.use(delegator).from("TestFieldType").where("testFieldTypeId", id).queryOne();
-            assertEquals("testFieldTypeId", id, testValue.get("testFieldTypeId"));
+            assertEquals(id, testValue.get("testFieldTypeId"), "testFieldTypeId");
             Blob blob = (Blob) testValue.get("blobField");
             byte[] c = blob.getBytes(1, (int) blob.length());
-            assertEquals("Byte array read from entity is the same length", b.length, c.length);
+            assertEquals(b.length, c.length, "Byte array read from entity is the same length");
             for (int i = 0; i < b.length; i++) {
-                assertEquals("Byte array data[" + i + "]", b[i], c[i]);
+                assertEquals(b[i], c[i], "Byte array data[" + i + "]");
             }
             c = (byte[]) testValue.get("byteArrayField");
-            assertEquals("Byte array read from entity is the same length", b.length, c.length);
+            assertEquals(b.length, c.length, "Byte array read from entity is the same length");
             for (int i = 0; i < b.length; i++) {
-                assertEquals("Byte array data[" + i + "]", b[i], c[i]);
+                assertEquals(b[i], c[i], "Byte array data[" + i + "]");
             }
-            assertEquals("objectField", currentTimestamp, testValue.get("objectField"));
-            assertEquals("dateField", currentDate, testValue.get("dateField"));
-            assertEquals("timeField", currentTime, testValue.get("timeField"));
-            assertEquals("dateTimeField", currentTimestamp, testValue.get("dateTimeField"));
-            assertEquals("fixedPointField", fixedPoint, testValue.get("fixedPointField"));
-            assertEquals("floatingPointField", floatingPoint, testValue.get("floatingPointField"));
-            assertEquals("numericField", numeric, testValue.get("numericField"));
-            assertEquals("clobField", clobStr, testValue.get("clobField"));
+            assertEquals(currentTimestamp, testValue.get("objectField"), "objectField");
+            assertEquals(currentDate, testValue.get("dateField"), "dateField");
+            assertEquals(currentTime, testValue.get("timeField"), "timeField");
+            assertEquals(currentTimestamp, testValue.get("dateTimeField"), "dateTimeField");
+            assertEquals(fixedPoint, testValue.get("fixedPointField"), "fixedPointField");
+            assertEquals(floatingPoint, testValue.get("floatingPointField"), "floatingPointField");
+            assertEquals(numeric, testValue.get("numericField"), "numericField");
+            assertEquals(clobStr, testValue.get("clobField"), "clobField");
             testValue.set("blobField", null);
             testValue.set("byteArrayField", null);
             testValue.set("objectField", null);
@@ -973,17 +1034,17 @@ public class EntityTestSuite extends EntityTestCase {
             testValue.set("clobField", null);
             testValue.store();
             testValue = EntityQuery.use(delegator).from("TestFieldType").where("testFieldTypeId", id).queryOne();
-            assertEquals("testFieldTypeId", id, testValue.get("testFieldTypeId"));
-            assertNull("blobField null", testValue.get("blobField"));
-            assertNull("byteArrayField null", testValue.get("byteArrayField"));
-            assertNull("objectField null", testValue.get("objectField"));
-            assertNull("dateField null", testValue.get("dateField"));
-            assertNull("timeField null", testValue.get("timeField"));
-            assertNull("dateTimeField null", testValue.get("dateTimeField"));
-            assertNull("fixedPointField null", testValue.get("fixedPointField"));
-            assertNull("floatingPointField null", testValue.get("floatingPointField"));
-            assertNull("numericField null", testValue.get("numericField"));
-            assertNull("clobField null", testValue.get("clobField"));
+            assertEquals(id, testValue.get("testFieldTypeId"), "testFieldTypeId");
+            assertNull(testValue.get("blobField"), "blobField null");
+            assertNull(testValue.get("byteArrayField"), "byteArrayField null");
+            assertNull(testValue.get("objectField"), "objectField null");
+            assertNull(testValue.get("dateField"), "dateField null");
+            assertNull(testValue.get("timeField"), "timeField null");
+            assertNull(testValue.get("dateTimeField"), "dateTimeField null");
+            assertNull(testValue.get("fixedPointField"), "fixedPointField null");
+            assertNull(testValue.get("floatingPointField"), "floatingPointField null");
+            assertNull(testValue.get("numericField"), "numericField null");
+            assertNull(testValue.get("clobField"), "clobField null");
         } finally {
             // Remove all our newly inserted values.
             List<GenericValue> values = EntityQuery.use(delegator).from("TestFieldType").queryList();
@@ -1015,6 +1076,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * Tests EntitySaxReader, verification loading data with tag create, create-update, create-replace, delete
      */
+    @Test
+    @Order(27)
     public void testEntitySaxReaderCreation() throws Exception {
         Delegator delegator = getDelegator();
         String xmlContentLoad =
@@ -1030,26 +1093,28 @@ public class EntityTestSuite extends EntityTestCase {
                 + "</entity-engine-xml>";
         EntitySaxReader reader = new EntitySaxReader(delegator);
         long numberLoaded = reader.parse(xmlContentLoad);
-        assertEquals("Create Entity loaded ", 4, numberLoaded);
+        assertEquals(4, numberLoaded, "Create Entity loaded ");
         GenericValue t1 = EntityQuery.use(delegator).from("Testing").where("testingId", "T1").queryOne();
         GenericValue t2 = EntityQuery.use(delegator).from("Testing").where("testingId", "T2").cache(true).queryOne();
-        assertNotNull("Create Testing(T1)", t1);
-        assertEquals("Create Testing(T1).testingTypeId", "JUNIT-TEST", t1.getString("testingTypeId"));
-        assertEquals("Create Testing(T1).testingName", "First test", t1.getString("testingName"));
-        assertEquals("Create Testing(T1).testingSize", Long.valueOf(10), t1.getLong("testingSize"));
-        assertEquals("Create Testing(T1).testingDate", UtilDateTime.toTimestamp("01/01/2010 00:00:00"), t1.getTimestamp("testingDate"));
+        assertNotNull(t1, "Create Testing(T1)");
+        assertEquals("JUNIT-TEST", t1.getString("testingTypeId"), "Create Testing(T1).testingTypeId");
+        assertEquals("First test", t1.getString("testingName"), "Create Testing(T1).testingName");
+        assertEquals(Long.valueOf(10), t1.getLong("testingSize"), "Create Testing(T1).testingSize");
+        assertEquals(UtilDateTime.toTimestamp("01/01/2010 00:00:00"), t1.getTimestamp("testingDate"), "Create Testing(T1).testingDate");
 
-        assertNotNull("Create Testing(T2)", t2);
-        assertEquals("Create Testing(T2).testingTypeId", "JUNIT-TEST2", t2.getString("testingTypeId"));
-        assertEquals("Create Testing(T2).testingName", "Second test", t2.getString("testingName"));
-        assertEquals("Create Testing(T2).testingSize", Long.valueOf(20), t2.getLong("testingSize"));
-        assertEquals("Create Testing(T2).testingDate", UtilDateTime.toTimestamp("02/01/2010 00:00:00"), t2.getTimestamp("testingDate"));
+        assertNotNull(t2, "Create Testing(T2)");
+        assertEquals("JUNIT-TEST2", t2.getString("testingTypeId"), "Create Testing(T2).testingTypeId");
+        assertEquals("Second test", t2.getString("testingName"), "Create Testing(T2).testingName");
+        assertEquals(Long.valueOf(20), t2.getLong("testingSize"), "Create Testing(T2).testingSize");
+        assertEquals(UtilDateTime.toTimestamp("02/01/2010 00:00:00"), t2.getTimestamp("testingDate"), "Create Testing(T2).testingDate");
     }
 
     /**
      * Test entity sax reader create skip.
      * @throws Exception the exception
      */
+    @Test
+    @Order(28)
     public void testEntitySaxReaderCreateSkip() throws Exception {
         Delegator delegator = getDelegator();
         String xmlContentLoad =
@@ -1067,19 +1132,21 @@ public class EntityTestSuite extends EntityTestCase {
                 + "</create>";
         reader = new EntitySaxReader(delegator);
         numberLoaded += reader.parse(xmlContentLoad);
-        assertEquals("Create Skip Entity loaded ", 3, numberLoaded);
+        assertEquals(3, numberLoaded, "Create Skip Entity loaded ");
         GenericValue t1 = EntityQuery.use(delegator).from("Testing").where("testingId", "reader-create-skip").queryOne();
-        assertNotNull("Create Skip Testing(T1)", t1);
-        assertEquals("Create Skip Testing(T1).testingTypeId", "reader-create-skip", t1.getString("testingTypeId"));
-        assertEquals("Create Skip Testing(T1).testingName", "reader create skip", t1.getString("testingName"));
-        assertEquals("Create Skip Testing(T1).testingSize", Long.valueOf(10), t1.getLong("testingSize"));
-        assertEquals("Create Skip Testing(T1).testingDate", UtilDateTime.toTimestamp("01/01/2010 00:00:00"), t1.getTimestamp("testingDate"));
+        assertNotNull(t1, "Create Skip Testing(T1)");
+        assertEquals("reader-create-skip", t1.getString("testingTypeId"), "Create Skip Testing(T1).testingTypeId");
+        assertEquals("reader create skip", t1.getString("testingName"), "Create Skip Testing(T1).testingName");
+        assertEquals(Long.valueOf(10), t1.getLong("testingSize"), "Create Skip Testing(T1).testingSize");
+        assertEquals(UtilDateTime.toTimestamp("01/01/2010 00:00:00"), t1.getTimestamp("testingDate"), "Create Skip Testing(T1).testingDate");
     }
 
     /**
      * Test entity sax reader update.
      * @throws Exception the exception
      */
+    @Test
+    @Order(29)
     public void testEntitySaxReaderUpdate() throws Exception {
         Delegator delegator = getDelegator();
         String xmlContentLoad =
@@ -1097,26 +1164,28 @@ public class EntityTestSuite extends EntityTestCase {
                 + "</entity-engine-xml>";
         EntitySaxReader reader = new EntitySaxReader(delegator);
         long numberLoaded = reader.parse(xmlContentLoad);
-        assertEquals("Update Entity loaded ", 5, numberLoaded);
+        assertEquals(5, numberLoaded, "Update Entity loaded ");
         GenericValue t1 = EntityQuery.use(delegator).from("Testing").where("testingId", "create-update-T1").queryOne();
         GenericValue t3 = EntityQuery.use(delegator).from("Testing").where("testingId", "create-update-T3").queryOne();
-        assertNotNull("Update Testing(T1)", t1);
-        assertEquals("Update Testing(T1).testingTypeId", "create-update", t1.getString("testingTypeId"));
-        assertEquals("Update Testing(T1).testingName", "First test update", t1.getString("testingName"));
-        assertEquals("Update Testing(T1).testingSize", Long.valueOf(20), t1.getLong("testingSize"));
-        assertEquals("Update Testing(T1).testingDate", UtilDateTime.toTimestamp("01/01/2010 00:00:00"), t1.getTimestamp("testingDate"));
+        assertNotNull(t1, "Update Testing(T1)");
+        assertEquals("create-update", t1.getString("testingTypeId"), "Update Testing(T1).testingTypeId");
+        assertEquals("First test update", t1.getString("testingName"), "Update Testing(T1).testingName");
+        assertEquals(Long.valueOf(20), t1.getLong("testingSize"), "Update Testing(T1).testingSize");
+        assertEquals(UtilDateTime.toTimestamp("01/01/2010 00:00:00"), t1.getTimestamp("testingDate"), "Update Testing(T1).testingDate");
 
-        assertNotNull("Update Testing(T3)", t3);
-        assertEquals("Update Testing(T3).testingTypeId", "create-updated", t3.getString("testingTypeId"));
-        assertEquals("Update Testing(T3).testingName", "Third test", t3.getString("testingName"));
-        assertEquals("Update Testing(T3).testingSize", Long.valueOf(30), t3.getLong("testingSize"));
-        assertEquals("Update Testing(T3).testingDate", UtilDateTime.toTimestamp("03/01/2010 00:00:00"), t3.getTimestamp("testingDate"));
+        assertNotNull(t3, "Update Testing(T3)");
+        assertEquals("create-updated", t3.getString("testingTypeId"), "Update Testing(T3).testingTypeId");
+        assertEquals("Third test", t3.getString("testingName"), "Update Testing(T3).testingName");
+        assertEquals(Long.valueOf(30), t3.getLong("testingSize"), "Update Testing(T3).testingSize");
+        assertEquals(UtilDateTime.toTimestamp("03/01/2010 00:00:00"), t3.getTimestamp("testingDate"), "Update Testing(T3).testingDate");
     }
 
     /**
      * Test entity sax reader replace.
      * @throws Exception the exception
      */
+    @Test
+    @Order(30)
     public void testEntitySaxReaderReplace() throws Exception {
         Delegator delegator = getDelegator();
         String xmlContentLoad =
@@ -1132,26 +1201,28 @@ public class EntityTestSuite extends EntityTestCase {
                 + "</entity-engine-xml>";
         EntitySaxReader reader = new EntitySaxReader(delegator);
         long numberLoaded = reader.parse(xmlContentLoad);
-        assertEquals("Replace Entity loaded ", 4, numberLoaded);
+        assertEquals(4, numberLoaded, "Replace Entity loaded ");
         GenericValue t1 = EntityQuery.use(delegator).from("Testing").where("testingId", "create-replace-T1").queryOne();
         GenericValue t2 = EntityQuery.use(delegator).from("Testing").where("testingId", "create-replace-T2").queryOne();
-        assertNotNull("Replace Testing(T1)", t1);
-        assertEquals("Replace Testing(T1).testingTypeId", "create-replace", t1.getString("testingTypeId"));
-        assertEquals("Replace Testing(T1).testingName", "First test replace", t1.getString("testingName"));
-        assertNull("Replace Testing(T1).testingSize", t1.getLong("testingSize"));
-        assertNull("Replace Testing(T1).testingDate", t1.getTimestamp("testingDate"));
+        assertNotNull(t1, "Replace Testing(T1)");
+        assertEquals("create-replace", t1.getString("testingTypeId"), "Replace Testing(T1).testingTypeId");
+        assertEquals("First test replace", t1.getString("testingName"), "Replace Testing(T1).testingName");
+        assertNull(t1.getLong("testingSize"), "Replace Testing(T1).testingSize");
+        assertNull(t1.getTimestamp("testingDate"), "Replace Testing(T1).testingDate");
 
-        assertNotNull("Replace Testing(T2)", t2);
-        assertEquals("Replace Testing(T2).testingTypeId", "create-replace", t2.getString("testingTypeId"));
-        assertEquals("Replace Testing(T2).testingName", "Second test update", t2.getString("testingName"));
-        assertEquals("Replace Testing(T2).testingSize", Long.valueOf(20), t2.getLong("testingSize"));
-        assertEquals("Replace Testing(T2).testingDate", UtilDateTime.toTimestamp("02/01/2010 00:00:00"), t2.getTimestamp("testingDate"));
+        assertNotNull(t2, "Replace Testing(T2)");
+        assertEquals("create-replace", t2.getString("testingTypeId"), "Replace Testing(T2).testingTypeId");
+        assertEquals("Second test update", t2.getString("testingName"), "Replace Testing(T2).testingName");
+        assertEquals(Long.valueOf(20), t2.getLong("testingSize"), "Replace Testing(T2).testingSize");
+        assertEquals(UtilDateTime.toTimestamp("02/01/2010 00:00:00"), t2.getTimestamp("testingDate"), "Replace Testing(T2).testingDate");
     }
 
     /**
      * Test entity sax reader delete.
      * @throws Exception the exception
      */
+    @Test
+    @Order(31)
     public void testEntitySaxReaderDelete() throws Exception {
         Delegator delegator = getDelegator();
         String xmlContentLoad =
@@ -1164,22 +1235,24 @@ public class EntityTestSuite extends EntityTestCase {
                         + "</delete>";
         EntitySaxReader reader = new EntitySaxReader(delegator);
         long numberLoaded = reader.parse(xmlContentLoad);
-        assertEquals("Delete Entity loaded ", 5, numberLoaded);
+        assertEquals(5, numberLoaded, "Delete Entity loaded ");
         GenericValue t1 = EntityQuery.use(delegator).from("Testing").where("testingId", "T1").queryOne();
         GenericValue t2 = EntityQuery.use(delegator).from("Testing").where("testingId", "T2").queryOne();
         GenericValue t3 = EntityQuery.use(delegator).from("Testing").where("testingId", "T3").queryOne();
-        assertNull("Delete Testing(T1)", t1);
-        assertNull("Delete Testing(T2)", t2);
-        assertNull("Delete Testing(T3)", t3);
+        assertNull(t1, "Delete Testing(T1)");
+        assertNull(t2, "Delete Testing(T2)");
+        assertNull(t3, "Delete Testing(T3)");
         GenericValue testType = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "JUNIT-TEST").queryOne();
-        assertNull("Delete TestingType 1", testType);
+        assertNull(testType, "Delete TestingType 1");
         testType = EntityQuery.use(delegator).from("TestingType").where("testingTypeId", "JUNIT-TEST2").queryOne();
-        assertNull("Delete TestingType 2", testType);
+        assertNull(testType, "Delete TestingType 2");
     }
 
     /**
      * Test sequence value item.
      */
+    @Test
+    @Order(32)
     public void testSequenceValueItem() {
         Delegator delegator = getDelegator();
         SequenceUtil sequencer = new SequenceUtil(delegator.getGroupHelperInfo(delegator.getEntityGroupName("SequenceValueItem")),
@@ -1199,6 +1272,8 @@ public class EntityTestSuite extends EntityTestCase {
     /**
      * Test sequence value item with concurrent threads.
      */
+    @Test
+    @Order(33)
     public void testSequenceValueItemWithConcurrentThreads() {
         Delegator delegator = getDelegator();
         final SequenceUtil sequencer = new SequenceUtil(delegator.getGroupHelperInfo(delegator.getEntityGroupName("SequenceValueItem")),
@@ -1237,8 +1312,8 @@ public class EntityTestSuite extends EntityTestCase {
         long endTime = System.currentTimeMillis();
         long totalTime = endTime - startTime;
         Debug.logInfo("testSequenceValueItemWithConcurrentThreads total time (ms): " + totalTime, MODULE);
-        assertFalse("Null sequence id returned", nullSeqIdReturned.get());
-        assertFalse("Duplicate sequence id returned", duplicateFound.get());
+        assertFalse(nullSeqIdReturned.get(), "Null sequence id returned");
+        assertFalse(duplicateFound.get(), "Duplicate sequence id returned");
     }
 
     /**
@@ -1253,6 +1328,8 @@ public class EntityTestSuite extends EntityTestCase {
         This test assess that running the same number of sql statements withing one transaction is faster than running
         them with individual transactions.
      */
+    @Test
+    @Order(34)
     public void testOneBigTransactionIsFasterThanSeveralSmallOnes() {
         boolean transactionStarted = false;
         long startTime = System.currentTimeMillis();
@@ -1277,7 +1354,7 @@ public class EntityTestSuite extends EntityTestCase {
         long totalTimeOneTransaction = endTime - startTime;
         Debug.logInfo("Selected " + totalNumberOfRows + " rows with " + numberOfQueries + " queries (all contained in one big transaction) in "
                 + totalTimeOneTransaction + " ms", MODULE);
-        assertTrue("Errors detected executing the big transaction", noErrors);
+        assertTrue(noErrors, "Errors detected executing the big transaction");
 
         totalNumberOfRows = 0;
         noErrors = true;
@@ -1300,8 +1377,8 @@ public class EntityTestSuite extends EntityTestCase {
         long totalTimeSeveralSmallTransactions = endTime - startTime;
         Debug.logInfo("Selected " + totalNumberOfRows + " rows with " + numberOfQueries + " queries (each in its own transaction) in "
                 + totalTimeSeveralSmallTransactions + " ms", MODULE);
-        assertTrue("Errors detected executing the small transactions", noErrors);
-        assertTrue("One big transaction was not faster than several small ones", totalTimeOneTransaction < totalTimeSeveralSmallTransactions);
+        assertTrue(noErrors, "Errors detected executing the small transactions");
+        assertTrue(totalTimeOneTransaction < totalTimeSeveralSmallTransactions, "One big transaction was not faster than several small ones");
     }
 
     private final class TestObserver implements Observer {

--- a/framework/entity/src/test/java/org/apache/ofbiz/entity/test/EntityUtilTestSuite.java
+++ b/framework/entity/src/test/java/org/apache/ofbiz/entity/test/EntityUtilTestSuite.java
@@ -18,27 +18,29 @@
  *******************************************************************************/
 package org.apache.ofbiz.entity.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.ofbiz.base.util.StringUtil;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.condition.EntityCondition;
 import org.apache.ofbiz.entity.condition.EntityExpr;
 import org.apache.ofbiz.entity.condition.EntityOperator;
-import org.apache.ofbiz.entity.testtools.EntityTestCase;
 import org.apache.ofbiz.entity.util.EntityUtil;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class EntityUtilTestSuite extends EntityTestCase {
+@JunitJupiterTest
+public class EntityUtilTestSuite implements JupiterTestHelper {
 
     private static final String MODULE = EntityUtilTestSuite.class.getName();
 
     public static final long TEST_COUNT = 1000;
-
-    public EntityUtilTestSuite(String name) {
-        super(name);
-    }
 
     private List<GenericValue> prepareGenericValueList() {
         List<GenericValue> newValues = new ArrayList<>();
@@ -52,63 +54,71 @@ public class EntityUtilTestSuite extends EntityTestCase {
     /**
      * Test get field list from entity list.
      */
+    @Test
+    @Order(1)
     public void testGetFieldListFromEntityList() {
         List<GenericValue> newValues = prepareGenericValueList();
         List<String> descriptionList = EntityUtil.getFieldListFromEntityList(newValues, "description", false);
-        assertEquals("Get not distinct field list from " + TEST_COUNT + " entity", TEST_COUNT, descriptionList.size());
-        assertEquals("Get first description value", "Description 0", descriptionList.get(0));
-        assertEquals("Get tens description value", "Description 0", descriptionList.get(10));
+        assertEquals(TEST_COUNT, descriptionList.size(), "Get not distinct field list from " + TEST_COUNT + " entity");
+        assertEquals("Description 0", descriptionList.get(0), "Get first description value");
+        assertEquals("Description 0", descriptionList.get(10), "Get tens description value");
 
         descriptionList = EntityUtil.getFieldListFromEntityList(newValues, "description", true);
-        assertEquals("Get distinct field list from " + TEST_COUNT + " entity, modulo 10 values", 10, descriptionList.size());
-        assertEquals("Get first description value", "Description 0", descriptionList.get(0));
+        assertEquals(10, descriptionList.size(), "Get distinct field list from " + TEST_COUNT + " entity, modulo 10 values");
+        assertEquals("Description 0", descriptionList.get(0), "Get first description value");
     }
 
     /**
      * Test filter by condition.
      */
+    @Test
+    @Order(2)
     public void testFilterByCondition() {
         List<GenericValue> newValues = prepareGenericValueList();
         EntityExpr condition = EntityCondition.makeCondition("description", "Description 0");
         List<GenericValue> filteredValues = EntityUtil.filterByCondition(newValues, condition);
-        assertEquals("Filter on 10% description condition " + TEST_COUNT + " entity", TEST_COUNT / 10, filteredValues.size());
-        assertEquals("Get first description value", "Description 0", filteredValues.get(0).get("description"));
+        assertEquals(TEST_COUNT / 10, filteredValues.size(), "Filter on 10% description condition " + TEST_COUNT + " entity");
+        assertEquals("Description 0", filteredValues.get(0).get("description"), "Get first description value");
 
         filteredValues = EntityUtil.filterOutByCondition(newValues, condition);
-        assertEquals("Filter out on 10% description condition " + TEST_COUNT + " entity", TEST_COUNT - TEST_COUNT / 10, filteredValues.size());
-        assertEquals("Get first description value", "Description 1", filteredValues.get(0).get("description"));
+        assertEquals(TEST_COUNT - TEST_COUNT / 10, filteredValues.size(), "Filter out on 10% description condition " + TEST_COUNT + " entity");
+        assertEquals("Description 1", filteredValues.get(0).get("description"), "Get first description value");
     }
 
     /**
      * Test filter by and.
      */
+    @Test
+    @Order(3)
     public void testFilterByAnd() {
         List<GenericValue> newValues = prepareGenericValueList();
         List<EntityExpr> condition = UtilMisc.toList(EntityCondition.makeCondition("description", "Description 0"),
                 EntityCondition.makeCondition("testingId", "00010"));
         List<GenericValue> filteredWithMap = EntityUtil.filterByAnd(newValues, UtilMisc.toMap("description", "Description 0", "testingId", "00010"));
         List<GenericValue> filteredWithCondition = EntityUtil.filterByAnd(newValues, condition);
-        assertEquals("Filter with same condition using Map and List<EntityExpr> ", filteredWithCondition, filteredWithMap);
+        assertEquals(filteredWithCondition, filteredWithMap, "Filter with same condition using Map and List<EntityExpr> ");
 
         condition = UtilMisc.toList(EntityCondition.makeCondition("description", "Description 0"),
                 EntityCondition.makeCondition("testingId", EntityOperator.LIKE, "000%"));
         filteredWithCondition = EntityUtil.filterByAnd(newValues, condition);
-        assertEquals("Filter condition using List<EntityExpr> must have 10 results", 10, filteredWithCondition.size());
+        assertEquals(10, filteredWithCondition.size(), "Filter condition using List<EntityExpr> must have 10 results");
         filteredWithCondition.forEach(genericValue ->
-                assertEquals("Filter condition using List<EntityExpr> must get simple description",
-                        "Description 0", genericValue.get("description")));
+                assertEquals("Description 0", genericValue.get("description"),
+                        "Filter condition using List<EntityExpr> must get simple description"));
     }
 
     /**
      * Test filter by or.
      */
+    @Test
+    @Order(4)
     public void testFilterByOr() {
         List<GenericValue> newValues = prepareGenericValueList();
         List<EntityExpr> condition = UtilMisc.toList(EntityCondition.makeCondition("description", "Description 0"),
                 EntityCondition.makeCondition("testingId", "00001"));
         List<GenericValue> filteredWithCondition = EntityUtil.filterByOr(newValues, condition);
 
-        assertEquals("Filter condition using List<EntityExpr> must have " + (TEST_COUNT / 10 + 1) + " results",
-                TEST_COUNT / 10 + 1, filteredWithCondition.size());
+        assertEquals(TEST_COUNT / 10 + 1, filteredWithCondition.size(),
+                "Filter condition using List<EntityExpr> must have " + (TEST_COUNT / 10 + 1) + " results");
     }
 }

--- a/framework/entity/testdef/entitytests.xml
+++ b/framework/entity/testdef/entitytests.xml
@@ -21,9 +21,9 @@ under the License.
 <test-suite suite-name="entitytests"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
-    <test-case case-name="entity-tests"><junit-test-suite class-name="org.apache.ofbiz.entity.test.EntityTestSuite"/></test-case>
-    <test-case case-name="entity-util-tests"><junit-test-suite class-name="org.apache.ofbiz.entity.test.EntityUtilTestSuite"/></test-case>
-    <test-case case-name="entity-crypto-tests"><junit-test-suite class-name="org.apache.ofbiz.entity.test.EntityCryptoTestSuite"/></test-case>
-    <test-case case-name="entity-query-tests"><junit-test-suite class-name="org.apache.ofbiz.entity.test.EntityQueryTestSuite"/></test-case>
-    <test-case case-name="entity-util-properties-tests"><junit-test-suite class-name="org.apache.ofbiz.entity.test.EntityUtilPropertiesTests"/></test-case>
+    <test-case case-name="entity-tests"><jupiter-test-suite class-name="org.apache.ofbiz.entity.test.EntityTestSuite"/></test-case>
+    <test-case case-name="entity-util-tests"><jupiter-test-suite class-name="org.apache.ofbiz.entity.test.EntityUtilTestSuite"/></test-case>
+    <test-case case-name="entity-crypto-tests"><jupiter-test-suite class-name="org.apache.ofbiz.entity.test.EntityCryptoTestSuite"/></test-case>
+    <test-case case-name="entity-query-tests"><jupiter-test-suite class-name="org.apache.ofbiz.entity.test.EntityQueryTestSuite"/></test-case>
+    <test-case case-name="entity-util-properties-tests"><jupiter-test-suite class-name="org.apache.ofbiz.entity.test.EntityUtilPropertiesTests"/></test-case>
 </test-suite>

--- a/framework/minilang/src/test/java/org/apache/ofbiz/minilang/test/MiniLangTests.java
+++ b/framework/minilang/src/test/java/org/apache/ofbiz/minilang/test/MiniLangTests.java
@@ -18,6 +18,11 @@
  *******************************************************************************/
 package org.apache.ofbiz.minilang.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -29,18 +34,17 @@ import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilXml;
 import org.apache.ofbiz.minilang.SimpleMethod;
 import org.apache.ofbiz.minilang.method.MethodContext;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
-public class MiniLangTests extends OFBizTestCase {
+@JunitJupiterTest
+public class MiniLangTests implements JupiterTestHelper {
 
     private static final String MODULE = MiniLangTests.class.getName();
 
-    private final boolean traceEnabled;
-
-    public MiniLangTests(String name) {
-        super(name);
-        traceEnabled = "true".equals(UtilProperties.getPropertyValue("minilang", "unit.tests.trace.enabled"));
-    }
+    private final boolean traceEnabled = "true".equals(UtilProperties.getPropertyValue("minilang", "unit.tests.trace.enabled"));
 
     private static Map<String, Object> createContext() {
         return UtilMisc.toMap("locale", Locale.US, "timeZone", TimeZone.getTimeZone("GMT"));
@@ -63,45 +67,49 @@ public class MiniLangTests extends OFBizTestCase {
      * Test assignment operators.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testAssignmentOperators() throws Exception {
         // <check-errors> and <add-error> tests
         SimpleMethod methodToTest = createSimpleMethod("<simple-method name=\"testCheckErrors\"><check-errors/></simple-method>");
         MethodContext context = createServiceMethodContext();
         String result = methodToTest.exec(context);
-        assertEquals("<check-errors> success result", methodToTest.getDefaultSuccessCode(), result);
+        assertEquals(methodToTest.getDefaultSuccessCode(), result, "<check-errors> success result");
         List<String> messages = context.getEnv(methodToTest.getServiceErrorMessageListName());
-        assertNull("<check-errors> null error message list", messages);
+        assertNull(messages, "<check-errors> null error message list");
         methodToTest = createSimpleMethod("<simple-method name=\"testCheckErrors\"><add-error><fail-message message=\"This should fail\"/>"
                 + "</add-error><check-errors/></simple-method>");
         context = createServiceMethodContext();
         result = methodToTest.exec(context);
-        assertEquals("<check-errors> error result", methodToTest.getDefaultErrorCode(), result);
+        assertEquals(methodToTest.getDefaultErrorCode(), result, "<check-errors> error result");
         messages = context.getEnv(methodToTest.getServiceErrorMessageListName());
-        assertNotNull("<check-errors> error message list", messages);
-        assertTrue("<check-errors> error message text", messages.contains("This should fail"));
+        assertNotNull(messages, "<check-errors> error message list");
+        assertTrue(messages.contains("This should fail"), "<check-errors> error message text");
         // <assert>, <not>, and <if-empty> tests
         methodToTest = createSimpleMethod("<simple-method name=\"testAssert\"><assert><not><if-empty field=\"locale\"/></not></assert>"
                 + "<check-errors/></simple-method>");
         context = createServiceMethodContext();
         result = methodToTest.exec(context);
-        assertEquals("<assert> success result", methodToTest.getDefaultSuccessCode(), result);
+        assertEquals(methodToTest.getDefaultSuccessCode(), result, "<assert> success result");
         messages = context.getEnv(methodToTest.getServiceErrorMessageListName());
-        assertNull("<assert> null error message list", messages);
+        assertNull(messages, "<assert> null error message list");
         methodToTest = createSimpleMethod("<simple-method name=\"testAssert\"><assert><if-empty field=\"locale\"/></assert><check-errors/>"
                 + "</simple-method>");
         context = createServiceMethodContext();
         result = methodToTest.exec(context);
-        assertEquals("<assert> error result", methodToTest.getDefaultErrorCode(), result);
+        assertEquals(methodToTest.getDefaultErrorCode(), result, "<assert> error result");
         messages = context.getEnv(methodToTest.getServiceErrorMessageListName());
-        assertNotNull("<assert> error message list", messages);
+        assertNotNull(messages, "<assert> error message list");
         String errorMessage = messages.get(0);
-        assertTrue("<assert> error message text", errorMessage.startsWith("Assertion failed:"));
+        assertTrue(errorMessage.startsWith("Assertion failed:"), "<assert> error message text");
     }
 
     /**
      * Test field to result operation.
      * @throws Exception the exception
      */
+    @Test
+    @Order(2)
     public void testFieldToResultOperation() throws Exception {
         String simpleMethodXml = "<simple-method name=\"testFieldToResult\">"
                 + "  <set field=\"resultValue\" value=\"someResultValue\"/>"
@@ -112,8 +120,8 @@ public class MiniLangTests extends OFBizTestCase {
         SimpleMethod methodToTest = createSimpleMethod(simpleMethodXml);
         MethodContext context = createServiceMethodContext();
         String result = methodToTest.exec(context);
-        assertEquals("testFieldToResult success result", methodToTest.getDefaultSuccessCode(), result);
-        assertEquals("Plain expression result name set", "someResultValue", context.getResult("constantResultName"));
-        assertEquals("Nested expression result name set", "someResultValue", context.getResult("dynamicResultName"));
+        assertEquals(methodToTest.getDefaultSuccessCode(), result, "testFieldToResult success result");
+        assertEquals("someResultValue", context.getResult("constantResultName"), "Plain expression result name set");
+        assertEquals("someResultValue", context.getResult("dynamicResultName"), "Nested expression result name set");
     }
 }

--- a/framework/minilang/testdef/MinilangTests.xml
+++ b/framework/minilang/testdef/MinilangTests.xml
@@ -23,7 +23,7 @@
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-case case-name="MiniLangUnitTests">
-        <junit-test-suite class-name="org.apache.ofbiz.minilang.test.MiniLangTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.minilang.test.MiniLangTests"/>
     </test-case>
 
 </test-suite>

--- a/framework/rest-api/src/test/java/org/apache/ofbiz/ws/rs/test/RestServicesTests.java
+++ b/framework/rest-api/src/test/java/org/apache/ofbiz/ws/rs/test/RestServicesTests.java
@@ -19,6 +19,11 @@
 
 package org.apache.ofbiz.ws.rs.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
@@ -26,16 +31,16 @@ import java.util.Map;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.service.ServiceUtil;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class RestServicesTests extends OFBizTestCase {
-
-    public RestServicesTests(String name) {
-        super(name);
-    }
+@JunitJupiterTest
+public class RestServicesTests implements JupiterTestHelper {
 
     /**
      * Verifies that the {@code generateAuthTokenService} returns a success response
@@ -46,14 +51,16 @@ public class RestServicesTests extends OFBizTestCase {
      *
      * @throws Exception if the service call or entity lookup fails unexpectedly
      */
+    @Test
+    @Order(1)
     public void testGenerateAuthTokenReturnsSuccess() throws Exception {
         GenericValue userLogin = getDelegator().findOne("UserLogin", UtilMisc.toMap("userLoginId", "admin"), false);
-        assertNotNull("admin userLogin must exist in demo data", userLogin);
+        assertNotNull(userLogin, "admin userLogin must exist in demo data");
 
         Map<String, Object> ctx = UtilMisc.toMap("userLogin", (Object) userLogin);
         Map<String, Object> result = getDispatcher().runSync("generateAuthTokenService", ctx);
 
-        assertTrue("Service should return success", ServiceUtil.isSuccess(result));
+        assertTrue(ServiceUtil.isSuccess(result), "Service should return success");
     }
 
     /**
@@ -65,6 +72,8 @@ public class RestServicesTests extends OFBizTestCase {
      *
      * @throws Exception if the service call or entity lookup fails unexpectedly
      */
+    @Test
+    @Order(2)
     public void testGenerateAuthTokenAccessTokenPresent() throws Exception {
         GenericValue userLogin = getDelegator().findOne("UserLogin", UtilMisc.toMap("userLoginId", "admin"), false);
 
@@ -73,8 +82,8 @@ public class RestServicesTests extends OFBizTestCase {
                 UtilMisc.toMap("userLogin", (Object) userLogin));
 
         String accessToken = (String) result.get("access_token");
-        assertNotNull("access_token should not be null", accessToken);
-        assertFalse("access_token should not be empty", accessToken.isEmpty());
+        assertNotNull(accessToken, "access_token should not be null");
+        assertFalse(accessToken.isEmpty(), "access_token should not be empty");
     }
 
     /**
@@ -86,6 +95,8 @@ public class RestServicesTests extends OFBizTestCase {
      *
      * @throws Exception if the service call or entity lookup fails unexpectedly
      */
+    @Test
+    @Order(3)
     public void testGenerateAuthTokenTokenTypeIsBearer() throws Exception {
         GenericValue userLogin = getDelegator().findOne("UserLogin", UtilMisc.toMap("userLoginId", "admin"), false);
 
@@ -93,7 +104,7 @@ public class RestServicesTests extends OFBizTestCase {
                 "generateAuthTokenService",
                 UtilMisc.toMap("userLogin", (Object) userLogin));
 
-        assertEquals("token_type should be Bearer", "Bearer", result.get("token_type"));
+        assertEquals("Bearer", result.get("token_type"), "token_type should be Bearer");
     }
 
     /**
@@ -107,6 +118,8 @@ public class RestServicesTests extends OFBizTestCase {
      * @throws Exception if the service call or entity lookup fails unexpectedly,
      *                   or if {@code expires_in} cannot be parsed as an integer
      */
+    @Test
+    @Order(4)
     public void testGenerateAuthTokenExpiresInIsValid() throws Exception {
         GenericValue userLogin = getDelegator().findOne("UserLogin", UtilMisc.toMap("userLoginId", "admin"), false);
 
@@ -115,13 +128,13 @@ public class RestServicesTests extends OFBizTestCase {
                 UtilMisc.toMap("userLogin", (Object) userLogin));
 
         String expiresIn = (String) result.get("expires_in");
-        assertNotNull("expires_in should not be null", expiresIn);
+        assertNotNull(expiresIn, "expires_in should not be null");
 
         int expiresCurrent = Integer.parseInt(expiresIn);
-        assertTrue("expires_in should be a positive number", expiresCurrent > 0);
+        assertTrue(expiresCurrent > 0, "expires_in should be a positive number");
 
         int expiresTarget = 1800;
-        assertTrue("expires_in should match the configured amount", expiresCurrent == expiresTarget);
+        assertTrue(expiresCurrent == expiresTarget, "expires_in should match the configured amount");
     }
 
     /**
@@ -135,6 +148,8 @@ public class RestServicesTests extends OFBizTestCase {
      *
      * @throws Exception if the service call or entity lookup fails unexpectedly
      */
+    @Test
+    @Order(5)
     public void testGenerateAuthTokenTokenIsValidJwtFormat() throws Exception {
         GenericValue userLogin = getDelegator().findOne("UserLogin", UtilMisc.toMap("userLoginId", "admin"), false);
 
@@ -144,7 +159,7 @@ public class RestServicesTests extends OFBizTestCase {
 
         String accessToken = (String) result.get("access_token");
         String[] parts = accessToken.split("\\.");
-        assertEquals("JWT should have 3 parts (header.payload.signature)", 3, parts.length);
+        assertEquals(3, parts.length, "JWT should have 3 parts (header.payload.signature)");
     }
 
     /**
@@ -157,12 +172,14 @@ public class RestServicesTests extends OFBizTestCase {
      *
      * @throws Exception if the service call or entity lookup fails unexpectedly
      */
+    @Test
+    @Order(6)
     public void testGenerateAuthTokenDifferentUsersGetDifferentTokens() throws Exception {
         GenericValue adminLogin = getDelegator().findOne("UserLogin", UtilMisc.toMap("userLoginId", "admin"), false);
         GenericValue systemLogin = getDelegator().findOne("UserLogin", UtilMisc.toMap("userLoginId", "system"), false);
 
-        assertNotNull("admin userLogin must exist", adminLogin);
-        assertNotNull("system userLogin must exist", systemLogin);
+        assertNotNull(adminLogin, "admin userLogin must exist");
+        assertNotNull(systemLogin, "system userLogin must exist");
 
         Map<String, Object> adminResult = getDispatcher().runSync(
                 "generateAuthTokenService",
@@ -173,8 +190,8 @@ public class RestServicesTests extends OFBizTestCase {
                 UtilMisc.toMap("userLogin", (Object) systemLogin));
 
         assertFalse(
-                "Different users should receive different tokens",
-                adminResult.get("access_token").equals(systemResult.get("access_token")));
+                adminResult.get("access_token").equals(systemResult.get("access_token")),
+                "Different users should receive different tokens");
     }
 
     /**
@@ -182,6 +199,8 @@ public class RestServicesTests extends OFBizTestCase {
      *
      * @throws Exception if the service call or entity lookup fails unexpectedly
      */
+    @Test
+    @Order(7)
     public void testGenerateAuthTokenIssuerAndUserLoginIdInPayload() throws Exception {
         GenericValue adminLogin = getDelegator().findOne("UserLogin", UtilMisc.toMap("userLoginId", "admin"), false);
         Map<String, Object> adminResult = getDispatcher().runSync(
@@ -200,8 +219,8 @@ public class RestServicesTests extends OFBizTestCase {
         String iss = claims.path("iss").asText(null);
         String userLoginId = claims.path("userLoginId").asText(null);
 
-        assertTrue("Issuer is ApacheOFBiz", iss.equals("ApacheOFBiz"));
-        assertTrue("UserLoginId is admin", userLoginId.equals("admin"));
+        assertTrue(iss.equals("ApacheOFBiz"), "Issuer is ApacheOFBiz");
+        assertTrue(userLoginId.equals("admin"), "UserLoginId is admin");
     }
 
     private static String padBase64(String input) {

--- a/framework/rest-api/testdef/rest-apiTests.xml
+++ b/framework/rest-api/testdef/rest-apiTests.xml
@@ -22,6 +22,6 @@ under the License.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
     <test-case case-name="rest-api-services-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.ws.rs.test.RestServicesTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.ws.rs.test.RestServicesTests"/>
     </test-case>
 </test-suite>

--- a/framework/service/src/test/groovy/org/apache/ofbiz/service/test/ServiceMultipleNodeRecoveryTest.groovy
+++ b/framework/service/src/test/groovy/org/apache/ofbiz/service/test/ServiceMultipleNodeRecoveryTest.groovy
@@ -24,21 +24,23 @@ import org.apache.ofbiz.entity.condition.EntityConditionBuilder
 import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.config.ServiceConfigUtil
 import org.apache.ofbiz.service.job.JobManager
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
 import java.sql.Timestamp
 
 // ./gradlew "ofbiz --test component=service --test suitename=servicetests --test case=service-multiple-node-recovery"
 
-class ServiceMultipleNodeRecoveryTest extends OFBizTestCase {
+@JunitJupiterTest
+class ServiceMultipleNodeRecoveryTest implements JupiterTestHelper {
 
     private static final Timestamp LAST_HOUR = UtilDateTime.adjustTimestamp(UtilDateTime.nowTimestamp(), Calendar.HOUR, -1)
     private static final String POOL_ID = ServiceConfigUtil.getServiceEngine().getThreadPool().getSendToPool()
 
-    ServiceMultipleNodeRecoveryTest(String name) {
-        super(name)
-    }
-
+    @Test
+    @Order(1)
     void testMultipleNodeRecoveryAfterOneFail() {
         Timestamp now = UtilDateTime.nowTimestamp()
         long leaseExpiryMillis = ServiceConfigUtil.getServiceEngine().getThreadPool().getLeaseExpiryMillis()
@@ -104,6 +106,8 @@ class ServiceMultipleNodeRecoveryTest extends OFBizTestCase {
                 .queryCount() == 1
     }
 
+    @Test
+    @Order(2)
     void testMultipleNodeRecoveryHearbeat() {
         Timestamp now = UtilDateTime.nowTimestamp()
         GenericValue sysUserLogin = delegator.findOne('UserLogin', true, 'userLoginId', 'system')

--- a/framework/service/src/test/groovy/org/apache/ofbiz/service/test/ServicePurgeTest.groovy
+++ b/framework/service/src/test/groovy/org/apache/ofbiz/service/test/ServicePurgeTest.groovy
@@ -22,16 +22,16 @@ import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.util.EntityQuery
 import org.apache.ofbiz.service.config.ServiceConfigUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
 // ./gradlew "ofbiz --test component=service --test suitename=servicetests --test case=service-purge-test"
 
-class ServicePurgeTest  extends OFBizTestCase {
+@JunitJupiterTest
+class ServicePurgeTest implements JupiterTestHelper {
 
-    ServicePurgeTest(String name) {
-        super(name)
-    }
-
+    @Test
     void testRuntimeDataIsCleanedAfterServicePurge() {
         GenericValue sysUserLogin = delegator.findOne('UserLogin', true, 'userLoginId', 'system')
         String jobId = delegator.getNextSeqId('JobSandbox')

--- a/framework/service/src/test/groovy/org/apache/ofbiz/service/test/engine/TrackerEngineTest.groovy
+++ b/framework/service/src/test/groovy/org/apache/ofbiz/service/test/engine/TrackerEngineTest.groovy
@@ -20,21 +20,21 @@ package org.apache.ofbiz.service.test.engine
 
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.service.ServiceUtil
-import org.apache.ofbiz.service.testtools.OFBizTestCase
 import org.apache.ofbiz.service.tracker.JobTracker
 import org.apache.ofbiz.service.tracker.JobTrackerFactory
 import org.apache.ofbiz.service.tracker.JobTrackerListener
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Test
 
 /**
  * First time : ./gradlew 'ofbiz  -l readers=seed,seed-initial -l delegator=test'
  * ./gradlew 'ofbiz -t component=service -t suitename=servicetests -t case=engine-tracker-tests'
  */
-class TrackerEngineTest extends OFBizTestCase {
+@JunitJupiterTest
+class TrackerEngineTest implements JupiterTestHelper {
 
-    TrackerEngineTest(String name) {
-        super(name)
-    }
-
+    @Test
     void testTrackedServiceAreTracked() {
         GenericValue sysUser = delegator.findOne('UserLogin', true, 'userLoginId', 'system')
         Map result = dispatcher.runSync('TestTopLevelServiceThatPlansTrackedServices', [userLogin: sysUser])

--- a/framework/service/src/test/java/org/apache/ofbiz/service/test/GroovyDslServiceEngineTests.java
+++ b/framework/service/src/test/java/org/apache/ofbiz/service/test/GroovyDslServiceEngineTests.java
@@ -18,27 +18,22 @@
  *******************************************************************************/
 package org.apache.ofbiz.service.test;
 
-import org.apache.ofbiz.base.util.UtilMisc;
-import org.apache.ofbiz.service.ModelService;
-import org.apache.ofbiz.service.ServiceUtil;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
-public class GroovyDslServiceEngineTests extends OFBizTestCase {
+import org.apache.ofbiz.base.util.UtilMisc;
+import org.apache.ofbiz.service.ModelService;
+import org.apache.ofbiz.service.ServiceUtil;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Test;
 
-    public GroovyDslServiceEngineTests(String name) {
-        super(name);
-    }
+@JunitJupiterTest
+public class GroovyDslServiceEngineTests implements JupiterTestHelper {
 
-    @Override
-    protected void setUp() throws Exception {
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-    }
-
+    @Test
     public final void testGroovyServices() throws Exception {
         String pingMsg = "Unit Test";
         Map<String, Object> pingMap = UtilMisc.toMap("ping", pingMsg);

--- a/framework/service/src/test/java/org/apache/ofbiz/service/test/ServiceEngineTests.java
+++ b/framework/service/src/test/java/org/apache/ofbiz/service/test/ServiceEngineTests.java
@@ -18,39 +18,37 @@
  *******************************************************************************/
 package org.apache.ofbiz.service.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Map;
 
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.service.ModelService;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
-public class ServiceEngineTests extends OFBizTestCase {
-
-    public ServiceEngineTests(String name) {
-        super(name);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-    }
+@JunitJupiterTest
+public class ServiceEngineTests implements JupiterTestHelper {
 
     /**
      * Test basic java invocation.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testBasicJavaInvocation() throws Exception {
         Map<String, Object> result = getDispatcher().runSync("testScv", UtilMisc.toMap("message", "Unit Test"));
-        assertEquals("Service result success", ModelService.RESPOND_SUCCESS, result.get(ModelService.RESPONSE_MESSAGE));
+        assertEquals(ModelService.RESPOND_SUCCESS, result.get(ModelService.RESPONSE_MESSAGE), "Service result success");
     }
 
     /**
      * Test a seca with condition in
      * @throws Exception the exception
      */
+    @Test
+    @Order(2)
     public void testConditionSecaInInvocation() throws Exception {
         Map<String, Object> result = getDispatcher().runSync("ping", UtilMisc.toMap("message", "present"));
         assertEquals("set message to condition in message", result.get("message"));
@@ -64,9 +62,11 @@ public class ServiceEngineTests extends OFBizTestCase {
      * Test a basic clojure invocation
      * @throws Exception the exception
      */
+    @Test
+    @Order(3)
     public void testBasicClojureInvocation() throws Exception {
         Map<String, Object> result = getDispatcher().runSync("testClojureSvc", UtilMisc.toMap("message", "Unit Test"));
-        assertEquals("Service result success", ModelService.RESPOND_SUCCESS, result.get(ModelService.RESPONSE_MESSAGE));
+        assertEquals(ModelService.RESPOND_SUCCESS, result.get(ModelService.RESPONSE_MESSAGE), "Service result success");
     }
 
 }

--- a/framework/service/src/test/java/org/apache/ofbiz/service/test/ServiceEntityAutoTests.java
+++ b/framework/service/src/test/java/org/apache/ofbiz/service/test/ServiceEntityAutoTests.java
@@ -18,6 +18,11 @@
  *******************************************************************************/
 package org.apache.ofbiz.service.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Locale;
@@ -31,26 +36,20 @@ import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.service.GenericServiceException;
 import org.apache.ofbiz.service.ServiceUtil;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
-public class ServiceEntityAutoTests extends OFBizTestCase {
-
-    public ServiceEntityAutoTests(String name) {
-        super(name);
-    }
-
-    @Override
-    protected void setUp() throws Exception {
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-    }
+@JunitJupiterTest
+public class ServiceEntityAutoTests implements JupiterTestHelper {
 
     /**
      * Test entity auto create singl pk entity.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testEntityAutoCreateSinglPkEntity() throws Exception {
         Delegator delegator = getDelegator();
         //test create with given pk
@@ -79,6 +78,8 @@ public class ServiceEntityAutoTests extends OFBizTestCase {
      * Test entity auto create double pk entity.
      * @throws Exception the exception
      */
+    @Test
+    @Order(2)
     public void testEntityAutoCreateDoublePkEntity() throws Exception {
         Delegator delegator = getDelegator();
         delegator.create("Testing", "testingId", "TESTING_2");
@@ -113,6 +114,8 @@ public class ServiceEntityAutoTests extends OFBizTestCase {
      * Test entity auto create multi pk entity.
      * @throws Exception the exception
      */
+    @Test
+    @Order(3)
     public void testEntityAutoCreateMultiPkEntity() throws Exception {
         Delegator delegator = getDelegator();
         delegator.create("TestingNode", "testingNodeId", "NODE_1");
@@ -141,6 +144,8 @@ public class ServiceEntityAutoTests extends OFBizTestCase {
      * Test entity auto update entity.
      * @throws Exception the exception
      */
+    @Test
+    @Order(4)
     public void testEntityAutoUpdateEntity() throws Exception {
         Delegator delegator = getDelegator();
         delegator.create("Testing", "testingId", "TESTING_4", "testingName", "entity auto testing");
@@ -163,6 +168,8 @@ public class ServiceEntityAutoTests extends OFBizTestCase {
      * Test entity auto delete entity.
      * @throws Exception the exception
      */
+    @Test
+    @Order(5)
     public void testEntityAutoDeleteEntity() throws Exception {
         Delegator delegator = getDelegator();
         delegator.create("Testing", "testingId", "TESTING_5");
@@ -186,6 +193,8 @@ public class ServiceEntityAutoTests extends OFBizTestCase {
      * Test entity auto expire entity.
      * @throws Exception the exception
      */
+    @Test
+    @Order(6)
     public void testEntityAutoExpireEntity() throws Exception {
         Delegator delegator = getDelegator();
         Timestamp now = UtilDateTime.nowTimestamp();
@@ -199,14 +208,14 @@ public class ServiceEntityAutoTests extends OFBizTestCase {
         assertTrue(ServiceUtil.isSuccess(results));
         GenericValue testingNodeMember = EntityQuery.use(delegator).from("TestingNodeMember").where(testingNodeMemberPkMap).queryOne();
         Timestamp expireDate = testingNodeMember.getTimestamp("thruDate");
-        assertNotNull("Expire thruDate set ", expireDate);
+        assertNotNull(expireDate, "Expire thruDate set ");
 
         //test expire to ensure the thruDate isn't update but extendThruDate is
         results = getDispatcher().runSync("testEntityAutoExpireTestingNodeMember", testingNodeMemberPkMap);
         assertTrue(ServiceUtil.isSuccess(results));
         testingNodeMember = EntityQuery.use(delegator).from("TestingNodeMember").where(testingNodeMemberPkMap).queryOne();
         assertTrue(expireDate.compareTo(testingNodeMember.getTimestamp("thruDate")) == 0);
-        assertNotNull("Expire extendThruDate set ", testingNodeMember.getTimestamp("extendThruDate"));
+        assertNotNull(testingNodeMember.getTimestamp("extendThruDate"), "Expire extendThruDate set ");
 
         //test expire a specific field
         delegator.create("TestFieldType", "testFieldTypeId", "TESTING_6");
@@ -214,7 +223,7 @@ public class ServiceEntityAutoTests extends OFBizTestCase {
         results = getDispatcher().runSync("testEntityAutoExpireTestFieldType", testingExpireMap);
         assertTrue(ServiceUtil.isSuccess(results));
         GenericValue testFieldType = EntityQuery.use(delegator).from("TestFieldType").where("testFieldTypeId", "TESTING_6").queryOne();
-        assertNotNull("Expire dateTimeField set", testFieldType.getTimestamp("dateTimeField"));
+        assertNotNull(testFieldType.getTimestamp("dateTimeField"), "Expire dateTimeField set");
 
         //test expire a specific field with in value
         delegator.create("TestFieldType", "testFieldTypeId", "TESTING_6bis");
@@ -230,6 +239,8 @@ public class ServiceEntityAutoTests extends OFBizTestCase {
      * Test entity auto entity status concept.
      * @throws Exception the exception
      */
+    @Test
+    @Order(7)
     public void testEntityAutoEntityStatusConcept() throws Exception {
         Delegator delegator = getDelegator();
         delegator.create("Testing", "testingId", "TESTING_7");

--- a/framework/service/src/test/java/org/apache/ofbiz/service/test/ServicePermissionTests.java
+++ b/framework/service/src/test/java/org/apache/ofbiz/service/test/ServicePermissionTests.java
@@ -18,23 +18,29 @@
  *******************************************************************************/
 package org.apache.ofbiz.service.test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.service.ServiceAuthException;
 import org.apache.ofbiz.service.ServiceUtil;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-public class ServicePermissionTests extends OFBizTestCase {
-
-    public ServicePermissionTests(String name) {
-        super(name);
-    }
+@JunitJupiterTest
+public class ServicePermissionTests implements JupiterTestHelper {
 
     /**
      * Test permission success.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testPermissionSuccess() throws Exception {
         Map<String, Object> testingPermMap = UtilMisc.toMap("userLogin", getUserLogin("permUser1"));
         Map<String, Object> results = getDispatcher().runSync("testSimplePermission", testingPermMap);
@@ -45,6 +51,8 @@ public class ServicePermissionTests extends OFBizTestCase {
      * Test service permission success.
      * @throws Exception the exception
      */
+    @Test
+    @Order(2)
     public void testServicePermissionSuccess() throws Exception {
         Map<String, Object> testingPermMap = UtilMisc.toMap("userLogin", getUserLogin("permUser1"), "givePermission", "Y");
         Map<String, Object> results = getDispatcher().runSync("testSimpleServicePermission", testingPermMap);
@@ -55,11 +63,13 @@ public class ServicePermissionTests extends OFBizTestCase {
      * Test service permission error.
      * @throws Exception the exception
      */
+    @Test
+    @Order(3)
     public void testServicePermissionError() throws Exception {
         Map<String, Object> testingPermMap = UtilMisc.toMap("userLogin", getUserLogin("permUser1"), "givePermission", "N");
         try {
             Map<String, Object> results = getDispatcher().runSync("testSimpleServicePermission", testingPermMap);
-            assertFalse("The testGroupPermission don't raise service exception", ServiceUtil.isError(results));
+            assertFalse(ServiceUtil.isError(results), "The testGroupPermission don't raise service exception");
         } catch (ServiceAuthException e) {
             assertNotNull(e);
         }
@@ -69,6 +79,8 @@ public class ServicePermissionTests extends OFBizTestCase {
      * Test group permission success.
      * @throws Exception the exception
      */
+    @Test
+    @Order(4)
     public void testGroupPermissionSuccess() throws Exception {
         Map<String, Object> testingPermMap = UtilMisc.toMap("userLogin", getUserLogin("permUser1"), "givePermission", "Y");
         Map<String, Object> results = getDispatcher().runSync("testSimpleGroupAndPermission", testingPermMap);
@@ -83,11 +95,13 @@ public class ServicePermissionTests extends OFBizTestCase {
      * Test permission failed.
      * @throws Exception the exception
      */
+    @Test
+    @Order(5)
     public void testPermissionFailed() throws Exception {
         Map<String, Object> testingPermMap = UtilMisc.toMap("userLogin", getUserLogin("permUser2"));
         try {
             Map<String, Object> results = getDispatcher().runSync("testSimplePermission", testingPermMap);
-            assertFalse("The service testSimplePermission don't raise service exception", ServiceUtil.isError(results));
+            assertFalse(ServiceUtil.isError(results), "The service testSimplePermission don't raise service exception");
         } catch (ServiceAuthException e) {
             assertNotNull(e);
         }
@@ -97,11 +111,13 @@ public class ServicePermissionTests extends OFBizTestCase {
      * Test service permission failed.
      * @throws Exception the exception
      */
+    @Test
+    @Order(6)
     public void testServicePermissionFailed() throws Exception {
         Map<String, Object> testingPermMap = UtilMisc.toMap("userLogin", getUserLogin("permUser2"), "givePermission", "N");
         try {
             Map<String, Object> results = getDispatcher().runSync("testSimpleServicePermission", testingPermMap);
-            assertFalse("The service testServicePermission don't raise service exception", ServiceUtil.isError(results));
+            assertFalse(ServiceUtil.isError(results), "The service testServicePermission don't raise service exception");
         } catch (ServiceAuthException e) {
             assertNotNull(e);
         }
@@ -111,11 +127,13 @@ public class ServicePermissionTests extends OFBizTestCase {
      * Test group permission failed.
      * @throws Exception the exception
      */
+    @Test
+    @Order(7)
     public void testGroupPermissionFailed() throws Exception {
         Map<String, Object> testingPermMap = UtilMisc.toMap("userLogin", getUserLogin("permUser2"), "givePermission", "Y");
         try {
             Map<String, Object> results = getDispatcher().runSync("testSimpleGroupAndPermission", testingPermMap);
-            assertFalse("The testGroupPermission don't raise service exception", ServiceUtil.isError(results));
+            assertFalse(ServiceUtil.isError(results), "The testGroupPermission don't raise service exception");
         } catch (ServiceAuthException e) {
             assertNotNull(e);
         }
@@ -123,7 +141,7 @@ public class ServicePermissionTests extends OFBizTestCase {
         testingPermMap = UtilMisc.toMap("userLogin", getUserLogin("permUser1"), "givePermission", "N");
         try {
             Map<String, Object> results = getDispatcher().runSync("testSimpleGroupOrPermission", testingPermMap);
-            assertFalse("The testGroupPermission don't raise service exception", ServiceUtil.isError(results));
+            assertFalse(ServiceUtil.isError(results), "The testGroupPermission don't raise service exception");
         } catch (ServiceAuthException e) {
             assertNotNull(e);
         }

--- a/framework/service/src/test/java/org/apache/ofbiz/service/test/ServiceSOAPTests.java
+++ b/framework/service/src/test/java/org/apache/ofbiz/service/test/ServiceSOAPTests.java
@@ -18,6 +18,8 @@
  */
 package org.apache.ofbiz.service.test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,20 +27,22 @@ import java.util.Map;
 import org.apache.ofbiz.base.util.UtilDateTime;
 import org.apache.ofbiz.base.util.UtilGenerics;
 import org.apache.ofbiz.entity.GenericValue;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
-public class ServiceSOAPTests extends OFBizTestCase {
+@JunitJupiterTest
+public class ServiceSOAPTests implements JupiterTestHelper {
 
     private static final String MODULE = ServiceSOAPTests.class.getName();
-
-    public ServiceSOAPTests(String name) {
-        super(name);
-    }
 
     /**
      * Test soap simple service.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testSOAPSimpleService() throws Exception {
         Map<String, Object> serviceContext = new HashMap<>();
         serviceContext.put("defaultValue", Double.valueOf("123.4567"));
@@ -50,6 +54,8 @@ public class ServiceSOAPTests extends OFBizTestCase {
      * Test soap service.
      * @throws Exception the exception
      */
+    @Test
+    @Order(2)
     public void testSOAPService() throws Exception {
         Map<String, Object> serviceContext = new HashMap<>();
         GenericValue testing = getDelegator().makeValue("Testing");

--- a/framework/service/testdef/servicetests.xml
+++ b/framework/service/testdef/servicetests.xml
@@ -21,11 +21,11 @@ under the License.
 <test-suite suite-name="servicetests"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
-    <test-case case-name="service-tests"><junit-test-suite class-name="org.apache.ofbiz.service.test.ServiceEngineTests"/></test-case>
-    <test-case case-name="service-groovy-DSL-tests"><junit-test-suite
+    <test-case case-name="service-tests"><jupiter-test-suite class-name="org.apache.ofbiz.service.test.ServiceEngineTests"/></test-case>
+    <test-case case-name="service-groovy-DSL-tests"><jupiter-test-suite
             class-name="org.apache.ofbiz.service.test.GroovyDslServiceEngineTests"/></test-case>
     <!-- <test-case case-name="service-soap-tests"><junit-test-suite class-name="org.apache.ofbiz.service.test.ServiceSOAPTests"/></test-case> -->
-    <test-case case-name="service-entity-auto-tests"><junit-test-suite class-name="org.apache.ofbiz.service.test.ServiceEntityAutoTests"/></test-case>
+    <test-case case-name="service-entity-auto-tests"><jupiter-test-suite class-name="org.apache.ofbiz.service.test.ServiceEntityAutoTests"/></test-case>
 
     <test-case case-name="load-service-test-data">
         <entity-xml action="load" entity-xml-url="component://service/testdef/data/ServiceTestData.xml"/>
@@ -37,7 +37,7 @@ under the License.
         <entity-xml action="assert" entity-xml-url="component://service/testdef/data/ServiceDeadLockRetryAssertData.xml"/>
     </test-case>
     <test-case case-name="engine-tracker-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.service.test.engine.TrackerEngineTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.service.test.engine.TrackerEngineTest"/>
     </test-case>
     <!-- this case is failing, so commenting out by default until an automatic fix can be found
     <test-case case-name="service-lock-wait-timeout-retry-test">
@@ -75,12 +75,12 @@ under the License.
         <entity-xml entity-xml-url="component://service/testdef/data/PermissionServiceTestData.xml"/>
     </test-case>
     <test-case case-name="service-permission-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.service.test.ServicePermissionTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.service.test.ServicePermissionTests"/>
     </test-case>
     <test-case case-name="service-purge-test">
-        <junit-test-suite class-name="org.apache.ofbiz.service.test.ServicePurgeTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.service.test.ServicePurgeTest"/>
     </test-case>
     <test-case case-name="service-multiple-node-recovery">
-        <junit-test-suite class-name="org.apache.ofbiz.service.test.ServiceMultipleNodeRecoveryTest"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.service.test.ServiceMultipleNodeRecoveryTest"/>
     </test-case>
 </test-suite>

--- a/framework/webapp/src/test/groovy/org/apache/ofbiz/webapp/test/OfbizPathShortenerTests.groovy
+++ b/framework/webapp/src/test/groovy/org/apache/ofbiz/webapp/test/OfbizPathShortenerTests.groovy
@@ -18,14 +18,17 @@
  *******************************************************************************/
 package org.apache.ofbiz.webapp.test
 
-import org.apache.ofbiz.service.testtools.OFBizTestCase
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
 import org.apache.ofbiz.webapp.OfbizPathShortener
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
 
-class OfbizPathShortenerTests extends OFBizTestCase {
+@JunitJupiterTest
+class OfbizPathShortenerTests implements JupiterTestHelper {
 
-    OfbizPathShortenerTests(String name) {
-        super(name)
-    }
+    @Test
+    @Order(1)
     void testComputeLongUrlToShortUrl() {
         String longUri = 'passwordChange?USERNAME=admin&TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxML' +
                 'LL.eyJ1c2VyTG9naW5JZCI6Imx1Y2lsZS5wZWxsZXRpZXJAZWRsbi5vcmciLCJpc3MiOiJBcGFjaGVPRkJpeiIsImV4cCI6MTcyNTU' +
@@ -33,6 +36,8 @@ class OfbizPathShortenerTests extends OFBizTestCase {
                 'jl4rTxgoEYuRMoHg&JavaScriptEnabled=Y&Albert=Yoda'
         assert OfbizPathShortener.resolveShortenedPath(this.getDelegator(), longUri).length() < 11
     }
+    @Test
+    @Order(2)
     void testResolveLongUrlComputedFromShort() {
         String longUri = 'passwordChange?USERNAME=admin&TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxML' +
                 'LL.eyJ1c2VyTG9naW5JZCI6Imx1Y2lsZS5wZWxsZXRpZXJAZWRsbi5vcmciLCJpc3MiOiJBcGFjaGVPRkJpeiIsImV4cCI6MTcyNTU' +
@@ -41,6 +46,8 @@ class OfbizPathShortenerTests extends OFBizTestCase {
         String shortUri = OfbizPathShortener.resolveShortenedPath(this.getDelegator(), longUri)
         assert longUri == OfbizPathShortener.resolveOriginalPathFromShortened(this.getDelegator(), shortUri)
     }
+    @Test
+    @Order(3)
     void testResolveLongUrlComputedFromShortAlreadyStored() {
         String longUri = 'passwordChange?USERNAME=admin&TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxML' +
                 'LL.eyJ1c2VyTG9naW5JZCI6Imx1Y2lsZS5wZWxsZXRpZXJAZWRsbi5vcmciLCJpc3MiOiJBcGFjaGVPRkJpeiIsImV4cCI6MTcyNTU' +

--- a/framework/webapp/testdef/webapptests.xml
+++ b/framework/webapp/testdef/webapptests.xml
@@ -20,5 +20,5 @@
 <test-suite suite-name="webapptests"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
-    <test-case case-name="PathShortener-tests"><junit-test-suite class-name="org.apache.ofbiz.webapp.test.OfbizPathShortenerTests"/></test-case>
+    <test-case case-name="PathShortener-tests"><jupiter-test-suite class-name="org.apache.ofbiz.webapp.test.OfbizPathShortenerTests"/></test-case>
 </test-suite>

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/test/WidgetMacroLibraryTests.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/test/WidgetMacroLibraryTests.java
@@ -19,27 +19,31 @@
 
 package org.apache.ofbiz.widget.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.InputStream;
 
 import org.apache.ofbiz.base.start.Start;
 import org.apache.ofbiz.base.util.HttpClient;
 import org.apache.ofbiz.base.util.HttpClientException;
 import org.apache.ofbiz.base.util.SSLUtil;
-import org.apache.ofbiz.service.testtools.OFBizTestCase;
+import org.apache.ofbiz.testtools.JunitJupiterTest;
+import org.apache.ofbiz.testtools.JupiterTestHelper;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.pdf.PDFParser;
 import org.apache.tika.sax.BodyContentHandler;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 
 
-public class WidgetMacroLibraryTests extends OFBizTestCase {
+@JunitJupiterTest
+public class WidgetMacroLibraryTests implements JupiterTestHelper {
 
     private String screenUrl = "https://localhost:8443/webtools/control/WebtoolsLayoutDemo"; //use existing screen to present most of layout use case
     private final String authentificationQuery = "?USERNAME=admin&PASSWORD=ofbiz";
-
-    public WidgetMacroLibraryTests(String name) {
-        super(name);
-    }
 
     /**
      * Prepare the http client to call the demo layout screen
@@ -56,6 +60,8 @@ public class WidgetMacroLibraryTests extends OFBizTestCase {
      * Test html macro library.
      * @throws Exception the exception
      */
+    @Test
+    @Order(1)
     public void testHtmlMacroLibrary() throws Exception {
         HttpClient http = initHttpClient();
         if (Start.getInstance().getConfig().getPortOffset() != 0) {
@@ -64,96 +70,106 @@ public class WidgetMacroLibraryTests extends OFBizTestCase {
         }
         http.setUrl(screenUrl.concat(authentificationQuery));
         String screenOutString = http.post();
-        assertNotNull("Response failed from ofbiz", screenOutString);
-        assertEquals("Response contentType isn't good : " + http.getResponseContentType(), "text/html;charset=UTF-8", http.getResponseContentType());
+        assertNotNull(screenOutString, "Response failed from ofbiz");
+        assertEquals("text/html;charset=UTF-8", http.getResponseContentType(), "Response contentType isn't good : " + http.getResponseContentType());
 
         //Test if a ftl macro error is present
-        assertFalse("Html Screen contains Macro on error : see " + screenUrl + " for more detail",
-                screenOutString.contains("FreeMarker template error:"));
+        assertFalse(screenOutString.contains("FreeMarker template error:"),
+                "Html Screen contains Macro on error : see " + screenUrl + " for more detail");
     }
 
     /**
      * Test text macro library.
      * @throws Exception the exception
      */
+    @Test
+    @Order(2)
     public void testTextMacroLibrary() throws Exception {
         String screentextUrl = screenUrl.concat("Text");
         HttpClient http = initHttpClient();
         http.setUrl(screentextUrl.concat(authentificationQuery));
         String screenOutString = http.post();
-        assertNotNull("Response failed from ofbiz", screenOutString);
-        assertEquals("Response contentType isn't good : " + http.getResponseContentType(), "text/html;charset=UTF-8", http.getResponseContentType());
+        assertNotNull(screenOutString, "Response failed from ofbiz");
+        assertEquals("text/html;charset=UTF-8", http.getResponseContentType(), "Response contentType isn't good : " + http.getResponseContentType());
 
         //Test if a ftl macro error is present
-        assertFalse("Text Screen contains Macro on error : see " + screentextUrl + " for more detail",
-                screenOutString.contains("FreeMarker template error:"));
+        assertFalse(screenOutString.contains("FreeMarker template error:"),
+                "Text Screen contains Macro on error : see " + screentextUrl + " for more detail");
     }
 
     /**
      * Test xml macro library.
      * @throws Exception the exception
      */
+    @Test
+    @Order(3)
     public void testXmlMacroLibrary() throws Exception {
         String screenxmlUrl = screenUrl.concat("Xml");
         HttpClient http = initHttpClient();
         http.setUrl(screenxmlUrl.concat(authentificationQuery));
         String screenOutString = http.post();
-        assertNotNull("Response failed from ofbiz", screenOutString);
-        assertEquals("Response contentType isn't good : " + http.getResponseContentType(), "text/xml;charset=UTF-8", http.getResponseContentType());
+        assertNotNull(screenOutString, "Response failed from ofbiz");
+        assertEquals("text/xml;charset=UTF-8", http.getResponseContentType(), "Response contentType isn't good : " + http.getResponseContentType());
 
         //Test if a ftl macro error is present
-        assertFalse("Xml Screen contains Macro on error : see " + screenxmlUrl + " for more detail",
-                screenOutString.contains("FreeMarker template error:"));
+        assertFalse(screenOutString.contains("FreeMarker template error:"),
+                "Xml Screen contains Macro on error : see " + screenxmlUrl + " for more detail");
     }
 
     /**
      * Test csv macro library.
      * @throws Exception the exception
      */
+    @Test
+    @Order(4)
     public void testCsvMacroLibrary() throws Exception {
         String screencsvUrl = screenUrl.concat("Csv");
         HttpClient http = initHttpClient();
         http.setUrl(screencsvUrl.concat(authentificationQuery));
         String screenOutString = http.post();
-        assertNotNull("Response failed from ofbiz", screenOutString);
-        assertEquals("Response contentType isn't good : " + http.getResponseContentType(), "text/csv;charset=UTF-8", http.getResponseContentType());
+        assertNotNull(screenOutString, "Response failed from ofbiz");
+        assertEquals("text/csv;charset=UTF-8", http.getResponseContentType(), "Response contentType isn't good : " + http.getResponseContentType());
 
         //Test if a ftl macro error is present
-        assertFalse("Csv Screen contains Macro on error : see " + screencsvUrl + " for more detail",
-                screenOutString.contains("FreeMarker template error:"));
+        assertFalse(screenOutString.contains("FreeMarker template error:"),
+                "Csv Screen contains Macro on error : see " + screencsvUrl + " for more detail");
     }
 
     /**
      * Test xls macro library.
      * @throws Exception the exception
      */
+    @Test
+    @Order(5)
     public void testXlsMacroLibrary() throws Exception {
         String screenxlsUrl = screenUrl.concat("Xls");
         HttpClient http = initHttpClient();
         http.setUrl(screenxlsUrl.concat(authentificationQuery));
         String screenOutString = http.post();
-        assertNotNull("Response failed from ofbiz", screenOutString);
-        assertEquals("Response contentType isn't good : " + http.getResponseContentType(), "application/vnd.ms-excel;charset=UTF-8",
-                http.getResponseContentType());
+        assertNotNull(screenOutString, "Response failed from ofbiz");
+        assertEquals("application/vnd.ms-excel;charset=UTF-8",
+                http.getResponseContentType(), "Response contentType isn't good : " + http.getResponseContentType());
 
         //Test if a ftl macro error is present
-        assertFalse("Csv Screen contains Macro on error : see " + screenxlsUrl + " for more detail",
-                screenOutString.contains("FreeMarker template error:"));
+        assertFalse(screenOutString.contains("FreeMarker template error:"),
+                "Csv Screen contains Macro on error : see " + screenxlsUrl + " for more detail");
     }
 
     /**
      * Test fop macro library.
      * @throws Exception the exception
      */
+    @Test
+    @Order(6)
     public void testFopMacroLibrary() throws Exception {
         String screentextUrl = screenUrl.concat("Fop");
         HttpClient http = initHttpClient();
         http.setUrl(screentextUrl.concat(authentificationQuery));
         //FIXME need to check if the stream is an application-pdf that don't contains ftl stack trace
         InputStream screenInputStream = http.postStream();
-        assertNotNull("Response failed from ofbiz", screenInputStream);
-        assertEquals("Response contentType isn't good : " + http.getResponseContentType(), "application/pdf;charset=UTF-8",
-                http.getResponseContentType());
+        assertNotNull(screenInputStream, "Response failed from ofbiz");
+        assertEquals("application/pdf;charset=UTF-8",
+                http.getResponseContentType(), "Response contentType isn't good : " + http.getResponseContentType());
 
         String screenOutString = "";
         try {
@@ -165,7 +181,7 @@ public class WidgetMacroLibraryTests extends OFBizTestCase {
             screenInputStream.close();
         }
         //Test if a ftl macro error is present
-        assertFalse("Fop Screen contains Macro on error : see " + screentextUrl + " for more detail",
-                screenOutString.contains("FreeMarker template error:"));
+        assertFalse(screenOutString.contains("FreeMarker template error:"),
+                "Fop Screen contains Macro on error : see " + screentextUrl + " for more detail");
     }
 }

--- a/framework/widget/testdef/widgettests.xml
+++ b/framework/widget/testdef/widgettests.xml
@@ -22,6 +22,6 @@
         xsi:noNamespaceSchemaLocation="https://ofbiz.apache.org/dtds/test-suite.xsd">
 
     <test-case case-name="widget-tests">
-        <junit-test-suite class-name="org.apache.ofbiz.widget.test.WidgetMacroLibraryTests"/>
+        <jupiter-test-suite class-name="org.apache.ofbiz.widget.test.WidgetMacroLibraryTests"/>
     </test-case>
 </test-suite>


### PR DESCRIPTION
I took care of the following work:

1) Migrated all 20 testdef-wired JUnit3 test classes across base, common, entity, minilang, rest-api, service, webapp, and widget to Jupiter: extends OFBizTestCase/EntityTestCase -> implements JupiterTestHelper, @JunitJupiterTest on the class, @Test (+ @Order matching declaration order for multi-method files) on each method, testdef <junit-test-suite> -> <jupiter-test-suite>.

2) Moved every migrated file still under src/main/{java,groovy} to src/test/{java,groovy} (common: 1 file, entity: 4, minilang: 1, rest-api: 1, service: 8, widget: 1).

3) Reordered JUnit3-style message-first assertEquals/assertTrue/ assertFalse/assertNotNull/assertNull calls to JUnit 5's message-last convention across every converted file (highest volume in EntityTestSuite: 150 of 159 call sites).

4) Dropped 3 dead no-op setUp()/tearDown() overrides (GroovyDslServiceEngineTests, ServiceEngineTests,
ServiceEntityAutoTests).

5) Left service/ServiceSOAPTests.java's testdef entry commented out (pre-existing, disabled before this work) - converted the class for consistency but it stays unwired, out of scope to re-enable.

6) Verified every migrated suite via scoped and full testIntegration runs, all passing with 0 failures/errors.