### PR TITLE
Implemented: rest-api response configurable to contain null values (OFBIZ-12585)

### DIFF
--- a/framework/rest-api/config/rest-api.properties
+++ b/framework/rest-api/config/rest-api.properties
@@ -17,3 +17,8 @@
 # under the License.
 ###############################################################################
 rest-api.auth.baseSecurityGroupPermission = REST-API_ADMIN
+
+### Configures jackson serialization inclusion. Possible values are:
+#   ALWAYS,NON_NULL,NON_ABSENT,NON_EMPTY,NON_DEFAULT,CUSTOM,USE_DEFAULTS
+rest-api.jackson.serialization.inclusion.value=NON_NULL
+rest-api.jackson.serialization.inclusion.content=NON_NULL

--- a/framework/rest-api/src/main/java/org/apache/ofbiz/ws/rs/spi/impl/JacksonConfig.java
+++ b/framework/rest-api/src/main/java/org/apache/ofbiz/ws/rs/spi/impl/JacksonConfig.java
@@ -18,6 +18,9 @@
  *******************************************************************************/
 package org.apache.ofbiz.ws.rs.spi.impl;
 
+import org.apache.ofbiz.base.util.Debug;
+import org.apache.ofbiz.base.util.UtilProperties;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
@@ -34,6 +37,11 @@ import jakarta.ws.rs.ext.Provider;
 @Provider
 public class JacksonConfig implements ContextResolver<ObjectMapper> {
 
+    private static final String MODULE = JacksonConfig.class.getName();
+    private static final String INCLUDE_VALUE = UtilProperties.getPropertyValue(
+            "rest-api", "rest-api.jackson.serialization.inclusion.value", "NON_NULL");
+    private static final String INCLUDE_CONTENT = UtilProperties.getPropertyValue(
+            "rest-api", "rest-api.jackson.serialization.inclusion.content", "NON_NULL");
     private final ObjectMapper objectMapper;
 
     /**
@@ -53,10 +61,13 @@ public class JacksonConfig implements ContextResolver<ObjectMapper> {
      * <p>Additionally, custom serializers are registered for REST link representations</p>
      */
     public JacksonConfig() {
+        JsonInclude.Include jsonIncludeValue = resolveInclude(INCLUDE_VALUE);
+        JsonInclude.Include jsonIncludeContent = resolveInclude(INCLUDE_CONTENT);
+
         objectMapper = JsonMapper.builder()
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+                .defaultPropertyInclusion(JsonInclude.Value.construct(jsonIncludeValue, jsonIncludeContent))
                 .visibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .build();
@@ -70,4 +81,17 @@ public class JacksonConfig implements ContextResolver<ObjectMapper> {
         return objectMapper;
     }
 
+    /**
+     * Small Helper to map from Include-Strings in .properties to valid JsonInclude
+     * @param String value equal to JsonInclude.Include enum
+     * @return JsonInclude.Include
+     */
+    private static JsonInclude.Include resolveInclude(String value) {
+        try {
+            return JsonInclude.Include.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            Debug.logWarning("Invalid jackson inclusion value [%s], falling back to NON_NULL", MODULE, value);
+            return JsonInclude.Include.NON_NULL;
+        }
+    }
 }

--- a/framework/rest-api/src/main/java/org/apache/ofbiz/ws/rs/util/ServiceRequestWorker.java
+++ b/framework/rest-api/src/main/java/org/apache/ofbiz/ws/rs/util/ServiceRequestWorker.java
@@ -18,10 +18,9 @@
  *******************************************************************************/
 package org.apache.ofbiz.ws.rs.util;
 
-import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
-import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.service.ModelParam;
 import org.apache.ofbiz.service.ModelService;
 
@@ -32,9 +31,7 @@ public final class ServiceRequestWorker {
             ModelParam outParam = service.getParam(outParamName);
             if (!outParam.isInternal()) {
                 Object value = result.get(outParamName);
-                if (UtilValidate.isNotEmpty(value)) {
-                    responseData.put(outParamName, value);
-                }
+                responseData.put(outParamName, value);
             }
         }
         return responseData;


### PR DESCRIPTION
* Added properties to configure JacksonConfig. Can be set to ALWAYS to
    return null values. Note that when dealing with custom POJOs the same
    behaviour can be achieved via @JsonInclude(Include.NON_NULL) annotation.
    ServiceRequestWorker.extractResponseData was reworked not to filter out
    null values, as this is already done by JacksonConfig.