### PR TITLE
Fixed: PDF upload accepted embedded attachments when ZUGFeRD upload was disabled (OFBIZ-13485)

### DIFF
--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -1022,7 +1022,7 @@ public class SecuredUpload {
         }
         File file = new File(fileName);
         boolean safeState = false;
-        boolean canParseZUGFeRD = true;
+        boolean canParseZUGFeRD = false;
         try {
             if (Objects.isNull(file) || !file.exists()) {
                 return safeState;
@@ -1061,6 +1061,8 @@ public class SecuredUpload {
                                         + " is not a readable (valid and secure) PDF file. For security reason it's not accepted as a such file",
                                         MODULE);
 
+                            } else {
+                                canParseZUGFeRD = true;
                             }
                         } catch (SAXException | ParserConfigurationException | IOException e) {
                             safeState = false;


### PR DESCRIPTION
Fixed: PDF upload accepted embedded attachments when ZUGFeRD upload was
disabled (OFBIZ-13485)

canParseZUGFeRD was initialized to true and only ever reset to false inside
the ZUGFeRD-compliant-upload branch. When allowZUGFeRDCompliantUpload=false,
that branch never ran, so any PDF containing embedded files of any type was
reported safe regardless of content. Initializing canParseZUGFeRD to false
restores fail-closed behavior for that path.

Also fixes a related regression: in the secure ZUGFeRD sub-mode
(allowZUGFeRDnotSecure=false), canParseZUGFeRD was never set back to true on
successful XML validation, so legitimate ZUGFeRD invoices were always
rejected under the shipped defaults.