### PR TITLE
Fix Docker image build: copy test-reports.gradle in the builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY lib/ lib/
 # We use a regex to match the plugins directory to avoid a build error when the directory doesn't exist.
 COPY plugin[s]/ plugins/
 COPY themes/ themes/
-COPY APACHE2_HEADER build.gradle common.gradle gradle.properties NOTICE settings.gradle dependencies.gradle .
+COPY APACHE2_HEADER build.gradle common.gradle gradle.properties NOTICE settings.gradle dependencies.gradle test-reports.gradle .
 
 # Build OFBiz while mounting a gradle cache
 RUN --mount=type=cache,id=gradle-cache,sharing=locked,target=/root/.gradle \


### PR DESCRIPTION
build.gradle applies test-reports.gradle since #1584, but the Dockerfile's explicit file COPY list wasn't updated to include it, so the file is missing in the build context and the image build fails during Gradle configuration.

