### PR TITLE
Fixed: getDependentDropdownValues doesn't work with services using filterByDate (OFBIZ-11724)

### DIFF
--- a/themes/common-theme/template/includes/SetDependentDropdownValuesJs.ftl
+++ b/themes/common-theme/template/includes/SetDependentDropdownValuesJs.ftl
@@ -17,13 +17,19 @@ specific language governing permissions and limitations
 under the License.
 -->
 <#assign requestName><@ofbizUrl>${requestName}</@ofbizUrl></#assign>
+<#-- mainId may list several parent fields, comma separated, when the dependent drop-down
+     depends on more than one input. The form name prefix has to be applied to each field
+     in turn: applying it once to the whole list leaves every field after the first
+     without a prefix, so its value never reaches the service (OFBIZ-11724). -->
+<#assign mainFieldIds><#list mainId?split(",") as fieldId>${dependentForm}_${fieldId?trim}<#sep>,</#sep></#list></#assign>
+<#assign mainFieldSelector><#list mainId?split(",") as fieldId>#${dependentForm}_${fieldId?trim}<#sep>,</#sep></#list></#assign>
 <script type="text/javascript">
     jQuery(document).ready(function () {
-        if (jQuery('#${dependentForm}_${mainId}').length) {
-            jQuery('#${dependentForm}_${mainId}').change(function (e, data) {
-                getDependentDropdownValues('${requestName}', '${paramKey}', '${dependentForm}_${mainId}', '${dependentForm}_${dependentId}', '${responseName}', '${dependentKeyName}', '${descName}');
+        if (jQuery('${mainFieldSelector}').length) {
+            jQuery('${mainFieldSelector}').change(function (e, data) {
+                getDependentDropdownValues('${requestName}', '${paramKey}', '${mainFieldIds}', '${dependentForm}_${dependentId}', '${responseName}', '${dependentKeyName}', '${descName}');
             });
-            getDependentDropdownValues('${requestName}', '${paramKey}', '${dependentForm}_${mainId}', '${dependentForm}_${dependentId}', '${responseName}', '${dependentKeyName}', '${descName}', '${selectedDependentOption}');
+            getDependentDropdownValues('${requestName}', '${paramKey}', '${mainFieldIds}', '${dependentForm}_${dependentId}', '${responseName}', '${dependentKeyName}', '${descName}', '${selectedDependentOption}');
         <#if focusFieldName??>
             jQuery('#${focusFieldName}').focus();
         </#if>


### PR DESCRIPTION
Thanks to Pierre Smits for reporting this back in 2020 and, in particular, for pinpointing that only the first parameter of the list was ever being used. That observation is what made the root cause findable.

### The problem

A dependent drop-down is wired up through three layers: the screen XML declares `paramKey`, `mainId`, `dependentId` and friends; `SetDependentDropdownValuesJs.ftl` turns those into JavaScript; and `getDependentDropdownValues` in `miscAjaxFunctions.js` makes the Ajax call. Since form field ids are `FormName_FieldName`, the template glues the form name onto the field name.

The JavaScript has supported *several* parent fields for a long time — it splits both `paramKey` and `paramField` on commas and builds an array of parameters. The template never did. It applied the form-name prefix once, to the front of the whole list, so `mainId="fieldA,fieldB"` rendered as:

```
#NewUser_fieldA,fieldB
```

Only the first field carries the prefix. Because a comma in a CSS selector means "or", jQuery still matched the first field and the drop-down looked like it worked — but when the JavaScript split `paramField` back apart, the second entry resolved to nothing and its value was never sent. A service relying on `filterByDate` therefore never received a date, which is exactly the symptom in the issue title.

### The change

`mainId` is split on commas and the form-name prefix is applied to each field in turn, for both the jQuery selector and the `paramField` argument. The change handler now binds to every parent field, so changing any of them refreshes the dependent drop-down. Each entry is also trimmed, since the JavaScript side does not trim.

The whole change is one file, ten lines, four of them comment.

### Compatibility

For a single-valued `mainId` the rendered output is unchanged. There are 14 callers of this template today — 11 here and 3 in ofbiz-plugins — and every one passes a single value, so none are affected.

I verified this rather than assuming it: I captured the generated script for the single-parameter `NewCustomer` screen before the change, applied the fix, restarted (the template is cached), and diffed. The output is byte-identical.

Worth noting for anyone reproducing this: the template is included with `multi-block="true"`, so `HtmlWidget` strips the script out of the page body and serves it from `getJs?name=SetDependentDropdownValuesJs`. Grepping the page HTML finds nothing, which makes a naive before/after page diff pass trivially.

### Companion example

There is currently nothing in OFBiz that passes two parameters to a dependent drop-down, which I suspect is why this went unnoticed for so long — there was nothing to click that failed. apache/ofbiz-plugins#353 adds a worked two-parameter example to the Form Widget Examples screen. It depends on this fix, so this PR should go in first.

### Testing

Verified on a local instance: the two-parameter example emits both field names prefixed, the pre-existing single-parameter screens are byte-identical to before, and the plugins-side integration test passes (27 tests, 0 failures).

One caveat I would rather state up front than have discovered in review: with the fix in place, picking a date from a calendar widget refreshes the dependent drop-down, but typing one by hand does not. That is pre-existing framework-wide `date-time` behaviour — the datepicker fires `change` on the hidden canonical input while the typed path in `OfbizUtil.js` does not — rather than anything introduced here, so I have kept it out of this issue and will raise it separately. To be precise about the evidence: I established the calendar path by reading the vendored `jquery-ui.js` `_selectDate` and the rendered markup, not by observing it in a browser.

Happy to adjust any of this if a different approach is preferred.
