### PR TITLE
Fixed: isExecutable() mime-type comparisons never matched Tika's actual types (OFBIZ-13486)

### DIFF
--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -1133,9 +1133,9 @@ public class SecuredUpload {
         // Check for ELF (Linux) and scripts
         if ("application/x-elf".equals(mimeType)
                 || "application/x-sh".equals(mimeType)
-                || "application/text/x-perl".equals(mimeType)
-                || "application/text/x-ruby".equals(mimeType)
-                || "application/text/x-python".equals(mimeType)) {
+                || "text/x-perl".equals(mimeType)
+                || "text/x-ruby".equals(mimeType)
+                || "text/x-python".equals(mimeType)) {
             Debug.logError("The file " + fileName + " is a Linux executable, for security reason it's not accepted", MODULE);
             return true;
         }


### PR DESCRIPTION
SecuredUpload.isExecutable() compared Tika's detected mime type against
"application/text/x-perl", "application/text/x-ruby", "application/text/x-python",
but Tika (verified against this project's tika-core:3.3.1 dependency) actually
registers these as "text/x-perl", "text/x-ruby", "text/x-python" with no
"application/" prefix, so the comparisons have been dead code since introduction.
Corrects the three strings to match Tika's actual output.