### PR TITLE
Fixed: URLConnector.openUntrustedConnection(...) public overloads silently performed trusted SSL connections (OFBIZ-13484)

### DIFF
--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/URLConnector.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/URLConnector.java
@@ -100,15 +100,15 @@ public class URLConnector {
 
     // allow untrusted certs
     public static URLConnection openUntrustedConnection(URL url) throws IOException {
-        return openConnection(url, 30000);
+        return openUntrustedConnection(url, 30000);
     }
 
     public static URLConnection openUntrustedConnection(URL url, int timeout) throws IOException {
-        return openConnection(url, timeout, null, SSLUtil.getHostCertNormalCheck());
+        return openUntrustedConnection(url, timeout, null, SSLUtil.getHostCertNormalCheck());
     }
 
     public static URLConnection openUntrustedConnection(URL url, String clientCertAlias) throws IOException {
-        return openConnection(url, 30000, clientCertAlias, SSLUtil.getHostCertNormalCheck());
+        return openUntrustedConnection(url, 30000, clientCertAlias, SSLUtil.getHostCertNormalCheck());
     }
 
     static URLConnection openUntrustedConnection(URL url, int timeout, String clientCertAlias, int hostCertLevel) throws IOException {


### PR DESCRIPTION
Fixed: URLConnector.openUntrustedConnection(...) public overloads silently performed trusted SSL connections (OFBIZ-13484)

The three public openUntrustedConnection overloads delegated to the trusted openConnection(...) path instead of the untrusted one, so trustAnyCert was always false despite the method name and "allow untrusted certs" comment. Only the package-private 4-arg overload (the one HttpClient actually calls) set trustAnyCert=true correctly. This change makes the three public overloads delegate to openUntrustedConnection(...) instead, mirroring the existing trusted-path delegation pattern. Not exploitable in-tree today since the only caller already used the correct overload, but it silently broke the public API contract for any external caller expecting untrusted/self-signed-cert behavior.

Backported from trunk (#1569).