### PR TITLE
Fixed: distTar/distZip ships unused Node.js runtime caches, bloating the distribution archive (OFBIZ-13491)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ application {
 
 distributions.main.contents.from(rootDir) {
     include 'framework/**', 'applications/**', 'themes/**', 'plugins/**'
+    // Excludes each node-gradle subproject's downloaded Node.js runtime cache --
+    // it's build-tool cache, never read at runtime.
+    exclude '**/.gradle/**'
 }
 
 javadoc {


### PR DESCRIPTION
Backported from trunk (#1630). The main distribution's CopySpec included framework/**, applications/**, themes/**, plugins/** wholesale, which unintentionally swept up each node-gradle subproject's downloaded Node.js runtime cache (.gradle/nodejs) alongside actual source/runtime files. Excludes **/.gradle/** from the distribution contents so this build-tool cache, never read at runtime, is no longer packaged. Verified by building distTar and confirming no .gradle directories remain in the extracted archive while node_modules stays intact for themes/common-theme, plugins/example, and plugins/projectmgr (framework/rest-api doesn't exist on this branch). Shrinks the packaged distribution by roughly 582MB.