### PR TITLE
[OFBIZ-10399] Remove deprecated in parameters and its usage from create content service

### DIFF
--- a/applications/content/minilang/content/ContentEvents.xml
+++ b/applications/content/minilang/content/ContentEvents.xml
@@ -45,8 +45,6 @@ under the License.
         <log level="info" message="currentContent: ${currentContent}"/>
 
         <set field="context.contentPurposeTypeId" from-field="parameters.contentPurposeTypeId"/>
-        <string-to-list list="targetOperationList" string="CONTENT_CREATE"/>
-        <set field="context.targetOperationList" from-field="targetOperationList"/>
         <session-to-field field="context.userLogin" session-name="userLogin"/>
 
         <call-service in-map-name="context" service-name="createContent">

--- a/applications/content/servicedef/services_content.xml
+++ b/applications/content/servicedef/services_content.xml
@@ -34,15 +34,6 @@
         <attribute name="contentAssocTypeId" type="String" mode="INOUT" optional="true"/>
         <attribute name="contentIdFrom" type="String" mode="INOUT" optional="true"/>
         <attribute name="contentIdTo" type="String" mode="INOUT" optional="true"/>
-        <!-- TODO: the following fields are deprecated; but will not be removed until all services and callers are updated -->
-        <attribute mode="IN" name="targetOperationList" optional="true" type="List"/>
-        <attribute mode="IN" name="targetOperationString" optional="true" type="String"/>
-        <attribute mode="IN" name="contentPurposeList" optional="true" type="List"/>
-        <attribute mode="IN" name="contentPurposeString" optional="true" type="String"/>
-        <attribute mode="IN" name="skipPermissionCheck" optional="true" type="String"/>
-        <attribute mode="IN" name="displayFailCond" optional="true" type="Boolean"/>
-        <attribute mode="INOUT" name="roleTypeList" optional="true" type="List"/>
-        <!-- end of deprecated fields -->
         <override name="contentTypeId" default-value="DOCUMENT"/>
         <override name="statusId" default-value="CTNT_IN_PROGRESS"/>
         <override name="contentName" allow-html="safe"/>

--- a/applications/content/src/main/java/org/apache/ofbiz/content/ContentManagementEvents.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/ContentManagementEvents.java
@@ -252,10 +252,6 @@ public class ContentManagementEvents {
                         serviceIn.put("contentAssocTypeId", "PUBLISH_LINK");
                         serviceIn.put("fromDate", nowTimestamp);
                         serviceIn.put("contentIdTo", currentSubContentId);
-                        serviceIn.put("roleTypeList", roleTypeList);
-                        serviceIn.put("targetOperationList", targetOperationList);
-                        // TODO check if this should be removed (see above)
-                        serviceIn.put("contentPurposeList", contentPurposeList);
                         result = dispatcher.runSync("createContentAssoc", serviceIn);
                         if (ServiceUtil.isError(result)) {
                             String errorMessage = ServiceUtil.getErrorMessage(result);
@@ -270,10 +266,6 @@ public class ContentManagementEvents {
                         serviceIn.put("contentAssocTypeId", "PUBLISH_LINK");
                         serviceIn.put("fromDate", nowTimestamp);
                         serviceIn.put("contentIdTo", contentId);
-                        serviceIn.put("roleTypeList", roleTypeList);
-                        serviceIn.put("targetOperationList", targetOperationList);
-                        // TODO check if this should be removed (see above)
-                        serviceIn.put("contentPurposeList", contentPurposeList);
                         result = dispatcher.runSync("createContentAssoc", serviceIn);
                         if (ServiceUtil.isError(result)) {
                             String errorMessage = ServiceUtil.getErrorMessage(result);

--- a/applications/content/src/main/java/org/apache/ofbiz/content/ContentManagementServices.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/ContentManagementServices.java
@@ -313,8 +313,6 @@ public class ContentManagementServices {
                 ModelService contentModel = dispatcher.getDispatchContext().getModelService("createContent");
                 contentContext.putAll(contentModel.makeValid(content, ModelService.IN_PARAM));
                 contentContext.put("userLogin", userLogin);
-                contentContext.put("displayFailCond", bDisplayFailCond);
-                contentContext.put("skipPermissionCheck", context.get("skipPermissionCheck"));
                 Debug.logInfo("In persistContentAndAssoc calling createContent with content: " + contentContext, MODULE);
                 Map<String, Object> thisResult = dispatcher.runSync("createContent", contentContext);
                 if (ServiceUtil.isError(thisResult) || ServiceUtil.isFailure(thisResult)) {
@@ -377,8 +375,6 @@ public class ContentManagementServices {
             }
             Map<String, Object> contentAssocContext = new HashMap<>();
             contentAssocContext.put("userLogin", userLogin);
-            contentAssocContext.put("displayFailCond", bDisplayFailCond);
-            contentAssocContext.put("skipPermissionCheck", context.get("skipPermissionCheck"));
             Map<String, Object> thisResult = null;
             try {
                 GenericValue contentAssocExisting = EntityQuery.use(delegator).from("ContentAssoc").where(contentAssoc.getPrimaryKey()).queryOne();

--- a/applications/content/src/test/groovy/org/apache/ofbiz/content/content/ContentTests.groovy
+++ b/applications/content/src/test/groovy/org/apache/ofbiz/content/content/ContentTests.groovy
@@ -202,4 +202,43 @@ class ContentTests implements JupiterTestHelper {
         assert serviceResult.view
     }
 
+    @Test
+    @Order(9)
+    void testCreateContent() {
+        Map serviceCtx = [:]
+        serviceCtx.contentName = 'Test Content'
+        serviceCtx.contentTypeId = 'DOCUMENT'
+        serviceCtx.statusId = 'CTNT_IN_PROGRESS'
+        serviceCtx.userLogin = userLogin
+        Map serviceResult = dispatcher.runSync('createContent', serviceCtx)
+        assert ServiceUtil.isSuccess(serviceResult)
+        assert serviceResult.contentId
+
+        GenericValue content = from('Content')
+                .where('contentId', serviceResult.contentId)
+                .queryOne()
+        assert content
+        assert content.contentName == 'Test Content'
+        assert content.contentTypeId == 'DOCUMENT'
+    }
+
+    @Test
+    @Order(10)
+    void testPersistContentAndAssoc() {
+        Map serviceCtx = [:]
+        serviceCtx.contentName = 'Test Content Persist'
+        serviceCtx.contentTypeId = 'DOCUMENT'
+        serviceCtx.statusId = 'CTNT_IN_PROGRESS'
+        serviceCtx.userLogin = userLogin
+        Map serviceResult = dispatcher.runSync('persistContentAndAssoc', serviceCtx)
+        assert ServiceUtil.isSuccess(serviceResult)
+        assert serviceResult.contentId
+
+        GenericValue content = from('Content')
+                .where('contentId', serviceResult.contentId)
+                .queryOne()
+        assert content
+        assert content.contentName == 'Test Content Persist'
+    }
+
 }


### PR DESCRIPTION
### Summary
Removed deprecated IN parameters and their usage from the `createContent` service and related service calls.

### Key Changes
- **`services_content.xml`**: Removed deprecated IN/INOUT attributes (`targetOperationList`, `targetOperationString`, `contentPurposeList`, `contentPurposeString`, `skipPermissionCheck`, `displayFailCond`, `roleTypeList`) and deprecated comments from `createContent` service definition.
- **`ContentEvents.xml`**: Removed setting `targetOperationList` in context prior to calling `createContent`.
- **`ContentManagementServices.java`**: Removed setting deprecated permission check parameters (`displayFailCond`, `skipPermissionCheck`) prior to calling `createContent` and `createContentAssoc`.
- **`ContentManagementEvents.java`**: Cleaned up obsolete parameter entries (`roleTypeList`, `targetOperationList`, `contentPurposeList`) and legacy TODO comments prior to calling `createContentAssoc`.
- **`ContentTests.groovy`**: Added unit test coverage (`testCreateContent`, `testPersistContentAndAssoc`).

