### PR TITLE
Fixed: Remove unused code from ContentServices class file (OFBIZ-10397)

### DIFF
--- a/applications/content/servicedef/services.xml
+++ b/applications/content/servicedef/services.xml
@@ -366,14 +366,10 @@
         <attribute mode="OUT" name="deactivatedList" optional="false" type="List"/>
     </service>
 
-    <service name="deactivateContentAssoc" engine="java"
-        transaction-timeout="7200"
-            location="org.apache.ofbiz.content.content.ContentServices" invoke="deactivateContentAssoc" auth="true">
+    <service name="deactivateContentAssoc" default-entity-name="ContentAssoc" engine="entity-auto" invoke="expire" auth="true">
         <description>Set thruDate to now for ContentAssoc entity</description>
-        <attribute mode="IN" name="contentIdTo" optional="true" type="String"/>
-        <attribute mode="IN" name="contentId" optional="true" type="String"/>
-        <attribute mode="IN" name="contentAssocTypeId" optional="true" type="String"/>
-        <attribute mode="IN" name="fromDate" optional="true" type="Timestamp"/>
+        <permission-service service-name="genericContentPermission" main-action="UPDATE"/>
+        <auto-attributes include="pk" mode="IN" optional="false"/>
     </service>
 
     <service name="createArticleContent" engine="groovy" transaction-timeout="300" auth="true"
@@ -397,41 +393,7 @@
         <attribute name="threadContentId" type="String" mode="IN" optional="true"/>
         <attribute name="summaryData" type="String" mode="IN" optional="true"/>
     </service>
-    <!-- SubContent Render Services -->
-    <service name="renderSubContentAsText" engine="java"
-            location="org.apache.ofbiz.content.content.ContentServices" invoke="renderSubContentAsText" auth="false">
-        <description>Get the subcontent and render</description>
-        <attribute mode="IN" name="contentId" optional="true" type="String"/>
-        <attribute mode="IN" name="mapKey" optional="true" type="String"/>
-        <attribute mode="IN" name="outWriter" optional="false" type="java.io.Writer">
-            <type-validate>
-                <fail-property resource="ContentErrorUiLabels" property="ContentRequiredFieldMissingOutWriter"/>
-            </type-validate>
-        </attribute>
-        <attribute mode="IN" name="subContentId" optional="true" type="String"/>
-        <attribute mode="IN" name="templateContext" optional="false" type="Map">
-            <type-validate>
-                <fail-property resource="ContentErrorUiLabels" property="ContentRequiredFieldMissingTemplateContext"/>
-            </type-validate>
-        </attribute>
-        <attribute mode="IN" name="locale" optional="true" type="String"/>
-        <attribute mode="IN" name="mimeTypeId" optional="true" type="String"/>
-        <attribute mode="IN" name="fromDate" optional="true" type="Timestamp"/>
-        <attribute mode="IN" name="subContentDataResourceView" optional="true" type="org.apache.ofbiz.entity.GenericValue"/>
-        <attribute mode="OUT" name="view" optional="true" type="org.apache.ofbiz.entity.GenericValue"/>
-        <attribute mode="OUT" name="textData" optional="true" type="String"/>
-    </service>
-    <service name="renderContentAsText" engine="java"
-            location="org.apache.ofbiz.content.content.ContentServices" invoke="renderContentAsText" auth="false">
-        <description>Get the subcontent and render</description>
-        <attribute mode="IN" name="contentId" optional="true" type="String"/>
-        <attribute mode="IN" name="outWriter" optional="true" type="java.io.Writer"/>
-        <attribute mode="IN" name="templateContext" optional="true" type="Map"/>
-        <attribute mode="IN" name="locale" optional="true" type="String"/>
-        <attribute mode="IN" name="mimeTypeId" optional="true" type="String"/>
-        <attribute mode="IN" name="subContentDataResourceView" optional="true" type="org.apache.ofbiz.entity.GenericValue"/>
-        <attribute mode="OUT" name="textData" optional="true" type="String"/>
-    </service>
+
     <service name="renderDataResourceAsText" engine="java"
             location="org.apache.ofbiz.content.data.DataServices" invoke="renderDataResourceAsText" auth="false">
         <description>Get the dataResource and render</description>
@@ -722,56 +684,7 @@
         </attribute>
         <attribute name="contentAssocTypeId" type="String" mode="IN" optional="true"/>
     </service>
-    <service name="publishContent" auth="true" engine="java" transaction-timeout="7200"
-            location="org.apache.ofbiz.content.content.ContentServices" invoke="publishContent">
-        <description>Change statusId to published (CTNT_PUBLISHED)</description>
-        <attribute mode="IN" name="content" optional="false" type="org.apache.ofbiz.entity.GenericValue">
-            <type-validate>
-                <fail-property resource="ContentErrorUiLabels" property="ContentRequiredFieldMissingContent"/>
-            </type-validate>
-        </attribute>
-    </service>
 
-    <!-- these three services are for use in screen widget files -->
-    <service name="getPrefixedMembers" auth="false" engine="java" transaction-timeout="7200"
-            location="org.apache.ofbiz.content.content.ContentServices" invoke="getPrefixedMembers">
-        <description>Gets all the members of the input map that start with the prefix</description>
-        <attribute mode="IN" name="mapIn" optional="true" type="java.util.Map"/>
-        <attribute name="prefix" type="String" mode="IN" optional="false">
-            <type-validate>
-                <fail-property resource="ContentErrorUiLabels" property="ContentRequiredFieldMissingPrefix"/>
-            </type-validate>
-        </attribute>
-        <attribute mode="OUT" name="mapOut" optional="true" type="java.util.Map"/>
-    </service>
-    <service name="splitString" auth="false" engine="java" transaction-timeout="7200"
-            location="org.apache.ofbiz.content.content.ContentServices" invoke="splitString">
-        <description>Splits input string </description>
-        <attribute name="inputString" type="String" mode="IN" optional="true"/>
-        <attribute name="delimiter" type="String" mode="IN" optional="true"/>
-        <attribute mode="OUT" name="outputList" optional="true" type="java.util.List"/>
-    </service>
-    <service name="joinString" auth="false" engine="java" transaction-timeout="7200"
-            location="org.apache.ofbiz.content.content.ContentServices" invoke="joinString">
-        <description>Splits input string </description>
-        <attribute name="inputList" type="java.util.List" mode="IN" optional="false">
-            <type-validate>
-                <fail-property resource="ContentErrorUiLabels" property="ContentRequiredFieldMissingInputList"/>
-            </type-validate>
-        </attribute>
-        <attribute name="delimiter" type="String" mode="IN" optional="true"/>
-        <attribute mode="OUT" name="outputString" optional="true" type="String"/>
-    </service>
-    <service name="urlEncodeArgs" auth="false" engine="java" transaction-timeout="7200"
-            location="org.apache.ofbiz.content.content.ContentServices" invoke="urlEncodeArgs">
-        <description>URL encodes map</description>
-        <attribute name="mapIn" type="java.util.Map" mode="IN" optional="false">
-            <type-validate>
-                <fail-property resource="ContentErrorUiLabels" property="ContentRequiredFieldMissingMapIn"/>
-            </type-validate>
-        </attribute>
-        <attribute mode="OUT" name="outputString" optional="true" type="String"/>
-    </service>
 
     <!-- blog services -->
     <service name="createBlogEntry" engine="groovy" auth="true"

--- a/applications/content/src/main/java/org/apache/ofbiz/content/content/ContentServices.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/content/ContentServices.java
@@ -18,24 +18,16 @@
  *******************************************************************************/
 package org.apache.ofbiz.content.content;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.ofbiz.base.util.Debug;
-import org.apache.ofbiz.base.util.GeneralException;
-import org.apache.ofbiz.base.util.StringUtil;
 import org.apache.ofbiz.base.util.UtilDateTime;
-import org.apache.ofbiz.base.util.UtilFormatOut;
 import org.apache.ofbiz.base.util.UtilGenerics;
-import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilValidate;
@@ -104,7 +96,7 @@ public class ContentServices {
         for (GenericValue content : contentList) {
             serviceInMap.put("currentContent", content);
             try {
-                permResults = dispatcher.runSync("checkContentPermission", serviceInMap);
+                permResults = dispatcher.runSync("genericContentPermission", serviceInMap);
                 if (ServiceUtil.isError(permResults)) {
                     return ServiceUtil.returnError(ServiceUtil.getErrorMessage(permResults));
                 }
@@ -113,8 +105,8 @@ public class ContentServices {
                 return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE, "ContentPermissionNotGranted", locale));
             }
 
-            String permissionStatus = (String) permResults.get("permissionStatus");
-            if (permissionStatus != null && "granted".equalsIgnoreCase(permissionStatus)) {
+            Boolean hasPermission = (Boolean) permResults.get("hasPermission");
+            if (Boolean.TRUE.equals(hasPermission)) {
                 permittedList.add(content);
             }
 
@@ -122,101 +114,6 @@ public class ContentServices {
 
         results.put("contentList", permittedList);
         return results;
-    }
-
-    /**
-     * Update a ContentAssoc service. The work is done in a separate method so that complex services that need this
-     * functionality do not need to incur the reflection performance penalty.
-     */
-    public static Map<String, Object> deactivateContentAssoc(DispatchContext dctx, Map<String, ? extends Object> rcontext) {
-        Map<String, Object> context = UtilMisc.makeMapWritable(rcontext);
-        context.put("entityOperation", "_UPDATE");
-        List<String> targetOperationList = ContentWorker.prepTargetOperationList(context, "_UPDATE");
-
-        List<String> contentPurposeList = ContentWorker.prepContentPurposeList(context);
-        context.put("targetOperationList", targetOperationList);
-        context.put("contentPurposeList", contentPurposeList);
-        context.put("skipPermissionCheck", null);
-
-        Map<String, Object> result = deactivateContentAssocMethod(dctx, context);
-        return result;
-    }
-
-    /**
-     * Update a ContentAssoc method. The work is done in this separate method so that complex services that need this
-     * functionality do not need to incur the reflection performance penalty.
-     */
-    public static Map<String, Object> deactivateContentAssocMethod(DispatchContext dctx, Map<String, ? extends Object> rcontext) {
-        Map<String, Object> context = UtilMisc.makeMapWritable(rcontext);
-        Delegator delegator = dctx.getDelegator();
-        LocalDispatcher dispatcher = dctx.getDispatcher();
-        Map<String, Object> result = new HashMap<>();
-        Locale locale = (Locale) context.get("locale");
-        context.put("entityOperation", "_UPDATE");
-        List<String> targetOperationList = ContentWorker.prepTargetOperationList(context, "_UPDATE");
-
-        List<String> contentPurposeList = ContentWorker.prepContentPurposeList(context);
-        context.put("targetOperationList", targetOperationList);
-        context.put("contentPurposeList", contentPurposeList);
-
-        GenericValue pk = delegator.makeValue("ContentAssoc");
-        pk.setAllFields(context, false, null, Boolean.TRUE);
-        pk.setAllFields(context, false, "ca", Boolean.TRUE);
-
-        GenericValue contentAssoc = null;
-        try {
-            contentAssoc = EntityQuery.use(delegator).from("ContentAssoc").where(pk).queryOne();
-        } catch (GenericEntityException e) {
-            Debug.logError(e, "Entity Error:" + e.getMessage(), MODULE);
-            return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE, "ContentAssocRetrievingError",
-                    UtilMisc.toMap("errorString", e.getMessage()), locale));
-        }
-
-        if (contentAssoc == null) {
-            return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE, "ContentAssocDeactivatingError", locale));
-        }
-
-        GenericValue userLogin = (GenericValue) context.get("userLogin");
-        String userLoginId = (String) userLogin.get("userLoginId");
-        String lastModifiedByUserLogin = userLoginId;
-        Timestamp lastModifiedDate = UtilDateTime.nowTimestamp();
-        contentAssoc.put("lastModifiedByUserLogin", lastModifiedByUserLogin);
-        contentAssoc.put("lastModifiedDate", lastModifiedDate);
-        contentAssoc.put("thruDate", UtilDateTime.nowTimestamp());
-
-        String permissionStatus = null;
-        Map<String, Object> serviceInMap = new HashMap<>();
-        serviceInMap.put("userLogin", context.get("userLogin"));
-        serviceInMap.put("targetOperationList", targetOperationList);
-        serviceInMap.put("contentPurposeList", contentPurposeList);
-        serviceInMap.put("entityOperation", context.get("entityOperation"));
-        serviceInMap.put("contentIdTo", contentAssoc.get("contentIdTo"));
-        serviceInMap.put("contentIdFrom", contentAssoc.get("contentId"));
-
-        Map<String, Object> permResults = null;
-        try {
-            permResults = dispatcher.runSync("checkAssocPermission", serviceInMap);
-            if (ServiceUtil.isError(permResults)) {
-                return ServiceUtil.returnError(ServiceUtil.getErrorMessage(permResults));
-            }
-        } catch (GenericServiceException e) {
-            Debug.logError(e, "Problem checking permissions", "ContentServices");
-            return ServiceUtil.returnError(UtilProperties.getMessage(RESOURCE, "ContentPermissionNotGranted", locale));
-        }
-        permissionStatus = (String) permResults.get("permissionStatus");
-
-        if (permissionStatus != null && "granted".equals(permissionStatus)) {
-            try {
-                contentAssoc.store();
-            } catch (GenericEntityException e) {
-                return ServiceUtil.returnError(e.getMessage());
-            }
-        } else {
-            String errorMsg = ContentWorker.prepPermissionErrorMsg(permResults);
-            return ServiceUtil.returnError(errorMsg);
-        }
-
-        return result;
     }
 
     /**
@@ -282,96 +179,7 @@ public class ContentServices {
         return results;
     }
 
-    /**
-     * Get and render subcontent associated with template id and mapkey. If subContentId is supplied, that content will be rendered
-     * without searching for other matching content.
-     */
-    public static Map<String, Object> renderSubContentAsText(DispatchContext dctx, Map<String, ? extends Object> context) {
-        Map<String, Object> results = new HashMap<>();
-        LocalDispatcher dispatcher = dctx.getDispatcher();
 
-        Map<String, Object> templateContext = UtilGenerics.cast(context.get("templateContext"));
-        String contentId = (String) context.get("contentId");
-
-        if (templateContext != null && UtilValidate.isEmpty(contentId)) {
-            contentId = (String) templateContext.get("contentId");
-        }
-        String mapKey = (String) context.get("mapKey");
-        if (templateContext != null && UtilValidate.isEmpty(mapKey)) {
-            mapKey = (String) templateContext.get("mapKey");
-        }
-        String mimeTypeId = (String) context.get("mimeTypeId");
-        if (templateContext != null && UtilValidate.isEmpty(mimeTypeId)) {
-            mimeTypeId = (String) templateContext.get("mimeTypeId");
-        }
-        Locale locale = (Locale) context.get("locale");
-        if (templateContext != null && locale == null) {
-            locale = (Locale) templateContext.get("locale");
-        }
-
-        Writer out = (Writer) context.get("outWriter");
-        Writer outWriter = new StringWriter();
-
-        if (templateContext == null) {
-            templateContext = new HashMap<>();
-        }
-
-        try {
-            ContentWorker.renderSubContentAsText(dispatcher, contentId, outWriter, mapKey, templateContext, locale, mimeTypeId, true);
-            out.write(outWriter.toString());
-            results.put("textData", outWriter.toString());
-        } catch (GeneralException | IOException e) {
-            Debug.logError(e, "Error rendering sub-content text", MODULE);
-            return ServiceUtil.returnError(e.toString());
-        }
-
-        return results;
-
-    }
-
-    /**
-     * Get and render subcontent associated with template id and mapkey. If subContentId is supplied, that content will be rendered
-     * without searching for other matching content.
-     */
-    public static Map<String, Object> renderContentAsText(DispatchContext dctx, Map<String, ? extends Object> context) {
-        Map<String, Object> results = new HashMap<>();
-        LocalDispatcher dispatcher = dctx.getDispatcher();
-        Writer out = (Writer) context.get("outWriter");
-
-        Map<String, Object> templateContext = UtilGenerics.cast(context.get("templateContext"));
-        String contentId = (String) context.get("contentId");
-        if (templateContext != null && UtilValidate.isEmpty(contentId)) {
-            contentId = (String) templateContext.get("contentId");
-        }
-        String mimeTypeId = (String) context.get("mimeTypeId");
-        if (templateContext != null && UtilValidate.isEmpty(mimeTypeId)) {
-            mimeTypeId = (String) templateContext.get("mimeTypeId");
-        }
-        Locale locale = (Locale) context.get("locale");
-        if (templateContext != null && locale == null) {
-            locale = (Locale) templateContext.get("locale");
-        }
-
-        if (templateContext == null) {
-            templateContext = new HashMap<>();
-        }
-
-        Writer outWriter = new StringWriter();
-        GenericValue view = (GenericValue) context.get("subContentDataResourceView");
-        if (view != null && view.containsKey("contentId")) {
-            contentId = view.getString("contentId");
-        }
-
-        try {
-            ContentWorker.renderContentAsText(dispatcher, contentId, outWriter, templateContext, locale, mimeTypeId, null, null, true);
-            if (out != null) out.write(outWriter.toString());
-            results.put("textData", outWriter.toString());
-        } catch (GeneralException | IOException e) {
-            Debug.logError(e, "Error rendering sub-content text", MODULE);
-            return ServiceUtil.returnError(e.toString());
-        }
-        return results;
-    }
 
     public static Map<String, Object> linkContentToPubPt(DispatchContext dctx, Map<String, ? extends Object> context) {
         Map<String, Object> results = new HashMap<>();
@@ -453,84 +261,7 @@ public class ContentServices {
         return results;
     }
 
-    public static Map<String, Object> publishContent(DispatchContext dctx, Map<String, ? extends Object> context) throws GenericServiceException {
-        Map<String, Object> result = new HashMap<>();
-        GenericValue content = (GenericValue) context.get("content");
 
-        try {
-            content.put("statusId", "CTNT_PUBLISHED");
-            content.store();
-        } catch (GenericEntityException e) {
-            Debug.logError(e.getMessage(), MODULE);
-            return ServiceUtil.returnError(e.getMessage());
-        }
-        return result;
-    }
-
-    public static Map<String, Object> getPrefixedMembers(DispatchContext dctx, Map<String, ? extends Object> context) throws GenericServiceException {
-        Map<String, Object> result = new HashMap<>();
-        Map<String, Object> mapIn = UtilGenerics.cast(context.get("mapIn"));
-        String prefix = (String) context.get("prefix");
-        Map<String, Object> mapOut = new HashMap<>();
-        result.put("mapOut", mapOut);
-        if (mapIn != null) {
-            Set<Map.Entry<String, Object>> entrySet = mapIn.entrySet();
-            for (Map.Entry<String, Object> entry : entrySet) {
-                String key = entry.getKey();
-                if (key.startsWith(prefix)) {
-                    Object value = entry.getValue();
-                    mapOut.put(key, value);
-                }
-            }
-        }
-        return result;
-    }
-
-    public static Map<String, Object> splitString(DispatchContext dctx, Map<String, ? extends Object> context) throws GenericServiceException {
-        Map<String, Object> result = new HashMap<>();
-        List<String> outputList = new LinkedList<>();
-        String delimiter = UtilFormatOut.checkEmpty((String) context.get("delimiter"), "|");
-        String inputString = (String) context.get("inputString");
-        if (UtilValidate.isNotEmpty(inputString)) {
-            outputList = StringUtil.split(inputString, delimiter);
-        }
-        result.put("outputList", outputList);
-        return result;
-    }
-
-    public static Map<String, Object> joinString(DispatchContext dctx, Map<String, ? extends Object> context) throws GenericServiceException {
-        Map<String, Object> result = new HashMap<>();
-        String outputString = null;
-        String delimiter = UtilFormatOut.checkEmpty((String) context.get("delimiter"), "|");
-        List<String> inputList = UtilGenerics.cast(context.get("inputList"));
-        if (inputList != null) {
-            outputString = StringUtil.join(inputList, delimiter);
-        }
-        result.put("outputString", outputString);
-        return result;
-    }
-
-    public static Map<String, Object> urlEncodeArgs(DispatchContext dctx, Map<String, ? extends Object> context) throws GenericServiceException {
-        Map<String, Object> result = new HashMap<>();
-        Map<String, Object> mapFiltered = new HashMap<>();
-        Map<String, Object> mapIn = UtilGenerics.cast(context.get("mapIn"));
-        if (mapIn != null) {
-            Set<Map.Entry<String, Object>> entrySet = mapIn.entrySet();
-            for (Map.Entry<String, Object> entry : entrySet) {
-                String key = entry.getKey();
-                Object value = entry.getValue();
-                if (value instanceof String) {
-                    if (UtilValidate.isNotEmpty(value)) {
-                        mapFiltered.put(key, value);
-                    }
-                } else if (value != null) {
-                    mapFiltered.put(key, value);
-                }
-            }
-            String outputString = UtilHttp.urlEncodeArgs(mapFiltered);
-            result.put("outputString", outputString);
-        }
-        return result;
-    }
 
 }
+

--- a/applications/content/src/test/groovy/org/apache/ofbiz/content/content/ContentTests.groovy
+++ b/applications/content/src/test/groovy/org/apache/ofbiz/content/content/ContentTests.groovy
@@ -202,4 +202,48 @@ class ContentTests implements JupiterTestHelper {
         assert serviceResult.view
     }
 
+    @Test
+    @Order(9)
+    void testDeactivateContentAssoc() {
+        Map serviceCtx = [:]
+        serviceCtx.contentId = 'TEST_CONTENT1'
+        serviceCtx.contentIdTo = 'TEST_CONTENT2'
+        serviceCtx.contentAssocTypeId = 'SUB_CONTENT'
+        serviceCtx.fromDate = UtilDateTime.nowTimestamp()
+        serviceCtx.userLogin = userLogin
+        Map createResult = dispatcher.runSync('createContentAssoc', serviceCtx)
+        assert ServiceUtil.isSuccess(createResult)
+
+        Map deactivateCtx = [:]
+        deactivateCtx.contentId = 'TEST_CONTENT1'
+        deactivateCtx.contentIdTo = 'TEST_CONTENT2'
+        deactivateCtx.contentAssocTypeId = 'SUB_CONTENT'
+        deactivateCtx.fromDate = serviceCtx.fromDate
+        deactivateCtx.userLogin = userLogin
+        Map deactivateResult = dispatcher.runSync('deactivateContentAssoc', deactivateCtx)
+        assert ServiceUtil.isSuccess(deactivateResult)
+
+        GenericValue assoc = from('ContentAssoc')
+                .where('contentId', 'TEST_CONTENT1',
+                        'contentIdTo', 'TEST_CONTENT2',
+                        'contentAssocTypeId', 'SUB_CONTENT',
+                        'fromDate', serviceCtx.fromDate)
+                .queryOne()
+        assert assoc
+        assert assoc.thruDate != null
+    }
+
+    @Test
+    @Order(10)
+    void testFindRelatedContent() {
+        GenericValue content = from('Content').where('contentId', 'TEST_CONTENT1').queryOne()
+        assert content
+        Map serviceCtx = [:]
+        serviceCtx.currentContent = content
+        serviceCtx.userLogin = userLogin
+        Map serviceResult = dispatcher.runSync('findRelatedContent', serviceCtx)
+        assert ServiceUtil.isSuccess(serviceResult)
+        assert serviceResult.contentList != null
+    }
+
 }

--- a/applications/content/widget/cms/CMSScreens.xml
+++ b/applications/content/widget/cms/CMSScreens.xml
@@ -26,9 +26,7 @@ under the License.
             <actions>
                 <set field="titleProperty" value="PageTitleFindCMSContent"/>
                 <set field="entityName" value="ContentAssocDataResourceViewFrom"/>
-                <service service-name="urlEncodeArgs" result-map="result">
-                    <field-map field-name="mapIn" from-field="requestParameters"/>
-                </service>
+
                 <set field="viewIndex" from-field="requestParameters.VIEW_INDEX" type="Integer" default-value="0"/>
                 <set field="viewSize" from-field="requestParameters.VIEW_SIZE" type="Integer" default-value="20"/>
                 <set field="currentCMSMenuItemName" value="contentfind" to-scope="user"/>


### PR DESCRIPTION
### Description
This PR addresses Jira ticket [OFBIZ-10397](https://issues.apache.org/jira/browse/OFBIZ-10397): Remove unused code from ContentServices class file.

### Key Changes
1. **Converted `deactivateContentAssoc`**:
   - Converted `deactivateContentAssoc` in `services.xml` to `engine="entity-auto" invoke="expire" default-entity-name="ContentAssoc"` with `<permission-service service-name="genericContentPermission" main-action="UPDATE"/>`.
   - Removed legacy custom Java methods `deactivateContentAssoc` and `deactivateContentAssocMethod` from `ContentServices.java`.

2. **Purged Unused Services & Methods**:
   - Removed definitions and Java implementation methods for:
     - `urlEncodeArgs` (and its unused invocation in `CMSScreens.xml`)
     - `joinString`
     - `splitString`
     - `getPrefixedMembers`
     - `publishContent`
     - `renderContentAsText`
     - `renderSubContentAsText`

3. **Permission Service Refactoring**:
   - Refactored `findRelatedContent` in `ContentServices.java` to use standard `genericContentPermission` instead of legacy `checkContentPermission`.

4. **Unit Tests**:
   - Added unit test cases `testDeactivateContentAssoc` and `testFindRelatedContent` in `ContentTests.groovy`.

### Verification
- `./gradlew compileJava compileTestGroovy` — **SUCCESS**
- `./gradlew checkstyleMain codenarcTest` — **SUCCESS**
- `./gradlew "ofbiz --test component=content --test suite=contenttests"` — **PASSED**