### PR TITLE
Improved: Authorization enforcement for HumanRes category tree data access (#1637)

### DIFF
--- a/applications/humanres/config/HumanResErrorUiLabels.xml
+++ b/applications/humanres/config/HumanResErrorUiLabels.xml
@@ -60,4 +60,7 @@
     <property key="HumanResFromDateAlreadyExist">
         <value xml:lang="en">This FromDate : ${parameters.estimatedStartDate} already exist.</value>
     </property>
+    <property key="HumanResViewPermissionError">
+        <value xml:lang="en">You do not have permission to view Human Resources organization data.</value>
+    </property>
 </resource>

--- a/applications/humanres/src/main/java/org/apache/ofbiz/humanres/HumanResEvents.java
+++ b/applications/humanres/src/main/java/org/apache/ofbiz/humanres/HumanResEvents.java
@@ -28,6 +28,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.UtilGenerics;
+import org.apache.ofbiz.base.util.UtilHttp;
+import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntityException;
@@ -36,6 +38,7 @@ import org.apache.ofbiz.entity.condition.EntityCondition;
 import org.apache.ofbiz.entity.condition.EntityOperator;
 import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.party.party.PartyHelper;
+import org.apache.ofbiz.security.Security;
 
 public class HumanResEvents {
     private static final String MODULE = HumanResEvents.class.getName();
@@ -43,6 +46,14 @@ public class HumanResEvents {
 
     // Please note : the structure of map in this function is according to the JSON data map of the jsTree
     public static String getChildHRCategoryTree(HttpServletRequest request, HttpServletResponse response) {
+        Security security = (Security) request.getAttribute("security");
+        if (security == null || !security.hasEntityPermission("HUMANRES", "_VIEW", request.getSession())) {
+            String errMsg = UtilProperties.getMessage(RES_ERROR, "HumanResViewPermissionError", UtilHttp.getLocale(request));
+            request.setAttribute("_ERROR_MESSAGE_", errMsg);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            Debug.logWarning("Unauthorized attempt to access getHRChild by partyId param [%s]", MODULE, request.getParameter("partyId"));
+            return "error";
+        }
         Delegator delegator = (Delegator) request.getAttribute("delegator");
         String partyId = request.getParameter("partyId");
         String onclickFunction = request.getParameter("onclickFunction");

--- a/applications/humanres/webapp/humanres/WEB-INF/controller.xml
+++ b/applications/humanres/webapp/humanres/WEB-INF/controller.xml
@@ -1052,7 +1052,7 @@ under the License.
         <response name="error" type="view" value="EditEmplLeaveStatus"/>
     </request-map>
     <request-map uri="getHRChild">
-        <security auth="false" https="true"/>
+        <security auth="true" https="true"/>
         <event type="java" path="org.apache.ofbiz.humanres.HumanResEvents" invoke="getChildHRCategoryTree"/>
         <response name="success" type="request" value="json"/>
         <response name="error" type="request" value="json"/>


### PR DESCRIPTION
- The getHRChild request now requires authentication.
- The backing handler additionally verifies that the caller holds the HUMANRES_VIEW permission before returning any data.
- Unit tests were added covering the denied and allowed cases.

Thank you @Krishnauprit18 for your help in this contribution.

(cherry picked from commit fbd3e7648052f32c9a05d3af7ae8cf305dffad95)

