### PR TITLE
Remove FOP auto-detect font scanning to stop 169 lines noisy font-load warnings/errors

### DIFF
--- a/framework/webapp/config/fop.xconf
+++ b/framework/webapp/config/fop.xconf
@@ -96,7 +96,12 @@ the location of this file.
           <font-triplet name="ArialMT" style="normal" weight="bold"/>
         </font>
         -->
-          <auto-detect/>
+          <!-- auto-detect is intentionally omitted: it scans every OS-installed font (including
+               ones FOP's parser can't read, e.g. macOS .ttc/CFF-OpenType files), which only adds
+               noisy WARN/ERROR log lines. All OFBiz FO templates use either the bundled NotoSans
+               font below or one of FOP's built-in base-14 fonts (Helvetica, Times, Courier,
+               Symbol, ZapfDingbats), so OS font discovery isn't needed. If a custom template
+               needs to resolve an OS-installed font by name, re-add <auto-detect/> here. -->
           <directory>framework/resources/fonts/NotoSans</directory>
           <auto-embed/>
       </fonts>


### PR DESCRIPTION
`framework/webapp/config/fop.xconf` has `<auto-detect/>` enabled for the PDF renderer, which makes FOP scan every OS-installed font at startup so any font-family name in an FO template can resolve to something on disk. On macOS several system fonts aren't parseable by FOP's font loader (`.ttc` collections, CFF-flavored OpenType files, fonts without a Unicode cmap table), so FOP logs a WARN/ERROR for each one it can't use. This shows up as a large block of font-loading noise on every FOP render during `testIntegration`.

All FO templates shipped in this repo and in the plugins repo only use the bundled `NotoSans` font (already loaded via the `<directory>` entry below `auto-detect`) or one of FOP's built-in base-14 fonts (`Helvetica`, `Times`, `Courier`, `Symbol`, `ZapfDingbats`), none of which need OS font discovery. Removing `auto-detect` drops the noise without affecting how any shipped template renders.

Verified with `./gradlew testIntegration`: build still succeeds and `WidgetMacroLibraryTests.testFopMacroLibrary` still passes, with the font-loading warnings/errors gone from the log.
