### PR TITLE
OFBIZ-13457 Add REST list query helpers 

### DIFF
--- a/applications/manufacturing/servicedef/services_bom.xml
+++ b/applications/manufacturing/servicedef/services_bom.xml
@@ -158,11 +158,15 @@ under the License.
         <attribute mode="IN" name="productAssocTypeId" optional="true" type="String"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
+        <attribute mode="IN" name="sort" optional="true" type="String"/>
         <attribute mode="OUT" name="pageIndex" optional="false" type="Integer"/>
         <attribute mode="OUT" name="pageSize" optional="false" type="Integer"/>
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="products" optional="false" type="java.util.List"/>
     </service>
     <service name="findProductLookupOptions" engine="groovy" auth="true"
@@ -172,11 +176,15 @@ under the License.
         <attribute mode="IN" name="query" optional="true" type="String"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
+        <attribute mode="IN" name="sort" optional="true" type="String"/>
         <attribute mode="OUT" name="pageIndex" optional="false" type="Integer"/>
         <attribute mode="OUT" name="pageSize" optional="false" type="Integer"/>
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="products" optional="false" type="java.util.List"/>
     </service>
     <service name="getBomSnapshot" engine="groovy" auth="true"
@@ -269,11 +277,15 @@ under the License.
         <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
+        <attribute mode="IN" name="sort" optional="true" type="String"/>
         <attribute mode="OUT" name="pageIndex" optional="false" type="Integer"/>
         <attribute mode="OUT" name="pageSize" optional="false" type="Integer"/>
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="facilities" optional="false" type="java.util.List"/>
     </service>
     <service name="findBomTypes" engine="groovy" auth="true"
@@ -282,11 +294,15 @@ under the License.
         <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
+        <attribute mode="IN" name="sort" optional="true" type="String"/>
         <attribute mode="OUT" name="pageIndex" optional="false" type="Integer"/>
         <attribute mode="OUT" name="pageSize" optional="false" type="Integer"/>
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="bomTypes" optional="false" type="java.util.List"/>
     </service>
 </services>

--- a/applications/manufacturing/servicedef/services_lookup.xml
+++ b/applications/manufacturing/servicedef/services_lookup.xml
@@ -25,6 +25,7 @@ under the License.
     <service name="findCostComponentOptions" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServices.groovy" invoke="findCostComponentOptions">
         <description>Find cost component types and calculation records used by manufacturing setup screens, so REST clients can populate cost-rate selectors without issuing separate generic entity queries.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="OUT" name="costComponentTypes" optional="false" type="java.util.List"/>
         <attribute mode="OUT" name="costComponentCalcs" optional="false" type="java.util.List"/>
     </service>
@@ -34,11 +35,15 @@ under the License.
         <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
+        <attribute mode="IN" name="sort" optional="true" type="String"/>
         <attribute mode="OUT" name="pageIndex" optional="false" type="Integer"/>
         <attribute mode="OUT" name="pageSize" optional="false" type="Integer"/>
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="facilities" optional="false" type="java.util.List"/>
     </service>
     <service name="findManufacturingPlants" engine="groovy" auth="true"
@@ -47,16 +52,21 @@ under the License.
         <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
+        <attribute mode="IN" name="sort" optional="true" type="String"/>
         <attribute mode="OUT" name="pageIndex" optional="false" type="Integer"/>
         <attribute mode="OUT" name="pageSize" optional="false" type="Integer"/>
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="facilities" optional="false" type="java.util.List"/>
     </service>
     <service name="findFixedAssets" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServices.groovy" invoke="findFixedAssets">
         <description>Find fixed assets available to manufacturing workflows, with REST paging and sorting, so routing and other manufacturing applications can select equipment or tool references from a stable lookup payload.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="fixedAssetTypeId" optional="true" type="String"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
@@ -66,24 +76,15 @@ under the License.
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="fixedAssets" optional="false" type="java.util.List"/>
     </service>
     <service name="searchProducts" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServices.groovy" invoke="searchProducts">
         <description>Search products by ID, product name, or internal name using the shared manufacturing product lookup shape, so REST clients can reuse one product picker contract across BOM, routing, and related manufacturing flows.</description>
-        <attribute mode="IN" name="query" optional="true" type="String"/>
-        <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
-        <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
-        <attribute mode="OUT" name="pageIndex" optional="false" type="Integer"/>
-        <attribute mode="OUT" name="pageSize" optional="false" type="Integer"/>
-        <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
-        <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
-        <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
-        <attribute mode="OUT" name="products" optional="false" type="java.util.List"/>
-    </service>
-    <service name="searchParties" engine="groovy" auth="true"
-            location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServices.groovy" invoke="searchParties">
-        <description>Search parties by ID or display name with REST paging and sorting, so manufacturing applications can assign people or groups to operations without depending on UI-specific party lookup screens.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="query" optional="true" type="String"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
@@ -93,6 +94,27 @@ under the License.
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
+        <attribute mode="OUT" name="products" optional="false" type="java.util.List"/>
+    </service>
+    <service name="searchParties" engine="groovy" auth="true"
+            location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServices.groovy" invoke="searchParties">
+        <description>Search parties by ID or display name with REST paging and sorting, so manufacturing applications can assign people or groups to operations without depending on UI-specific party lookup screens.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
+        <attribute mode="IN" name="query" optional="true" type="String"/>
+        <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
+        <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
+        <attribute mode="IN" name="sort" optional="true" type="String"/>
+        <attribute mode="OUT" name="pageIndex" optional="false" type="Integer"/>
+        <attribute mode="OUT" name="pageSize" optional="false" type="Integer"/>
+        <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
+        <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
+        <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="parties" optional="false" type="java.util.List"/>
     </service>
 </services>

--- a/applications/manufacturing/servicedef/services_production_run.xml
+++ b/applications/manufacturing/servicedef/services_production_run.xml
@@ -45,6 +45,9 @@ under the License.
         <attribute name="totalCount" type="Long" mode="OUT" optional="false"/>
         <attribute name="totalPages" type="Long" mode="OUT" optional="false"/>
         <attribute name="hasNext" type="Boolean" mode="OUT" optional="false"/>
+        <attribute name="previousPageCount" type="Long" mode="OUT" optional="true"/>
+        <attribute name="nextPageCount" type="Long" mode="OUT" optional="true"/>
+        <attribute name="links" type="Map" mode="OUT" optional="true"/>
         <attribute name="productionRuns" type="List" mode="OUT" optional="false"/>
     </service>
     <service name="getProductionRunDetails" engine="groovy"

--- a/applications/manufacturing/servicedef/services_routing.xml
+++ b/applications/manufacturing/servicedef/services_routing.xml
@@ -68,10 +68,11 @@ under the License.
         <attribute mode="OUT" name="setupTime" type="BigDecimal" optional="true"/>
         <attribute mode="OUT" name="taskUnitTime" type="BigDecimal" optional="true"/>
     </service>
-    <!-- API wrappers for the manufacturing suite Routing and Cost Management PWA -->
+    <!-- Routing and cost management services for reusable list and detail data. -->
     <service name="findProductRoutings" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy" invoke="findProductRoutings">
         <description>Find routing templates with product-link and task-count summary fields needed by routing management list views, while keeping create and update operations delegated to native WorkEffort services.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="query" optional="true" type="String"/>
         <attribute mode="IN" name="productId" optional="true" type="String"/>
         <attribute mode="IN" name="routingId" optional="true" type="String"/>
@@ -86,11 +87,15 @@ under the License.
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="routings" optional="false" type="java.util.List"/>
     </service>
     <service name="findRoutingTaskPurposeTypeOptions" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy" invoke="findRoutingTaskPurposeTypeOptions">
         <description>Find routing task purpose type options from WorkEffortPurposeType using the same paged REST response shape as other manufacturing lookups, so routing task forms can load valid operation-purpose values from OFBiz data.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
         <attribute mode="IN" name="sort" optional="true" type="String"/>
@@ -99,11 +104,15 @@ under the License.
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="purposeTypes" optional="false" type="java.util.List"/>
     </service>
     <service name="searchRoutingTasksForRouting" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy" invoke="searchRoutingTasksForRouting">
         <description>Search reusable routing task definitions by ID or name for operation selection, returning only task records suitable for linking into a routing through native WorkEffortAssoc services.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="query" optional="true" type="String"/>
         <attribute mode="IN" name="pageIndex" optional="true" type="Integer"/>
         <attribute mode="IN" name="pageSize" optional="true" type="Integer"/>
@@ -113,11 +122,15 @@ under the License.
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="tasks" optional="false" type="java.util.List"/>
     </service>
     <service name="getRoutingDetails" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy" invoke="getRoutingDetails">
         <description>Get one routing template with its product outputs, associated operations, available task choices, and cost rows in one response, reducing REST round trips for routing detail screens without replacing native write services.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="routingId" optional="true" type="String"/>
         <attribute mode="IN" name="workEffortId" optional="true" type="String"/>
         <attribute mode="OUT" name="routingId" optional="false" type="String"/>
@@ -134,6 +147,7 @@ under the License.
     <service name="expireRoutingGoodStandard" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy" invoke="expireRoutingGoodStandard">
         <description>Expire a routing product or task output association by setting WorkEffortGoodStandard.thruDate, preserving historical routing data while giving REST delete operations an explicit service for the native composite key.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="UPDATE"/>
         <attribute mode="IN" name="workEffortId" optional="false" type="String"/>
         <attribute mode="IN" name="productId" optional="false" type="String"/>
         <attribute mode="IN" name="workEffortGoodStdTypeId" optional="false" type="String"/>
@@ -148,6 +162,7 @@ under the License.
     <service name="findRoutingTasks" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy" invoke="findRoutingTasks">
         <description>Find routing task definitions with work center, cost, output, tool, and operator summary data needed by routing operation list views, while keeping task maintenance backed by native WorkEffort services.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="query" optional="true" type="String"/>
         <attribute mode="IN" name="workEffortId" optional="true" type="String"/>
         <attribute mode="IN" name="routingTaskId" optional="true" type="String"/>
@@ -161,11 +176,15 @@ under the License.
         <attribute mode="OUT" name="totalCount" optional="false" type="Long"/>
         <attribute mode="OUT" name="totalPages" optional="false" type="Long"/>
         <attribute mode="OUT" name="hasNext" optional="false" type="Boolean"/>
+        <attribute mode="OUT" name="previousPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="nextPageCount" optional="true" type="Long"/>
+        <attribute mode="OUT" name="links" optional="true" type="Map"/>
         <attribute mode="OUT" name="tasks" optional="false" type="java.util.List"/>
     </service>
     <service name="getRoutingTaskDetails" engine="groovy" auth="true"
             location="component://manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy" invoke="getRoutingTaskDetails">
         <description>Get one routing task definition with routing usage, cost rates, outputs, tool standards, operator assignments, and fixed asset context in one response, giving operation detail screens a complete read model without adding write wrappers for native child services.</description>
+        <permission-service service-name="manufacturingPermissionService" main-action="VIEW"/>
         <attribute mode="IN" name="routingTaskId" optional="true" type="String"/>
         <attribute mode="IN" name="taskId" optional="true" type="String"/>
         <attribute mode="IN" name="workEffortId" optional="true" type="String"/>

--- a/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/BomManagementServices.groovy
+++ b/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/BomManagementServices.groovy
@@ -42,11 +42,17 @@ Map findBomProducts() {
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
+    List orderBy
+    try {
+        orderBy = bomProductOrderBy(queryOptions.sort)
+    } catch (IllegalArgumentException e) {
+        return ServiceUtil.returnError(e.message)
+    }
     List bomTypeIds = bomAssocTypeIds()
     if (!bomTypeIds) {
-        return success(RestApiUtil.getPagedResult('products', [], queryOptions, 0L, null))
+        return success(RestApiUtil.getPagedResult('products', [], queryOptions, 0L,
+                RestApiUtil.getRelativeRequestPath(binding)))
     }
-
     List selectedBomTypeIds = UtilValidate.isNotEmpty(parameters.productAssocTypeId)
             ? [parameters.productAssocTypeId]
             : bomTypeIds
@@ -61,7 +67,8 @@ Map findBomProducts() {
         Set matchingProductIds = EntityUtil.searchIds(delegator, 'Product', 'productId',
                 ['productId', 'productName', 'internalName'], parameters.query, 500)
         if (!matchingProductIds) {
-            return success(RestApiUtil.getPagedResult('products', [], queryOptions, 0L, null))
+            return success(RestApiUtil.getPagedResult('products', [], queryOptions, 0L,
+                    RestApiUtil.getRelativeRequestPath(binding)))
         }
         conditions.add(EntityCondition.makeCondition('productId', EntityOperator.IN, matchingProductIds as List))
     }
@@ -70,7 +77,7 @@ Map findBomProducts() {
     EntityQuery query = select('productId', 'productAssocTypeId').from('ProductAssoc')
             .where(whereCondition).filterByDate().distinct()
     long totalCount = query.queryCount()
-    List rows = query.orderBy('productId', 'productAssocTypeId')
+    List rows = query.orderBy(orderBy)
             .queryPagedList(queryOptions.pageIndex, queryOptions.pageSize).getData()
     Set productIds = rows*.productId.findAll { it } as Set
     Map productsById = EntityUtil.lookupById(delegator, 'Product', 'productId', productIds, false)
@@ -92,7 +99,8 @@ Map findBomProducts() {
                 activeFromDate: componentSummary.activeFromDate
         ]
     }
-    return success(RestApiUtil.getPagedResult('products', products, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('products', products, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
 }
 
 Map getBomSnapshot() {
@@ -355,12 +363,18 @@ Map findBomTypes() {
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
+    List orderBy
+    try {
+        orderBy = bomTypeOrderBy(queryOptions.sort)
+    } catch (IllegalArgumentException e) {
+        return ServiceUtil.returnError(e.message)
+    }
     EntityQuery query = from('ProductAssocType')
             .select('productAssocTypeId', 'description')
             .where(parentTypeId: 'PRODUCT_COMPONENT')
             .cache(true)
     long totalCount = query.queryCount()
-    List bomTypes = query.orderBy('description', 'productAssocTypeId')
+    List bomTypes = query.orderBy(orderBy)
             .queryPagedList(queryOptions.pageIndex, queryOptions.pageSize).getData()
             .collect { GenericValue productAssocType ->
                 String productAssocTypeId = productAssocType.productAssocTypeId
@@ -371,7 +385,23 @@ Map findBomTypes() {
                         label: description
                 ]
             }
-    return success(RestApiUtil.getPagedResult('bomTypes', bomTypes, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('bomTypes', bomTypes, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
+}
+
+List bomProductOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            productId: 'productId',
+            productAssocTypeId: 'productAssocTypeId',
+            bomType: 'productAssocTypeId'
+    ], ['productId', 'productAssocTypeId'])
+}
+
+List bomTypeOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            productAssocTypeId: 'productAssocTypeId',
+            description: 'description'
+    ], ['description', 'productAssocTypeId'])
 }
 
 List bomAssocTypeIds() {

--- a/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServices.groovy
+++ b/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServices.groovy
@@ -36,9 +36,16 @@ Map findProductLookupOptions() {
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
+    List orderBy
+    try {
+        orderBy = productLookupOrderBy(queryOptions.sort)
+    } catch (IllegalArgumentException e) {
+        return ServiceUtil.returnError(e.message)
+    }
     String queryText = parameters.query?.trim()
     if (UtilValidate.isEmpty(queryText)) {
-        return success(RestApiUtil.getPagedResult('products', [], queryOptions, 0L, null))
+        return success(RestApiUtil.getPagedResult('products', [], queryOptions, 0L,
+                RestApiUtil.getRelativeRequestPath(binding)))
     }
 
     EntityCondition searchCondition = EntityUtil.upperLikeAny(['productId', 'productName', 'internalName'], queryText)
@@ -46,7 +53,7 @@ Map findProductLookupOptions() {
             .select('productId', 'productName', 'internalName', 'productTypeId', 'quantityUomId')
             .where(searchCondition)
     long totalCount = productQuery.queryCount()
-    List productRows = productQuery.orderBy('productId')
+    List productRows = productQuery.orderBy(orderBy)
             .queryPagedList(queryOptions.pageIndex, queryOptions.pageSize).getData()
     List products = productRows.collect { GenericValue product ->
         String productName = ManufacturingServiceUtil.displayProductName(product)
@@ -59,7 +66,8 @@ Map findProductLookupOptions() {
                 label: productName
         ]
     }
-    return success(RestApiUtil.getPagedResult('products', products, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('products', products, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
 }
 
 Map searchProducts() {
@@ -76,19 +84,14 @@ Map searchParties() {
     Map filters = queryOptions.filters
     List orderBy
     try {
-        orderBy = RestApiUtil.resolveOrderBy(queryOptions.sort, [
-                partyId: 'partyId',
-                partyName: 'groupName',
-                groupName: 'groupName',
-                firstName: 'firstName',
-                lastName: 'lastName'
-        ], ['partyId'])
+        orderBy = partyLookupOrderBy(queryOptions.sort)
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
     String queryText = filters.query?.trim()
     if (UtilValidate.isEmpty(queryText)) {
-        return success(RestApiUtil.getPagedResult('parties', [], queryOptions, 0L, null))
+        return success(RestApiUtil.getPagedResult('parties', [], queryOptions, 0L,
+                RestApiUtil.getRelativeRequestPath(binding)))
     }
 
     EntityCondition searchCondition = EntityUtil.upperLikeAny(['partyId', 'firstName', 'lastName', 'groupName'], queryText)
@@ -107,7 +110,8 @@ Map searchParties() {
                 label: partyName
         ]
     }
-    return success(RestApiUtil.getPagedResult('parties', parties, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('parties', parties, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
 }
 
 Map findFixedAssets() {
@@ -120,11 +124,7 @@ Map findFixedAssets() {
     Map filters = queryOptions.filters
     List orderBy
     try {
-        orderBy = RestApiUtil.resolveOrderBy(queryOptions.sort, [
-                fixedAssetId: 'fixedAssetId',
-                fixedAssetName: 'fixedAssetName',
-                fixedAssetTypeId: 'fixedAssetTypeId'
-        ], ['fixedAssetName', 'fixedAssetId'])
+        orderBy = fixedAssetLookupOrderBy(queryOptions.sort)
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
@@ -149,7 +149,8 @@ Map findFixedAssets() {
                         label: fixedAssetName
                 ]
             }
-    return success(RestApiUtil.getPagedResult('fixedAssets', fixedAssets, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('fixedAssets', fixedAssets, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
 }
 
 Map findCostComponentOptions() {
@@ -202,11 +203,17 @@ Map findFacilitiesByTypes(List facilityTypeIds) {
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
+    List orderBy
+    try {
+        orderBy = facilityLookupOrderBy(queryOptions.sort)
+    } catch (IllegalArgumentException e) {
+        return ServiceUtil.returnError(e.message)
+    }
     EntityQuery query = from('Facility')
             .select('facilityId', 'facilityName', 'facilityTypeId')
             .where(EntityCondition.makeCondition('facilityTypeId', EntityOperator.IN, facilityTypeIds))
     long totalCount = query.queryCount()
-    List facilities = query.orderBy('facilityName', 'facilityId')
+    List facilities = query.orderBy(orderBy)
             .queryPagedList(queryOptions.pageIndex, queryOptions.pageSize).getData()
             .collect { GenericValue facility ->
                 String facilityId = facility.facilityId
@@ -219,5 +226,42 @@ Map findFacilitiesByTypes(List facilityTypeIds) {
                         label: label
                 ]
     }
-    return success(RestApiUtil.getPagedResult('facilities', facilities, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('facilities', facilities, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
+}
+
+List productLookupOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            productId: 'productId',
+            productName: 'productName',
+            internalName: 'internalName',
+            productTypeId: 'productTypeId',
+            quantityUomId: 'quantityUomId'
+    ], ['productId'])
+}
+
+List partyLookupOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            partyId: 'partyId',
+            partyName: 'groupName',
+            groupName: 'groupName',
+            firstName: 'firstName',
+            lastName: 'lastName'
+    ], ['partyId'])
+}
+
+List fixedAssetLookupOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            fixedAssetId: 'fixedAssetId',
+            fixedAssetName: 'fixedAssetName',
+            fixedAssetTypeId: 'fixedAssetTypeId'
+    ], ['fixedAssetName', 'fixedAssetId'])
+}
+
+List facilityLookupOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            facilityId: 'facilityId',
+            facilityName: 'facilityName',
+            facilityTypeId: 'facilityTypeId'
+    ], ['facilityName', 'facilityId'])
 }

--- a/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy
+++ b/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServices.groovy
@@ -42,14 +42,7 @@ Map findProductRoutings() {
     Map filters = queryOptions.filters
     List orderBy
     try {
-        orderBy = RestApiUtil.resolveOrderBy(queryOptions.sort, [
-                routingId: 'workEffortId',
-                workEffortId: 'workEffortId',
-                workEffortName: 'workEffortName',
-                currentStatusId: 'currentStatusId',
-                status: 'currentStatusId',
-                quantityToProduce: 'quantityToProduce'
-        ], ['workEffortId'])
+        orderBy = routingOrderBy(queryOptions.sort)
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
@@ -57,7 +50,8 @@ Map findProductRoutings() {
     if (UtilValidate.isNotEmpty(filters.productId)) {
         Set productRoutingIds = routingIdsForProducts([filters.productId] as Set)
         if (!productRoutingIds) {
-            return success(RestApiUtil.getPagedResult('routings', [], queryOptions, 0L, null))
+            return success(RestApiUtil.getPagedResult('routings', [], queryOptions, 0L,
+                    RestApiUtil.getRelativeRequestPath(binding)))
         }
         conditions.add(EntityCondition.makeCondition('workEffortId', EntityOperator.IN, productRoutingIds as List))
     }
@@ -74,7 +68,8 @@ Map findProductRoutings() {
             matchingRoutingIds.addAll(routingIdsForProducts(matchingProductIds))
         }
         if (!matchingRoutingIds) {
-            return success(RestApiUtil.getPagedResult('routings', [], queryOptions, 0L, null))
+            return success(RestApiUtil.getPagedResult('routings', [], queryOptions, 0L,
+                    RestApiUtil.getRelativeRequestPath(binding)))
         }
         conditions.add(EntityCondition.makeCondition('workEffortId', EntityOperator.IN, matchingRoutingIds as List))
     }
@@ -107,7 +102,8 @@ Map findProductRoutings() {
                 taskCount: taskCounts[routing.workEffortId] ?: 0
         ]
     }
-    return success(RestApiUtil.getPagedResult('routings', routingList, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('routings', routingList, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
 }
 
 Map getRoutingDetails() {
@@ -203,19 +199,14 @@ Map routingTaskList(boolean requireQuery) {
     Map filters = queryOptions.filters
     List orderBy
     try {
-        orderBy = RestApiUtil.resolveOrderBy(queryOptions.sort, [
-                routingTaskId: 'workEffortId',
-                workEffortId: 'workEffortId',
-                workEffortName: 'workEffortName',
-                workEffortPurposeTypeId: 'workEffortPurposeTypeId',
-                fixedAssetId: 'fixedAssetId'
-        ], ['workEffortName', 'workEffortId'])
+        orderBy = routingTaskOrderBy(queryOptions.sort)
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
     String queryText = filters.query?.toString()?.trim()
     if (requireQuery && UtilValidate.isEmpty(queryText)) {
-        return RestApiUtil.getPagedResult('tasks', [], queryOptions, 0L, null)
+        return RestApiUtil.getPagedResult('tasks', [], queryOptions, 0L,
+                RestApiUtil.getRelativeRequestPath(binding))
     }
 
     List conditions = [EntityCondition.makeCondition('workEffortTypeId', 'ROU_TASK')]
@@ -243,7 +234,8 @@ Map routingTaskList(boolean requireQuery) {
             'workEffortPurposeTypeId', rows*.workEffortPurposeTypeId.findAll { it } as Set)
     List tasks = rows.collect { GenericValue task -> taskMap(task, null, workCenters, purposeTypes) }
 
-    return RestApiUtil.getPagedResult('tasks', tasks, queryOptions, totalCount, null)
+    return RestApiUtil.getPagedResult('tasks', tasks, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding))
 }
 
 Map getRoutingTaskDetails() {
@@ -267,10 +259,7 @@ Map findRoutingTaskPurposeTypeOptions() {
     }
     List orderBy
     try {
-        orderBy = RestApiUtil.resolveOrderBy(queryOptions.sort, [
-                workEffortPurposeTypeId: 'workEffortPurposeTypeId',
-                description: 'description'
-        ], ['workEffortPurposeTypeId'])
+        orderBy = routingPurposeTypeOrderBy(queryOptions.sort)
     } catch (IllegalArgumentException e) {
         return ServiceUtil.returnError(e.message)
     }
@@ -291,7 +280,36 @@ Map findRoutingTaskPurposeTypeOptions() {
                 ]
             }
 
-    return success(RestApiUtil.getPagedResult('purposeTypes', purposeTypes, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('purposeTypes', purposeTypes, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
+}
+
+List routingOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            routingId: 'workEffortId',
+            workEffortId: 'workEffortId',
+            workEffortName: 'workEffortName',
+            currentStatusId: 'currentStatusId',
+            status: 'currentStatusId',
+            quantityToProduce: 'quantityToProduce'
+    ], ['workEffortId'])
+}
+
+List routingTaskOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            routingTaskId: 'workEffortId',
+            workEffortId: 'workEffortId',
+            workEffortName: 'workEffortName',
+            workEffortPurposeTypeId: 'workEffortPurposeTypeId',
+            fixedAssetId: 'fixedAssetId'
+    ], ['workEffortName', 'workEffortId'])
+}
+
+List routingPurposeTypeOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            workEffortPurposeTypeId: 'workEffortPurposeTypeId',
+            description: 'description'
+    ], ['workEffortPurposeTypeId'])
 }
 
 Map taskDetailMap(GenericValue task) {

--- a/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunQueryServices.groovy
+++ b/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunQueryServices.groovy
@@ -38,6 +38,12 @@ Map findProductionRuns() {
         return ServiceUtil.returnError(e.message)
     }
     Map filters = queryOptions.filters
+    List orderBy
+    try {
+        orderBy = productionRunOrderBy(queryOptions.sort)
+    } catch (IllegalArgumentException e) {
+        return ServiceUtil.returnError(e.message)
+    }
 
     String productionRunId = filters.productionRunId ?: filters.workEffortId
     List conditions = [
@@ -85,28 +91,13 @@ Map findProductionRuns() {
         Set productIds = EntityUtil.searchIds(delegator, 'Product', 'productId',
                 ['productId', 'productName', 'internalName'], filters.productName, 500)
         if (!productIds) {
-            return success(RestApiUtil.getPagedResult('productionRuns', [], queryOptions, 0L, null))
+            return success(RestApiUtil.getPagedResult('productionRuns', [], queryOptions, 0L,
+                    RestApiUtil.getRelativeRequestPath(binding)))
         }
         conditions.add(EntityCondition.makeCondition('productId', EntityOperator.IN, productIds as List))
     }
 
     EntityCondition whereCondition = EntityCondition.makeCondition(conditions, EntityOperator.AND)
-    List orderBy
-    try {
-        orderBy = RestApiUtil.resolveOrderBy(queryOptions.sort, [
-                estimatedStartDate: 'estimatedStartDate',
-                actualStartDate: 'actualStartDate',
-                status: 'currentStatusId',
-                currentStatusId: 'currentStatusId',
-                productId: 'productId',
-                facilityId: 'facilityId',
-                productionRunId: 'workEffortId',
-                workEffortId: 'workEffortId',
-                workEffortName: 'workEffortName'
-        ], ['-estimatedStartDate', 'workEffortId'])
-    } catch (IllegalArgumentException e) {
-        return ServiceUtil.returnError(e.message)
-    }
 
     EntityQuery productionRunQuery = from('WorkEffortAndGoods').where(whereCondition)
     long totalCount = productionRunQuery.queryCount()
@@ -119,7 +110,8 @@ Map findProductionRuns() {
         productionRunSummaryMap(productionRun, lookups)
     }
 
-    return success(RestApiUtil.getPagedResult('productionRuns', productionRuns, queryOptions, totalCount, null))
+    return success(RestApiUtil.getPagedResult('productionRuns', productionRuns, queryOptions, totalCount,
+            RestApiUtil.getRelativeRequestPath(binding)))
 }
 
 Map getProductionRunDetails() {
@@ -283,6 +275,20 @@ Map buildProductionRunLookups(List productionRuns, List productionRunGoods, List
             uoms: EntityUtil.lookupById(delegator, 'Uom', 'uomId', uomIds),
             roles: EntityUtil.lookupById(delegator, 'RoleType', 'roleTypeId', roleTypeIds)
     ]
+}
+
+List productionRunOrderBy(String sortExpression) {
+    return RestApiUtil.resolveOrderBy(sortExpression, [
+            estimatedStartDate: 'estimatedStartDate',
+            actualStartDate: 'actualStartDate',
+            status: 'currentStatusId',
+            currentStatusId: 'currentStatusId',
+            productId: 'productId',
+            facilityId: 'facilityId',
+            productionRunId: 'workEffortId',
+            workEffortId: 'workEffortId',
+            workEffortName: 'workEffortName'
+    ], ['-estimatedStartDate', 'workEffortId'])
 }
 
 Map productionRunSummaryMap(GenericValue productionRun, Map lookups) {

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/api/BomManagementServicesTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/api/BomManagementServicesTests.groovy
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ofbiz.manufacturing.api
+
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+import org.apache.ofbiz.service.ServiceUtil
+import org.apache.ofbiz.ws.rs.util.RestApiUtil
+import org.apache.ofbiz.ws.rs.util.RestQueryOptions
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+
+class BomManagementServicesTests {
+
+    @Test
+    void testBomProductSortMapsFrameworkFields() {
+        BomManagementServices services = new BomManagementServices()
+
+        assert services.bomProductOrderBy('-bomType') == ['-productAssocTypeId', 'productId']
+    }
+
+    @Test
+    void testBomTypeSortMapsFrameworkFields() {
+        BomManagementServices services = new BomManagementServices()
+
+        assert services.bomTypeOrderBy('-productAssocTypeId') == ['-productAssocTypeId', 'description']
+    }
+
+    @Test
+    void testBomDefaultSortsMatchContracts() {
+        BomManagementServices services = new BomManagementServices()
+
+        assert services.bomProductOrderBy(null) == ['productId', 'productAssocTypeId']
+        assert services.bomTypeOrderBy(null) == ['description', 'productAssocTypeId']
+    }
+
+    @Test
+    void testBomProductRejectsUnsupportedSortField() {
+        BomManagementServices services = new BomManagementServices()
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+            services.bomProductOrderBy('productName')
+        }
+        assert exception.message == 'Unsupported sort field: productName'
+    }
+
+    @Test
+    void testFindBomProductsRejectsUnsupportedSortBeforeEmptyResults() {
+        BomManagementServices services = new BomManagementServices()
+        services.binding.setVariable('parameters', [sort: 'productName'])
+
+        Map result = services.findBomProducts()
+
+        assert ServiceUtil.isError(result)
+        assert ServiceUtil.getErrorMessage(result) == 'Unsupported sort field: productName'
+    }
+
+    @Test
+    void testFrameworkRequestPathReturnsNullWithoutRequestBinding() {
+        BomManagementServices services = new BomManagementServices()
+
+        assert RestApiUtil.getRelativeRequestPath(services.binding) == null
+    }
+
+    @Test
+    void testFrameworkNavigationMetadataAndLinksUseRequestPath() {
+        BomManagementServices services = new BomManagementServices()
+        MockHttpServletRequest request = new MockHttpServletRequest()
+        request.setRequestURI('/rest/manufacturing/boms/products')
+        request.setQueryString('pageIndex=1&pageSize=1&productAssocTypeId=MANUF_COMPONENT')
+        services.binding.setVariable('request', request)
+        RestQueryOptions queryOptions = RestQueryOptions.fromParameters([
+                pageIndex: 1,
+                pageSize: 1,
+                productAssocTypeId: 'MANUF_COMPONENT'
+        ])
+
+        Map result = RestApiUtil.getPagedResult('products', [], queryOptions, 3L,
+                RestApiUtil.getRelativeRequestPath(services.binding))
+
+        assert result.previousPageCount == 1L
+        assert result.nextPageCount == 1L
+        assert result.links instanceof Map
+        assert result.links.self.href == '/rest/manufacturing/boms/products?productAssocTypeId=MANUF_COMPONENT&pageIndex=1&pageSize=1'
+        assert result.links.prev.href == '/rest/manufacturing/boms/products?productAssocTypeId=MANUF_COMPONENT&pageIndex=0&pageSize=1'
+        assert result.links.next.href == '/rest/manufacturing/boms/products?productAssocTypeId=MANUF_COMPONENT&pageIndex=2&pageSize=1'
+    }
+
+}

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServicesTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/api/ManufacturingLookupServicesTests.groovy
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ofbiz.manufacturing.api
+
+import org.apache.ofbiz.ws.rs.util.RestApiUtil
+import org.apache.ofbiz.ws.rs.util.RestQueryOptions
+import org.apache.ofbiz.service.ServiceUtil
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+
+class ManufacturingLookupServicesTests {
+
+    @Test
+    void testProductSortMapsFrameworkFields() {
+        ManufacturingLookupServices services = new ManufacturingLookupServices()
+
+        assert services.productLookupOrderBy('-productName') == ['-productName', 'productId']
+    }
+
+    @Test
+    void testProductLookupRejectsUnsupportedSortWithoutQuery() {
+        ManufacturingLookupServices services = new ManufacturingLookupServices()
+        services.binding.setVariable('parameters', [sort: 'notAField'])
+
+        Map result = services.findProductLookupOptions()
+
+        assert ServiceUtil.isError(result)
+        assert ServiceUtil.getErrorMessage(result) == 'Unsupported sort field: notAField'
+    }
+
+    @Test
+    void testFacilitySortMapsFrameworkFields() {
+        ManufacturingLookupServices services = new ManufacturingLookupServices()
+
+        assert services.facilityLookupOrderBy('-facilityName') == ['-facilityName', 'facilityId']
+    }
+
+    @Test
+    void testLookupDefaultSortsMatchContracts() {
+        ManufacturingLookupServices services = new ManufacturingLookupServices()
+
+        assert services.productLookupOrderBy(null) == ['productId']
+        assert services.partyLookupOrderBy(null) == ['partyId']
+        assert services.fixedAssetLookupOrderBy(null) == ['fixedAssetName', 'fixedAssetId']
+        assert services.facilityLookupOrderBy(null) == ['facilityName', 'facilityId']
+    }
+
+    @Test
+    void testFrameworkRequestPathReturnsNullWithoutRequestBinding() {
+        ManufacturingLookupServices services = new ManufacturingLookupServices()
+
+        assert RestApiUtil.getRelativeRequestPath(services.binding) == null
+    }
+
+    @Test
+    void testFrameworkNavigationMetadataAndLinksUseRequestPath() {
+        ManufacturingLookupServices services = new ManufacturingLookupServices()
+        MockHttpServletRequest request = new MockHttpServletRequest()
+        request.setRequestURI('/rest/manufacturing/lookups/products')
+        request.setQueryString('pageIndex=1&pageSize=1&query=MAT')
+        services.binding.setVariable('request', request)
+        RestQueryOptions queryOptions = RestQueryOptions.fromParameters([
+                pageIndex: 1,
+                pageSize: 1,
+                query: 'MAT'
+        ])
+
+        Map result = RestApiUtil.getPagedResult('products', [], queryOptions, 3L,
+                RestApiUtil.getRelativeRequestPath(services.binding))
+
+        assert result.previousPageCount == 1L
+        assert result.nextPageCount == 1L
+        assert result.links instanceof Map
+        assert result.links.self.href == '/rest/manufacturing/lookups/products?query=MAT&pageIndex=1&pageSize=1'
+        assert result.links.prev.href == '/rest/manufacturing/lookups/products?query=MAT&pageIndex=0&pageSize=1'
+        assert result.links.next.href == '/rest/manufacturing/lookups/products?query=MAT&pageIndex=2&pageSize=1'
+    }
+
+}

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServicesTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/api/RoutingCostManagementServicesTests.groovy
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ofbiz.manufacturing.api
+
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+import org.apache.ofbiz.ws.rs.util.RestApiUtil
+import org.apache.ofbiz.ws.rs.util.RestQueryOptions
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+
+class RoutingCostManagementServicesTests {
+
+    @Test
+    void testRoutingSortMapsFrameworkFields() {
+        RoutingCostManagementServices services = new RoutingCostManagementServices()
+
+        assert services.routingOrderBy('-status') == ['-currentStatusId', 'workEffortId']
+    }
+
+    @Test
+    void testRoutingTaskSortMapsFrameworkFields() {
+        RoutingCostManagementServices services = new RoutingCostManagementServices()
+
+        assert services.routingTaskOrderBy('-routingTaskId') == ['-workEffortId', 'workEffortName']
+    }
+
+    @Test
+    void testRoutingPurposeTypeSortMapsFrameworkFields() {
+        RoutingCostManagementServices services = new RoutingCostManagementServices()
+
+        assert services.routingPurposeTypeOrderBy('-description') == ['-description', 'workEffortPurposeTypeId']
+    }
+
+    @Test
+    void testRoutingDefaultSortsMatchContracts() {
+        RoutingCostManagementServices services = new RoutingCostManagementServices()
+
+        assert services.routingOrderBy(null) == ['workEffortId']
+        assert services.routingTaskOrderBy(null) == ['workEffortName', 'workEffortId']
+        assert services.routingPurposeTypeOrderBy(null) == ['workEffortPurposeTypeId']
+    }
+
+    @Test
+    void testRoutingRejectsUnsupportedSortField() {
+        RoutingCostManagementServices services = new RoutingCostManagementServices()
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+            services.routingOrderBy('productId')
+        }
+        assert exception.message == 'Unsupported sort field: productId'
+    }
+
+    @Test
+    void testFrameworkRequestPathReturnsNullWithoutRequestBinding() {
+        RoutingCostManagementServices services = new RoutingCostManagementServices()
+
+        assert RestApiUtil.getRelativeRequestPath(services.binding) == null
+    }
+
+    @Test
+    void testFrameworkNavigationMetadataAndLinksUseRequestPath() {
+        RoutingCostManagementServices services = new RoutingCostManagementServices()
+        MockHttpServletRequest request = new MockHttpServletRequest()
+        request.setRequestURI('/rest/manufacturing/routings')
+        request.setQueryString('pageIndex=1&pageSize=1&currentStatusId=ROU_ACTIVE')
+        services.binding.setVariable('request', request)
+        RestQueryOptions queryOptions = RestQueryOptions.fromParameters([
+                pageIndex: 1,
+                pageSize: 1,
+                currentStatusId: 'ROU_ACTIVE'
+        ])
+
+        Map result = RestApiUtil.getPagedResult('routings', [], queryOptions, 3L,
+                RestApiUtil.getRelativeRequestPath(services.binding))
+
+        assert result.previousPageCount == 1L
+        assert result.nextPageCount == 1L
+        assert result.links instanceof Map
+        assert result.links.self.href == '/rest/manufacturing/routings?currentStatusId=ROU_ACTIVE&pageIndex=1&pageSize=1'
+        assert result.links.prev.href == '/rest/manufacturing/routings?currentStatusId=ROU_ACTIVE&pageIndex=0&pageSize=1'
+        assert result.links.next.href == '/rest/manufacturing/routings?currentStatusId=ROU_ACTIVE&pageIndex=2&pageSize=1'
+    }
+
+}

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunQueryServicesTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/jobshopmgt/ProductionRunQueryServicesTests.groovy
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ofbiz.manufacturing.jobshopmgt
+
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+import org.apache.ofbiz.service.ServiceUtil
+import org.apache.ofbiz.ws.rs.util.RestApiUtil
+import org.apache.ofbiz.ws.rs.util.RestQueryOptions
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+
+class ProductionRunQueryServicesTests {
+
+    @Test
+    void testProductionRunSortMapsFrameworkFields() {
+        ProductionRunQueryServices services = new ProductionRunQueryServices()
+
+        assert services.productionRunOrderBy('-status') == ['-currentStatusId', '-estimatedStartDate', 'workEffortId']
+        assert services.productionRunOrderBy('productionRunId') == ['workEffortId', '-estimatedStartDate']
+    }
+
+    @Test
+    void testProductionRunDefaultSortMatchesContract() {
+        ProductionRunQueryServices services = new ProductionRunQueryServices()
+
+        assert services.productionRunOrderBy(null) == ['-estimatedStartDate', 'workEffortId']
+    }
+
+    @Test
+    void testProductionRunRejectsUnsupportedSortField() {
+        ProductionRunQueryServices services = new ProductionRunQueryServices()
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+            services.productionRunOrderBy('productName')
+        }
+        assert exception.message == 'Unsupported sort field: productName'
+    }
+
+    @Test
+    void testFindProductionRunsRejectsUnsupportedSortBeforeEmptyProductNameResults() {
+        ProductionRunQueryServices services = new ProductionRunQueryServices()
+        services.binding.setVariable('parameters', [sort: 'productName', productName: 'NO_MATCH'])
+
+        Map result = services.findProductionRuns()
+
+        assert ServiceUtil.isError(result)
+        assert ServiceUtil.getErrorMessage(result) == 'Unsupported sort field: productName'
+    }
+
+    @Test
+    void testFrameworkRequestPathReturnsNullWithoutRequestBinding() {
+        ProductionRunQueryServices services = new ProductionRunQueryServices()
+
+        assert RestApiUtil.getRelativeRequestPath(services.binding) == null
+    }
+
+    @Test
+    void testFrameworkNavigationMetadataAndLinksUseRequestPath() {
+        ProductionRunQueryServices services = new ProductionRunQueryServices()
+        MockHttpServletRequest request = new MockHttpServletRequest()
+        request.setRequestURI('/rest/manufacturing/production-runs')
+        request.setQueryString('pageIndex=1&pageSize=1&statusId=PRUN_CREATED')
+        services.binding.setVariable('request', request)
+        RestQueryOptions queryOptions = RestQueryOptions.fromParameters([
+                pageIndex: 1,
+                pageSize: 1,
+                statusId: 'PRUN_CREATED'
+        ])
+
+        Map result = RestApiUtil.getPagedResult('productionRuns', [], queryOptions, 3L,
+                RestApiUtil.getRelativeRequestPath(services.binding))
+
+        assert result.previousPageCount == 1L
+        assert result.nextPageCount == 1L
+        assert result.links instanceof Map
+        assert result.links.self.href == '/rest/manufacturing/production-runs?statusId=PRUN_CREATED&pageIndex=1&pageSize=1'
+        assert result.links.prev.href == '/rest/manufacturing/production-runs?statusId=PRUN_CREATED&pageIndex=0&pageSize=1'
+        assert result.links.next.href == '/rest/manufacturing/production-runs?statusId=PRUN_CREATED&pageIndex=2&pageSize=1'
+    }
+
+}

--- a/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
+++ b/framework/base/src/main/java/org/apache/ofbiz/base/util/UtilHttp.java
@@ -833,6 +833,19 @@ public final class UtilHttp {
     }
 
     /**
+     * Returns the relative request URI plus query string, without scheme, host, or port.
+     *
+     * @param request the servlet request to read
+     * @return the relative request URI with query string, or {@code null} when the request is unavailable
+     */
+    public static String getRelativeRequestPath(HttpServletRequest request) {
+        if (request == null || UtilValidate.isEmpty(request.getRequestURI())) {
+            return null;
+        }
+        return request.getRequestURI() + (UtilValidate.isNotEmpty(request.getQueryString()) ? "?" + request.getQueryString() : "");
+    }
+
+    /**
      * Resolve the method send with the request.
      * check first the parameter _method before return the request method
      * @param request

--- a/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilHttpTest.java
+++ b/framework/base/src/test/java/org/apache/ofbiz/base/util/UtilHttpTest.java
@@ -156,6 +156,19 @@ public final class UtilHttpTest {
     }
 
     @Test
+    public void getRelativeRequestPathIncludesQueryString() {
+        when(req.getRequestURI()).thenReturn("/rest/items");
+        when(req.getQueryString()).thenReturn("pageIndex=1&pageSize=1");
+
+        assertThat(UtilHttp.getRelativeRequestPath(req), equalTo("/rest/items?pageIndex=1&pageSize=1"));
+    }
+
+    @Test
+    public void getRelativeRequestPathReturnsNullWhenRequestMissing() {
+        assertNull(UtilHttp.getRelativeRequestPath(null));
+    }
+
+    @Test
     public void ampmMakeParamValueFromComposite() {
         when(req.getParameter("meetingDate_c_compositeType")).thenReturn("Timestamp");
 

--- a/framework/rest-api/src/main/java/org/apache/ofbiz/ws/rs/util/RestApiUtil.java
+++ b/framework/rest-api/src/main/java/org/apache/ofbiz/ws/rs/util/RestApiUtil.java
@@ -24,6 +24,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -34,14 +35,18 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ofbiz.base.util.UtilGenerics;
+import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilValidate;
+import org.apache.ofbiz.base.util.collections.MapComparator;
 import org.apache.ofbiz.service.ModelService;
 import org.apache.ofbiz.ws.rs.core.ResponseStatus;
 import org.apache.ofbiz.ws.rs.response.Error;
 import org.apache.ofbiz.ws.rs.response.Success;
 
+import groovy.lang.Binding;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -434,8 +439,106 @@ public final class RestApiUtil {
     }
 
     /**
+     * Returns a page slice from an already computed list.
+     * <p>
+     * Purpose: lets REST services apply framework-style pagination after they
+     * build derived rows that cannot be paged directly through EntityQuery.
+     *
+     * @param rows the complete in-memory result list
+     * @param pageIndex the zero-based page index
+     * @param pageSize the requested page size
+     * @param <T> the row type
+     * @return a new list containing the requested page, or an empty list when the page is beyond the result size
+     */
+    public static <T> List<T> pageList(List<T> rows, int pageIndex, int pageSize) {
+        if (UtilValidate.isEmpty(rows)) {
+            return Collections.emptyList();
+        }
+        long fromIndex = (long) pageIndex * pageSize;
+        if (fromIndex >= rows.size()) {
+            return Collections.emptyList();
+        }
+        int safeFromIndex = (int) fromIndex;
+        int toIndex = Math.min(safeFromIndex + pageSize, rows.size());
+        return new ArrayList<>(rows.subList(safeFromIndex, toIndex));
+    }
+
+    /**
+     * Sorts already computed map rows using REST sort-expression syntax.
+     * <p>
+     * Purpose: lets REST services expose the same {@code sort} contract for
+     * derived map rows that EntityQuery-backed endpoints expose for entity rows.
+     * The framework MapComparator performs the row comparison while this method
+     * handles REST sort validation and stable fallback ordering.
+     *
+     * @param rows the complete in-memory result rows
+     * @param sortExpression comma-separated REST sort tokens, optionally prefixed with {@code -}
+     * @param allowedFields endpoint-supported map fields, or {@code null}/empty to apply syntax-only validation
+     * @param fallbackComparator stable comparator used when no sort was requested or requested values tie
+     * @return a sorted list, or an empty list when no rows exist
+     * @throws IllegalArgumentException when a sort token is malformed or unsupported
+     */
+    public static List<Map<String, Object>> sortMapRows(List<Map<String, Object>> rows, String sortExpression,
+            Set<String> allowedFields, Comparator<Map<String, Object>> fallbackComparator) {
+        List<String> sortTokens = validateSortFields(sortExpression, allowedFields);
+        if (UtilValidate.isEmpty(rows)) {
+            return Collections.emptyList();
+        }
+        Comparator<Map<String, Object>> rowComparator = fallbackComparator;
+        if (UtilValidate.isNotEmpty(sortTokens)) {
+            MapComparator sortComparator = new MapComparator(sortTokens);
+            rowComparator = (left, right) -> {
+                int comparison = sortComparator.compare(UtilGenerics.cast(left), UtilGenerics.cast(right));
+                return comparison != 0 ? comparison : fallbackComparator.compare(left, right);
+            };
+        }
+        return new ArrayList<>(rows.stream()
+                .sorted(rowComparator)
+                .toList());
+    }
+
+    /**
+     * Extracts the relative request URI plus query string for pagination link generation.
+     * <p>
+     * Purpose: REST pagination links operate on the request path stored in
+     * {@link RestListResponseBuilder}, not on an absolute URL. This keeps API
+     * responses consistent with existing relative link output while avoiding
+     * repeated URI/query-string assembly in individual services. Use
+     * {@code UtilHttp.getFullRequestUrl(request)} when an absolute URL is needed.
+     *
+     * @param request the originating servlet request
+     * @return the relative request URI with query string, or {@code null} when the request is unavailable
+     */
+    public static String getRelativeRequestPath(HttpServletRequest request) {
+        return UtilHttp.getRelativeRequestPath(request);
+    }
+
+    /**
+     * Extracts the relative request path from a Groovy service binding when an
+     * HTTP request is available.
+     * <p>
+     * Purpose: REST-exposed Groovy services can be invoked through HTTP or
+     * directly through the service engine. Direct service calls do not bind a
+     * servlet request, so this helper centralizes the safe missing-request check
+     * while still letting HTTP calls generate pagination links.
+     *
+     * @param binding the Groovy service script binding
+     * @return the relative request URI with query string, or {@code null} when no servlet request is bound
+     */
+    public static String getRelativeRequestPath(Binding binding) {
+        if (binding == null || !binding.hasVariable("request")) {
+            return null;
+        }
+        Object request = binding.getVariable("request");
+        return request instanceof HttpServletRequest ? getRelativeRequestPath((HttpServletRequest) request) : null;
+    }
+
+    /**
      * Validates candidate filter parameters against an optional endpoint-defined
      * allowlist while preserving insertion order.
+     * <p>
+     * Purpose: lets REST services share framework filter validation instead of
+     * implementing endpoint-local allowlist checks.
      *
      * @param filters the candidate filter parameters collected from the request
      * @param allowedFields the endpoint-supported filter fields, or
@@ -443,13 +546,16 @@ public final class RestApiUtil {
      * @return the validated filter parameters in insertion order
      * @throws IllegalArgumentException when a filter field is unsupported
      */
-    static Map<String, Object> validateFilterParameters(Map<String, ?> filters, Set<String> allowedFields) {
+    public static Map<String, Object> validateFilterParameters(Map<String, ?> filters, Set<String> allowedFields) {
         return validateFilterParameters(filters, allowedFields, null, null);
     }
 
     /**
      * Validates candidate direct filter parameters against optional endpoint-defined
      * policies while preserving insertion order.
+     * <p>
+     * Purpose: lets REST services share filter allowlist, repeatable-parameter,
+     * and per-field value validation rules.
      *
      * @param filters the candidate filter parameters collected from the request
      * @param allowedFields the endpoint-supported filter fields, or
@@ -460,7 +566,7 @@ public final class RestApiUtil {
      * @return the validated filter parameters in insertion order
      * @throws IllegalArgumentException when a filter field or value is invalid
      */
-    static Map<String, Object> validateFilterParameters(Map<String, ?> filters, Set<String> allowedFields,
+    public static Map<String, Object> validateFilterParameters(Map<String, ?> filters, Set<String> allowedFields,
             Set<String> repeatableFields, Map<String, FilterValueValidator> valueValidators) {
         if (UtilValidate.isEmpty(filters)) {
             return Collections.emptyMap();

--- a/framework/rest-api/src/test/java/org/apache/ofbiz/ws/rs/util/RestApiUtilPaginationTest.java
+++ b/framework/rest-api/src/test/java/org/apache/ofbiz/ws/rs/util/RestApiUtilPaginationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,7 +12,10 @@ import java.util.Set;
 
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 
+import groovy.lang.Binding;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
 
 public final class RestApiUtilPaginationTest {
@@ -107,6 +111,69 @@ public final class RestApiUtilPaginationTest {
     }
 
     @Test
+    public void sortsMapRowsByRestSortExpression() {
+        List<Map<String, Object>> rows = List.of(
+                UtilMisc.toMap("itemId", "ITEM-A", "locationId", "LOC1"),
+                UtilMisc.toMap("itemId", "ITEM-C", "locationId", "LOC1"),
+                UtilMisc.toMap("itemId", "ITEM-B", "locationId", "LOC1"));
+
+        List<Map<String, Object>> sortedRows = RestApiUtil.sortMapRows(rows, "-itemId",
+                Set.of("itemId", "locationId"), Comparator.comparing(row -> (String) row.get("itemId")));
+
+        assertEquals(List.of("ITEM-C", "ITEM-B", "ITEM-A"), sortedRows.stream().map(row -> row.get("itemId")).toList());
+    }
+
+    @Test
+    public void rejectsUnsupportedMapRowSortFields() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                RestApiUtil.sortMapRows(List.of(Map.of("itemId", "ITEM-A")), "notAField",
+                        Set.of("itemId"), Comparator.comparing(row -> (String) row.get("itemId"))));
+
+        assertEquals("Unsupported sort field: notAField", exception.getMessage());
+    }
+
+    @Test
+    public void rejectsUnsupportedMapRowSortFieldsWhenRowsEmpty() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                RestApiUtil.sortMapRows(List.of(), "notAField",
+                        Set.of("itemId"), Comparator.comparing(row -> (String) row.get("itemId"))));
+
+        assertEquals("Unsupported sort field: notAField", exception.getMessage());
+    }
+
+    @Test
+    public void returnsMutableSortedMapRows() {
+        List<Map<String, Object>> rows = List.of(Map.of("itemId", "ITEM-A"));
+        List<Map<String, Object>> sortedRows = RestApiUtil.sortMapRows(rows, "itemId",
+                Set.of("itemId"), Comparator.comparing(row -> (String) row.get("itemId")));
+
+        sortedRows.add(Map.of("itemId", "ITEM-B"));
+
+        assertEquals(2, sortedRows.size());
+    }
+
+    @Test
+    public void pagesAlreadyComputedLists() {
+        List<String> page = RestApiUtil.pageList(List.of("a", "b", "c", "d"), 1, 2);
+
+        assertEquals(List.of("c", "d"), page);
+    }
+
+    @Test
+    public void returnsEmptyPageWhenComputedPageStartsAfterListEnd() {
+        List<String> page = RestApiUtil.pageList(List.of("a", "b"), 2, 2);
+
+        assertEquals(List.of(), page);
+    }
+
+    @Test
+    public void returnsEmptyPageWhenComputedPageIndexOverflowsIntMultiplication() {
+        List<String> page = RestApiUtil.pageList(List.of("a", "b"), Integer.MAX_VALUE, 100);
+
+        assertEquals(List.of(), page);
+    }
+
+    @Test
     public void serializesAvailableRelationsAsHttpLinkHeader() {
         Map<String, Object> links = new LinkedHashMap<>();
         links.put("first", RestApiUtil.makeLinkMap("/rest/items?pageIndex=0&pageSize=20", Map.of("rel", "first")));
@@ -164,7 +231,7 @@ public final class RestApiUtilPaginationTest {
     public void rejectsRepeatedFilterValuesWhenFieldIsNotRepeatable() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
                 RestApiUtil.validateFilterParameters(
-                        UtilMisc.toMap("statusId", List.of("PRUN_CREATED", "PRUN_RUNNING")),
+                        UtilMisc.toMap("statusId", List.of("STATE_CREATED", "STATE_RUNNING")),
                         Set.of("statusId"), null, null));
 
         assertEquals("Filter parameter does not support repeated values: statusId", exception.getMessage());
@@ -173,10 +240,10 @@ public final class RestApiUtilPaginationTest {
     @Test
     public void preservesRepeatedFilterValuesWhenFieldIsRepeatable() {
         Map<String, Object> validatedFilters = RestApiUtil.validateFilterParameters(
-                UtilMisc.toMap("statusId", List.of("PRUN_CREATED", "PRUN_RUNNING")),
+                UtilMisc.toMap("statusId", List.of("STATE_CREATED", "STATE_RUNNING")),
                 Set.of("statusId"), Set.of("statusId"), null);
 
-        assertEquals(List.of("PRUN_CREATED", "PRUN_RUNNING"), validatedFilters.get("statusId"));
+        assertEquals(List.of("STATE_CREATED", "STATE_RUNNING"), validatedFilters.get("statusId"));
     }
 
     @Test
@@ -212,5 +279,39 @@ public final class RestApiUtilPaginationTest {
         Response response = RestApiUtil.success("Success", Map.of("items", List.of()));
 
         assertNull(response.getHeaderString("Link"));
+    }
+
+    @Test
+    public void buildsRelativeRequestPathWithQueryString() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/rest/items");
+        request.setQueryString("pageIndex=1&pageSize=1");
+
+        assertEquals("/rest/items?pageIndex=1&pageSize=1", RestApiUtil.getRelativeRequestPath(request));
+    }
+
+    @Test
+    public void returnsNullRelativeRequestPathWhenRequestMissing() {
+        assertNull(RestApiUtil.getRelativeRequestPath((HttpServletRequest) null));
+    }
+
+    @Test
+    public void buildsRelativeRequestPathFromGroovyBinding() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/rest/items");
+        request.setQueryString("pageIndex=1&pageSize=1");
+        Binding binding = new Binding(Map.of("request", request));
+
+        assertEquals("/rest/items?pageIndex=1&pageSize=1", RestApiUtil.getRelativeRequestPath(binding));
+    }
+
+    @Test
+    public void returnsNullRelativeRequestPathWhenGroovyBindingHasNoRequest() {
+        assertNull(RestApiUtil.getRelativeRequestPath(new Binding()));
+    }
+
+    @Test
+    public void returnsNullRelativeRequestPathWhenGroovyBindingHasNonServletRequest() {
+        assertNull(RestApiUtil.getRelativeRequestPath(new Binding(Map.of("request", "notARequest"))));
     }
 }


### PR DESCRIPTION

## Summary

Adds reusable REST list-query helpers and applies them to manufacturing list APIs for Production Run, BOM, Routing, and shared lookups.

## Changes

- Add framework helpers for computed-list pagination, map-row sorting, filter validation, and relative request-path lookup.
- Align Production Run, BOM, Routing, and Manufacturing Lookup list services with the REST `sort` + pagination response contract.
- Preserve framework paging metadata:
  - `pageIndex`
  - `pageSize`
  - `totalCount`
  - `totalPages`
  - `hasNext`
  - `previousPageCount`
  - `nextPageCount`
  - `links`
- Use public REST `sort` parameters while keeping EntityQuery `orderBy` as an internal implementation detail.
- Add focused tests for the framework helper behavior and the manufacturing API retrofits.
