### PR TITLE
OFBIZ-12374: TaxAuthority lookup allows selecting parties without the TaxAuthority role

### DIFF
--- a/applications/accounting/webapp/accounting/WEB-INF/controller.xml
+++ b/applications/accounting/webapp/accounting/WEB-INF/controller.xml
@@ -2302,6 +2302,10 @@ under the License.
         <security auth="true" https="true"/>
         <response name="success" type="view" value="LookupSupplier"/>
     </request-map>
+    <request-map uri="LookupTaxAuthority">
+        <security auth="true" https="true"/>
+        <response name="success" type="view" value="LookupTaxAuthority"/>
+    </request-map>
     <request-map uri="depositWithdrawPayments">
         <security auth="true" https="true"/>
         <event type="service" invoke="depositWithdrawPayments"/>
@@ -2860,6 +2864,7 @@ under the License.
     <view-map name="PaymentsDepositWithdraw" type="screen" page="component://accounting/widget/FinAccountScreens.xml#PaymentsDepositWithdraw"/>
     <view-map name="LookupCustomerName" type="screen" page="component://party/widget/partymgr/LookupScreens.xml#LookupCustomerName"/>
     <view-map name="LookupSupplier" type="screen" page="component://party/widget/partymgr/LookupScreens.xml#LookupSupplier"/>
+    <view-map name="LookupTaxAuthority" type="screen" page="component://party/widget/partymgr/LookupScreens.xml#LookupTaxAuthority"/>
     <view-map name="NewDepositSlip" type="screen" page="component://accounting/widget/FinAccountScreens.xml#NewDepositSlip"/>
     <view-map name="InventoryValuation" type="screen" page="component://accounting/widget/ReportFinancialSummaryScreens.xml#InventoryValuation"/>
     <view-map name="InventoryValuationPdf" type="screenfop" page="component://accounting/widget/ReportFinancialSummaryScreens.xml#InventoryValuationPdf" content-type="application/pdf" encoding="none"/>

--- a/applications/accounting/widget/TaxAuthorityForms.xml
+++ b/applications/accounting/widget/TaxAuthorityForms.xml
@@ -48,8 +48,8 @@ under the License.
         <alt-target use-when="taxAuthority==null" target="createTaxAuthority"/>
         <auto-fields-service service-name="updateTaxAuthority" map-name="taxAuthority"/>
         <field use-when="taxAuthority!=null" name="taxAuthPartyId" title="${uiLabelMap.PartyParty}"><display/></field>
-        <field use-when="taxAuthority==null&amp;&amp;taxAuthPartyId==null" name="taxAuthPartyId" title="${uiLabelMap.PartyParty}" required-field="true"><lookup target-form-name="LookupPartyName"/></field>
-        <field use-when="taxAuthority==null&amp;&amp;taxAuthPartyId!=null" name="taxAuthPartyId" title="${uiLabelMap.PartyParty}" tooltip="${uiLabelMap.CommonCannotBeFound}:[${taxAuthPartyId}]"><lookup target-form-name="LookupPartyName"/></field>
+        <field use-when="taxAuthority==null&amp;&amp;taxAuthPartyId==null" name="taxAuthPartyId" title="${uiLabelMap.PartyParty}" required-field="true"><lookup target-form-name="LookupTaxAuthority"/></field>
+        <field use-when="taxAuthority==null&amp;&amp;taxAuthPartyId!=null" name="taxAuthPartyId" title="${uiLabelMap.PartyParty}" tooltip="${uiLabelMap.CommonCannotBeFound}:[${taxAuthPartyId}]"><lookup target-form-name="LookupTaxAuthority"/></field>
         <field use-when="taxAuthority!=null" name="taxAuthGeoId" title="${uiLabelMap.CommonGeo}"><display/></field>
         <field use-when="taxAuthority==null&amp;&amp;taxAuthGeoId==null" name="taxAuthGeoId" title="${uiLabelMap.CommonGeo}" required-field="true"><lookup target-form-name="LookupGeo"/></field>
         <field use-when="taxAuthority==null&amp;&amp;taxAuthGeoId!=null" name="taxAuthGeoId" title="${uiLabelMap.CommonGeo}" tooltip="${uiLabelMap.CommonCannotBeFound}:[${taxAuthGeoId}]"><lookup target-form-name="LookupGeo"/></field>

--- a/applications/party/widget/partymgr/LookupForms.xml
+++ b/applications/party/widget/partymgr/LookupForms.xml
@@ -467,6 +467,39 @@ under the License.
         <field name="lastName"  title="${uiLabelMap.PartyLastName}"><display/></field>
         <field name="groupName" title="${uiLabelMap.PartyGroupName}"><display/></field>
     </form>
+    <form name="LookupTaxAuthority" target="LookupTaxAuthority" type="single"
+          header-row-style="header-row" default-table-style="basic-table">
+        <field name="roleTypeId"><hidden value="TAX_AUTHORITY"/></field>
+        <field name="partyId" title="${uiLabelMap.PartyPartyId}"><text-find/></field>
+        <field name="partyTypeId" title="${uiLabelMap.PartyTypeId}">
+            <drop-down allow-empty="true">
+                <entity-options entity-name="PartyType"/>
+            </drop-down>
+        </field>
+        <field name="firstName" title="${uiLabelMap.PartyFirstName}"><text-find/></field>
+        <field name="lastName"  title="${uiLabelMap.PartyLastName}"><text-find/></field>
+        <field name="groupName" title="${uiLabelMap.PartyGroupName}"><text-find/></field>
+        <field name="noConditionFind"><hidden value="Y"/><!-- if this isn't there then with all fields empty no query will be done --></field>
+        <field name="submitButton" title="${uiLabelMap.CommonFind}"><submit button-type="button"/></field>
+    </form>
+    <form name="ListLookupTaxAuthority" type="list" list-name="listIt" paginate-target="LookupTaxAuthority"
+          odd-row-style="alternate-row" default-table-style="basic-table hover-bar">
+        <actions>
+            <set field="inputFields" from-field="parameters"/>
+            <set field="orderBy" value="partyId"/>
+            <set field="entityName" value="PartyRoleNameDetail"/>
+            <script location="component://party/src/main/groovy/org/apache/ofbiz/party/party/FindLookUp.groovy"/>
+        </actions>
+        <field name="partyId" title="${uiLabelMap.PartyPartyId}"  widget-style="smallSubmit">
+            <hyperlink description="${partyId}" target="javascript:set_value('${partyId}')" also-hidden="false" target-type="plain"/>
+        </field>
+        <field name="partyTypeId" title="${uiLabelMap.PartyTypeId}">
+            <display-entity also-hidden="false" entity-name="PartyType"/>
+        </field>
+        <field name="firstName" title="${uiLabelMap.PartyFirstName}"><display/></field>
+        <field name="lastName"  title="${uiLabelMap.PartyLastName}"><display/></field>
+        <field name="groupName" title="${uiLabelMap.PartyGroupName}"><display/></field>
+    </form>
     <form name="LookupEmployee" target="LookupEmployee" type="single"
         header-row-style="header-row" default-table-style="basic-table">
         <field name="roleTypeId"><hidden value="EMPLOYEE"/></field>

--- a/applications/party/widget/partymgr/LookupScreens.xml
+++ b/applications/party/widget/partymgr/LookupScreens.xml
@@ -488,6 +488,34 @@ under the License.
             </widgets>
         </section>
     </screen>
+    <screen name="LookupTaxAuthority">
+        <section>
+            <condition>
+                <if-service-permission service-name="partyBasePermissionCheck" main-action="VIEW"/>
+            </condition>
+            <actions>
+                <property-map resource="PartyUiLabels" map-name="uiLabelMap" global="true"/>
+                <set field="title" from-field="uiLabelMap.PartyLookupPartyByName"/>
+                <set field="queryString" from-field="result.queryString"/>
+                <set field="viewIndex" from-field="parameters.VIEW_INDEX" type="Integer" default-value="0"/>
+                <set field="viewSizeDefaultValue" value="${groovy: modelTheme.getDefaultViewSize()}" type="Integer"/>
+                <set field="viewSize" from-field="parameters.VIEW_SIZE" type="Integer" default-value="${viewSizeDefaultValue}"/>
+                <set field="entityName" value="PartyRoleNameDetail"/>
+                <set field="searchFields" value="[partyId, firstName, middleName, lastName, groupName]"/>
+                <set field="conditionFields.roleTypeId" value="TAX_AUTHORITY" />
+            </actions>
+            <widgets>
+                <decorator-screen name="LookupDecorator" location="component://common/widget/CommonScreens.xml">
+                    <decorator-section name="search-options">
+                        <include-form name="LookupTaxAuthority" location="component://party/widget/partymgr/LookupForms.xml"/>
+                    </decorator-section>
+                    <decorator-section name="search-results">
+                        <include-form name="ListLookupTaxAuthority" location="component://party/widget/partymgr/LookupForms.xml"/>
+                    </decorator-section>
+                </decorator-screen>
+            </widgets>
+        </section>
+    </screen>
     <screen name="LookupEmployee">
         <section>
             <condition>


### PR DESCRIPTION
### Jira ticket
https://issues.apache.org/jira/browse/OFBIZ-12374

### Purpose and Description
On the Create/Edit Tax Authority page (`accounting/control/createTaxAuthority`), the `taxAuthPartyId` field uses the generic `LookupPartyName` lookup form, which searches all parties regardless of role. Any party — not just ones holding the `TAX_AUTHORITY` `PartyRole` — can be selected and submitted, exactly as reported in OFBIZ-12374.

OFBiz already has an established pattern for this exact problem elsewhere in the same file set: `LookupSupplier` and `LookupGovernmentAgency` are role-scoped lookup forms/screens that restrict results to parties holding a specific role (`SUPPLIER`, `GOV_AGENCY` respectively), wired through `PartyRoleNameDetail`/`conditionFields.roleTypeId`. This PR adds the same pattern for `TAX_AUTHORITY`:

- `applications/party/widget/partymgr/LookupForms.xml`: new `LookupTaxAuthority` (search form) and `ListLookupTaxAuthority` (results form), mirroring `LookupSupplier`/`ListLookupSupplier` field-for-field, with a hidden `roleTypeId=TAX_AUTHORITY` filter.
- `applications/party/widget/partymgr/LookupScreens.xml`: new `LookupTaxAuthority` screen, mirroring the `LookupSupplier` screen's actions (`entityName=PartyRoleNameDetail`, `conditionFields.roleTypeId=TAX_AUTHORITY`).
- `applications/accounting/webapp/accounting/WEB-INF/controller.xml`: new `LookupTaxAuthority` request-map and view-map, mirroring the existing `LookupSupplier` entries.
- `applications/accounting/widget/TaxAuthorityForms.xml`: both `taxAuthPartyId` lookup fields on `EditTaxAuthority` now target `LookupTaxAuthority` instead of `LookupPartyName`.

I checked `createTaxAuthority` (`entity-auto`/`create` on the `TaxAuthority` entity) and confirmed it does not itself create a `PartyRole` — so this fix assumes, per the ticket description, that a party is first given the `TAX_AUTHORITY` role via the standard Party Manager Roles UI before being selectable here, which matches the reporter's expected behavior.

### Notes / limitations
I don't have a running OFBiz instance in this environment to exercise the lookup UI end-to-end, so this was verified by close reading against the live `LookupSupplier`/`LookupGovernmentAgency` precedent (same entity, same filtering mechanism, same controller wiring shape) rather than manual testing. Happy to adjust if a reviewer spots something that only shows up at runtime.

### Related issues
Note: OFBIZ-12370 (InvoiceRole), OFBIZ-12372 (BillingAccountRole), and OFBIZ-12373 (FinAccountRole) describe the same underlying pattern (unfiltered party lookup for a role-based field) in sibling areas. I scoped this PR to OFBIZ-12374 only; happy to follow up on the others if this approach looks right to a maintainer.

### Checklist
- [x] My code follows the code style of this project
- [x] My change requires changes to the documentation
- [ ] I have updated the documentation accordingly (n/a — no user-facing docs for this internal lookup form)
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my changes (no automated UI test coverage exists for the sibling `LookupSupplier`/`LookupGovernmentAgency` forms either; happy to add if there's a preferred pattern)