### PR TITLE
Move misplaced order promotion labels to error bundle, fix test data field typos

### DIFF
--- a/applications/accounting/testdef/data/AccountingTestsData.xml
+++ b/applications/accounting/testdef/data/AccountingTestsData.xml
@@ -57,7 +57,7 @@ under the License.
     <Agreement agreementId="1010" agreementTypeId="COMMISSION_AGREEMENT" description="Commission Agreement" partyIdFrom="DEMO_COMPANY" partyIdTo="DEMO_COMPANY1" roleTypeIdFrom="SUPPLIER" roleTypeIdTo="DISTRIBUTOR" fromDate="2016-09-29 00:00:00"/>
     <AgreementItem agreementId="1010" agreementItemSeqId="0001" currencyUomId="USD" agreementItemTypeId="AGREEMENT_COMMISSION" agreementText="Commission in USD"/>
     <AgreementProductAppl agreementId="1010" agreementItemSeqId="0001" productId="TestProduct2"/>
-    <AgreementTerm agreementTermId="1010" termTypeId="FIN_COMM_VARIABLE" agreementId="1010" agreementItemSeqId="0001" productId="TestProduct2" invoiceItemTypeId="COMM_INV_ITEM" fromDate="2016-09-29 00:00:00" thruDate="2017-09-29 00:00:00" termValue="10" termDays="30" minQuantity="1" maxQuantity="100" description="Agreement Term for Test Product 2 Commission"/>
+    <AgreementTerm agreementTermId="1010" termTypeId="FIN_COMM_VARIABLE" agreementId="1010" agreementItemSeqId="0001" invoiceItemTypeId="COMM_INV_ITEM" fromDate="2016-09-29 00:00:00" thruDate="2017-09-29 00:00:00" termValue="10" termDays="30" minQuantity="1" maxQuantity="100" description="Agreement Term for Test Product 2 Commission"/>
     <!-- For Testing service updateBudgetStatus -->
     <Budget budgetId="9999" budgetTypeId="CAPITAL_BUDGET" comments="This is the capital budget"/>
     <BudgetStatus budgetId="9999" statusId="BG_CREATED" statusDate="2016-09-29 00:00:00"/>

--- a/applications/order/config/OrderErrorUiLabels.xml
+++ b/applications/order/config/OrderErrorUiLabels.xml
@@ -2008,6 +2008,32 @@
         <value xml:lang="zh">用于已定义订单 ${orderId} 的工作流数量大于1</value>
         <value xml:lang="zh-TW">用于已定義訂單 ${orderId} 的工作流數量大于1</value>
     </property>
+    <property key="OrderNoAgreementFoundWithIdNotDoingPromotions">
+        <value xml:lang="ar">لا يوجد اتفاقية ذات دليل ليس بها ترويجات</value>
+        <value xml:lang="de">Keine Vereinbarung mit dieser ID gefunden. Es werden keine Aktionen angewendet</value>
+        <value xml:lang="en">No Agreement Found With Id Not Doing Promotions</value>
+        <value xml:lang="fr">Pas d'accord trouvé avec cette référence. Aucune promotion activée</value>
+        <value xml:lang="it">Nessun contratto trovato con questo id nessuna promozione verrà creata</value>
+        <value xml:lang="ja">プロモーションをしていないIDで同意書はありません</value>
+        <value xml:lang="nl">Geen contract gevonden; promos worden niet toegepast</value>
+        <value xml:lang="pt-BR">Nenhum acordo encontrado com ID sem fazer promoções</value>
+        <value xml:lang="vi">Không có 'thỏa thuận' nào với Id và không thực hiện Khuyến mãi</value>
+        <value xml:lang="zh">没有找到带有不做促销的标识的合同</value>
+        <value xml:lang="zh-TW">找不到帶有不做促銷識別的合約</value>
+    </property>
+    <property key="OrderNoAgreementItemFoundForAgreementWithIdNotDoingPromotions">
+        <value xml:lang="ar">لا يوجد بند اتفاقية ذو دليل ليس به ترويجات</value>
+        <value xml:lang="de">Kein Vereinbarungselement mit dieser ID gefunden. Es werden keine Aktionen angewendet</value>
+        <value xml:lang="en">No Agreement Item Found With Id Not Doing Promotions</value>
+        <value xml:lang="fr">Pas ligne d'accord trouvée avec cette référence. Aucune promotion activée</value>
+        <value xml:lang="it">Nessuna riga contratto trovata con questo id nessuna promozione verrà creata</value>
+        <value xml:lang="ja">プロモーションをしていないIDで同意書はありません</value>
+        <value xml:lang="nl">Geen contractregel gevonden; promos worden niet toegepast</value>
+        <value xml:lang="pt-BR">Nenhum artigo encontrado com ID sem fazer promoções</value>
+        <value xml:lang="vi">Không có 'điều khoản thỏa thuận' nào với Id và không thực hiện Khuyến mãi</value>
+        <value xml:lang="zh">没有找到带有不做促销的标识的合同条款</value>
+        <value xml:lang="zh-TW">找不到帶有不做促銷的識別的合約條款</value>
+    </property>
     <property key="OrderNoAgreementSpecified">
         <value xml:lang="ar">لم تحدد إتفاقية</value>
         <value xml:lang="de">Keine Vereinbarung festgelegt</value>

--- a/applications/order/config/OrderUiLabels.xml
+++ b/applications/order/config/OrderUiLabels.xml
@@ -6477,32 +6477,6 @@
         <value xml:lang="zh">没有有效地址</value>
         <value xml:lang="zh-TW">沒有有效位址</value>
     </property>
-    <property key="OrderNoAgreementFoundWithIdNotDoingPromotions">
-        <value xml:lang="ar">لا يوجد اتفاقية ذات دليل ليس بها ترويجات</value>
-        <value xml:lang="de">Keine Vereinbarung mit dieser ID gefunden. Es werden keine Aktionen angewendet</value>
-        <value xml:lang="en">No Agreement Found With Id Not Doing Promotions</value>
-        <value xml:lang="fr">Pas d'accord trouvé avec cette référence. Aucune promotion activée</value>
-        <value xml:lang="it">Nessun contratto trovato con questo id nessuna promozione verrà creata</value>
-        <value xml:lang="ja">プロモーションをしていないIDで同意書はありません</value>
-        <value xml:lang="nl">Geen contract gevonden; promos worden niet toegepast</value>
-        <value xml:lang="pt-BR">Nenhum acordo encontrado com ID sem fazer promoções</value>
-        <value xml:lang="vi">Không có 'thỏa thuận' nào với Id và không thực hiện Khuyến mãi</value>
-        <value xml:lang="zh">没有找到带有不做促销的标识的合同</value>
-        <value xml:lang="zh-TW">找不到帶有不做促銷識別的合約</value>
-    </property>
-    <property key="OrderNoAgreementItemFoundForAgreementWithIdNotDoingPromotions">
-        <value xml:lang="ar">لا يوجد بند اتفاقية ذو دليل ليس به ترويجات</value>
-        <value xml:lang="de">Kein Vereinbarungselement mit dieser ID gefunden. Es werden keine Aktionen angewendet</value>
-        <value xml:lang="en">No Agreement Item Found With Id Not Doing Promotions</value>
-        <value xml:lang="fr">Pas ligne d'accord trouvée avec cette référence. Aucune promotion activée</value>
-        <value xml:lang="it">Nessuna riga contratto trovata con questo id nessuna promozione verrà creata</value>
-        <value xml:lang="ja">プロモーションをしていないIDで同意書はありません</value>
-        <value xml:lang="nl">Geen contractregel gevonden; promos worden niet toegepast</value>
-        <value xml:lang="pt-BR">Nenhum artigo encontrado com ID sem fazer promoções</value>
-        <value xml:lang="vi">Không có 'điều khoản thỏa thuận' nào với Id và không thực hiện Khuyến mãi</value>
-        <value xml:lang="zh">没有找到带有不做促销的标识的合同条款</value>
-        <value xml:lang="zh-TW">找不到帶有不做促銷的識別的合約條款</value>
-    </property>
     <property key="OrderNoChannel">
         <value xml:lang="ar">لا يوجد قناة</value>
         <value xml:lang="de">Kein Kanal</value>

--- a/applications/order/testdef/data/OrderTestData.xml
+++ b/applications/order/testdef/data/OrderTestData.xml
@@ -70,7 +70,7 @@ under the License.
     <Shipment shipmentId="1014" shipmentTypeId="SALES_SHIPMENT" primaryOrderId="DEMO10090" primaryShipGroupSeqId="00001" statusId="SHIPMENT_SHIPPED"/>
     <ShipmentItem shipmentId="1014" shipmentItemSeqId="00001"/>
 
-    <Invoice invoiceId="TEST_DEMO10090" partyId="TestDemoCustomer" partyIdFrom="Company" invoiceDate="2009-08-17 14:56:44.573" statusId="INVOICE_PAID" currencyUom="USD"/>
+    <Invoice invoiceId="TEST_DEMO10090" partyId="TestDemoCustomer" partyIdFrom="Company" invoiceDate="2009-08-17 14:56:44.573" statusId="INVOICE_PAID" currencyUomId="USD"/>
     <InvoiceItem invoiceId="TEST_DEMO10090" invoiceItemSeqId="00001" invoiceItemTypeId="PINV_FPROD_ITEM" productId="GZ-2644" quantity="2.000000" amount="38.40" description="GZ-2644-0 Round Gizmo"/>
     <OrderItemBilling orderId="TEST_DEMO10090" orderItemSeqId="00001" invoiceId="TEST_DEMO10090" invoiceItemSeqId="00001" quantity="2.000000" amount="38.40"/>
     <OrderPaymentPreference orderPaymentPreferenceId="TEST_DEMO10090" orderId="TEST_DEMO10090" paymentMethodTypeId="EFT_ACCOUNT" maxAmount="76.80" statusId="PAYMENT_SETTLED" createdDate="2009-08-17 14:56:44.573"/>


### PR DESCRIPTION
ProductPromoWorker looks up OrderNoAgreementFoundWithIdNotDoingPromotions and OrderNoAgreementItemFoundForAgreementWithIdNotDoingPromotions from the OrderErrorUiLabels bundle, but both were only defined in OrderUiLabels, causing missing-label warnings at runtime. Moved them to the correct file.

Also fixed two test fixture typos found via the same testIntegration run:
- AgreementTerm test data had a productId attribute that isn't a real field on that entity.
- Invoice test data used currencyUom instead of the actual field name currencyUomId.

Verified by re-running testIntegration: build stays successful, no suite regressions, and the missing-label/invalid-field warnings are gone from the log.