### PR TITLE
Fixed: ControlFilter's FreeMarker-interpolation guard was unreachable due to fail-open security check (OFBIZ-13492)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/LoginWorker.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/LoginWorker.java
@@ -1443,9 +1443,14 @@ public final class LoginWorker {
     }
 
     public static boolean hasBasePermission(GenericValue userLogin, HttpServletRequest request) {
+        ServletContext context = request.getServletContext();
         Security security = (Security) request.getAttribute("security");
+        if (security == null) {
+            // ContextFilter may not have run yet for this request (e.g. when ControlFilter is mapped
+            // before ContextFilter); the same Security instance is already cached on the ServletContext.
+            security = (Security) context.getAttribute("security");
+        }
         if (security != null) {
-            ServletContext context = request.getServletContext();
             String serverId = (String) context.getAttribute("_serverId");
             // get a context path from the request, if it is empty then assume it is the root mount point
             String contextPath = request.getContextPath();

--- a/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/ControlFilterTests.java
+++ b/framework/webapp/src/test/java/org/apache/ofbiz/webapp/control/ControlFilterTests.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -51,6 +52,8 @@ public class ControlFilterTests {
         req = mock(HttpServletRequest.class);
         when(req.getSession()).thenReturn(session);
         when(req.getContextPath()).thenReturn("");
+        // A real HttpServletRequest always has a ServletContext; LoginWorker.hasBasePermission() relies on this.
+        when(req.getServletContext()).thenReturn(mock(ServletContext.class));
         resp = mock(HttpServletResponse.class);
         next = mock(FilterChain.class);
         filter = new ControlFilter();


### PR DESCRIPTION
Backported from trunk (#1641). LoginWorker.hasBasePermission() returned true whenever the request-scoped "security" attribute was unresolved, which was effectively always the case since ControlFilter runs before ContextFilter (the attribute's source) in nearly every webapp's filter-mapping order. This made the SSTI/Freemarker-interpolation guard added for OFBIZ-12594/OFBIZ-12602 unreachable across the framework, for any request. hasBasePermission() now falls back to the Security instance cached on the ServletContext when the request attribute is null, since ContextFilter only ever copies that same object into the request scope each call. Adapted only for this branch's pre-Jakarta javax.servlet API and JUnit4-style test — same behavioral fix as trunk.