### PR TITLE
Fixed: isExecutable() missed Tika's ELF sub-types, letting real Linux binaries through the check (OFBIZ-13486)

### DIFF
--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -1109,8 +1109,14 @@ public class SecuredUpload {
             Debug.logError("The file " + fileName + " is a Windows executable, for security reason it's not accepted", MODULE);
             return true;
         }
-        // Check for ELF (Linux) and scripts
+        // Check for ELF (Linux) and scripts. Tika reports the generic application/x-elf only for
+        // ELF files it can't further classify; real-world binaries are detected as one of its
+        // more specific sub-types below (e.g. every PIE-compiled executable or shared library).
         if ("application/x-elf".equals(mimeType)
+                || "application/x-executable".equals(mimeType)
+                || "application/x-sharedlib".equals(mimeType)
+                || "application/x-object".equals(mimeType)
+                || "application/x-coredump".equals(mimeType)
                 || "application/x-sh".equals(mimeType)
                 || "text/x-perl".equals(mimeType)
                 || "text/x-ruby".equals(mimeType)


### PR DESCRIPTION
SecuredUpload.isExecutable() only matched the generic mimeType application/x-elf, but Tika (verified against tika-core:3.3.1) classifies real ELF binaries into more specific sub-types instead — application/x-executable, application/x-sharedlib, application/x-object, application/x-coredump — so actual executables and shared libraries passed the check undetected. Confirmed with two real ELF files (a JNA native .so and a JDK's bin/java PIE executable), both detected as application/x-sharedlib and missed by the old check. Adds the four sub-types to the check.

Backported from trunk (#1600).