### PR TITLE
Every ofbiz-launched dev server needs test classes on its classpath,

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1396,8 +1396,15 @@ tasks.addRule('Pattern: ofbizBackground <Commands>: Execute OFBiz startup comman
 def createOfbizCommandTask(taskName, arguments) {
     task(type: JavaExec, dependsOn: classes, taskName) {
         jvmArgs(application.applicationDefaultJvmArgs)
+        // Every ofbiz-launched dev server needs test classes on its classpath, not just one
+        // started with --test/-t: webtools' "Run Test" screen (RunTestEvents -> TestRunContainer)
+        // loads jupiter-test-suite/junit-test-suite classes by name inside whatever JVM is already
+        // running, regardless of how that JVM was started. OFBIZ-13402 moved those classes out of
+        // src/main/* (and so out of sourceSets.main) to keep them out of release artifacts; this
+        // task is a local dev-run launcher, never a release-packaging task, so widening its
+        // classpath here doesn't reintroduce test code into anything that gets distributed.
+        classpath = sourceSets.main.runtimeClasspath + sourceSets.test.runtimeClasspath
         if (taskName ==~ /^ofbiz.*(--test|-t).*/) {
-            classpath = sourceSets.main.runtimeClasspath + sourceSets.test.runtimeClasspath
             // TestRunContainer.java writes one XML per suite as "<suite.getName()>.xml" and only
             // ever overwrites the suites a run actually re-executes - nothing here deletes the
             // rest first. Left alone, a narrower run (suitename=... filtering to one component) or
@@ -1412,8 +1419,6 @@ def createOfbizCommandTask(taskName, arguments) {
             }
             finalizedBy(createTestReport)
             finalizedBy(createFramedTestReport)
-        } else {
-            classpath = sourceSets.main.runtimeClasspath
         }
         mainClass = application.mainClass
         args arguments


### PR DESCRIPTION
Every ofbiz-launched dev server needs test classes on its classpath, not just one started with --test/-t: webtools' "Run Test" screen (RunTestEvents -> TestRunContainer) loads jupiter-test-suite/junit-test-suite classes by name inside whatever JVM is already running, regardless of how that JVM was started. OFBIZ-13402 moved those classes out of src/main/* (and so out of sourceSets.main) to keep them out of release artifacts; this task is a local dev-run launcher, never a release-packaging task, so widening its classpath here doesn't reintroduce test code into anything that gets distributed.
