### PR TITLE
Fixed: JWT refresh tokens no longer accepted as access tokens (OFBIZ-13493)

### DIFF
--- a/framework/rest-api/src/main/java/org/apache/ofbiz/ws/rs/security/auth/APIAuthFilter.java
+++ b/framework/rest-api/src/main/java/org/apache/ofbiz/ws/rs/security/auth/APIAuthFilter.java
@@ -112,7 +112,7 @@ public class APIAuthFilter implements ContainerRequestFilter {
             return;
         }
         String jwtToken = JWTManager.getHeaderAuthBearerToken(httpRequest);
-        Map<String, Object> claims = JWTManager.validateToken(delegator, jwtToken);
+        Map<String, Object> claims = JWTManager.validateAccessToken(delegator, jwtToken);
         if (claims.containsKey(ModelService.ERROR_MESSAGE)) {
             abortWithUnauthorized(requestContext, true, "Unauthorized: " + (String) claims.get(ModelService.ERROR_MESSAGE));
         } else {

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/JWTManager.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/JWTManager.java
@@ -467,14 +467,14 @@ public class JWTManager {
     }
 
     /**
-     * Validate the token usingJWTManager::validateToken
+     * Validate the token usingJWTManager::validateAccessToken
      * If it fails, returns a ModelService.ERROR_MESSAGE in the result
      * @param jwtToken The JWT which normally contains the userLoginId
      * @param key the secret key to decrypt the token
      * @return Map of name, value pairs composing the result
      */
     private static Map<String, Object> validateJwtToken(Delegator delegator, String jwtToken) {
-        Map<String, Object> result = validateToken(delegator, jwtToken);
+        Map<String, Object> result = validateAccessToken(delegator, jwtToken);
         if (result.containsKey(ModelService.ERROR_MESSAGE)) {
             // Something unexpected happened here
             Debug.logWarning("There was a problem with the JWT token, no single sign on user login possible.", MODULE);
@@ -492,6 +492,22 @@ public class JWTManager {
         Map<String, Object> claims = validateToken(delegator, refreshToken);
         if (!claims.containsKey("type") || !"refresh".equals(claims.get("type"))) {
             return ServiceUtil.returnError("Invalid refresh token.");
+        }
+        return claims;
+    }
+
+    /**
+     * Validates a JWT for use as an access credential, rejecting it if it is a refresh token.
+     * Refresh tokens are signed with the same key as access tokens but carry a much longer
+     * expiration, so they must never be accepted outside the dedicated refresh flow.
+     * @param delegator the delegator
+     * @param jwtToken the JWT to validate
+     * @return the token claims if it is a valid, non-refresh token, or an error entry otherwise
+     */
+    public static Map<String, Object> validateAccessToken(Delegator delegator, String jwtToken) {
+        Map<String, Object> claims = validateToken(delegator, jwtToken);
+        if (!claims.containsKey(ModelService.ERROR_MESSAGE) && "refresh".equals(claims.get("type"))) {
+            return ServiceUtil.returnError("Invalid access token.");
         }
         return claims;
     }

--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/TokenFilter.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/TokenFilter.java
@@ -63,7 +63,7 @@ public class TokenFilter implements Filter {
         String token = JWTManager.getHeaderAuthBearerToken(httpRequest);
 
         if (UtilValidate.isNotEmpty(token)) {
-            Map<String, Object> result = JWTManager.validateToken(delegator, token);
+            Map<String, Object> result = JWTManager.validateAccessToken(delegator, token);
             String userLoginId = (String) result.get("userLoginId");
             if (UtilValidate.isNotEmpty(result.get(ModelService.ERROR_MESSAGE))) {
                 httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);


### PR DESCRIPTION
createRefreshToken() signs refresh tokens with the same key as access tokens and a much longer expiration (24h vs 30min by default), but validateToken() never checked the "type" claim, so checkJWTLogin(), TokenFilter, and the REST API's APIAuthFilter all accepted a refresh token presented directly as a Bearer access credential, extending a leaked refresh token's usable window well beyond what the access-token lifetime is meant to allow. JWTManager.validateAccessToken() now rejects tokens with type: "refresh", and all three call sites use it instead of calling validateToken() directly. validateToken() and validateRefreshToken() are unchanged, so the refresh flow itself is unaffected.