### PR TITLE
Rename MailDkimConfig.domain to signingDomain to avoid reserved SQL word

### DIFF
--- a/framework/common/entitydef/entitymodel.xml
+++ b/framework/common/entitydef/entitymodel.xml
@@ -947,7 +947,7 @@ under the License.
             <description>Optional link to a MailSmtpConfig row; unset today, ready for per-relay DKIM
             once multi-SMTP-config support exists</description>
         </field>
-        <field name="domain" type="value"><description>Signing domain, e.g. example.com</description></field>
+        <field name="signingDomain" type="value"><description>Signing domain, e.g. example.com</description></field>
         <field name="selector" type="value"><description>DKIM selector, e.g. ofbiz</description></field>
         <field name="privateKey" type="very-long" encrypt="true">
             <description>PKCS#8 PEM RSA private key</description>

--- a/framework/common/src/main/java/org/apache/ofbiz/common/email/EmailServices.java
+++ b/framework/common/src/main/java/org/apache/ofbiz/common/email/EmailServices.java
@@ -794,7 +794,7 @@ public class EmailServices {
         if (config == null || !"Y".equals(config.getString("enabled"))) {
             return mail;
         }
-        String domain = config.getString("domain");
+        String domain = config.getString("signingDomain");
         String selector = config.getString("selector");
         String privateKeyPem = config.getString("privateKey");
         if (UtilValidate.isEmpty(domain) || UtilValidate.isEmpty(selector) || UtilValidate.isEmpty(privateKeyPem)) {
@@ -840,7 +840,7 @@ public class EmailServices {
         if (config == null) {
             return ServiceUtil.returnError("No MailDkimConfig found for ID [" + mailDkimConfigId + "]");
         }
-        String domain = config.getString("domain");
+        String domain = config.getString("signingDomain");
         String selector = config.getString("selector");
         String privateKeyPem = config.getString("privateKey");
         if (UtilValidate.isEmpty(domain) || UtilValidate.isEmpty(selector) || UtilValidate.isEmpty(privateKeyPem)) {

--- a/framework/common/src/test/java/org/apache/ofbiz/common/email/EmailServicesDkimTests.java
+++ b/framework/common/src/test/java/org/apache/ofbiz/common/email/EmailServicesDkimTests.java
@@ -131,7 +131,7 @@ public final class EmailServicesDkimTests {
     public void dkimSignReturnsOriginalWhenIncompleteConfig() throws Exception {
         GenericValue config = mock(GenericValue.class);
         when(config.getString("enabled")).thenReturn("Y");
-        when(config.getString("domain")).thenReturn("example.com");
+        when(config.getString("signingDomain")).thenReturn("example.com");
         when(config.getString("selector")).thenReturn("");
         when(config.getString("privateKey")).thenReturn("");
         when(config.getString("mailDkimConfigId")).thenReturn("TEST_DKIM_1");
@@ -144,7 +144,7 @@ public final class EmailServicesDkimTests {
     public void dkimSignReturnsOriginalWhenPrivateKeyIsGarbage() throws Exception {
         GenericValue config = mock(GenericValue.class);
         when(config.getString("enabled")).thenReturn("Y");
-        when(config.getString("domain")).thenReturn("example.com");
+        when(config.getString("signingDomain")).thenReturn("example.com");
         when(config.getString("selector")).thenReturn("ofbiz");
         when(config.getString("privateKey")).thenReturn("not a real key");
         when(config.getString("mailDkimConfigId")).thenReturn("TEST_DKIM_1");
@@ -157,7 +157,7 @@ public final class EmailServicesDkimTests {
     public void dkimSignWrapsAndSignsWhenFullyConfigured() throws Exception {
         GenericValue config = mock(GenericValue.class);
         when(config.getString("enabled")).thenReturn("Y");
-        when(config.getString("domain")).thenReturn("example.com");
+        when(config.getString("signingDomain")).thenReturn("example.com");
         when(config.getString("selector")).thenReturn("ofbiz");
         when(config.getString("privateKey")).thenReturn(testPrivateKeyPem);
         when(config.getString("mailDkimConfigId")).thenReturn("TEST_DKIM_1");
@@ -184,7 +184,7 @@ public final class EmailServicesDkimTests {
     public void dkimSignatureVerifiesAgainstDerivedPublicKey() throws Exception {
         GenericValue config = mock(GenericValue.class);
         when(config.getString("enabled")).thenReturn("Y");
-        when(config.getString("domain")).thenReturn("example.com");
+        when(config.getString("signingDomain")).thenReturn("example.com");
         when(config.getString("selector")).thenReturn("ofbiz");
         when(config.getString("privateKey")).thenReturn(testPrivateKeyPem);
         when(config.getString("mailDkimConfigId")).thenReturn("TEST_DKIM_1");


### PR DESCRIPTION
DOMAIN is a reserved word in some databases (H2 included), which was logged as a [FieldNameRW] warning at every delegator startup. Renamed the field and updated the two places that referenced it by name.

This entity was added very recently and hasn't shipped in a release, so the rename carries no migration concern.

Verified by running the DKIM unit tests (all pass) and a full testIntegration run: build stays successful, no suite regressions, and the reserved-word warning is gone from the log.