### PR TITLE
Fixed: noWebshellInMetadata NPEs when readMetadata can't parse the file

### DIFF
--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -672,6 +672,7 @@ public class SecuredUpload {
             metadata = ImageMetadataReader.readMetadata(file);
         } catch (ImageProcessingException | IOException error) {
             Debug.logError("================== Not saved for security reason ==================" + error, MODULE);
+            return false;
         }
 
         for (Directory directory : metadata.getDirectories()) {


### PR DESCRIPTION
Backported from trunk (#1622).

Imaging.guessFormat() only checks a file's magic number, so a malformed file that still starts with a valid PNG/JPEG/GIF/TIFF signature reaches noWebshellInMetadata(). When ImageMetadataReader.readMetadata() then fails to parse it, metadata stayed null and the following metadata.getDirectories() call threw an unhandled NullPointerException instead of rejecting the upload cleanly. Confirmed live against metadata-extractor:2.20.0 with a minimal 8-byte file containing only the PNG signature. Returns false in the catch block so the file is rejected the same way any other unparseable upload is.