### PR TITLE
Fix broken README include in unit-tests.adoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ parameters are passed:
 
 ### Testing tasks
 
-<!-- tag: testingtasks -->
+<!-- tag::testingtasks[] -->
 
 #### Execute all unit tests (no need access to the DB)
 
@@ -565,7 +565,7 @@ Listens on port **5005**
 
 `gradlew "ofbiz --test component=entity" --debug-jvm`
 
-<!-- endtag: testingtasks -->
+<!-- end::testingtasks[] -->
 
 
 ### Miscellaneous tasks

--- a/framework/testtools/src/docs/asciidoc/unit-tests.adoc
+++ b/framework/testtools/src/docs/asciidoc/unit-tests.adoc
@@ -139,7 +139,7 @@ like this:
 == How to run a unit test?
 You can run unit test by run 'gradle' with following target:
 
-include::../../../../../README.adoc[tag=testingtasks, leveloffset=-1]
+include::../../../../../README.md[tag=testingtasks, leveloffset=-1]
 
 
 == Possible error messages


### PR DESCRIPTION
The testing-tasks section in `framework/testtools/src/docs/asciidoc/unit-tests.adoc` was included from `README.adoc`, which no longer exists (renamed to `README.md` at some point) - the include silently failed to resolve.

Also switches `README.md`'s tag markers around that section from a made-up `tag:`/`endtag:` convention to Asciidoctor's actual `tag::name[]`/`end::name[]` syntax, since the include still wouldn't resolve with just the filename fixed - verified by rendering the file standalone before and after.