### PR TITLE
Enabling the junit & integration test results history for few days. 

### DIFF
--- a/framework/testtools/config/testtools.properties
+++ b/framework/testtools/config/testtools.properties
@@ -22,13 +22,13 @@
 #    next run. Default: false - current behavior (no history; each run's output is simply
 #    overwritten in place, as it always has been). Same gradlew commands either way; only this
 #    setting changes.
-test.history=false
+test.history=true
 
 # -- Days to retain archived test-run history before the daily purge job removes it. Only read
 #    when test.history=true above. Uncomment and set an actual value (e.g. 7) to enable
 #    retention/purge; if test.history=true but this stays commented, history accumulates
 #    indefinitely until you set a number.
-#test.history.days=7
+test.history.days=7
 
 # -- Directory gradlew test's history is archived under, when test.history=true above. Relative
 #    paths resolve against the project root. Default (commented): build/test-reports-history - a


### PR DESCRIPTION
Enabling the junit & integration test results history for few days. 
It will help me in testing of this feature in trunk. I will disable it in near future.
