### PR TITLE
Fixed: Fixes broken classpath file created using gradlew eclipse (OFBIZ-13481)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -374,6 +374,11 @@ eclipse.classpath.file.whenMerged { classpath ->
             entry.path ==~ /(\/+themes)$/ )
         }
     }
+
+    // remove .pom artifacts from classpath
+    classpath.entries.removeAll { entry ->
+        entry.kind == 'lib' && entry.path.endsWith('.pom')
+    }
 }
 tasks.eclipse.dependsOn(cleanEclipse)
 


### PR DESCRIPTION

* Adds a filter to the existing whenMerged hook to filter entrys whose kind="lib" and that end in .pom before the classpath gets written to xml.
