### PR TITLE
Fixed: Remove HOSTCERT_MIN_CHECK from SSLUtil (OFBIZ-13482) (backport to release24.09)

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/SSLUtil.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/SSLUtil.java
@@ -19,24 +19,19 @@
 package org.apache.ofbiz.base.util;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.security.Principal;
 import java.security.SecureRandom;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
@@ -55,7 +50,6 @@ public final class SSLUtil {
     private static final String MODULE = SSLUtil.class.getName();
 
     private static final int HOSTCERT_NO_CHECK = 0;
-    private static final int HOSTCERT_MIN_CHECK = 1;
     private static final int HOSTCERT_NORMAL_CHECK = 2;
 
     private static boolean loadedProps = false;
@@ -96,10 +90,6 @@ public final class SSLUtil {
 
     public static int getHostCertNoCheck() {
         return HOSTCERT_NO_CHECK;
-    }
-
-    public static int getHostCertMinCheck() {
-        return HOSTCERT_MIN_CHECK;
     }
 
     static int getHostCertNormalCheck() {
@@ -257,36 +247,6 @@ public final class SSLUtil {
 
     public static HostnameVerifier getHostnameVerifier(int level) {
         switch (level) {
-        case HOSTCERT_MIN_CHECK:
-            return (hostname, session) -> {
-                Certificate[] peerCerts;
-                try {
-                    peerCerts = session.getPeerCertificates();
-                } catch (SSLPeerUnverifiedException e) {
-                    // cert not verified
-                    Debug.logWarning(e.getMessage(), MODULE);
-                    return false;
-                }
-                for (Certificate peerCert : peerCerts) {
-                    try {
-                        Principal x500s = session.getPeerPrincipal();
-                        Map<String, String> subjectMap = KeyStoreUtil.getX500Map(x500s);
-                        if (Debug.infoOn()) {
-                            byte[] encodedCert = peerCert.getEncoded();
-                            Debug.logInfo(new BigInteger(encodedCert).toString(16)
-                                    + " :: " + subjectMap.get("CN"), MODULE);
-                        }
-                        peerCert.verify(peerCert.getPublicKey());
-                    } catch (RuntimeException e) {
-                        throw e;
-                    } catch (Exception e) {
-                        // certificate not valid
-                        Debug.logWarning("Certificate is not valid!", MODULE);
-                        return false;
-                    }
-                }
-                return true;
-            };
         case HOSTCERT_NO_CHECK:
             return (hostname, session) -> true;
         default:


### PR DESCRIPTION
Fixed: Remove HOSTCERT_MIN_CHECK from SSLUtil (OFBIZ-13482)

HOSTCERT_MIN_CHECK's HostnameVerifier never compared the hostname to the
certificate (CWE-297): it called peerCert.verify(peerCert.getPublicKey()),
a self-signed check unrelated to any hostname or trust-store semantic.
Removed the level along with its public getHostCertMinCheck() accessor;
nothing in-tree used it, and HOSTCERT_NORMAL_CHECK already gets full,
correct hostname validation for free from the JDK's default verifier.

Backport of trunk PR #1559.