### PR TITLE
OFBIZ-13422: Grant MANUFACTURING_CREATE to SUPPLYADMIN test group

### DIFF
--- a/applications/manufacturing/testdef/data/ManufacturingTestsData.xml
+++ b/applications/manufacturing/testdef/data/ManufacturingTestsData.xml
@@ -38,6 +38,7 @@ under the License.
     <UserLoginSecurityGroup userLoginId="TestManufAdmin" groupId="MANUFADMIN" fromDate="2001-05-13 00:00:00"/>
     <SecurityGroup groupId="SUPPLYADMIN" description="Supply Chain Admin group, has permissions to execute requirement based manufacturing tasks." groupName="Supply Admin"/>
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="SUPPLYADMIN" permissionId="MANUFACTURING_VIEW"/>
+    <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="SUPPLYADMIN" permissionId="MANUFACTURING_CREATE"/>
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="SUPPLYADMIN" permissionId="WORKEFFORTMGR_CREATE"/>
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="SUPPLYADMIN" permissionId="WORKEFFORTMGR_UPDATE"/>
     <SecurityGroupPermission fromDate="2001-05-13 12:00:00.0" groupId="SUPPLYADMIN" permissionId="ACCOUNTING_CREATE"/>


### PR DESCRIPTION
createProductionRun now enforces a manufacturing CREATE permission check (OFBIZ-13422). The SUPPLYADMIN test security group, whose stated purpose is running requirement-based manufacturing tasks, didn't have that permission, so ProductionRunTests.testCreateProductionRunForRequirement failed in testIntegration with a security error.

This adds MANUFACTURING_CREATE to the SUPPLYADMIN group.

Verified with a full `testIntegration` run: BUILD SUCCESSFUL, all suites passing including productionruntests (10/10).