### PR TITLE
Fixed: Broken javamail-container sample in ofbiz-component.xml

### DIFF
--- a/framework/service/ofbiz-component.xml
+++ b/framework/service/ofbiz-component.xml
@@ -65,7 +65,7 @@ under the License.
     <!-- if delete-mail is set to true, will delete messages after fetching them. otherwise, will try to mark them as seen
         mail.store.protocol supports both imap and pop3, but pop3 will not be able to mark messages as seen, so you would need to delete them-->
     <!-- To use the mail listerner just uncomment and go...
-    <container name="javamail-container" class="org.apache.ofbiz.service.mail.JavaMailContainer">
+    <container name="javamail-container" loaders="main" class="org.apache.ofbiz.service.mail.JavaMailContainer">
         <property name="delegator-name" value="default"/>
         <property name="dispatcher-name" value="JavaMailDispatcher"/>
         <property name="run-as-user" value="system"/>
@@ -73,12 +73,12 @@ under the License.
         <property name="delete-mail" value="false"/>
         <property name="maxSize" value="100000"/>
         <property name="default-listener" value="store-listener">
-        <property name="mail.store.protocol" value="imap"/>
-        <property name="mail.host" value="[host]"/>
-        <property name="mail.port" value="110"/>
-        <property name="mail.user" value="[user]"/>
-        <property name="mail.pass" value="[pass]"/>
-        <property name="mail.debug" value="false"/>
+            <property name="mail.store.protocol" value="imap"/>
+            <property name="mail.host" value="[host]"/>
+            <property name="mail.port" value="110"/>
+            <property name="mail.user" value="[user]"/>
+            <property name="mail.pass" value="[pass]"/>
+            <property name="mail.debug" value="false"/>
         </property>
     </container>
     -->


### PR DESCRIPTION
Fixed: Broken javamail-container sample in ofbiz-component.xml

The commented-out javamail-container sample was missing loaders="main", which throws a NullPointerException at container-load time as soon as it's uncommented. Also fixed the indentation of the nested mail.* properties so the existing nesting reads correctly.