### PR TITLE
Fix EntityXmlAssertTest test-count inflation and its masked servicetests dependency

### DIFF
--- a/framework/service/testdef/servicetests.xml
+++ b/framework/service/testdef/servicetests.xml
@@ -71,7 +71,7 @@ under the License.
     </test-case>
 
     <test-case case-name="load-data-service-permission-tests">
-        <entity-xml entity-xml-url="component://service/testdef/data/PermissionServiceTestData.xml"/>
+        <entity-xml action="load" entity-xml-url="component://service/testdef/data/PermissionServiceTestData.xml"/>
     </test-case>
     <test-case case-name="service-permission-tests">
         <jupiter-test-suite class-name="org.apache.ofbiz.service.test.ServicePermissionTests"/>

--- a/framework/testtools/src/main/java/org/apache/ofbiz/testtools/EntityXmlAssertTest.java
+++ b/framework/testtools/src/main/java/org/apache/ofbiz/testtools/EntityXmlAssertTest.java
@@ -23,7 +23,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.ofbiz.base.location.FlexibleLocation;
-import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.util.EntityDataAssert;
 import org.apache.ofbiz.entity.util.EntitySaxReader;
@@ -34,8 +33,6 @@ import junit.framework.AssertionFailedError;
 import junit.framework.TestResult;
 
 public class EntityXmlAssertTest extends OFBizTestCase {
-
-    private static final String MODULE = ServiceTest.class.getName();
 
     private String entityXmlUrlString;
     private String action;
@@ -53,17 +50,13 @@ public class EntityXmlAssertTest extends OFBizTestCase {
     }
 
     @Override
-    @SuppressWarnings("lossy-conversions")
     public int countTestCases() {
-        int testCaseCount = 0;
-        try {
-            URL entityXmlURL = FlexibleLocation.resolveLocation(entityXmlUrlString);
-            EntitySaxReader reader = new EntitySaxReader(getDelegator());
-            testCaseCount += (int) reader.parse(entityXmlURL);
-        } catch (Exception e) {
-            Debug.logError(e, "Error getting test case count", MODULE);
-        }
-        return testCaseCount;
+        // One EntityXmlAssertTest instance is one test case, same as ServiceTest/SimpleMethodTest.
+        // This used to return the number of <entity> records in entityXmlUrlString instead, which
+        // JUnit 3's TestResult.startTest() adds into the suite's overall run count - inflating the
+        // "tests" total reported in the JUnit XML/HTML report by the size of the referenced data file,
+        // rather than the number of test cases actually run.
+        return 1;
     }
 
     @Override


### PR DESCRIPTION
### Problem

`EntityXmlAssertTest.countTestCases()` returned the number of `<entity>` records in the referenced XML file instead of `1`. JUnit 3's `TestResult.startTest()` adds this into the suite's run count on every test start, so the `tests` total reported in the JUnit XML/HTML report ends up inflated by the size of the referenced data file rather than reflecting the number of test cases actually run - e.g. `scrumtests` reported `tests="478"` while only 41 `<testcase>` elements were ever written.

### Fix

`countTestCases()` now returns `1`, matching `ServiceTest` and `SimpleMethodTest`.

That method's old implementation called `EntitySaxReader.parse()`, which performs real inserts via `delegator.storeAll()` - it wasn't just counting. Since `TestResult.startTest()` calls `countTestCases()` right before every test runs, this had become a load side effect that was masking a missing `action="load"` on `servicetests.xml`'s `load-data-service-permission-tests` case: that case had no `action` attribute, so it silently defaulted to `action="assert"`, and only ever passed because `countTestCases()` had accidentally already loaded its own fixture data first. Added the explicit `action="load"` so the load no longer depends on that side effect.

Checked the rest of the codebase for other `<entity-xml>` elements missing `action=`; this was the only one.

### Verification

Fresh `cleanAll loadAll` + `test` + `testIntegration` run: 650 integration tests / 0 failures / 0 errors, 599 unit tests / 0 failures.