### PR TITLE
Fixed: error in creating category image content. (OFBIZ-12011)

### DIFF
--- a/applications/product/servicedef/services.xml
+++ b/applications/product/servicedef/services.xml
@@ -985,6 +985,7 @@ under the License.
         <auto-attributes include="nonpk" mode="IN" optional="true"/>
         <auto-attributes include="nonpk" mode="IN" entity-name="Content" optional="true"/>
         <attribute name="dataResourceTypeId" type="String" mode="IN" optional="true"/>
+        <override name="contentId" mode="INOUT"/>
         <override name="prodCatContentTypeId" optional="false"/>
     </service>
     <service name="updateDownloadContentForCategory" default-entity-name="ProductCategoryContent" engine="groovy"

--- a/applications/product/servicedef/services.xml
+++ b/applications/product/servicedef/services.xml
@@ -985,7 +985,7 @@ under the License.
         <auto-attributes include="nonpk" mode="IN" optional="true"/>
         <auto-attributes include="nonpk" mode="IN" entity-name="Content" optional="true"/>
         <attribute name="dataResourceTypeId" type="String" mode="IN" optional="true"/>
-        <override name="contentId" mode="INOUT"/>
+        <override name="contentId" mode="INOUT" optional="true"/>
         <override name="prodCatContentTypeId" optional="false"/>
     </service>
     <service name="updateDownloadContentForCategory" default-entity-name="ProductCategoryContent" engine="groovy"

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/product/category/CategoryContentServicesScript.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/product/category/CategoryContentServicesScript.groovy
@@ -24,6 +24,7 @@ import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.util.EntityUtil
 import org.apache.ofbiz.service.ModelService
+import org.apache.ofbiz.service.ServiceUtil
 
 /**
  * Create Content For Product Category
@@ -176,23 +177,33 @@ Map createDownloadContentForCategory() {
         uploadedFile: parameters.uploadedFile
     ]
     Map creDatRes = run service: 'createDataResource', with: data
+    if (!ServiceUtil.isSuccess(creDatRes)) {
+        return creDatRes
+    }
     parameters.dataResourceId = creDatRes.dataResourceId
     // create attach upload to data resource
     Map attachMap = dispatcher.getDispatchContext().makeValidContext('attachUploadToDataResource', ModelService.IN_PARAM, parameters)
-    attachMap = [
+    attachMap.putAll([
         uploadedFile: parameters.uploadedFile,
         _uploadedFile_fileName: parameters._uploadedFile_fileName,
         _uploadedFile_contentType: parameters._uploadedFile_contentType
-    ]
-    run service: 'attachUploadToDataResource', with: attachMap
+    ])
+    Map attachResult = run service: 'attachUploadToDataResource', with: attachMap
+    if (!ServiceUtil.isSuccess(attachResult)) {
+        return attachResult
+    }
     // create content from dataResource
     Map contentMap = dispatcher.getDispatchContext().makeValidContext('createContentFromDataResource', ModelService.IN_PARAM, parameters)
     contentMap.contentTypeId = 'DOCUMENT'
     Map creConRes = run service: 'createContentFromDataResource', with: contentMap
+    if (!ServiceUtil.isSuccess(creConRes)) {
+        return creConRes
+    }
     createCategoryContent.contentId = creConRes.contentId
 
-    createCategoryContent.contentId = parameters.contentId
-    run service: 'createCategoryContent', with: createCategoryContent
+    Map createCategoryResult = run service: 'createCategoryContent', with: createCategoryContent
+    createCategoryResult.contentId = creConRes.contentId
+    return createCategoryResult
 }
 
 /**

--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/product/category/CategoryContentServicesScript.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/product/category/CategoryContentServicesScript.groovy
@@ -202,6 +202,9 @@ Map createDownloadContentForCategory() {
     createCategoryContent.contentId = creConRes.contentId
 
     Map createCategoryResult = run service: 'createCategoryContent', with: createCategoryContent
+    if (!ServiceUtil.isSuccess(creConRes)) {
+        return createCategoryResult
+    }
     createCategoryResult.contentId = creConRes.contentId
     return createCategoryResult
 }

--- a/applications/product/widget/catalog/CategoryForms.xml
+++ b/applications/product/widget/catalog/CategoryForms.xml
@@ -299,7 +299,7 @@ under the License.
                 <parameter param-name="contentId"/>
             </hyperlink>
         </field>
-        <field name="imageData" title="${uiLabelMap.ProductFile}"><file/></field>
+        <field name="uploadedFile" title="${uiLabelMap.ProductFile}"><file/></field>
         <field name="fileDataResourceId"><hidden/></field>
         <field name="productCategoryId"><hidden/></field>
         <field name="prodCatContentTypeId"><hidden/></field>


### PR DESCRIPTION
Fixed: error in creating category image content
(OFBIZ-12011)

Explanation : the root cause was essentially a combination of incorrect parameter/field handling and missing ID propagation between the services involved in the category image upload process.

The fix ensures that the uploaded image is correctly received, its data resource is maintained, the generated content remains identifiable, and any service failure is properly surfaced

Thanks:
Aakash Jain for reporting the issue.