### PR TITLE
Fixed: OFBizApplicationSecurity.hasRolePermission no longer treats an empty roles list as unrestricted access (OFBIZ-13495)

### DIFF
--- a/applications/securityext/src/main/java/org/apache/ofbiz/securityext/security/OFBizApplicationSecurity.java
+++ b/applications/securityext/src/main/java/org/apache/ofbiz/securityext/security/OFBizApplicationSecurity.java
@@ -185,7 +185,7 @@ public class OFBizApplicationSecurity implements Security {
         String entityName = null;
         EntityCondition condition = null;
         Map<String, String> simpleRoleMap = SIMPLE_ROLE_ENT.get(application);
-        if (simpleRoleMap != null && roles != null) {
+        if (simpleRoleMap != null && roles != null && !roles.isEmpty()) {
             entityName = simpleRoleMap.get("name");
             String pkey = simpleRoleMap.get("pkey");
             if (pkey != null) {


### PR DESCRIPTION
An empty (but non-null) roles list passed to OFBizApplicationSecurity.hasRolePermission caused EntityCondition to silently drop the empty OR-of-roleTypeId sub-condition instead of evaluating it as always-false, so a user holding only the scoped "_ROLE" permission (e.g. ORDERMGR_ROLE) could pass role-based access checks for any role instead of none, and this change guards the SIMPLE_ROLE_ENT condition-building with roles.isEmpty() so an empty list correctly denies role-based access while leaving the standard entity-permission fallback unaffected, closing a latent gap in the live production Security implementation even though no caller in the current codebase passes an empty roles list today.