### PR TITLE
Enable REST API support in test cases in applications

### DIFF
--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgAdminTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgAdminTests.groovy
@@ -31,9 +31,11 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testGetFXConversion() {
+        String uomId = testParams.uomId ?: 'EUR'
+        String uomIdTo = testParams.uomIdTo ?: 'USD'
         Map serviceCtx = [
-                uomId: 'EUR',
-                uomIdTo: 'USD',
+                uomId: uomId,
+                uomIdTo: uomIdTo,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getFXConversion', serviceCtx)
@@ -43,37 +45,42 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testAddPaymentMethodTypeGlAssignment() {
+        String paymentMethodTypeId = testParams.paymentMethodTypeId ?: 'GIFT_CARD'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
+        String glAccountId = testParams.glAccountId ?: '999999'
         Map serviceCtx = [
-            paymentMethodTypeId: 'GIFT_CARD',
-            organizationPartyId: 'DEMO_COMPANY1',
-            glAccountId: '999999',
+            paymentMethodTypeId: paymentMethodTypeId,
+            organizationPartyId: organizationPartyId,
+            glAccountId: glAccountId,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('addPaymentMethodTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue paymentMethodTypeGlAccount = from('PaymentMethodTypeGlAccount')
-                .where('paymentMethodTypeId', 'GIFT_CARD',
-                        'organizationPartyId', 'DEMO_COMPANY1')
+                .where('paymentMethodTypeId', paymentMethodTypeId,
+                        'organizationPartyId', organizationPartyId)
                 .queryOne()
         assert paymentMethodTypeGlAccount
-        assert paymentMethodTypeGlAccount.glAccountId == '999999'
+        assert paymentMethodTypeGlAccount.glAccountId == glAccountId
     }
 
     @Test
     @Order(3)
     void testRemovePaymentTypeGlAssignment() {
+        String paymentTypeId = testParams.paymentTypeId ?: 'COMMISSION_PAYMENT'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
         Map serviceCtx = [
-                paymentTypeId: 'COMMISSION_PAYMENT',
-                organizationPartyId: 'DEMO_COMPANY1',
+                paymentTypeId: paymentTypeId,
+                organizationPartyId: organizationPartyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('removePaymentTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue paymentMethodTypeGlAccount = from('PaymentGlAccountTypeMap')
-                .where('paymentTypeId', 'COMMISSION_PAYMENT',
-                        'organizationPartyId', 'DEMO_COMPANY1')
+                .where('paymentTypeId', paymentTypeId,
+                        'organizationPartyId', organizationPartyId)
                 .queryOne()
         assert !paymentMethodTypeGlAccount
     }
@@ -81,45 +88,50 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testCreatePartyAcctgPreference() {
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        String refundPaymentMethodId = testParams.refundPaymentMethodId ?: '9020'
         Map serviceCtx = [
-                partyId: 'DEMO_COMPANY',
-                refundPaymentMethodId: '9020',
+                partyId: partyId,
+                refundPaymentMethodId: refundPaymentMethodId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyAcctgPreference', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyAcctgPreference = from('PartyAcctgPreference')
-                .where('partyId', 'DEMO_COMPANY')
+                .where('partyId', partyId)
                 .queryOne()
         assert partyAcctgPreference
-        assert partyAcctgPreference.partyId == 'DEMO_COMPANY'
-        assert partyAcctgPreference.refundPaymentMethodId == '9020'
+        assert partyAcctgPreference.partyId == partyId
+        assert partyAcctgPreference.refundPaymentMethodId == refundPaymentMethodId
     }
 
     @Test
     @Order(5)
     void testUpdatePartyAcctgPreference() {
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY1'
+        String refundPaymentMethodId = testParams.refundPaymentMethodId ?: '9020'
         Map serviceCtx = [
-                partyId: 'DEMO_COMPANY1',
-                refundPaymentMethodId: '9020',
+                partyId: partyId,
+                refundPaymentMethodId: refundPaymentMethodId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyAcctgPreference', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyAcctgPreference = from('PartyAcctgPreference')
-                .where('partyId', 'DEMO_COMPANY1')
+                .where('partyId', partyId)
                 .queryOne()
         assert partyAcctgPreference
-        assert partyAcctgPreference.refundPaymentMethodId == '9020'
+        assert partyAcctgPreference.refundPaymentMethodId == refundPaymentMethodId
     }
 
     @Test
     @Order(6)
     void testGetPartyAccountingPreferences() {
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
         Map serviceCtx = [
-                organizationPartyId: 'DEMO_COMPANY1',
+                organizationPartyId: organizationPartyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getPartyAccountingPreferences', serviceCtx)
@@ -130,15 +142,16 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testSetAcctgCompany() {
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
         Map serviceCtx = [
-                organizationPartyId: 'DEMO_COMPANY1',
+                organizationPartyId: organizationPartyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('setAcctgCompany', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue userPreference = from('UserPreference')
-                .where('userPrefValue', 'DEMO_COMPANY1')
+                .where('userPrefValue', organizationPartyId)
                 .queryFirst()
         assert userPreference
         assert userPreference.userPrefGroupTypeId == 'GLOBAL_PREFERENCES'
@@ -148,9 +161,11 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testUpdateFXConversion() {
+        String uomId = testParams.uomId ?: 'INR'
+        String uomIdTo = testParams.uomIdTo ?: 'USD'
         Map serviceCtx = [
-                uomId: 'INR',
-                uomIdTo: 'USD',
+                uomId: uomId,
+                uomIdTo: uomIdTo,
                 conversionFactor: 2.0,
                 userLogin: userLogin
         ]
@@ -158,7 +173,7 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue uomConversionDated = from('UomConversionDated')
-                .where('uomId', 'INR', 'uomIdTo', 'USD')
+                .where('uomId', uomId, 'uomIdTo', uomIdTo)
                 .queryFirst()
         assert uomConversionDated
         assert uomConversionDated.conversionFactor == 2.0
@@ -167,37 +182,43 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
     @Test
     @Order(9)
     void testCreateGlAccountTypeDefault() {
+        String glAccountTypeId = testParams.glAccountTypeId ?: 'BALANCE_ACCOUNT'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
+        String glAccountId = testParams.glAccountId ?: '999999'
         Map serviceCtx = [
-                glAccountTypeId: 'BALANCE_ACCOUNT',
-                organizationPartyId: 'DEMO_COMPANY1',
-                glAccountId: '999999',
+                glAccountTypeId: glAccountTypeId,
+                organizationPartyId: organizationPartyId,
+                glAccountId: glAccountId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createGlAccountTypeDefault', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue glAccountTypeDefault = from('GlAccountTypeDefault')
-                .where('glAccountTypeId', 'BALANCE_ACCOUNT', 'organizationPartyId', 'DEMO_COMPANY1')
+                .where('glAccountTypeId', glAccountTypeId, 'organizationPartyId', organizationPartyId)
                 .queryOne()
         assert glAccountTypeDefault
-        assert glAccountTypeDefault.glAccountId == '999999'
+        assert glAccountTypeDefault.glAccountId == glAccountId
     }
 
     @Test
     @Order(10)
     void testRemoveGlAccountTypeDefault() {
+        String glAccountTypeId = testParams.glAccountTypeId ?: 'ACCOUNTS_PAYABLE'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
+        String glAccountId = testParams.glAccountId ?: '999999'
         Map serviceCtx = [
-                glAccountTypeId: 'ACCOUNTS_PAYABLE',
-                organizationPartyId: 'DEMO_COMPANY1',
-                glAccountId: '999999',
+                glAccountTypeId: glAccountTypeId,
+                organizationPartyId: organizationPartyId,
+                glAccountId: glAccountId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('removeGlAccountTypeDefault', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue glAccountTypeDefault = from('GlAccountTypeDefault')
-                .where('glAccountTypeId', 'ACCOUNTS_PAYABLE',
-                        'organizationPartyId', 'DEMO_COMPANY1')
+                .where('glAccountTypeId', glAccountTypeId,
+                        'organizationPartyId', organizationPartyId)
                 .queryOne()
         assert !glAccountTypeDefault
     }
@@ -205,37 +226,42 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
     @Test
     @Order(11)
     void testAddInvoiceItemTypeGlAssignment() {
+        String invoiceItemTypeId = testParams.invoiceItemTypeId ?: 'PINV_FPROD_ITEM'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
+        String glAccountId = testParams.glAccountId ?: '999999'
         Map serviceCtx = [
-                invoiceItemTypeId: 'PINV_FPROD_ITEM',
-                organizationPartyId: 'DEMO_COMPANY1',
-                glAccountId: '999999',
+                invoiceItemTypeId: invoiceItemTypeId,
+                organizationPartyId: organizationPartyId,
+                glAccountId: glAccountId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('addInvoiceItemTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue invoiceItemTypeGlAccount = from('InvoiceItemTypeGlAccount')
-                .where('invoiceItemTypeId', 'PINV_FPROD_ITEM',
-                        'organizationPartyId', 'DEMO_COMPANY1')
+                .where('invoiceItemTypeId', invoiceItemTypeId,
+                        'organizationPartyId', organizationPartyId)
                 .queryOne()
         assert invoiceItemTypeGlAccount
-        assert invoiceItemTypeGlAccount.glAccountId == '999999'
+        assert invoiceItemTypeGlAccount.glAccountId == glAccountId
     }
 
     @Test
     @Order(12)
     void testRemoveInvoiceItemTypeGlAssignment() {
+        String invoiceItemTypeId = testParams.invoiceItemTypeId ?: 'PINV_SALES_TAX'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
         Map serviceCtx = [
-                invoiceItemTypeId: 'PINV_SALES_TAX',
-                organizationPartyId: 'DEMO_COMPANY1',
+                invoiceItemTypeId: invoiceItemTypeId,
+                organizationPartyId: organizationPartyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('removeInvoiceItemTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue invoiceItemTypeGlAccount = from('InvoiceItemTypeGlAccount')
-                .where('invoiceItemTypeId', 'PINV_SALES_TAX',
-                        'organizationPartyId', 'DEMO_COMPANY1')
+                .where('invoiceItemTypeId', invoiceItemTypeId,
+                        'organizationPartyId', organizationPartyId)
                 .queryOne()
         assert !invoiceItemTypeGlAccount
     }
@@ -243,37 +269,42 @@ class AutoAcctgAdminTests implements JupiterTestHelper {
     @Test
     @Order(13)
     void testAddPaymentTypeGlAssignment() {
+        String paymentTypeId = testParams.paymentTypeId ?: 'TAX_PAYMENT'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
+        String glAccountTypeId = testParams.glAccountTypeId ?: 'TAX_ACCOUNT'
         Map serviceCtx = [
-                paymentTypeId: 'TAX_PAYMENT',
-                organizationPartyId: 'DEMO_COMPANY1',
-                glAccountTypeId: 'TAX_ACCOUNT',
+                paymentTypeId: paymentTypeId,
+                organizationPartyId: organizationPartyId,
+                glAccountTypeId: glAccountTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('addPaymentTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue paymentGlAccountTypeMap = from('PaymentGlAccountTypeMap')
-                .where('paymentTypeId', 'TAX_PAYMENT',
-                        'organizationPartyId', 'DEMO_COMPANY1')
+                .where('paymentTypeId', paymentTypeId,
+                        'organizationPartyId', organizationPartyId)
                 .queryOne()
         assert paymentGlAccountTypeMap
-        assert paymentGlAccountTypeMap.glAccountTypeId == 'TAX_ACCOUNT'
+        assert paymentGlAccountTypeMap.glAccountTypeId == glAccountTypeId
     }
 
     @Test
     @Order(14)
     void testRemovePaymentMethodTypeGlAssignment() {
+        String paymentMethodTypeId = testParams.paymentMethodTypeId ?: 'CASH'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY1'
         Map serviceCtx = [
-                paymentMethodTypeId: 'CASH',
-                organizationPartyId: 'DEMO_COMPANY1',
+                paymentMethodTypeId: paymentMethodTypeId,
+                organizationPartyId: organizationPartyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('removePaymentMethodTypeGlAssignment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue paymentMethodTypeGlAccount = from('PaymentMethodTypeGlAccount')
-                .where('paymentMethodTypeId', 'CASH',
-                        'organizationPartyId', 'DEMO_COMPANY1')
+                .where('paymentMethodTypeId', paymentMethodTypeId,
+                        'organizationPartyId', organizationPartyId)
                 .queryOne()
         assert !paymentMethodTypeGlAccount
     }

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgAgreementTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgAgreementTests.groovy
@@ -31,15 +31,16 @@ class AutoAcctgAgreementTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testAddPaymentMethodTypeGlAssignment() {
+        String agreementId = testParams.agreementId ?: '1000'
         Map serviceCtx = [
-                agreementId: '1000',
+                agreementId: agreementId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('expireAgreement', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue agreement = from('Agreement')
-                .where('agreementId', '1000')
+                .where('agreementId', agreementId)
                 .filterByDate()
                 .queryOne()
         assert agreement == null
@@ -48,10 +49,13 @@ class AutoAcctgAgreementTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testCopyAgreement() {
+        String agreementId = testParams.agreementId ?: '1010'
+        String copyAgreementTerms = testParams.copyAgreementTerms ?: 'N'
+        String copyAgreementProducts = testParams.copyAgreementProducts ?: 'Y'
         Map serviceCtx = [
-                agreementId: '1010',
-                copyAgreementTerms: 'N',
-                copyAgreementProducts: 'Y',
+                agreementId: agreementId,
+                copyAgreementTerms: copyAgreementTerms,
+                copyAgreementProducts: copyAgreementProducts,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('copyAgreement', serviceCtx)
@@ -73,10 +77,13 @@ class AutoAcctgAgreementTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testGetCommissionForProduct() {
+        String productId = testParams.productId ?: 'TestProduct2'
+        String invoiceItemSeqId = testParams.invoiceItemSeqId ?: 'COMM_INV_ITEM'
+        String invoiceItemTypeId = testParams.invoiceItemTypeId ?: 'COMM_INV_ITEM'
         Map serviceCtx = [
-                productId: 'TestProduct2',
-                invoiceItemSeqId: 'COMM_INV_ITEM',
-                invoiceItemTypeId: 'COMM_INV_ITEM',
+                productId: productId,
+                invoiceItemSeqId: invoiceItemSeqId,
+                invoiceItemTypeId: invoiceItemTypeId,
                 amount: 100.00,
                 userLogin: userLogin
         ]

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBudgetTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBudgetTests.groovy
@@ -31,31 +31,35 @@ class AutoAcctgBudgetTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateBudget() {
+        String budgetTypeId = testParams.budgetTypeId ?: 'CAPITAL_BUDGET'
+        String comments = testParams.comments ?: 'Capital Budget'
         Map serviceCtx = [:]
-        serviceCtx.budgetTypeId = 'CAPITAL_BUDGET'
-        serviceCtx.comments = 'Capital Budget'
+        serviceCtx.budgetTypeId = budgetTypeId
+        serviceCtx.comments = comments
         serviceCtx.userLogin = userLogin
         Map result = dispatcher.runSync('createBudget', serviceCtx)
         assert ServiceUtil.isSuccess(result)
 
         GenericValue budget = from('Budget').where(result).queryOne()
         assert budget
-        assert budget.budgetTypeId == 'CAPITAL_BUDGET'
-        assert budget.comments == 'Capital Budget'
+        assert budget.budgetTypeId == budgetTypeId
+        assert budget.comments == comments
     }
 
     @Test
     @Order(2)
     void testUpdateBudgetStatus() {
+        String budgetId = testParams.budgetId ?: '9999'
+        String statusId = testParams.statusId ?: 'BG_APPROVED'
         Map serviceCtx = [:]
-        serviceCtx.budgetId = '9999'
-        serviceCtx.statusId = 'BG_APPROVED'
+        serviceCtx.budgetId = budgetId
+        serviceCtx.statusId = statusId
         serviceCtx.userLogin = userLogin
         dispatcher.runSync('updateBudgetStatus', serviceCtx)
 
-        List<GenericValue> budgetStatuses = from('BudgetStatus').where('budgetId', '9999').orderBy('-statusDate').queryList()
+        List<GenericValue> budgetStatuses = from('BudgetStatus').where('budgetId', budgetId).orderBy('-statusDate').queryList()
         assert ! budgetStatuses?.isEmpty()
-        assert budgetStatuses[0].statusId == 'BG_APPROVED'
+        assert budgetStatuses[0].statusId == statusId
     }
 
 }

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgCostTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgCostTests.groovy
@@ -31,17 +31,20 @@ class AutoAcctgCostTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testUpdateProductAverageCostOnReceiveInventory() {
+        String facilityId = testParams.facilityId ?: 'DemoFacility1'
+        String productId = testParams.productId ?: 'TestProduct3'
+        String inventoryItemId = testParams.inventoryItemId ?: '9999'
         Map serviceCtx = [:]
-        serviceCtx.facilityId = 'DemoFacility1'
+        serviceCtx.facilityId = facilityId
         serviceCtx.quantityAccepted = new BigDecimal('10')
-        serviceCtx.productId = 'TestProduct3'
-        serviceCtx.inventoryItemId = '9999'
+        serviceCtx.productId = productId
+        serviceCtx.inventoryItemId = inventoryItemId
         serviceCtx.userLogin = userLogin
         Map result = dispatcher.runSync('updateProductAverageCostOnReceiveInventory', serviceCtx)
         assert ServiceUtil.isSuccess(result)
 
         GenericValue productAverageCost = from('ProductAverageCost').filterByDate()
-                                .where('productId', 'TestProduct3', 'facilityId', 'DemoFacility1').queryFirst()
+                                .where('productId', productId, 'facilityId', facilityId).queryFirst()
         assert productAverageCost
         assert productAverageCost.productAverageCostTypeId == 'SIMPLE_AVG_COST'
         assert productAverageCost.averageCost == 9

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFinAccountTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFinAccountTests.groovy
@@ -32,55 +32,61 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateFinAccount() {
+        String finAccountId = testParams.finAccountId ?: '1000'
+        String finAccountTypeId = testParams.finAccountTypeId ?: 'BANK_ACCOUNT'
+        String finAccountCode = testParams.finAccountCode ?: '1000'
         Map serviceCtx = [
-                finAccountId: '1000',
-                finAccountTypeId: 'BANK_ACCOUNT',
-                finAccountName: 'Bank Account',
-                finAccountCode: '1000',
-                currencyUomId: 'USD',
-                organizationPartyId: 'DEMO_COMPANY',
+                finAccountId: finAccountId,
+                finAccountTypeId: finAccountTypeId,
+                finAccountName: testParams.finAccountName ?: 'Bank Account',
+                finAccountCode: finAccountCode,
+                currencyUomId: testParams.currencyUomId ?: 'USD',
+                organizationPartyId: testParams.organizationPartyId ?: 'DEMO_COMPANY',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createFinAccount', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue finAccount = from('FinAccount')
-                                    .where('finAccountId', '1000', 'finAccountTypeId', 'BANK_ACCOUNT')
+                                    .where('finAccountId', finAccountId, 'finAccountTypeId', finAccountTypeId)
                                     .queryOne()
         assert finAccount
-        assert finAccount.finAccountCode == '1000'
+        assert finAccount.finAccountCode == finAccountCode
     }
 
     @Test
     @Order(2)
     void testUpdateFinAccount() {
+        String finAccountId = testParams.finAccountId ?: '1001'
+        String organizationPartyId = testParams.organizationPartyId ?: 'DEMO_COMPANY2'
         Map serviceCtx = [
-                finAccountId: '1001',
-                organizationPartyId: 'DEMO_COMPANY2',
+                finAccountId: finAccountId,
+                organizationPartyId: organizationPartyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateFinAccount', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue finAccount = from('FinAccount')
-                .where('finAccountId', '1001')
+                .where('finAccountId', finAccountId)
                 .queryOne()
         assert finAccount
-        assert finAccount.organizationPartyId == 'DEMO_COMPANY2'
+        assert finAccount.organizationPartyId == organizationPartyId
     }
 
     @Test
     @Order(3)
     void testDeleteFinAccount() {
+        String finAccountId = testParams.finAccountId ?: '1002'
         Map serviceCtx = [
-                finAccountId: '1002',
+                finAccountId: finAccountId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('deleteFinAccount', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue finAccount = from('FinAccount')
-                .where('finAccountId', '1002')
+                .where('finAccountId', finAccountId)
                 .queryOne()
         assert finAccount.thruDate != null
     }
@@ -88,19 +94,22 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testCreateFinAccountRole() {
+        String finAccountId = testParams.finAccountId ?: '1003'
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        String roleTypeId = testParams.roleTypeId ?: 'INTERNAL_ORGANIZATIO'
         Map serviceCtx = [
-                finAccountId: '1003',
-                partyId: 'DEMO_COMPANY',
-                roleTypeId: 'INTERNAL_ORGANIZATIO',
+                finAccountId: finAccountId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 fromDate: UtilDateTime.nowTimestamp(),
-                currencyUomId: 'USD',
+                currencyUomId: testParams.currencyUomId ?: 'USD',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createFinAccountRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue finAccountRole = from('FinAccountRole')
-                .where('finAccountId', '1003', 'partyId', 'DEMO_COMPANY', 'roleTypeId', 'INTERNAL_ORGANIZATIO')
+                .where('finAccountId', finAccountId, 'partyId', partyId, 'roleTypeId', roleTypeId)
                 .queryFirst()
         assert finAccountRole
     }
@@ -108,10 +117,13 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testUpdateFinAccountRole() {
+        String finAccountId = testParams.finAccountId ?: '1004'
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        String roleTypeId = testParams.roleTypeId ?: 'SUPPLIER'
         Map serviceCtx = [
-                finAccountId: '1004',
-                partyId: 'DEMO_COMPANY',
-                roleTypeId: 'SUPPLIER',
+                finAccountId: finAccountId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 fromDate: UtilDateTime.toTimestamp('11/03/2016 00:00:00'),
                 thruDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
@@ -120,7 +132,7 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue finAccountRole = from('FinAccountRole')
-                .where('finAccountId', '1004', 'partyId', 'DEMO_COMPANY', 'roleTypeId', 'SUPPLIER')
+                .where('finAccountId', finAccountId, 'partyId', partyId, 'roleTypeId', roleTypeId)
                 .queryFirst()
         assert finAccountRole
         assert finAccountRole.thruDate != null
@@ -129,10 +141,13 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testDeleteFinAccountRole() {
+        String finAccountId = testParams.finAccountId ?: '1004'
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        String roleTypeId = testParams.roleTypeId ?: 'SUPPLIER'
         Map serviceCtx = [
-                finAccountId: '1004',
-                partyId: 'DEMO_COMPANY',
-                roleTypeId: 'SUPPLIER',
+                finAccountId: finAccountId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 fromDate: UtilDateTime.toTimestamp('11/03/2016 00:00:00'),
                 userLogin: userLogin
         ]
@@ -140,7 +155,7 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue finAccountRole = from('FinAccountRole')
-                .where('finAccountId', '1004', 'partyId', 'DEMO_COMPANY', 'roleTypeId', 'SUPPLIER')
+                .where('finAccountId', finAccountId, 'partyId', partyId, 'roleTypeId', roleTypeId)
                 .queryFirst()
         assert finAccountRole == null
     }
@@ -148,16 +163,18 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testCreateFinAccountTrans() {
+        String finAccountId = testParams.finAccountId ?: '1003'
+        String finAccountTransTypeId = testParams.finAccountTransTypeId ?: 'ADJUSTMENT'
         Map serviceCtx = [
-                finAccountId: '1003',
-                finAccountTransTypeId: 'ADJUSTMENT',
+                finAccountId: finAccountId,
+                finAccountTransTypeId: finAccountTransTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createFinAccountTrans', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue finAccountTran = from('FinAccountTrans')
-                .where('finAccountId', '1003', 'finAccountTransTypeId', 'ADJUSTMENT')
+                .where('finAccountId', finAccountId, 'finAccountTransTypeId', finAccountTransTypeId)
                 .queryFirst()
         assert finAccountTran
     }
@@ -165,9 +182,11 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testCreateFinAccountStatus() {
+        String finAccountId = testParams.finAccountId ?: '1003'
+        String statusId = testParams.statusId ?: 'FNACT_ACTIVE'
         Map serviceCtx = [
-                finAccountId: '1003',
-                statusId: 'FNACT_ACTIVE',
+                finAccountId: finAccountId,
+                statusId: statusId,
                 statusDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -175,7 +194,7 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue finAccountStatus = from('FinAccountStatus')
-                .where('finAccountId', '1003', 'statusId', 'FNACT_ACTIVE')
+                .where('finAccountId', finAccountId, 'statusId', statusId)
                 .queryFirst()
         assert finAccountStatus
     }
@@ -183,10 +202,12 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     @Test
     @Order(9)
     void testCreateFinAccountAuth() {
+        String finAccountId = testParams.finAccountId ?: '1004'
+        String currencyUomId = testParams.currencyUomId ?: 'USD'
         Map serviceCtx = [
-                finAccountId: '1004',
+                finAccountId: finAccountId,
                 amount: new BigDecimal('100'),
-                currencyUomId: 'USD',
+                currencyUomId: currencyUomId,
                 authorizationDate: UtilDateTime.nowTimestamp(),
                 fromDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
@@ -199,13 +220,15 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testSetFinAccountTransStatus() {
+        String finAccountTransId = testParams.finAccountTransId ?: '1010'
+        String statusId = testParams.statusId ?: 'FINACT_TRNS_APPROVED'
         Map serviceCtx = [
-                finAccountTransId: '1010',
-                statusId: 'FINACT_TRNS_APPROVED',
+                finAccountTransId: finAccountTransId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         GenericValue finAccountTrans = from('FinAccountTrans')
-                .where('finAccountTransId', '1010')
+                .where('finAccountTransId', finAccountTransId)
                 .queryOne()
         String oldStatusId = finAccountTrans.statusId
 
@@ -213,10 +236,10 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         finAccountTrans = from('FinAccountTrans')
-                .where('finAccountTransId', '1010')
+                .where('finAccountTransId', finAccountTransId)
                 .queryOne()
         assert finAccountTrans
-        assert finAccountTrans.statusId == 'FINACT_TRNS_APPROVED'
+        assert finAccountTrans.statusId == statusId
         assert oldStatusId == 'FINACT_TRNS_CREATED'
     }
 

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFixedAssetTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFixedAssetTests.groovy
@@ -32,16 +32,17 @@ class AutoAcctgFixedAssetTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateFixedAssetMaint() {
+        String fixedAssetId = testParams.fixedAssetId ?: '1000'
         Map serviceCtx = [
-                fixedAssetId: '1000',
-                statusId: 'FAM_CREATED',
+                fixedAssetId: fixedAssetId,
+                statusId: testParams.statusId ?: 'FAM_CREATED',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createFixedAssetMaint', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetMaint = from('FixedAssetMaint')
-                .where('fixedAssetId', '1000')
+                .where('fixedAssetId', fixedAssetId)
                 .queryFirst()
 
         assert fixedAssetMaint
@@ -51,9 +52,11 @@ class AutoAcctgFixedAssetTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testCreateFixedAssetMeter() {
+        String fixedAssetId = testParams.fixedAssetId ?: '1000'
+        String productMeterTypeId = testParams.productMeterTypeId ?: 'DISTANCE'
         Map serviceCtx = [
-                   fixedAssetId: '1000',
-                   productMeterTypeId: 'DISTANCE',
+                   fixedAssetId: fixedAssetId,
+                   productMeterTypeId: productMeterTypeId,
                    readingDate: UtilDateTime.nowTimestamp(),
                    meterValue: new BigDecimal('10'),
                    userLogin: userLogin
@@ -61,7 +64,7 @@ class AutoAcctgFixedAssetTests implements JupiterTestHelper {
         Map serviceResult = dispatcher.runSync('createFixedAssetMeter', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         GenericValue fixedAssetMeter = from('FixedAssetMeter')
-                       .where('fixedAssetId', '1000', 'productMeterTypeId', 'DISTANCE')
+                       .where('fixedAssetId', fixedAssetId, 'productMeterTypeId', productMeterTypeId)
                        .queryFirst()
         assert fixedAssetMeter
         assert fixedAssetMeter.meterValue == BigDecimal.TEN
@@ -70,9 +73,11 @@ class AutoAcctgFixedAssetTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testCancelFixedAssetStdCost() {
+        String fixedAssetId = testParams.fixedAssetId ?: '1000'
+        String fixedAssetStdCostTypeId = testParams.fixedAssetStdCostTypeId ?: 'SETUP_COST'
         Map serviceCtx = [
-                        fixedAssetId: '1000',
-                        fixedAssetStdCostTypeId: 'SETUP_COST',
+                        fixedAssetId: fixedAssetId,
+                        fixedAssetStdCostTypeId: fixedAssetStdCostTypeId,
                         fromDate: UtilDateTime.toTimestamp('11/03/2016 00:00:00'),
                         userLogin: userLogin
         ]
@@ -80,7 +85,9 @@ class AutoAcctgFixedAssetTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetStdCost = from('FixedAssetStdCost')
-                .where('fixedAssetId', '1000', 'fixedAssetStdCostTypeId', 'SETUP_COST', 'fromDate', UtilDateTime.toTimestamp('11/03/2016 00:00:00'))
+                .where('fixedAssetId', fixedAssetId,
+                       'fixedAssetStdCostTypeId', fixedAssetStdCostTypeId,
+                       'fromDate', UtilDateTime.toTimestamp('11/03/2016 00:00:00'))
                 .queryFirst()
 
         assert fixedAssetStdCost

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgInvoiceTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgInvoiceTests.groovy
@@ -35,9 +35,9 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Order(1)
     void testCreateInvoiceContent() {
         Map serviceCtx = [
-            invoiceId: '1008',
-            contentId: '1000',
-            invoiceContentTypeId: 'COMMENTS',
+            invoiceId: testParams.invoiceId ?: '1008',
+            contentId: testParams.contentId ?: '1000',
+            invoiceContentTypeId: testParams.invoiceContentTypeId ?: 'COMMENTS',
             fromDate: UtilDateTime.nowTimestamp(),
             userLogin: userLogin
         ]
@@ -55,11 +55,13 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testCreateSimpleTextContentForInvoice() {
+        String invoiceId = testParams.invoiceId ?: '1009'
+        String invoiceContentTypeId = testParams.invoiceContentTypeId ?: 'COMMENTS'
         Map serviceCtx = [
-                invoiceId: '1009',
-                contentTypeId: 'DOCUMENT',
-                invoiceContentTypeId: 'COMMENTS',
-                text: 'Content for invoice # 1009',
+                invoiceId: invoiceId,
+                contentTypeId: testParams.contentTypeId ?: 'DOCUMENT',
+                invoiceContentTypeId: invoiceContentTypeId,
+                text: testParams.text ?: 'Content for invoice # 1009',
                 fromDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -67,8 +69,8 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue invoiceContent = from('InvoiceContent')
-                .where('invoiceId', '1009',
-                'invoiceContentTypeId', 'COMMENTS')
+                .where('invoiceId', invoiceId,
+                'invoiceContentTypeId', invoiceContentTypeId)
                 .queryFirst()
 
         assert invoiceContent
@@ -78,7 +80,7 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Order(3)
     void testCopyInvoice() {
         Map serviceCtx = [
-                invoiceIdToCopyFrom: '1000',
+                invoiceIdToCopyFrom: testParams.invoiceIdToCopyFrom ?: '1000',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('copyInvoice', serviceCtx)
@@ -91,9 +93,9 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Order(4)
     void testCreateInvoice() {
         Map serviceCtx = [
-                invoiceTypeId: 'PURCHASE_INVOICE',
-                partyIdFrom: 'DEMO_COMPANY',
-                partyId: 'DEMO_COMPANY1',
+                invoiceTypeId: testParams.invoiceTypeId ?: 'PURCHASE_INVOICE',
+                partyIdFrom: testParams.partyIdFrom ?: 'DEMO_COMPANY',
+                partyId: testParams.partyId ?: 'DEMO_COMPANY1',
                 invoiceDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -107,7 +109,7 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Order(5)
     void testGetInvoice() {
         Map serviceCtx = [
-                invoiceId: '1001',
+                invoiceId: testParams.invoiceId ?: '1001',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getInvoice', serviceCtx)
@@ -120,28 +122,30 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testSetInvoiceStatus() {
+        String invoiceId = testParams.invoiceId ?: '1002'
+        String statusId = testParams.statusId ?: 'INVOICE_APPROVED'
         Map serviceCtx = [
-                invoiceId: '1002',
-                statusId: 'INVOICE_APPROVED',
+                invoiceId: invoiceId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('setInvoiceStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue invoice = from('Invoice')
-                .where('invoiceId', '1002')
+                .where('invoiceId', invoiceId)
                 .queryOne()
 
         assert invoice
-        assert invoice.statusId == 'INVOICE_APPROVED'
+        assert invoice.statusId == statusId
     }
 
     @Test
     @Order(7)
     void testCopyInvoiceToTemplate() {
         Map serviceCtx = [
-                invoiceId: '1002',
-                invoiceTypeId: 'PURCHASE_INVOICE',
+                invoiceId: testParams.invoiceId ?: '1002',
+                invoiceTypeId: testParams.invoiceTypeId ?: 'PURCHASE_INVOICE',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('copyInvoiceToTemplate', serviceCtx)
@@ -154,8 +158,8 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Order(8)
     void testCreateInvoiceItem() {
         Map serviceCtx = [
-                invoiceId: '1003',
-                invoiceItemTypeId: 'PINV_FXASTPRD_ITEM',
+                invoiceId: testParams.invoiceId ?: '1003',
+                invoiceItemTypeId: testParams.invoiceItemTypeId ?: 'PINV_FXASTPRD_ITEM',
                 amount: 1,
                 userLogin: userLogin
         ]
@@ -169,9 +173,11 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Order(9)
     void testCreateInvoiceStatus() {
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
+        String invoiceId = testParams.invoiceId ?: '1004'
+        String statusId = testParams.statusId ?: 'INVOICE_IN_PROCESS'
         Map serviceCtx = [
-                invoiceId: '1004',
-                statusId: 'INVOICE_IN_PROCESS',
+                invoiceId: invoiceId,
+                statusId: statusId,
                 statusDate: nowTimestamp,
                 userLogin: userLogin
         ]
@@ -179,8 +185,8 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue invoiceStatus = from('InvoiceStatus')
-                .where('invoiceId', '1004',
-                        'statusId', 'INVOICE_IN_PROCESS',
+                .where('invoiceId', invoiceId,
+                        'statusId', statusId,
                         'statusDate', nowTimestamp)
                 .queryOne()
 
@@ -190,19 +196,22 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testCreateInvoiceRole() {
+        String invoiceId = testParams.invoiceId ?: '1006'
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        String roleTypeId = testParams.roleTypeId ?: 'INTERNAL_ORGANIZATIO'
         Map serviceCtx = [
-                invoiceId: '1006',
-                partyId: 'DEMO_COMPANY',
-                roleTypeId: 'INTERNAL_ORGANIZATIO',
+                invoiceId: invoiceId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createInvoiceRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue invoiceRole = from('InvoiceRole')
-                .where('invoiceId', '1006',
-                        'partyId', 'DEMO_COMPANY',
-                        'roleTypeId', 'INTERNAL_ORGANIZATIO')
+                .where('invoiceId', invoiceId,
+                        'partyId', partyId,
+                        'roleTypeId', roleTypeId)
                 .queryOne()
 
         assert invoiceRole
@@ -212,9 +221,9 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Order(11)
     void testCreateInvoiceTerm() {
         Map serviceCtx = [
-                invoiceId: '1006',
-                invoiceItemSeqId: '00001',
-                termTypeId: 'FINANCIAL_TERM',
+                invoiceId: testParams.invoiceId ?: '1006',
+                invoiceItemSeqId: testParams.invoiceItemSeqId ?: '00001',
+                termTypeId: testParams.termTypeId ?: 'FINANCIAL_TERM',
                 termValue: 50.00,
                 termDays: 10,
                 userLogin: userLogin
@@ -233,7 +242,7 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     @Order(12)
     void testCancelInvoice() {
         Map serviceCtx = [
-                invoiceId: '1007',
+                invoiceId: testParams.invoiceId ?: '1007',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('cancelInvoice', serviceCtx)

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgLedgerTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgLedgerTests.groovy
@@ -32,31 +32,33 @@ class AutoAcctgLedgerTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateAcctgTrans() {
+        String acctgTransTypeId = testParams.acctgTransTypeId ?: 'CREDIT_MEMO'
         Map serviceCtx = [:]
-        serviceCtx.acctgTransTypeId = 'CREDIT_MEMO'
-        serviceCtx.description = 'Test Credit Memo Transaction'
+        serviceCtx.acctgTransTypeId = acctgTransTypeId
+        serviceCtx.description = testParams.description ?: 'Test Credit Memo Transaction'
         serviceCtx.transactionDate = UtilDateTime.nowTimestamp()
-        serviceCtx.glFiscalTypeId = 'BUDGET'
+        serviceCtx.glFiscalTypeId = testParams.glFiscalTypeId ?: 'BUDGET'
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createAcctgTrans', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue acctgTrans = from('AcctgTrans').where('acctgTransId', serviceResult.acctgTransId).queryOne()
         assert acctgTrans.acctgTransId == serviceResult.acctgTransId
-        assert acctgTrans.acctgTransTypeId == 'CREDIT_MEMO'
+        assert acctgTrans.acctgTransTypeId == acctgTransTypeId
     }
     @Test
     @Order(2)
     void testCreateAcctgTransEntry() {
+        String acctgTransId = testParams.acctgTransId ?: '1000'
         Map serviceCtx = [
-            acctgTransId: '1000',
-            organizationPartyId: 'DEMO_COMPANY',
-            debitCreditFlag: 'C',
+            acctgTransId: acctgTransId,
+            organizationPartyId: testParams.organizationPartyId ?: 'DEMO_COMPANY',
+            debitCreditFlag: testParams.debitCreditFlag ?: 'C',
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createAcctgTransEntry', serviceCtx)
         GenericValue acctgTransEntry = from('AcctgTransEntry')
-                .where('acctgTransId', '1000', 'acctgTransEntrySeqId', serviceResult.acctgTransEntrySeqId).queryOne()
+                .where('acctgTransId', acctgTransId, 'acctgTransEntrySeqId', serviceResult.acctgTransEntrySeqId).queryOne()
         assert acctgTransEntry != null
     }
 

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgPaymentGatewayTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgPaymentGatewayTests.groovy
@@ -29,16 +29,18 @@ class AutoAcctgPaymentGatewayTests implements JupiterTestHelper {
 
     @Test
     void testUpdatePaymentGatewayConfig() {
+        String paymentGatewayConfigId = testParams.paymentGatewayConfigId ?: 'TEST_GATEWAY_CONFIG'
+        String description = testParams.description ?: 'Test Payment Gateway Config Id'
         Map serviceCtx = [:]
-        serviceCtx.paymentGatewayConfigId = 'TEST_GATEWAY_CONFIG'
-        serviceCtx.description = 'Test Payment Gateway Config Id'
+        serviceCtx.paymentGatewayConfigId = paymentGatewayConfigId
+        serviceCtx.description = description
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('updatePaymentGatewayConfig', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue paymentGatewayConfig = from('PaymentGatewayConfig').where('paymentGatewayConfigId', 'TEST_GATEWAY_CONFIG').queryOne()
+        GenericValue paymentGatewayConfig = from('PaymentGatewayConfig').where('paymentGatewayConfigId', paymentGatewayConfigId).queryOne()
         assert paymentGatewayConfig
-        assert paymentGatewayConfig.description  == 'Test Payment Gateway Config Id'
+        assert paymentGatewayConfig.description  == description
     }
 
 }

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgPaymentTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgPaymentTests.groovy
@@ -34,44 +34,48 @@ class AutoAcctgPaymentTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreatePayment() {
+        String paymentTypeId = testParams.paymentTypeId ?: 'CUSTOMER_PAYMENT'
+        String paymentMethodTypeId = testParams.paymentMethodTypeId ?: 'COMPANY_CHECK'
         Map serviceCtx = [:]
-        serviceCtx.paymentTypeId = 'CUSTOMER_PAYMENT'
-        serviceCtx.partyIdFrom = 'Company'
-        serviceCtx.partyIdTo = 'DemoCustCompany'
+        serviceCtx.paymentTypeId = paymentTypeId
+        serviceCtx.partyIdFrom = testParams.partyIdFrom ?: 'Company'
+        serviceCtx.partyIdTo = testParams.partyIdTo ?: 'DemoCustCompany'
         serviceCtx.amount = 100.00
-        serviceCtx.paymentMethodTypeId = 'COMPANY_CHECK'
+        serviceCtx.paymentMethodTypeId = paymentMethodTypeId
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createPayment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue payment = from('Payment').where('paymentId', serviceResult.paymentId).queryOne()
-        assert payment.paymentTypeId == 'CUSTOMER_PAYMENT'
-        assert payment.paymentMethodTypeId == 'COMPANY_CHECK'
+        assert payment.paymentTypeId == paymentTypeId
+        assert payment.paymentMethodTypeId == paymentMethodTypeId
     }
     @Test
     @Order(2)
     void testSetPaymentStatus() {
+        String paymentId = testParams.paymentId ?: '1000'
         Map serviceCtx = [:]
-        serviceCtx.paymentId = '1000'
-        serviceCtx.statusId = 'PAYMENT_AUTHORIZED'
+        serviceCtx.paymentId = paymentId
+        serviceCtx.statusId = testParams.statusId ?: 'PAYMENT_AUTHORIZED'
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('setPaymentStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue payment = from('Payment').where('paymentId', '1000').queryOne()
+        GenericValue payment = from('Payment').where('paymentId', paymentId).queryOne()
         assert payment
         assert serviceResult.oldStatusId == 'PAYMENT_NOT_AUTH'
     }
     @Test
     @Order(3)
     void testQuickSendPayment() {
+        String paymentId = testParams.paymentId ?: '1001'
         Map serviceCtx = [:]
-        serviceCtx.paymentId = '1001'
+        serviceCtx.paymentId = paymentId
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('quickSendPayment', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue payment = from('Payment').where('paymentId', '1001').queryOne()
+        GenericValue payment = from('Payment').where('paymentId', paymentId).queryOne()
         assert payment
         assert payment.statusId == 'PMNT_SENT'
     }
@@ -79,7 +83,7 @@ class AutoAcctgPaymentTests implements JupiterTestHelper {
     @Order(4)
     void testGetPayments() {
         Map serviceCtx = [
-            finAccountTransId: '1001',
+            finAccountTransId: testParams.finAccountTransId ?: '1001',
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getPayments', serviceCtx)
@@ -90,16 +94,19 @@ class AutoAcctgPaymentTests implements JupiterTestHelper {
     @Order(5)
     void testCreatePaymentContent() {
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
+        String paymentId = testParams.paymentId ?: '1006'
+        String paymentContentTypeId = testParams.paymentContentTypeId ?: 'COMMENTS'
+        String contentId = testParams.contentId ?: '1006'
         Map serviceCtx = [
-            paymentId: '1006',
-            paymentContentTypeId: 'COMMENTS',
-            contentId: '1006',
+            paymentId: paymentId,
+            paymentContentTypeId: paymentContentTypeId,
+            contentId: contentId,
             fromDate: nowTimestamp,
             userLogin: userLogin
         ]
         dispatcher.runSync('createPaymentContent', serviceCtx)
         GenericValue paymentContent = from('PaymentContent')
-                .where(paymentId: '1006', paymentContentTypeId: 'COMMENTS', contentId: '1006').filterByDate().queryFirst()
+                .where(paymentId: paymentId, paymentContentTypeId: paymentContentTypeId, contentId: contentId).filterByDate().queryFirst()
         assert paymentContent
     }
 

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgTransPurchaseTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgTransPurchaseTests.groovy
@@ -42,19 +42,19 @@ class AutoAcctgTransPurchaseTests implements JupiterTestHelper {
             Post condition : Credit in account 214000 - UNINVOICED ITEM RECEIPT amount = grand total of order.
                              Debit in account 140000- INVENTORY amount = grand total of order.
         */
-        String orderId = 'DEMO10091'
-        String shipmentId = '9999'
-        String productId = 'GZ-2644'
+        String orderId = testParams.orderId ?: 'DEMO10091'
+        String shipmentId = testParams.shipmentId ?: '9999'
+        String productId = testParams.productId ?: 'GZ-2644'
 
         Map serviceCtx = [
-                inventoryItemTypeId: 'NON_SERIAL_INV_ITEM',
+                inventoryItemTypeId: testParams.inventoryItemTypeId ?: 'NON_SERIAL_INV_ITEM',
                 productId: productId,
-                facilityId: 'WebStoreWarehouse',
+                facilityId: testParams.facilityId ?: 'WebStoreWarehouse',
                 quantityAccepted: new BigDecimal('5'),
                 quantityRejected: new BigDecimal('0'),
                 shipmentId: shipmentId,
                 orderId: orderId,
-                orderItemSeqId: '00001',
+                orderItemSeqId: testParams.orderItemSeqId ?: '00001',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('receiveInventoryProduct', serviceCtx)
@@ -112,7 +112,7 @@ class AutoAcctgTransPurchaseTests implements JupiterTestHelper {
         assert orderItemBilling
 
         Map serviceCtx = [
-                statusId: 'INVOICE_READY',
+                statusId: testParams.statusId ?: 'INVOICE_READY',
                 invoiceId: orderItemBilling.invoiceId,
                 userLogin: userLogin
         ]
@@ -151,10 +151,10 @@ class AutoAcctgTransPurchaseTests implements JupiterTestHelper {
                 * Credit; in account 111100 - "GENERAL CHECKING ACCOUNT"; amount: 290$; however this depends on the "Payment method type" selected;
                 * Debit; in account 216000 - "ACCOUNTS PAYABLE - UNAPPLIED PAYMENTS"; amount: 290$
          */
-        String paymentId = '9000'
+        String paymentId = testParams.paymentId ?: '9000'
 
         Map serviceCtx = [
-                statusId: 'PMNT_SENT',
+                statusId: testParams.statusId ?: 'PMNT_SENT',
                 paymentId: paymentId,
                 userLogin: userLogin
         ]

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgTransSalesTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgTransSalesTests.groovy
@@ -49,15 +49,15 @@ class AutoAcctgTransSalesTests implements JupiterTestHelper {
               * Credit; in account:140000 - Account Type:"INVENTORY_ACCOUNT"
               * Debit; in account:500000 - Account Type:"COGS_ACCOUNT"
         */
-        String shipmentId = '9998'
+        String shipmentId = testParams.shipmentId ?: '9998'
 
         Map serviceCtx = [
                 shipmentId: shipmentId,
-                shipGroupSeqId: '00001',
-                orderId: 'DEMO10090',
-                orderItemSeqId: '00001',
-                inventoryItemId: '9001',
-                productId: 'GZ-2644',
+                shipGroupSeqId: testParams.shipGroupSeqId ?: '00001',
+                orderId: testParams.orderId ?: 'DEMO10090',
+                orderItemSeqId: testParams.orderItemSeqId ?: '00001',
+                inventoryItemId: testParams.inventoryItemId ?: '9001',
+                productId: testParams.productId ?: 'GZ-2644',
                 quantity: new BigDecimal('2'),
                 userLogin: userLogin
         ]
@@ -116,11 +116,11 @@ class AutoAcctgTransSalesTests implements JupiterTestHelper {
                   shipment to the packed status (precondition 4).  Additionally it doesn't seem to be necessary to set the invoice status
                   to ready because the invoice is created in that state.
         */
-        String shipmentId = '9998'
+        String shipmentId = testParams.shipmentId ?: '9998'
 
         Map serviceCtx = [
                 shipmentId: shipmentId,
-                statusId: 'SHIPMENT_PACKED',
+                statusId: testParams.statusId ?: 'SHIPMENT_PACKED',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateShipment', serviceCtx)
@@ -199,10 +199,10 @@ class AutoAcctgTransSalesTests implements JupiterTestHelper {
         Map serviceCtx = [
                 partyIdFrom: customerRole.partyId,
                 amount: new BigDecimal('100'),
-                partyIdTo: 'Company',
-                paymentMethodTypeId: 'EFT_ACCOUNT',
-                paymentTypeId: 'CUSTOMER_PAYMENT',
-                statusId: 'PMNT_RECEIVED',
+                partyIdTo: testParams.partyIdTo ?: 'Company',
+                paymentMethodTypeId: testParams.paymentMethodTypeId ?: 'EFT_ACCOUNT',
+                paymentTypeId: testParams.paymentTypeId ?: 'CUSTOMER_PAYMENT',
+                statusId: testParams.statusId ?: 'PMNT_RECEIVED',
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPayment', serviceCtx)

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoInvoiceTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoInvoiceTests.groovy
@@ -163,8 +163,12 @@ class AutoInvoiceTests implements JupiterTestHelper {
               * ACCOUNTS PAYABLE 210000  - debitTotal $351.41 ; creditTotal:$1651.7 ; debitCreditDifference : $ -1300
               * UNINVOICED ITEM RECEIPTS 214000 - debitTotal :$408 ; creditTotal:$96 ; debitCreditDifference : $312
         */
+        String organizationPartyId = testParams.organizationPartyId ?: 'Company'
+        String payableGlAccountId = testParams.payableGlAccountId ?: '210000'
+        String uninvoicedGlAccountId = testParams.uninvoicedGlAccountId ?: '214000'
+
         Map serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 findDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -176,10 +180,10 @@ class AutoInvoiceTests implements JupiterTestHelper {
         serviceCtx.clear()
         serviceResult.clear()
         serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 customTimePeriodStartDate: customTimePeriod.fromDate,
                 customTimePeriodEndDate: customTimePeriod.thruDate,
-                glAccountId: '210000',
+                glAccountId: payableGlAccountId,
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
@@ -188,7 +192,7 @@ class AutoInvoiceTests implements JupiterTestHelper {
         BigDecimal payableDebitCreditDifference = serviceResult.debitCreditDifference
 
         serviceResult.clear()
-        serviceCtx.glAccountId = '214000'
+        serviceCtx.glAccountId = uninvoicedGlAccountId
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         BigDecimal uninvoicedCreditTotal = serviceResult.creditTotal
@@ -196,7 +200,7 @@ class AutoInvoiceTests implements JupiterTestHelper {
 
         serviceResult.clear()
         Map cancelInvoiceCtx = [
-                invoiceId: '8008',
+                invoiceId: testParams.invoiceId ?: '8008',
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('cancelInvoice', cancelInvoiceCtx)
@@ -205,7 +209,7 @@ class AutoInvoiceTests implements JupiterTestHelper {
         BigDecimal totalPayableDebitAmount = payableDebitTotal.add(48)
         BigDecimal totalPayableDebitCreditDifference = payableDebitCreditDifference.add(48)
         serviceResult.clear()
-        serviceCtx.glAccountId = '210000'
+        serviceCtx.glAccountId = payableGlAccountId
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         assert totalPayableDebitAmount == serviceResult.debitTotal
@@ -214,7 +218,7 @@ class AutoInvoiceTests implements JupiterTestHelper {
         BigDecimal totalUnInvoicedCreditAmount = uninvoicedCreditTotal.add(48)
         BigDecimal totalUnInvoicedDebitCreditDifference = uninvoicedDebitCreditDifference.subtract(48)
         serviceResult.clear()
-        serviceCtx.glAccountId = '214000'
+        serviceCtx.glAccountId = uninvoicedGlAccountId
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         assert totalUnInvoicedCreditAmount == serviceResult.creditTotal
@@ -236,8 +240,13 @@ class AutoInvoiceTests implements JupiterTestHelper {
                                                                           ; debitCreditDifference decreased of $82.86
               * GENERAL CHECKING ACCOUNT 111100 - debitTotal increased of $82.86 ; debitCreditDifference increased of $82.86
         */
+        String organizationPartyId = testParams.organizationPartyId ?: 'Company'
+        String payableGlAccountId = testParams.payableGlAccountId ?: '210000'
+        String checkingGlAccountId = testParams.checkingGlAccountId ?: '111100'
+        String paymentGroupId = testParams.paymentGroupId ?: '9000'
+
         Map serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 findDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -249,10 +258,10 @@ class AutoInvoiceTests implements JupiterTestHelper {
         serviceCtx.clear()
         serviceResult.clear()
         serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 customTimePeriodStartDate: customTimePeriod.fromDate,
                 customTimePeriodEndDate: customTimePeriod.thruDate,
-                glAccountId: '210000',
+                glAccountId: payableGlAccountId,
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
@@ -262,7 +271,7 @@ class AutoInvoiceTests implements JupiterTestHelper {
         BigDecimal payableDebitCreditDifference = serviceResult.debitCreditDifference
 
         serviceResult.clear()
-        serviceCtx.glAccountId = '111100'
+        serviceCtx.glAccountId = checkingGlAccountId
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         BigDecimal undepositedDebitTotal = serviceResult.debitTotal
@@ -270,14 +279,14 @@ class AutoInvoiceTests implements JupiterTestHelper {
 
         serviceResult.clear()
         Map cancelCheckRunPaymentsCtx = [
-                paymentGroupId: '9000',
+                paymentGroupId: paymentGroupId,
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('cancelCheckRunPayments', cancelCheckRunPaymentsCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue paymentGroupMemberAndTrans = from('PmtGrpMembrPaymentAndFinAcctTrans')
-                .where('paymentGroupId', '9000')
+                .where('paymentGroupId', paymentGroupId)
                 .queryFirst()
         if (paymentGroupMemberAndTrans && 'FINACT_TRNS_APPROVED' != paymentGroupMemberAndTrans.finAccountTransStatusId) {
             BigDecimal tempBig = 82.86
@@ -286,7 +295,7 @@ class AutoInvoiceTests implements JupiterTestHelper {
             BigDecimal totalPayableCreditAmount = 165.72G.add(payableCreditTotal)
             BigDecimal totalPayableDebitCreditDifference = payableDebitCreditDifference.subtract(tempBig)
             serviceResult.clear()
-            serviceCtx.glAccountId = '210000'
+            serviceCtx.glAccountId = payableGlAccountId
             serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
             assert ServiceUtil.isSuccess(serviceResult)
             assert totalPayableDebitAmount == serviceResult.debitTotal
@@ -296,7 +305,7 @@ class AutoInvoiceTests implements JupiterTestHelper {
             BigDecimal totalUndepositedDebitAmount = tempBig.add(undepositedDebitTotal)
             BigDecimal totalUndepositedDebitCreditDifference = tempBig.add(undepositedDebitCreditDifference)
             serviceResult.clear()
-            serviceCtx.glAccountId = '111100'
+            serviceCtx.glAccountId = checkingGlAccountId
             serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
             assert ServiceUtil.isSuccess(serviceResult)
             assert totalUndepositedDebitAmount == serviceResult.debitTotal

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoPaymentTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoPaymentTests.groovy
@@ -37,8 +37,8 @@ class AutoPaymentTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreatePaymentGroupAndMember() {
-        String paymentGroupTypeId = 'BATCH_PAYMENT'
-        String paymentGroupName = 'Payment Batch'
+        String paymentGroupTypeId = testParams.paymentGroupTypeId ?: 'BATCH_PAYMENT'
+        String paymentGroupName = testParams.paymentGroupName ?: 'Payment Batch'
         List paymentIds = ['demo10000', 'demo10001']
 
         Map serviceCtx = [
@@ -82,7 +82,7 @@ class AutoPaymentTests implements JupiterTestHelper {
                              Credit in account 210000- ACCOUNTS PAYABLE
                              Debit in account 213000 - CUSTOMER CREDIT
         */
-        String paymentId = '8000'
+        String paymentId = testParams.paymentId ?: '8000'
 
         Map serviceCtx = [
                 paymentId: paymentId,
@@ -131,11 +131,12 @@ class AutoPaymentTests implements JupiterTestHelper {
                              Credit in account 516100
                              Debit in account 210000 - ACCOUNTS PAYABLE
         */
-        String invoiceId = '8001'
+        String invoiceId = testParams.invoiceId ?: '8001'
+        String statusId = testParams.statusId ?: 'INVOICE_CANCELLED'
 
         Map serviceCtx = [
                 invoiceId: invoiceId,
-                statusId: 'INVOICE_CANCELLED',
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('setInvoiceStatus', serviceCtx)
@@ -145,7 +146,7 @@ class AutoPaymentTests implements JupiterTestHelper {
                 .where('invoiceId', invoiceId)
                 .queryOne()
         assert invoice
-        assert invoice.statusId == 'INVOICE_CANCELLED'
+        assert invoice.statusId == statusId
 
         GenericValue acctgTrans = from('AcctgTrans')
                 .where('invoiceId', invoiceId)
@@ -184,12 +185,15 @@ class AutoPaymentTests implements JupiterTestHelper {
                              Payment should be created with PaymentApplications.
                              PaymentGroup and PaymentGroupMembers should be created.
         */
+        String organizationPartyId = testParams.organizationPartyId ?: 'Company'
+        String paymentMethodTypeId = testParams.paymentMethodTypeId ?: 'COMPANY_CHECK'
+        String paymentMethodId = testParams.paymentMethodId ?: 'SC_CHECKING'
         Map serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 checkStartNumber: 100101L,
                 invoiceIds: ['8000', '8008'],
-                paymentMethodTypeId: 'COMPANY_CHECK',
-                paymentMethodId: 'SC_CHECKING',
+                paymentMethodTypeId: paymentMethodTypeId,
+                paymentMethodId: paymentMethodId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPaymentAndPaymentGroupForInvoices', serviceCtx)
@@ -220,7 +224,7 @@ class AutoPaymentTests implements JupiterTestHelper {
             Post condition : thruDate for PaymentGroupMember should be Not Null
                              payment status should be changed to PMNT_VOID.
         */
-        String paymentGroupId = '9001'
+        String paymentGroupId = testParams.paymentGroupId ?: '9001'
 
         Map serviceCtx = [
                 paymentGroupId: paymentGroupId,
@@ -247,10 +251,11 @@ class AutoPaymentTests implements JupiterTestHelper {
     void testDepositWithdrawPayments() {
         //List paymentIds = ['demo10001', 'demo10010']
         List paymentIds = ['demo10010']
+        String finAccountId = testParams.finAccountId ?: 'SC_CHECKING'
 
         Map serviceCtx = [
                 paymentIds: paymentIds,
-                finAccountId: 'SC_CHECKING',
+                finAccountId: finAccountId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('depositWithdrawPayments', serviceCtx)
@@ -276,12 +281,15 @@ class AutoPaymentTests implements JupiterTestHelper {
     void testDepositWithdrawPaymentsInSingleTrans() {
         List paymentIds = ['8004']
         BigDecimal paymentRunningTotal = new BigDecimal('0')
+        String finAccountId = testParams.finAccountId ?: 'SC_CHECKING'
+        String groupInOneTransaction = testParams.groupInOneTransaction ?: 'Y'
+        String paymentGroupTypeId = testParams.paymentGroupTypeId ?: 'BATCH_PAYMENT'
 
         Map serviceCtx = [
                 paymentIds: paymentIds,
-                finAccountId: 'SC_CHECKING',
-                groupInOneTransaction: 'Y',
-                paymentGroupTypeId: 'BATCH_PAYMENT',
+                finAccountId: finAccountId,
+                groupInOneTransaction: groupInOneTransaction,
+                paymentGroupTypeId: paymentGroupTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('depositWithdrawPayments', serviceCtx)
@@ -312,11 +320,12 @@ class AutoPaymentTests implements JupiterTestHelper {
             Post condition : FinAccountTrans status changes to CANCELED
                              Clear finAccountTransId field and update associated Payment record
         */
-        String finAccountTransId = '9102'
+        String finAccountTransId = testParams.finAccountTransId ?: '9102'
+        String statusId = testParams.statusId ?: 'FINACT_TRNS_CANCELED'
 
         Map serviceCtx = [
                 finAccountTransId: finAccountTransId,
-                statusId: 'FINACT_TRNS_CANCELED',
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('setFinAccountTransStatus', serviceCtx)
@@ -326,7 +335,7 @@ class AutoPaymentTests implements JupiterTestHelper {
                 .where('finAccountTransId', finAccountTransId)
                 .queryOne()
         assert finAccountTrans
-        assert finAccountTrans.statusId == 'FINACT_TRNS_CANCELED'
+        assert finAccountTrans.statusId == statusId
 
         GenericValue payment = from('Payment')
                 .where('paymentId', finAccountTrans.paymentId)
@@ -350,8 +359,9 @@ class AutoPaymentTests implements JupiterTestHelper {
               * Credit in account 112000- UNDEPOSITED RECEIPTS  ;debitTotal :$136.85 ; creditTotal: $136.85 ; debitCreditDifference : $0
               * Debit in account 120000 - ACCOUNTS RECEVABLE debitTotal :$774.17 ; creditTotal: $274.18 ; debitCreditDifference : $ 499.99
         */
+        String organizationPartyId = testParams.organizationPartyId ?: 'Company'
         Map serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 findDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -363,10 +373,10 @@ class AutoPaymentTests implements JupiterTestHelper {
         serviceCtx.clear()
         serviceResult.clear()
         serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 customTimePeriodStartDate: customTimePeriod.fromDate,
                 customTimePeriodEndDate: customTimePeriod.thruDate,
-                glAccountId: '120000',
+                glAccountId: testParams.glAccountId ?: '120000',
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
@@ -375,15 +385,16 @@ class AutoPaymentTests implements JupiterTestHelper {
         BigDecimal receivableDebitCreditDifference = serviceResult.debitCreditDifference
 
         serviceResult.clear()
-        serviceCtx.glAccountId = '112000'
+        serviceCtx.glAccountId = testParams.glAccountId ?: '112000'
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         BigDecimal undepositedCreditTotal = serviceResult.creditTotal
         BigDecimal undepositedDebitCreditDifference = serviceResult.debitCreditDifference
 
         serviceResult.clear()
+        String paymentId = testParams.paymentId ?: '8003'
         Map voidPaymentCtx = [
-                paymentId: '8003',
+                paymentId: paymentId,
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('voidPayment', voidPaymentCtx)
@@ -392,7 +403,7 @@ class AutoPaymentTests implements JupiterTestHelper {
         BigDecimal totalReceivableDebitAmount = receivableDebitTotal.add(new BigDecimal('20'))
         BigDecimal totalReceivableDebitCreditDifference = receivableDebitCreditDifference.add(new BigDecimal('20'))
         serviceResult.clear()
-        serviceCtx.glAccountId = '120000'
+        serviceCtx.glAccountId = testParams.glAccountId ?: '120000'
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert serviceResult
         assert totalReceivableDebitAmount == serviceResult.debitTotal
@@ -401,7 +412,7 @@ class AutoPaymentTests implements JupiterTestHelper {
         BigDecimal totalUndepositedCreditAmount = undepositedCreditTotal.add(new BigDecimal('20'))
         BigDecimal totalUndepositedDebitCreditDifference = undepositedDebitCreditDifference.subtract(new BigDecimal('20'))
         serviceResult.clear()
-        serviceCtx.glAccountId = '112000'
+        serviceCtx.glAccountId = testParams.glAccountId ?: '112000'
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert serviceResult
         assert totalUndepositedCreditAmount == serviceResult.creditTotal
@@ -427,8 +438,9 @@ class AutoPaymentTests implements JupiterTestHelper {
               * UNINVOICED ITEM RECEIPTS 214000 - debitTotal :$408 ; creditTotal:$48 ; debitCreditDifference : $360
               * GENERAL CHECKING ACCOUNT 111100 (for payment)- debitTotal :$136.85 ; creditTotal:$173.28 ; debitCreditDifference : $ -36.43
         */
+        String organizationPartyId = testParams.organizationPartyId ?: 'Company'
         Map serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 findDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -440,10 +452,10 @@ class AutoPaymentTests implements JupiterTestHelper {
         serviceCtx.clear()
         serviceResult.clear()
         serviceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 customTimePeriodStartDate: customTimePeriod.fromDate,
                 customTimePeriodEndDate: customTimePeriod.thruDate,
-                glAccountId: '210000',
+                glAccountId: testParams.glAccountId ?: '210000',
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
@@ -453,7 +465,7 @@ class AutoPaymentTests implements JupiterTestHelper {
         BigDecimal payableDebitCreditDifference = serviceResult.debitCreditDifference
 
         serviceResult.clear()
-        serviceCtx.glAccountId = '111100'
+        serviceCtx.glAccountId = testParams.glAccountId ?: '111100'
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         BigDecimal undepositedDebitTotal = serviceResult.debitTotal
@@ -461,12 +473,14 @@ class AutoPaymentTests implements JupiterTestHelper {
         BigDecimal undepositedDebitCreditDifference = serviceResult.debitCreditDifference
 
         serviceResult.clear()
+        String paymentMethodTypeId = testParams.paymentMethodTypeId ?: 'COMPANY_CHECK'
+        String paymentMethodId = testParams.paymentMethodId ?: 'SC_CHECKING'
         Map invoiceServiceCtx = [
-                organizationPartyId: 'Company',
+                organizationPartyId: organizationPartyId,
                 checkStartNumber: 100100L,
                 invoiceIds: ['8007'],
-                paymentMethodTypeId: 'COMPANY_CHECK',
-                paymentMethodId: 'SC_CHECKING',
+                paymentMethodTypeId: paymentMethodTypeId,
+                paymentMethodId: paymentMethodId,
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('createPaymentAndPaymentGroupForInvoices', invoiceServiceCtx)
@@ -479,7 +493,7 @@ class AutoPaymentTests implements JupiterTestHelper {
         BigDecimal totalPayableDebitAmount = tempBig.add(payableDebitTotal)
         BigDecimal totalPayableDebitCreditDifference = tempBig.add(payableDebitCreditDifference)
         serviceResult.clear()
-        serviceCtx.glAccountId = '210000'
+        serviceCtx.glAccountId = testParams.glAccountId ?: '210000'
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         assert totalPayableDebitAmount == serviceResult.debitTotal
@@ -489,7 +503,7 @@ class AutoPaymentTests implements JupiterTestHelper {
         BigDecimal totalUndepositedCreditAmount = tempBig.add(undepositedCreditTotal)
         BigDecimal totalUndepositedDebitCreditDifference = undepositedDebitCreditDifference.subtract(tempBig)
         serviceResult.clear()
-        serviceCtx.glAccountId = '111100'
+        serviceCtx.glAccountId = testParams.glAccountId ?: '111100'
         serviceResult = dispatcher.runSync('getAcctgTransEntriesAndTransTotal', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         assert undepositedDebitTotal == serviceResult.debitTotal

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/FixedAssetTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/FixedAssetTests.groovy
@@ -33,10 +33,11 @@ class FixedAssetTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateFixedAssetRegistration() {
+        String fixedAssetId = testParams.fixedAssetId ?: 'DEMO_VEHICLE_01'
         Map serviceCtx = [
-                fixedAssetId: 'DEMO_VEHICLE_01',
-                licenseNumber: '123456',
-                registrationNumber: 'abcdef',
+                fixedAssetId: fixedAssetId,
+                licenseNumber: testParams.licenseNumber ?: '123456',
+                registrationNumber: testParams.registrationNumber ?: 'abcdef',
                 registrationDate: UtilDateTime.toTimestamp('01/01/2020 00:00:00'),
                 fromDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
@@ -45,7 +46,7 @@ class FixedAssetTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetRegistration = from('FixedAssetRegistration')
-                .where('fixedAssetId', 'DEMO_VEHICLE_01')
+                .where('fixedAssetId', fixedAssetId)
                 .filterByDate().queryFirst()
         assert fixedAssetRegistration
     }
@@ -53,10 +54,11 @@ class FixedAssetTests implements JupiterTestHelper {
     @Order(2)
     void testUpdateFixedAssetRegistration() {
         Timestamp fromDate = UtilDateTime.toTimestamp('04/01/2020 00:00:00')
+        String fixedAssetId = testParams.fixedAssetId ?: 'DEMO_VEHICLE_01'
         Map serviceCtx = [
-                fixedAssetId: 'DEMO_VEHICLE_01',
-                licenseNumber: 'updated-123456',
-                registrationNumber: 'updated-abcdef',
+                fixedAssetId: fixedAssetId,
+                licenseNumber: testParams.licenseNumber ?: 'updated-123456',
+                registrationNumber: testParams.registrationNumber ?: 'updated-abcdef',
                 registrationDate: UtilDateTime.toTimestamp('01/01/2020 00:00:00'),
                 fromDate: fromDate,
                 thruDate: UtilDateTime.nowTimestamp(),
@@ -66,7 +68,7 @@ class FixedAssetTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetRegistration = from('FixedAssetRegistration')
-                .where('fixedAssetId', 'DEMO_VEHICLE_01', 'fromDate', fromDate)
+                .where('fixedAssetId', fixedAssetId, 'fromDate', fromDate)
                 .filterByDate().queryOne()
         assert !fixedAssetRegistration
     }
@@ -74,8 +76,9 @@ class FixedAssetTests implements JupiterTestHelper {
     @Order(3)
     void testDeleteFixedAssetRegistration() {
         Timestamp fromDate = UtilDateTime.toTimestamp('04/01/2020 00:00:00')
+        String fixedAssetId = testParams.fixedAssetId ?: 'DEMO_VEHICLE_01'
         Map serviceCtx = [
-                fixedAssetId: 'DEMO_VEHICLE_01',
+                fixedAssetId: fixedAssetId,
                 fromDate: fromDate,
                 userLogin: userLogin
         ]
@@ -83,16 +86,18 @@ class FixedAssetTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetRegistration = from('FixedAssetRegistration')
-                .where('fixedAssetId', 'DEMO_VEHICLE_01', 'fromDate', fromDate)
+                .where('fixedAssetId', fixedAssetId, 'fromDate', fromDate)
                 .queryOne()
         assert !fixedAssetRegistration
     }
     @Test
     @Order(4)
     void testCreateFixedAssetMeter() {
+        String fixedAssetId = testParams.fixedAssetId ?: 'DEMO_VEHICLE_01'
+        String productMeterTypeId = testParams.productMeterTypeId ?: 'ODOMETER'
         Map serviceCtx = [
-                fixedAssetId: 'DEMO_VEHICLE_01',
-                productMeterTypeId: 'ODOMETER',
+                fixedAssetId: fixedAssetId,
+                productMeterTypeId: productMeterTypeId,
                 readingDate: UtilDateTime.nowTimestamp(),
                 meterValue: BigDecimal.valueOf(65),
                 userLogin: userLogin
@@ -101,7 +106,7 @@ class FixedAssetTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetMeter = from('FixedAssetMeter')
-                .where('fixedAssetId', 'DEMO_VEHICLE_01', 'productMeterTypeId', 'ODOMETER')
+                .where('fixedAssetId', fixedAssetId, 'productMeterTypeId', productMeterTypeId)
                 .queryFirst()
         assert fixedAssetMeter
     }
@@ -109,9 +114,11 @@ class FixedAssetTests implements JupiterTestHelper {
     @Order(5)
     void testUpdateFixedAssetMeter() {
         Timestamp readingDate = UtilDateTime.toTimestamp('04/01/2020 00:00:00')
+        String fixedAssetId = testParams.fixedAssetId ?: 'DEMO_VEHICLE_01'
+        String productMeterTypeId = testParams.productMeterTypeId ?: 'ODOMETER'
         Map serviceCtx = [
-                fixedAssetId: 'DEMO_VEHICLE_01',
-                productMeterTypeId: 'ODOMETER',
+                fixedAssetId: fixedAssetId,
+                productMeterTypeId: productMeterTypeId,
                 readingDate: readingDate,
                 meterValue: BigDecimal.valueOf(85),
                 userLogin: userLogin
@@ -120,7 +127,7 @@ class FixedAssetTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetMeter = from('FixedAssetMeter')
-                .where('fixedAssetId', 'DEMO_VEHICLE_01', 'productMeterTypeId', 'ODOMETER', 'readingDate', readingDate)
+                .where('fixedAssetId', fixedAssetId, 'productMeterTypeId', productMeterTypeId, 'readingDate', readingDate)
                 .queryOne()
         assert fixedAssetMeter
     }
@@ -128,9 +135,11 @@ class FixedAssetTests implements JupiterTestHelper {
     @Order(6)
     void testDeleteFixedAssetMeter() {
         Timestamp readingDate = UtilDateTime.toTimestamp('04/01/2020 00:00:00')
+        String fixedAssetId = testParams.fixedAssetId ?: 'DEMO_VEHICLE_01'
+        String productMeterTypeId = testParams.productMeterTypeId ?: 'ODOMETER'
         Map serviceCtx = [
-                fixedAssetId: 'DEMO_VEHICLE_01',
-                productMeterTypeId: 'ODOMETER',
+                fixedAssetId: fixedAssetId,
+                productMeterTypeId: productMeterTypeId,
                 readingDate: readingDate,
                 userLogin: userLogin
         ]
@@ -138,23 +147,25 @@ class FixedAssetTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetMeter = from('FixedAssetMeter')
-                .where('fixedAssetId', 'DEMO_VEHICLE_01', 'productMeterTypeId', 'ODOMETER', 'readingDate', readingDate)
+                .where('fixedAssetId', fixedAssetId, 'productMeterTypeId', productMeterTypeId, 'readingDate', readingDate)
                 .queryOne()
         assert !fixedAssetMeter
     }
     @Test
     @Order(7)
     void testCreateFixedAssetGeoPoint() {
+        String fixedAssetId = testParams.fixedAssetId ?: 'DEMO_VEHICLE_01'
+        String geoPointId = testParams.geoPointId ?: '9000'
         Map serviceCtx = [
-                fixedAssetId: 'DEMO_VEHICLE_01',
-                geoPointId: '9000',
+                fixedAssetId: fixedAssetId,
+                geoPointId: geoPointId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createFixedAssetGeoPoint', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue fixedAssetGeoPoint = from('FixedAssetGeoPoint')
-                .where('fixedAssetId', 'DEMO_VEHICLE_01', 'geoPointId', '9000')
+                .where('fixedAssetId', fixedAssetId, 'geoPointId', geoPointId)
                 .filterByDate().queryFirst()
         assert fixedAssetGeoPoint
     }

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/InvoicePerShipmentTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/InvoicePerShipmentTests.groovy
@@ -47,7 +47,9 @@ class InvoicePerShipmentTests implements JupiterTestHelper {
          Step 3) Pack Shipment For Ship Group.
          Step 4) Check invoice should not created.
          */
-        List invoices = testInvoicePerShipment('GZ-1000', 'N')
+        String productId = testParams.productId ?: 'GZ-1000'
+        String invoicePerShipment = testParams.invoicePerShipment ?: 'N'
+        List invoices = testInvoicePerShipment(productId, invoicePerShipment)
         assert !invoices
     }
 
@@ -60,7 +62,9 @@ class InvoicePerShipmentTests implements JupiterTestHelper {
          Step 3) Pack Shipment For Ship Group.
          Step 4) Check invoice should be created.
          */
-        List invoices = testInvoicePerShipment('GZ-1000', 'Y')
+        String productId = testParams.productId ?: 'GZ-1000'
+        String invoicePerShipment = testParams.invoicePerShipment ?: 'Y'
+        List invoices = testInvoicePerShipment(productId, invoicePerShipment)
         assert invoices
     }
 
@@ -72,7 +76,9 @@ class InvoicePerShipmentTests implements JupiterTestHelper {
          Step 2) Pack Shipment For Ship Group.
          Step 3) Check invoice should not be created.
          */
-        List invoices = testInvoicePerShipment('GZ-2644', 'N')
+        String productId = testParams.productId ?: 'GZ-2644'
+        String invoicePerShipment = testParams.invoicePerShipment ?: 'N'
+        List invoices = testInvoicePerShipment(productId, invoicePerShipment)
         assert !invoices
     }
 
@@ -84,7 +90,9 @@ class InvoicePerShipmentTests implements JupiterTestHelper {
          Step 2) Pack Shipment For Ship Group.
          Step 3) Check invoice should be created.
          */
-        List invoices = testInvoicePerShipment('GZ-2644', 'Y')
+        String productId = testParams.productId ?: 'GZ-2644'
+        String invoicePerShipment = testParams.invoicePerShipment ?: 'Y'
+        List invoices = testInvoicePerShipment(productId, invoicePerShipment)
         assert invoices
     }
 
@@ -102,10 +110,10 @@ class InvoicePerShipmentTests implements JupiterTestHelper {
         String result = ShoppingCartEvents.routeOrderEntry(request, response)
         logInfo('===== >>> Event : routeOrderEntry, Response : ' + result)
 
-        request.setParameter('orderMode', 'SALES_ORDER')
-        request.setParameter('productStoreId', '9000')
-        request.setParameter('partyId', 'DemoCustomer')
-        request.setParameter('currencyUom', 'USD')
+        request.setParameter('orderMode', testParams.orderMode ?: 'SALES_ORDER')
+        request.setParameter('productStoreId', testParams.productStoreId ?: '9000')
+        request.setParameter('partyId', testParams.partyId ?: 'DemoCustomer')
+        request.setParameter('currencyUom', testParams.currencyUomId ?: 'USD')
         session.setAttribute('userLogin', userLogin)
 
         result = ShoppingCartEvents.initializeOrderEntry(request, response)
@@ -119,12 +127,12 @@ class InvoicePerShipmentTests implements JupiterTestHelper {
         result = ShoppingCartEvents.addToCart(request, response)
         logInfo('===== >>> Event : addToCart, Response : ' + result)
 
-        request.setParameter('checkoutpage', 'quick')
-        request.setParameter('shipping_contact_mech_id', '9015')
-        request.setParameter('shipping_method', 'GROUND@UPS')
-        request.setParameter('checkOutPaymentId', 'EXT_COD')
-        request.setParameter('is_gift', 'false')
-        request.setParameter('may_split', 'false')
+        request.setParameter('checkoutpage', testParams.checkoutpage ?: 'quick')
+        request.setParameter('shipping_contact_mech_id', testParams.shipping_contact_mech_id ?: '9015')
+        request.setParameter('shipping_method', testParams.shipping_method ?: 'GROUND@UPS')
+        request.setParameter('checkOutPaymentId', testParams.checkOutPaymentId ?: 'EXT_COD')
+        request.setParameter('is_gift', testParams.is_gift ?: 'false')
+        request.setParameter('may_split', testParams.may_split ?: 'false')
         request.setAttribute('shoppingCart', null)
 
         result = CheckOutEvents.setQuickCheckOutOptions(request, response)
@@ -158,21 +166,22 @@ class InvoicePerShipmentTests implements JupiterTestHelper {
         PackingSession packingSession = new PackingSession(dispatcher, userLogin)
         session.setAttribute('packingSession', packingSession)
         packingSession.setPrimaryOrderId(orderHeader.orderId)
-        packingSession.setPrimaryShipGroupSeqId('00001')
+        String shipGroupSeqId = testParams.shipGroupSeqId ?: '00001'
+        packingSession.setPrimaryShipGroupSeqId(shipGroupSeqId)
 
         Map packInput = [
                 orderId: orderHeader.orderId,
-                shipGroupSeqId: '00001',
+                shipGroupSeqId: shipGroupSeqId,
                 packingSession: packingSession,
                 nextPackageSeq: 1,
                 userLogin: userLogin,
-                selInfo: [_1: 'Y'],
-                pkgInfo: [_1: '1'],
-                qtyInfo: [_1: '1'],
+                selInfo: [_1: testParams.selInfo ?: 'Y'],
+                pkgInfo: [_1: testParams.pkgInfo ?: '1'],
+                qtyInfo: [_1: testParams.qtyInfo ?: '1'],
                 prdInfo: [_1: productId],
-                iteInfo: [_1: '00001'],
-                wgtInfo: [_1: '0'],
-                numPackagesInfo: [_1: '1']
+                iteInfo: [_1: testParams.iteInfo ?: '00001'],
+                wgtInfo: [_1: testParams.wgtInfo ?: '0'],
+                numPackagesInfo: [_1: testParams.numPackagesInfo ?: '1']
         ]
 
         Map serviceResult = dispatcher.runSync('packBulkItems', packInput)

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/PaymentApplicationTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/PaymentApplicationTests.groovy
@@ -36,8 +36,10 @@ class PaymentApplicationTests implements JupiterTestHelper {
     void testInvoiceAppl() {
         Map serviceInMap = [:]
         //from the test data
-        serviceInMap.invoiceId = 'appltest10000'
-        serviceInMap.paymentId = 'appltest10000'
+        String invoiceId = testParams.invoiceId ?: 'appltest10000'
+        String paymentId = testParams.paymentId ?: 'appltest10000'
+        serviceInMap.invoiceId = invoiceId
+        serviceInMap.paymentId = paymentId
         serviceInMap.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createPaymentApplication', serviceInMap)
         assert ServiceUtil.isSuccess(serviceResult)
@@ -66,8 +68,10 @@ class PaymentApplicationTests implements JupiterTestHelper {
     @Order(2)
     void testToPayment() {
         Map serviceInMap = [:]
-        serviceInMap.paymentId = 'appltest10000'
-        serviceInMap.toPaymentId = 'appltest10001'
+        String paymentId = testParams.paymentId ?: 'appltest10000'
+        String toPaymentId = testParams.toPaymentId ?: 'appltest10001'
+        serviceInMap.paymentId = paymentId
+        serviceInMap.toPaymentId = toPaymentId
         serviceInMap.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createPaymentApplication', serviceInMap)
         assert ServiceUtil.isSuccess(serviceResult)
@@ -99,8 +103,10 @@ class PaymentApplicationTests implements JupiterTestHelper {
     void testBillingAppl() {
         Map serviceInMap = [:]
         //from the test data
-        serviceInMap.paymentId = 'appltest10000'
-        serviceInMap.billingAccountId = 'appltest10000'
+        String paymentId = testParams.paymentId ?: 'appltest10000'
+        String billingAccountId = testParams.billingAccountId ?: 'appltest10000'
+        serviceInMap.paymentId = paymentId
+        serviceInMap.billingAccountId = billingAccountId
         serviceInMap.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createPaymentApplication', serviceInMap)
         assert ServiceUtil.isSuccess(serviceResult)
@@ -134,8 +140,10 @@ class PaymentApplicationTests implements JupiterTestHelper {
     void testTaxGeoId() {
         Map serviceInMap = [:]
         //from the test data
-        serviceInMap.paymentId = 'appltest10000'
-        serviceInMap.taxAuthGeoId = 'UT'
+        String paymentId = testParams.paymentId ?: 'appltest10000'
+        String taxAuthGeoId = testParams.taxAuthGeoId ?: 'UT'
+        serviceInMap.paymentId = paymentId
+        serviceInMap.taxAuthGeoId = taxAuthGeoId
         serviceInMap.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createPaymentApplication', serviceInMap)
         assert ServiceUtil.isSuccess(serviceResult)

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/RateTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/RateTests.groovy
@@ -35,9 +35,11 @@ class RateTests implements JupiterTestHelper {
     @Order(1)
     void testExpirePartyRate() {
         Timestamp fromDate = UtilDateTime.toTimestamp('07/04/2013 00:00:00')
+        String partyId = testParams.partyId ?: 'TEST_PARTY'
+        String rateTypeId = testParams.rateTypeId ?: 'AVERAGE_PAY_RATE'
         Map serviceCtx = [
-                partyId: 'TEST_PARTY',
-                rateTypeId: 'AVERAGE_PAY_RATE',
+                partyId: partyId,
+                rateTypeId: rateTypeId,
                 rateAmountFromDate: fromDate,
                 fromDate: fromDate,
                 userLogin: userLogin
@@ -45,7 +47,7 @@ class RateTests implements JupiterTestHelper {
         Map serviceResult = dispatcher.runSync('expirePartyRate', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyRate = from('PartyRate').where('rateTypeId', 'AVERAGE_PAY_RATE', 'partyId', 'TEST_PARTY', 'fromDate', fromDate).queryOne()
+        GenericValue partyRate = from('PartyRate').where('rateTypeId', rateTypeId, 'partyId', partyId, 'fromDate', fromDate).queryOne()
         assert partyRate
         assert partyRate.thruDate
     }
@@ -54,12 +56,16 @@ class RateTests implements JupiterTestHelper {
     @Order(2)
     void testUpdateRateAmount() {
         Timestamp fromDate = UtilDateTime.toTimestamp('04/07/2013 00:00:00')
+        String periodTypeId = testParams.periodTypeId ?: 'RATE_HOUR'
+        String rateTypeId = testParams.rateTypeId ?: 'OVERTIME'
+        String rateCurrencyUomId = testParams.rateCurrencyUomId ?: 'USD'
+        String emplPositionTypeId = testParams.emplPositionTypeId ?: 'TEST_EMPLOYEE'
         Map serviceCtx = [
-                periodTypeId: 'RATE_HOUR',
-                rateTypeId: 'OVERTIME',
-                rateCurrencyUomId: 'USD',
+                periodTypeId: periodTypeId,
+                rateTypeId: rateTypeId,
+                rateCurrencyUomId: rateCurrencyUomId,
                 rateAmount: BigDecimal.valueOf(25),
-                emplPositionTypeId: 'TEST_EMPLOYEE',
+                emplPositionTypeId: emplPositionTypeId,
                 fromDate: fromDate,
                 userLogin: userLogin
         ]
@@ -67,8 +73,13 @@ class RateTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue rateAmount = from('RateAmount')
-                .where('rateTypeId', 'OVERTIME', 'workEffortId', '_NA_', 'rateCurrencyUomId', 'USD', 'emplPositionTypeId', 'TEST_EMPLOYEE',
-                        'partyId', '_NA_', 'periodTypeId', 'RATE_HOUR', 'fromDate', fromDate).queryOne()
+                .where('rateTypeId', rateTypeId,
+                       'workEffortId', '_NA_',
+                       'rateCurrencyUomId', rateCurrencyUomId,
+                       'emplPositionTypeId', emplPositionTypeId,
+                       'partyId', '_NA_',
+                       'periodTypeId', periodTypeId,
+                       'fromDate', fromDate).queryOne()
         assert rateAmount
         assert rateAmount.rateAmount == 25
     }
@@ -76,9 +87,11 @@ class RateTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testGetRateAmount() {
+        String rateTypeId = testParams.rateTypeId ?: 'AVERAGE_PAY_RATE'
+        String workEffortId = testParams.workEffortId ?: 'Test_effort'
         Map serviceCtx = [
-                rateTypeId: 'AVERAGE_PAY_RATE',
-                workEffortId: 'Test_effort',
+                rateTypeId: rateTypeId,
+                workEffortId: workEffortId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getRateAmount', serviceCtx)
@@ -89,11 +102,15 @@ class RateTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testGetRatesAmountsFromWorkEffortId() {
+        String periodTypeId = testParams.periodTypeId ?: 'RATE_HOUR'
+        String rateCurrencyUomId = testParams.rateCurrencyUomId ?: 'USD'
+        String rateTypeId = testParams.rateTypeId ?: 'AVERAGE_PAY_RATE'
+        String workEffortId = testParams.workEffortId ?: 'Test_effort'
         Map serviceCtx = [
-                periodTypeId: 'RATE_HOUR',
-                rateCurrencyUomId: 'USD',
-                rateTypeId: 'AVERAGE_PAY_RATE',
-                workEffortId: 'Test_effort',
+                periodTypeId: periodTypeId,
+                rateCurrencyUomId: rateCurrencyUomId,
+                rateTypeId: rateTypeId,
+                workEffortId: workEffortId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getRatesAmountsFromWorkEffortId', serviceCtx)
@@ -104,11 +121,15 @@ class RateTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testGetRatesAmountsFromPartyId() {
+        String periodTypeId = testParams.periodTypeId ?: 'RATE_HOUR'
+        String rateCurrencyUomId = testParams.rateCurrencyUomId ?: 'USD'
+        String rateTypeId = testParams.rateTypeId ?: 'AVERAGE_PAY_RATE'
+        String partyId = testParams.partyId ?: 'TEST_PARTY'
         Map serviceCtx = [
-                periodTypeId: 'RATE_HOUR',
-                rateCurrencyUomId: 'USD',
-                rateTypeId: 'AVERAGE_PAY_RATE',
-                partyId: 'TEST_PARTY',
+                periodTypeId: periodTypeId,
+                rateCurrencyUomId: rateCurrencyUomId,
+                rateTypeId: rateTypeId,
+                partyId: partyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getRatesAmountsFromPartyId', serviceCtx)
@@ -119,11 +140,15 @@ class RateTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testGetRatesAmountsFromEmplPositionTypeId() {
+        String periodTypeId = testParams.periodTypeId ?: 'RATE_HOUR'
+        String rateCurrencyUomId = testParams.rateCurrencyUomId ?: 'USD'
+        String rateTypeId = testParams.rateTypeId ?: 'AVERAGE_PAY_RATE'
+        String emplPositionTypeId = testParams.emplPositionTypeId ?: 'TEST_EMPLOYEE'
         Map serviceCtx = [
-                periodTypeId: 'RATE_HOUR',
-                rateCurrencyUomId: 'USD',
-                rateTypeId: 'AVERAGE_PAY_RATE',
-                emplPositionTypeId: 'TEST_EMPLOYEE',
+                periodTypeId: periodTypeId,
+                rateCurrencyUomId: rateCurrencyUomId,
+                rateTypeId: rateTypeId,
+                emplPositionTypeId: emplPositionTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getRatesAmountsFromEmplPositionTypeId', serviceCtx)
@@ -135,10 +160,13 @@ class RateTests implements JupiterTestHelper {
     @Order(7)
     void testUpdatePartyRate() {
         Timestamp fromDate = UtilDateTime.toTimestamp('04/07/2013 00:00:00')
+        String partyId = testParams.partyId ?: 'TEST_PARTY'
+        String periodTypeId = testParams.periodTypeId ?: 'RATE_MONTH'
+        String rateTypeId = testParams.rateTypeId ?: 'DISCOUNTED'
         Map serviceCtx = [
-                partyId: 'TEST_PARTY',
-                periodTypeId: 'RATE_MONTH',
-                rateTypeId: 'DISCOUNTED',
+                partyId: partyId,
+                periodTypeId: periodTypeId,
+                rateTypeId: rateTypeId,
                 rateAmount: BigDecimal.valueOf(75),
                 fromDate: fromDate,
                 userLogin: userLogin
@@ -148,9 +176,9 @@ class RateTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue rateAmount = from('RateAmount')
-                .where('rateTypeId', 'DISCOUNTED', 'workEffortId', '_NA_', 'rateCurrencyUomId', 'USD', 'emplPositionTypeId', '_NA_',
-                        'partyId', 'TEST_PARTY', 'periodTypeId', 'RATE_MONTH', 'fromDate', fromDate).queryOne()
-        GenericValue partyRate = from('PartyRate').where('rateTypeId', 'DISCOUNTED', 'partyId', 'TEST_PARTY', 'fromDate', fromDate).queryOne()
+                .where('rateTypeId', rateTypeId, 'workEffortId', '_NA_', 'rateCurrencyUomId', 'USD', 'emplPositionTypeId', '_NA_',
+                        'partyId', partyId, 'periodTypeId', periodTypeId, 'fromDate', fromDate).queryOne()
+        GenericValue partyRate = from('PartyRate').where('rateTypeId', rateTypeId, 'partyId', partyId, 'fromDate', fromDate).queryOne()
 
         assert rateAmount
         assert partyRate
@@ -160,10 +188,11 @@ class RateTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testFilterRateAmountList() {
-        List<GenericValue> amountList = from('RateAmount').where('rateTypeId', 'AVERAGE_PAY_RATE', 'rateCurrencyUomId', 'USD').queryList()
+        String rateTypeId = testParams.rateTypeId ?: 'AVERAGE_PAY_RATE'
+        List<GenericValue> amountList = from('RateAmount').where('rateTypeId', rateTypeId, 'rateCurrencyUomId', 'USD').queryList()
         Map serviceCtx = [
                 ratesList: amountList,
-                rateTypeId: 'AVERAGE_PAY_RATE',
+                rateTypeId: rateTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('filterRateAmountList', serviceCtx)
@@ -175,10 +204,13 @@ class RateTests implements JupiterTestHelper {
     @Order(9)
     void testExpireRateAmount() {
         Timestamp fromDate = UtilDateTime.toTimestamp('07/04/2013 00:00:00')
+        String emplPositionTypeId = testParams.emplPositionTypeId ?: 'TEST_EMPLOYEE'
+        String rateTypeId = testParams.rateTypeId ?: 'AVERAGE_PAY_RATE'
+        String periodTypeId = testParams.periodTypeId ?: 'RATE_MONTH'
         Map serviceCtx = [
-                emplPositionTypeId: 'TEST_EMPLOYEE',
-                rateTypeId: 'AVERAGE_PAY_RATE',
-                periodTypeId: 'RATE_MONTH',
+                emplPositionTypeId: emplPositionTypeId,
+                rateTypeId: rateTypeId,
+                periodTypeId: periodTypeId,
                 fromDate: fromDate,
                 userLogin: userLogin
 
@@ -187,8 +219,8 @@ class RateTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue rateAmount = from('RateAmount')
-                .where('rateTypeId', 'AVERAGE_PAY_RATE', 'workEffortId', '_NA_', 'rateCurrencyUomId', 'USD',
-                        'emplPositionTypeId', 'TEST_EMPLOYEE', 'partyId', '_NA_', 'periodTypeId', 'RATE_MONTH', 'fromDate', fromDate).queryOne()
+                .where('rateTypeId', rateTypeId, 'workEffortId', '_NA_', 'rateCurrencyUomId', 'USD',
+                        'emplPositionTypeId', emplPositionTypeId, 'partyId', '_NA_', 'periodTypeId', periodTypeId, 'fromDate', fromDate).queryOne()
         assert rateAmount
         assert rateAmount.thruDate
     }

--- a/applications/content/src/test/groovy/org/apache/ofbiz/content/content/ContentTests.groovy
+++ b/applications/content/src/test/groovy/org/apache/ofbiz/content/content/ContentTests.groovy
@@ -32,56 +32,63 @@ class ContentTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testGetDataResource() {
+        String dataResourceId = testParams.dataResourceId ?: 'TEST_RESOURCE'
         Map serviceCtx = [:]
-        serviceCtx.dataResourceId = 'TEST_RESOURCE'
+        serviceCtx.dataResourceId = dataResourceId
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('getDataResource', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        assert serviceResult.resultData.dataResource.dataResourceId == 'TEST_RESOURCE'
+        assert serviceResult.resultData.dataResource.dataResourceId == dataResourceId
         assert serviceResult.resultData.dataResource.dataResourceTypeId == 'TEST_RESOURCE_TYPE'
     }
 
     @Test
     @Order(2)
     void testCreateDataCategory() {
+        String dataCategoryId = testParams.dataCategoryId ?: 'TEST_DATA_CATEGORY_1'
+        String categoryName = testParams.categoryName ?: 'Test Data Category 1'
         Map serviceCtx = [:]
-        serviceCtx.dataCategoryId = 'TEST_DATA_CATEGORY_1'
-        serviceCtx.categoryName = 'Test Data Category 1'
+        serviceCtx.dataCategoryId = dataCategoryId
+        serviceCtx.categoryName = categoryName
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createDataCategory', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue dataCategory = from('DataCategory')
-                .where('dataCategoryId', 'TEST_DATA_CATEGORY_1')
+                .where('dataCategoryId', dataCategoryId)
                 .queryOne()
         assert dataCategory
-        assert dataCategory.categoryName == 'Test Data Category 1'
+        assert dataCategory.categoryName == categoryName
     }
 
     @Test
     @Order(3)
     void testUpdateDataCategory() {
+        String dataCategoryId = testParams.dataCategoryId ?: 'TEST_DATA_CATEGORY_2'
+        String categoryName = testParams.categoryName ?: 'Test Data Category 2'
+        String updatedCategoryName = testParams.updatedCategoryName ?: 'Test Data Category 20'
+
         Map serviceCtx = [:]
-        serviceCtx.dataCategoryId = 'TEST_DATA_CATEGORY_2'
-        serviceCtx.categoryName = 'Test Data Category 2'
+        serviceCtx.dataCategoryId = dataCategoryId
+        serviceCtx.categoryName = categoryName
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createDataCategory', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         serviceCtx.clear()
-        serviceCtx.dataCategoryId = 'TEST_DATA_CATEGORY_2'
-        serviceCtx.categoryName = 'Test Data Category 20'
+        serviceCtx.dataCategoryId = dataCategoryId
+        serviceCtx.categoryName = updatedCategoryName
         serviceCtx.userLogin = userLogin
         serviceResult = dispatcher.runSync('updateDataCategory', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue dataCategory = from('DataCategory')
-                .where('categoryName', 'Test Data Category 2')
+                .where('categoryName', categoryName)
                 .queryFirst()
         assert !dataCategory
 
         dataCategory = from('DataCategory')
-                .where('categoryName', 'Test Data Category 20')
+                .where('categoryName', updatedCategoryName)
                 .queryFirst()
         assert dataCategory
     }
@@ -89,21 +96,23 @@ class ContentTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testDeleteDataCategory() {
+        String dataCategoryId = testParams.dataCategoryId ?: 'TEST_DATA_CATEGORY_3'
+        String categoryName = testParams.categoryName ?: 'Test Data Category 3'
         Map serviceCtx = [:]
-        serviceCtx.dataCategoryId = 'TEST_DATA_CATEGORY_3'
-        serviceCtx.categoryName = 'Test Data Category 3'
+        serviceCtx.dataCategoryId = dataCategoryId
+        serviceCtx.categoryName = categoryName
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createDataCategory', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         serviceCtx.clear()
-        serviceCtx.dataCategoryId = 'TEST_DATA_CATEGORY_3'
+        serviceCtx.dataCategoryId = dataCategoryId
         serviceCtx.userLogin = userLogin
         serviceResult = dispatcher.runSync('removeDataCategory', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue dataCategory = from('DataCategory')
-                .where('dataCategoryId', 'TEST_DATA_CATEGORY_3')
+                .where('dataCategoryId', dataCategoryId)
                 .queryOne()
         assert !dataCategory
     }
@@ -111,20 +120,23 @@ class ContentTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testCreateDataResourceRole() {
+        String dataResourceId = testParams.dataResourceId ?: 'TEST_DATA_RESOURCE_1'
+        String partyId = testParams.partyId ?: 'admin'
+        String roleTypeId = testParams.roleTypeId ?: 'OWNER'
         Map serviceCtx = [:]
-        serviceCtx.dataResourceId = 'TEST_DATA_RESOURCE_1'
+        serviceCtx.dataResourceId = dataResourceId
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createDataResource', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        serviceCtx.partyId = 'admin'
-        serviceCtx.roleTypeId = 'OWNER'
+        serviceCtx.partyId = partyId
+        serviceCtx.roleTypeId = roleTypeId
         serviceCtx.fromDate = UtilDateTime.toTimestamp('11/03/2016 00:00:00')
         serviceResult = dispatcher.runSync('createDataResourceRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue dataResourceRole = from('DataResourceRole')
-                .where('dataResourceId', 'TEST_DATA_RESOURCE_1', 'partyId', 'admin', 'roleTypeId', 'OWNER',
+                .where('dataResourceId', dataResourceId, 'partyId', partyId, 'roleTypeId', roleTypeId,
                 'fromDate', UtilDateTime.toTimestamp('11/03/2016 00:00:00'))
                 .queryOne()
         assert dataResourceRole
@@ -133,20 +145,23 @@ class ContentTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testUpdateDataResourceRole() {
+        String dataResourceId = testParams.dataResourceId ?: 'TEST_DATA_RESOURCE_2'
+        String partyId = testParams.partyId ?: 'admin'
+        String roleTypeId = testParams.roleTypeId ?: 'OWNER'
         Map serviceCtx = [:]
-        serviceCtx.dataResourceId = 'TEST_DATA_RESOURCE_2'
+        serviceCtx.dataResourceId = dataResourceId
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createDataResource', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        serviceCtx.partyId = 'admin'
-        serviceCtx.roleTypeId = 'OWNER'
+        serviceCtx.partyId = partyId
+        serviceCtx.roleTypeId = roleTypeId
         serviceCtx.fromDate = UtilDateTime.toTimestamp('11/03/2016 00:00:00')
         serviceResult = dispatcher.runSync('createDataResourceRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue dataResourceRole = from('DataResourceRole')
-                .where('dataResourceId', 'TEST_DATA_RESOURCE_2', 'partyId', 'admin')
+                .where('dataResourceId', dataResourceId, 'partyId', partyId)
                 .queryOne()
         assert dataResourceRole
         assert !dataResourceRole.thruDate
@@ -156,7 +171,7 @@ class ContentTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         dataResourceRole = from('DataResourceRole')
-                .where('dataResourceId', 'TEST_DATA_RESOURCE_2', 'partyId', 'admin')
+                .where('dataResourceId', dataResourceId, 'partyId', partyId)
                 .queryOne()
         assert dataResourceRole
         assert dataResourceRole.thruDate
@@ -165,20 +180,23 @@ class ContentTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testRemoveDataResourceRole() {
+        String dataResourceId = testParams.dataResourceId ?: 'TEST_DATA_RESOURCE_3'
+        String partyId = testParams.partyId ?: 'admin'
+        String roleTypeId = testParams.roleTypeId ?: 'OWNER'
         Map serviceCtx = [:]
-        serviceCtx.dataResourceId = 'TEST_DATA_RESOURCE_3'
+        serviceCtx.dataResourceId = dataResourceId
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('createDataResource', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        serviceCtx.partyId = 'admin'
-        serviceCtx.roleTypeId = 'OWNER'
+        serviceCtx.partyId = partyId
+        serviceCtx.roleTypeId = roleTypeId
         serviceCtx.fromDate = UtilDateTime.nowTimestamp()
         serviceResult = dispatcher.runSync('createDataResourceRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue dataResourceRole = from('DataResourceRole')
-                .where('dataResourceId', 'TEST_DATA_RESOURCE_3', 'partyId', 'admin')
+                .where('dataResourceId', dataResourceId, 'partyId', partyId)
                 .queryFirst()
         assert dataResourceRole
 
@@ -186,7 +204,7 @@ class ContentTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         dataResourceRole = from('DataResourceRole')
-                .where('dataResourceId', 'TEST_DATA_RESOURCE_3', 'partyId', 'admin')
+                .where('dataResourceId', dataResourceId, 'partyId', partyId)
                 .queryFirst()
         assert !dataResourceRole
     }
@@ -194,8 +212,9 @@ class ContentTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testGetContent() {
+        String contentId = testParams.contentId ?: 'TEST_CONTENT4'
         Map serviceCtx = [:]
-        serviceCtx.contentId = 'TEST_CONTENT4'
+        serviceCtx.contentId = contentId
         serviceCtx.userLogin = userLogin
         Map serviceResult = dispatcher.runSync('getContent', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/InventoryIssuanceTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/InventoryIssuanceTests.groovy
@@ -58,6 +58,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(1)
     void testS1_1_StrictIssuanceFailure() {
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
         String facId = 'WH_S1_1'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
             ownerPartyId: 'II_COMPANY', autoReservePrun: 'Y', allowInventoryReallocation: 'Y', reconcilePrunBackorders: 'N'])
@@ -67,7 +68,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
         // Run in a new transaction so an error-return does NOT poison the outer tx.
         Map result = dispatcher.runSync('issueProductionRunTask', [
-                workEffortId: weId, failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+                workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ], 0, true)
         assert ServiceUtil.isError(result)
     }
@@ -75,6 +76,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(2)
     void testS1_2_ForceWithReallocation() {
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
         String facId = 'WH_S1_2'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
             ownerPartyId: 'II_COMPANY', autoReservePrun: 'Y', allowInventoryReallocation: 'Y', reconcilePrunBackorders: 'N'])
@@ -89,7 +91,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
         // Action: Force issue. Should reallocate 50 from affected reservation.
         Map result = dispatcher.runSync('issueProductionRunTask', [
-                workEffortId: issuingWeId, failIfItemsAreNotAvailable: 'N', userLogin: userLogin
+                workEffortId: issuingWeId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
 
@@ -148,6 +150,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(4)
     void testS4_2_ProductionChainAutoSatisfaction() {
+        String statusId = testParams.statusId ?: 'PRUN_RUNNING'
+        String statusId1 = testParams.statusId1 ?: 'PRUN_COMPLETED'
         String facId = 'WH_CHAIN_RECON'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
             ownerPartyId: 'II_COMPANY', autoReservePrun: 'Y', allowInventoryReallocation: 'Y', reconcilePrunBackorders: 'Y'])
@@ -168,7 +172,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
         dispatcher.runSync('changeProductionRunTaskStatus', [
             productionRunId: prBId, workEffortId: prBTaskId,
-            statusId: 'PRUN_RUNNING', userLogin: userLogin
+            statusId: statusId, userLogin: userLogin
         ])
 
         GenericValue resB = from('WorkEffortInvRes').where('workEffortId', prBTaskId, 'productId', 'II_MAT_E_RAW').queryFirst()
@@ -181,7 +185,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
 
         dispatcher.runSync('changeProductionRunTaskStatus', [
             productionRunId: prBId, workEffortId: prBTaskId,
-            statusId: 'PRUN_COMPLETED', userLogin: userLogin
+            statusId: statusId1, userLogin: userLogin
         ])
 
         Map produceResult = dispatcher.runSync('productionRunProduce', [
@@ -203,6 +207,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(5)
     void testS3_2_NegativeReservationResolution() {
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_MAT_C_S3_2'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
         String facId = 'WH_S3_2'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
             ownerPartyId: 'II_COMPANY', autoReservePrun: 'Y', allowInventoryReallocation: 'Y', reconcilePrunBackorders: 'N'])
@@ -216,12 +222,12 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
                 'Initial state should be 20 backordered'
 
         dispatcher.runSync('createInventoryItemDetail', [
-                inventoryItemId: 'II_MAT_C_S3_2', quantityOnHandDiff: 50.0,
+                inventoryItemId: inventoryItemId, quantityOnHandDiff: 50.0,
                 availableToPromiseDiff: 50.0, accountingQuantityDiff: 50.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTask', [
-                workEffortId: weId, failIfItemsAreNotAvailable: 'N', userLogin: userLogin
+                workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
 
@@ -231,6 +237,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(6)
     void testS3_4_ImpactPlanAudit() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
         String facId = 'WH_S3_4'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
             ownerPartyId: 'II_COMPANY', autoReservePrun: 'Y', allowInventoryReallocation: 'Y', reconcilePrunBackorders: 'N'])
@@ -244,7 +251,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         String t4 = setUpProductionRun('II_PROD_MANUF', 7.5, facId)
 
         Map impactResult = dispatcher.runSync('getProductionRunTaskForceIssueImpact', [
-            workEffortId: t4, facilityId: facId, productId: 'II_MAT_A_COST', userLogin: userLogin
+            workEffortId: t4, facilityId: facId, productId: productId, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(impactResult)
 
@@ -263,6 +270,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(7)
     void testS3_5_AffectedReservationSanityGuard() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String requireInventory = testParams.requireInventory ?: 'N'
         String facId = 'WH_S3_5'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
             ownerPartyId: 'II_COMPANY', autoReservePrun: 'Y', allowInventoryReallocation: 'Y', reconcilePrunBackorders: 'N'])
@@ -270,9 +279,9 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         setUpInventory(facId, 'II_MAT_C_COST', 'II_MAT_C_S3_5', 100.0)
         String affectedWeId = setUpProductionRun('II_PROD_MANUF', 10.0, facId)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: affectedWeId, productId: 'II_MAT_A_COST', facilityId: facId,
+            workEffortId: affectedWeId, productId: productId, facilityId: facId,
             inventoryItemId: null, quantity: 20.0, quantityNotAvailable: 20.0,
-            requireInventory: 'N', userLogin: userLogin
+            requireInventory: requireInventory, userLogin: userLogin
         ])
 
         int resCount = from('WorkEffortInvRes').where('workEffortId', affectedWeId, 'productId', 'II_MAT_A_COST').queryCount()
@@ -281,7 +290,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         String issuingWeId = setUpProductionRun('II_PROD_MANUF', 5.0, facId)
 
         List impactList = [[
-            productId: 'II_MAT_A_COST', impactType: 'Production Task', impactId: affectedWeId,
+            productId: productId, impactType: 'Production Task', impactId: affectedWeId,
             inventoryItemId: 'II_MAT_A_S3_5', quantity: 10.0, type: 'REALLOCATED', impactedWorkEffortId: affectedWeId
         ]]
 
@@ -339,6 +348,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(9)
     void testS4_1_ReleaseWithRestore() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_MAT_A_S4_1'
         String facId = 'WH_S4_1'
         storeFacility([facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
             ownerPartyId: 'II_COMPANY', autoReservePrun: 'Y', allowInventoryReallocation: 'Y', reconcilePrunBackorders: 'N'])
@@ -348,8 +359,8 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         long countBefore = from('InventoryItemDetail').where('inventoryItemId', 'II_MAT_A_S4_1').queryCount()
 
         Map result = dispatcher.runSync('releaseProductionRunTaskComponent', [
-                workEffortId: weId, productId: 'II_MAT_A_COST',
-                inventoryItemId: 'II_MAT_A_S4_1', appendInventoryItemDetail: true, userLogin: userLogin
+                workEffortId: weId, productId: productId,
+                inventoryItemId: inventoryItemId, appendInventoryItemDetail: true, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
 
@@ -363,6 +374,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(10)
     void testS4_2_ReleaseSatisfaction() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
         String weId = setUpProductionRun('II_PROD_MANUF', 10.0)
 
         GenericValue resRecord = from('WorkEffortInvRes').where('workEffortId', weId, 'productId', 'II_MAT_A_COST').queryFirst()
@@ -372,7 +384,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         long countBefore = from('InventoryItemDetail').where('inventoryItemId', reservedItemId).queryCount()
 
         Map result = dispatcher.runSync('releaseProductionRunTaskComponent', [
-                workEffortId: weId, productId: 'II_MAT_A_COST',
+                workEffortId: weId, productId: productId,
                 inventoryItemId: reservedItemId, appendInventoryItemDetail: false, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
@@ -389,6 +401,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(11)
     void testS5_1_PolicyGateFail() {
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
         String itemId = 'II_INV_TRAD_S5_1'
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', itemId, 100.0)
         setUpInventory('WH_TRADITIONAL', 'II_MAT_C_COST', 'II_INV_TRAD_C_S5_1', 100.0)
@@ -399,7 +412,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         String issuingWeId = setUpProductionRun('II_PROD_MANUF', 10.0, 'WH_TRADITIONAL')
 
         Map result = dispatcher.runSync('issueProductionRunTask', [
-                workEffortId: issuingWeId, failIfItemsAreNotAvailable: 'N', userLogin: userLogin
+                workEffortId: issuingWeId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ], 0, true)
 
         assert ServiceUtil.isError(result)
@@ -410,6 +423,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(12)
     void testS5_2_APIPolicyEnforcement() {
+        String facilityId = testParams.facilityId ?: 'WH_TRADITIONAL'
         String itemId = 'II_INV_TRAD_S5_2'
         String issuingWeId = setUpProductionRun('II_PROD_MANUF', 10.0, 'WH_TRADITIONAL')
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', itemId, 100.0)
@@ -421,7 +435,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         ]]
 
         Map reallocResult = dispatcher.runSync('reallocateAndIssueInventory', [
-                workEffortId: issuingWeId, impactList: impactList, facilityId: 'WH_TRADITIONAL', userLogin: userLogin
+                workEffortId: issuingWeId, impactList: impactList, facilityId: facilityId, userLogin: userLogin
         ], 0, true)
 
         assert ServiceUtil.isError(reallocResult)
@@ -431,15 +445,18 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(13)
     void testS5_3_NightlyReconciliation() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_FLUID'
+        String requireInventory = testParams.requireInventory ?: 'N'
         String itemIdA = 'II_INV_FLUID_A_S5_3'
         String itemIdC = 'II_INV_FLUID_C_S5_3'
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', itemIdA, 100.0)
         setUpInventory('WH_FLUID', 'II_MAT_C_COST', itemIdC, 0.0)
         String affectedWeId = setUpProductionRun('II_PROD_MANUF', 10.0, 'WH_FLUID')
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: affectedWeId, productId: 'II_MAT_A_COST', facilityId: 'WH_FLUID',
+            workEffortId: affectedWeId, productId: productId, facilityId: facilityId,
             inventoryItemId: itemIdA, quantity: 20.0, quantityNotAvailable: 20.0,
-            requireInventory: 'N', userLogin: userLogin
+            requireInventory: requireInventory, userLogin: userLogin
         ])
 
         String backorderWeId = setUpProductionRun('II_PROD_MANUF', 5.0, 'WH_FLUID')
@@ -469,6 +486,11 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(14)
     void testS5_4_ReconFluidPolicy() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
+        String facilityId = testParams.facilityId ?: 'WH_FLUID'
+        String requireInventory = testParams.requireInventory ?: 'N'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_INV_FLUID_B_S5_4'
         String itemId = 'II_INV_FLUID_A_S5_4'
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', itemId, 5.0)
         setUpInventory('WH_FLUID', 'II_MAT_C_COST', 'II_INV_FLUID_C_S5_4', 100.0)
@@ -477,15 +499,15 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         String affectedWeId = setUpProductionRun('II_PROD_MANUF', 5.0, 'WH_FLUID')
 
         Map issueAffectedResult = dispatcher.runSync('issueProductionRunTaskComponent', [
-            workEffortId: affectedWeId, productId: 'II_MAT_A_COST', quantity: 5.0,
-            failIfItemsAreNotAvailable: 'N', userLogin: userLogin
+            workEffortId: affectedWeId, productId: productId, quantity: 5.0,
+            failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(issueAffectedResult)
 
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: affectedWeId, productId: 'II_MAT_A_COST', facilityId: 'WH_FLUID',
+            workEffortId: affectedWeId, productId: productId, facilityId: facilityId,
             inventoryItemId: itemId, quantity: 7.0, quantityNotAvailable: 7.0,
-            requireInventory: 'N', userLogin: userLogin
+            requireInventory: requireInventory, userLogin: userLogin
         ])
 
         String boWeId = setUpProductionRun('II_PROD_MANUF', 5.0, 'WH_FLUID')
@@ -497,7 +519,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         assert scaleQuantity(totalQna) == scaleQuantity(5.0) : 'Aggressive Auditor should have purged excess logical debt to match estimate ceiling'
 
         dispatcher.runSync('createInventoryItemDetail', [
-                inventoryItemId: 'II_INV_FLUID_B_S5_4', quantityOnHandDiff: 20.0,
+                inventoryItemId: inventoryItemId, quantityOnHandDiff: 20.0,
                 availableToPromiseDiff: 20.0, accountingQuantityDiff: 20.0, userLogin: userLogin
         ])
         dispatcher.runSync('reconcileInventoryForProductionJobs', [userLogin: userLogin])
@@ -511,6 +533,11 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(15)
     void testS5_5_ReconTraditionalPolicy() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
+        String facilityId = testParams.facilityId ?: 'WH_TRADITIONAL'
+        String requireInventory = testParams.requireInventory ?: 'N'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_INV_TRAD_B_S5_5'
         String itemId = 'II_INV_TRAD_A_S5_5'
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', itemId, 20.0)
         setUpInventory('WH_TRADITIONAL', 'II_MAT_C_COST', 'II_INV_TRAD_C_S5_5', 100.0)
@@ -519,21 +546,21 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         String weId = setUpProductionRun('II_PROD_MANUF', 5.0, 'WH_TRADITIONAL')
 
         Map issueScrapResult = dispatcher.runSync('issueProductionRunTaskComponent', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', quantity: 12.0,
-            failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+            workEffortId: weId, productId: productId, quantity: 12.0,
+            failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(issueScrapResult)
 
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', facilityId: 'WH_TRADITIONAL',
+            workEffortId: weId, productId: productId, facilityId: facilityId,
             inventoryItemId: itemId, quantity: 2.0, quantityNotAvailable: 2.0,
-            requireInventory: 'N', userLogin: userLogin
+            requireInventory: requireInventory, userLogin: userLogin
         ])
 
         String boWeId = setUpProductionRun('II_PROD_MANUF', 5.0, 'WH_TRADITIONAL')
         dispatcher.runSync('issueProductionRunTask', [workEffortId: boWeId, userLogin: userLogin])
         dispatcher.runSync('createInventoryItemDetail', [
-                inventoryItemId: 'II_INV_TRAD_B_S5_5', quantityOnHandDiff: 20.0,
+                inventoryItemId: inventoryItemId, quantityOnHandDiff: 20.0,
                 availableToPromiseDiff: 20.0, accountingQuantityDiff: 20.0, userLogin: userLogin
         ])
 
@@ -554,24 +581,30 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(16)
     void testS5_6_ReconSafePolicy() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
+        String facilityId = testParams.facilityId ?: 'WH_SAFE'
+        String inventoryItemId = testParams.inventoryItemId ?: 'INV_SAFE_A'
+        String requireInventory = testParams.requireInventory ?: 'N'
+        String inventoryItemId1 = testParams.inventoryItemId1 ?: 'INV_SAFE_C_HEAL'
         setUpInventory('WH_SAFE', 'II_MAT_A_COST', 'INV_SAFE_A', 20.0)
         setUpInventory('WH_SAFE', 'II_MAT_C_COST', 'INV_SAFE_C_HEAL', 0.0)
         String weId = setUpProductionRun('II_PROD_MANUF', 5.0, 'WH_SAFE')
         Map issueScrapResult = dispatcher.runSync('issueProductionRunTaskComponent', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', quantity: 12.0,
-            failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+            workEffortId: weId, productId: productId, quantity: 12.0,
+            failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(issueScrapResult)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', facilityId: 'WH_SAFE',
-            inventoryItemId: 'INV_SAFE_A', quantity: 5.0, quantityNotAvailable: 5.0,
-            requireInventory: 'N', userLogin: userLogin
+            workEffortId: weId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 5.0, quantityNotAvailable: 5.0,
+            requireInventory: requireInventory, userLogin: userLogin
         ])
 
         String boWeId = setUpProductionRun('II_PROD_MANUF', 5.0, 'WH_SAFE')
         dispatcher.runSync('issueProductionRunTask', [workEffortId: boWeId, userLogin: userLogin])
         dispatcher.runSync('createInventoryItemDetail', [
-                inventoryItemId: 'INV_SAFE_C_HEAL', quantityOnHandDiff: 20.0,
+                inventoryItemId: inventoryItemId1, quantityOnHandDiff: 20.0,
                 availableToPromiseDiff: 20.0, accountingQuantityDiff: 20.0, userLogin: userLogin
         ])
 
@@ -589,6 +622,13 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(17)
     void testM1_ManualLotReallocationSuccess() {
+        String workEffortId = testParams.workEffortId ?: 'WE_AFFECTED'
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_FLUID'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_MAN_FLUID'
+        String workEffortId1 = testParams.workEffortId1 ?: 'WE_ISSUING_FLUID'
+        String lotId = testParams.lotId ?: 'LOT_MANUAL_01'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', 'II_MAN_FLUID', 10.0)
         GenericValue item = from('InventoryItem').where('inventoryItemId', 'II_MAN_FLUID').queryOne()
         item.set('locationSeqId', 'FLOC_01')
@@ -596,18 +636,18 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         item.store()
 
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: 'WE_AFFECTED', productId: 'II_MAT_A_COST', facilityId: 'WH_FLUID',
-            inventoryItemId: 'II_MAN_FLUID', quantity: 10.0, userLogin: userLogin
+            workEffortId: workEffortId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 10.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTaskComponent', [
-            workEffortId: 'WE_ISSUING_FLUID', productId: 'II_MAT_A_COST',
-            lotId: 'LOT_MANUAL_01', quantity: 5.0, failIfItemsAreNotAvailable: 'N', userLogin: userLogin
+            workEffortId: workEffortId1, productId: productId,
+            lotId: lotId, quantity: 5.0, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
 
         assertInventoryIntegrity('II_MAT_A_COST', 'WE_ISSUING_FLUID', 5.0, 0.0, 0.0, 'WH_FLUID')
-        GenericValue affectedRes = from('WorkEffortInvRes').where(workEffortId: 'WE_AFFECTED').queryFirst()
+        GenericValue affectedRes = from('WorkEffortInvRes').where(workEffortId: workEffortId).queryFirst()
         assert scaleQuantity(affectedRes.getBigDecimal('quantityNotAvailable')) == scaleQuantity(5.0) :
                 'Affected reservation should be backordered by 5'
     }
@@ -615,34 +655,46 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(18)
     void testM2_ManualForceNegative() {
+        String workEffortId = testParams.workEffortId ?: 'WE_ISSUING_FLUID'
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_MAN_FLUID'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
+        String failIfItemsAreNotOnHand = testParams.failIfItemsAreNotOnHand ?: 'N'
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', 'II_MAN_FLUID', 0.0)
 
         Map result = dispatcher.runSync('issueProductionRunTaskComponent', [
-            workEffortId: 'WE_ISSUING_FLUID', productId: 'II_MAT_A_COST',
-            inventoryItemId: 'II_MAN_FLUID', quantity: 10.0,
-            failIfItemsAreNotAvailable: 'N', failIfItemsAreNotOnHand: 'N', userLogin: userLogin
+            workEffortId: workEffortId, productId: productId,
+            inventoryItemId: inventoryItemId, quantity: 10.0,
+            failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, failIfItemsAreNotOnHand: failIfItemsAreNotOnHand, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
 
-        GenericValue item = from('InventoryItem').where(inventoryItemId: 'II_MAN_FLUID').queryOne()
+        GenericValue item = from('InventoryItem').where(inventoryItemId: inventoryItemId).queryOne()
         assert scaleQuantity(item.getBigDecimal('quantityOnHandTotal')) == scaleQuantity(-10.0) : 'QOH should be -10'
     }
 
     @Test
     @Order(19)
     void testM3_UserStrictnessOverridesFacilityFluidity() {
+        String workEffortId = testParams.workEffortId ?: 'WE_AFFECTED'
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_FLUID'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_MAN_FLUID'
+        String workEffortId1 = testParams.workEffortId1 ?: 'WE_ISSUING_FLUID'
+        String lotId = testParams.lotId ?: 'LOT_MANUAL_01'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
         setUpInventory('WH_FLUID', 'II_MAT_A_COST', 'II_MAN_FLUID', 10.0)
         GenericValue item = from('InventoryItem').where('inventoryItemId', 'II_MAN_FLUID').queryOne()
         item.set('lotId', 'LOT_MANUAL_01')
         item.store()
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: 'WE_AFFECTED', productId: 'II_MAT_A_COST', facilityId: 'WH_FLUID',
-            inventoryItemId: 'II_MAN_FLUID', quantity: 10.0, userLogin: userLogin
+            workEffortId: workEffortId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 10.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTaskComponent', [
-            workEffortId: 'WE_ISSUING_FLUID', productId: 'II_MAT_A_COST',
-            lotId: 'LOT_MANUAL_01', quantity: 5.0, failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+            workEffortId: workEffortId1, productId: productId,
+            lotId: lotId, quantity: 5.0, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ], 0, true)
 
         assert ServiceUtil.isError(result)
@@ -656,18 +708,25 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(20)
     void testM4_FacilityStrictnessOverridesUserFluidity() {
+        String workEffortId = testParams.workEffortId ?: 'WE_AFFECTED'
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_TRADITIONAL'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_MAN_STRICT'
+        String workEffortId1 = testParams.workEffortId1 ?: 'WE_ISSUING_STRICT'
+        String locationSeqId = testParams.locationSeqId ?: 'TLOC_01'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', 'II_MAN_STRICT', 10.0)
         GenericValue item = from('InventoryItem').where('inventoryItemId', 'II_MAN_STRICT').queryOne()
         item.set('locationSeqId', 'TLOC_01')
         item.store()
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: 'WE_AFFECTED', productId: 'II_MAT_A_COST', facilityId: 'WH_TRADITIONAL',
-            inventoryItemId: 'II_MAN_STRICT', quantity: 10.0, userLogin: userLogin
+            workEffortId: workEffortId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 10.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTaskComponent', [
-            workEffortId: 'WE_ISSUING_STRICT', productId: 'II_MAT_A_COST',
-            locationSeqId: 'TLOC_01', quantity: 5.0, failIfItemsAreNotAvailable: 'N', userLogin: userLogin
+            workEffortId: workEffortId1, productId: productId,
+            locationSeqId: locationSeqId, quantity: 5.0, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ], 0, true)
 
         assert ServiceUtil.isError(result)
@@ -681,16 +740,21 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(21)
     void testM6_SelfConsumptionSuccessInStrictMode() {
+        String workEffortId = testParams.workEffortId ?: 'WE_ISSUING_STRICT'
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_TRADITIONAL'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_MAN_STRICT'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
         setUpInventory('WH_TRADITIONAL', 'II_MAT_A_COST', 'II_MAN_STRICT', 10.0)
 
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: 'WE_ISSUING_STRICT', productId: 'II_MAT_A_COST', facilityId: 'WH_TRADITIONAL',
-            inventoryItemId: 'II_MAN_STRICT', quantity: 10.0, userLogin: userLogin
+            workEffortId: workEffortId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 10.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTaskComponent', [
-            workEffortId: 'WE_ISSUING_STRICT', productId: 'II_MAT_A_COST',
-            inventoryItemId: 'II_MAN_STRICT', quantity: 5.0, failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+            workEffortId: workEffortId, productId: productId,
+            inventoryItemId: inventoryItemId, quantity: 5.0, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
 
         assert ServiceUtil.isSuccess(result)
@@ -700,6 +764,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(22)
     void testS5_7_NullPolicyDefaultsToStrict() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
         String facId = 'WH_NULL_POLICY'
         storeFacility([
             facilityId: facId, facilityName: facId, facilityTypeId: 'WAREHOUSE',
@@ -709,7 +774,7 @@ class InventoryIssuanceTests extends InventoryIssuanceTestSupport {
         String issuingWeId = setUpProductionRun('II_PROD_MANUF', 10.0, facId)
 
         Map impactResult = dispatcher.runSync('getProductionRunTaskForceIssueImpact', [
-            workEffortId: issuingWeId, facilityId: facId, productId: 'II_MAT_A_COST', userLogin: userLogin
+            workEffortId: issuingWeId, facilityId: facId, productId: productId, userLogin: userLogin
         ])
 
         assert ServiceUtil.isSuccess(impactResult)
@@ -769,10 +834,13 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(1)
     void testS6_1_ManualReserve_IssueDefault_Success() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_NO_AUTO_RES'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_S6_1'
         String weId = setUpNoAutoReserveProductionRun('II_S6_1', 100.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', facilityId: 'WH_NO_AUTO_RES',
-            inventoryItemId: 'II_S6_1', quantity: 20.0, userLogin: userLogin
+            workEffortId: weId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 20.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTask', [workEffortId: weId, userLogin: userLogin])
@@ -783,14 +851,18 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(2)
     void testS6_2_ManualReserve_IssueFailIfAvail_Y_Success() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_NO_AUTO_RES'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_S6_2'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
         String weId = setUpNoAutoReserveProductionRun('II_S6_2', 100.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', facilityId: 'WH_NO_AUTO_RES',
-            inventoryItemId: 'II_S6_2', quantity: 20.0, userLogin: userLogin
+            workEffortId: weId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 20.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTask', [
-            workEffortId: weId, failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+            workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
@@ -799,14 +871,20 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(3)
     void testS6_3_ManualReserve_IssueFailIfAvail_N_Success() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_NO_AUTO_RES'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_S6_3'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
+        String failIfItemsAreNotOnHand = testParams.failIfItemsAreNotOnHand ?: 'N'
         String weId = setUpNoAutoReserveProductionRun('II_S6_3', 100.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', facilityId: 'WH_NO_AUTO_RES',
-            inventoryItemId: 'II_S6_3', quantity: 20.0, userLogin: userLogin
+            workEffortId: weId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 20.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTask', [
-            workEffortId: weId, failIfItemsAreNotAvailable: 'N', failIfItemsAreNotOnHand: 'N', userLogin: userLogin
+            workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable,
+            failIfItemsAreNotOnHand: failIfItemsAreNotOnHand, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
@@ -825,10 +903,11 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(5)
     void testS6_5_NoReserve_DirectIssueFailIfAvail_Y_Success() {
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
         String weId = setUpNoAutoReserveProductionRun('II_S6_5', 100.0)
 
         Map result = dispatcher.runSync('issueProductionRunTask', [
-            workEffortId: weId, failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+            workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
@@ -837,10 +916,13 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(6)
     void testS6_6_NoReserve_DirectIssueFailIfAvail_N_Success() {
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
+        String failIfItemsAreNotOnHand = testParams.failIfItemsAreNotOnHand ?: 'N'
         String weId = setUpNoAutoReserveProductionRun('II_S6_6', 100.0)
 
         Map result = dispatcher.runSync('issueProductionRunTask', [
-            workEffortId: weId, failIfItemsAreNotAvailable: 'N', failIfItemsAreNotOnHand: 'N', userLogin: userLogin
+            workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable,
+            failIfItemsAreNotOnHand: failIfItemsAreNotOnHand, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, 80.0, 'WH_NO_AUTO_RES')
@@ -849,10 +931,13 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(7)
     void testS6_7_Insufficient_ManualReserve_IssueDefault_Fail() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_NO_AUTO_RES'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_S6_7'
         String weId = setUpNoAutoReserveProductionRun('II_S6_7', 0.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', facilityId: 'WH_NO_AUTO_RES',
-            inventoryItemId: 'II_S6_7', quantity: 20.0, userLogin: userLogin
+            workEffortId: weId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 20.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTask', [workEffortId: weId, userLogin: userLogin], 0, true)
@@ -862,14 +947,18 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(8)
     void testS6_8_Insufficient_ManualReserve_IssueFailIfAvail_Y_Fail() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_NO_AUTO_RES'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_S6_8'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
         String weId = setUpNoAutoReserveProductionRun('II_S6_8', 0.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', facilityId: 'WH_NO_AUTO_RES',
-            inventoryItemId: 'II_S6_8', quantity: 20.0, userLogin: userLogin
+            workEffortId: weId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 20.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTask', [
-            workEffortId: weId, failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+            workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ], 0, true)
         assert ServiceUtil.isError(result)
     }
@@ -877,14 +966,20 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(9)
     void testS6_9_Insufficient_ManualReserve_IssueFailIfAvail_N_Success() {
+        String productId = testParams.productId ?: 'II_MAT_A_COST'
+        String facilityId = testParams.facilityId ?: 'WH_NO_AUTO_RES'
+        String inventoryItemId = testParams.inventoryItemId ?: 'II_S6_9'
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
+        String failIfItemsAreNotOnHand = testParams.failIfItemsAreNotOnHand ?: 'N'
         String weId = setUpNoAutoReserveProductionRun('II_S6_9', 0.0)
         dispatcher.runSync('reserveWorkEffortInventoryItem', [
-            workEffortId: weId, productId: 'II_MAT_A_COST', facilityId: 'WH_NO_AUTO_RES',
-            inventoryItemId: 'II_S6_9', quantity: 20.0, userLogin: userLogin
+            workEffortId: weId, productId: productId, facilityId: facilityId,
+            inventoryItemId: inventoryItemId, quantity: 20.0, userLogin: userLogin
         ])
 
         Map result = dispatcher.runSync('issueProductionRunTask', [
-            workEffortId: weId, failIfItemsAreNotAvailable: 'N', failIfItemsAreNotOnHand: 'N', userLogin: userLogin
+            workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable,
+            failIfItemsAreNotOnHand: failIfItemsAreNotOnHand, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, -20.0, 'WH_NO_AUTO_RES')
@@ -901,9 +996,10 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(11)
     void testS6_11_Insufficient_NoReserve_DirectIssueFailIfAvail_Y_Fail() {
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'Y'
         String weId = setUpNoAutoReserveProductionRun('II_S6_11', 0.0)
         Map result = dispatcher.runSync('issueProductionRunTask', [
-            workEffortId: weId, failIfItemsAreNotAvailable: 'Y', userLogin: userLogin
+            workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable, userLogin: userLogin
         ], 0, true)
         assert ServiceUtil.isError(result)
     }
@@ -911,9 +1007,12 @@ class InventoryIssuancePolicyMatrixTests extends InventoryIssuanceTestSupport {
     @Test
     @Order(12)
     void testS6_12_Insufficient_NoReserve_DirectIssueFailIfAvail_N_Success() {
+        String failIfItemsAreNotAvailable = testParams.failIfItemsAreNotAvailable ?: 'N'
+        String failIfItemsAreNotOnHand = testParams.failIfItemsAreNotOnHand ?: 'N'
         String weId = setUpNoAutoReserveProductionRun('II_S6_12', 0.0)
         Map result = dispatcher.runSync('issueProductionRunTask', [
-            workEffortId: weId, failIfItemsAreNotAvailable: 'N', failIfItemsAreNotOnHand: 'N', userLogin: userLogin
+            workEffortId: weId, failIfItemsAreNotAvailable: failIfItemsAreNotAvailable,
+            failIfItemsAreNotOnHand: failIfItemsAreNotOnHand, userLogin: userLogin
         ])
         assert ServiceUtil.isSuccess(result)
         assertInventoryIntegrity('II_MAT_A_COST', weId, 20.0, 0.0, -20.0, 'WH_NO_AUTO_RES')

--- a/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/ProductionRunTests.groovy
+++ b/applications/manufacturing/src/test/groovy/org/apache/ofbiz/manufacturing/test/ProductionRunTests.groovy
@@ -34,8 +34,8 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(7)
     void testProductionRunCreation() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
-        String productId = 'PROD_MANUF'
-        String facilityId = 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
         BigDecimal quantity = 5.0
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Timestamp productionRunStartDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 1)
@@ -98,8 +98,10 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(5)
     void testProductionRunScheduleConfirm() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
-        String productId = 'PROD_MANUF'
-        String facilityId = 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String scheduledStatusId = testParams.scheduledStatusId ?: 'PRUN_SCHEDULED'
+        String printedStatusId = testParams.printedStatusId ?: 'PRUN_DOC_PRINTED'
         BigDecimal quantity = 5.0
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Timestamp productionRunStartDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 1)
@@ -116,7 +118,7 @@ class ProductionRunTests implements JupiterTestHelper {
         String productionRunId = serviceResult.productionRunId
 
         Map scheduleResult = dispatcher.runSync('changeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_SCHEDULED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: scheduledStatusId])
         assert ServiceUtil.isSuccess(scheduleResult)
 
         GenericValue productionRunHeader = from('WorkEffort').where('workEffortId', productionRunId).queryOne()
@@ -128,7 +130,7 @@ class ProductionRunTests implements JupiterTestHelper {
         assert productionRunTask.currentStatusId == 'PRUN_SCHEDULED'
 
         Map printResult = dispatcher.runSync('changeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_DOC_PRINTED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: printedStatusId])
         assert ServiceUtil.isSuccess(printResult)
 
         productionRunHeader = from('WorkEffort').where('workEffortId', productionRunId).queryOne()
@@ -144,8 +146,9 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(1)
     void testProductionRunDateChange() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
-        String productId = 'PROD_MANUF'
-        String facilityId = 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String scheduledStatusId = testParams.scheduledStatusId ?: 'PRUN_SCHEDULED'
         BigDecimal quantity = 5.0
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Timestamp productionRunStartDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 1)
@@ -162,7 +165,7 @@ class ProductionRunTests implements JupiterTestHelper {
         String productionRunId = serviceResult.productionRunId
 
         Map scheduleResult = dispatcher.runSync('changeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_SCHEDULED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: scheduledStatusId])
         assert ServiceUtil.isSuccess(scheduleResult)
 
         Timestamp productionRunNewStartDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 2)
@@ -187,8 +190,9 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(2)
     void testProductionRunCancelled() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
-        String productId = 'PROD_MANUF'
-        String facilityId = 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String scheduledStatusId = testParams.scheduledStatusId ?: 'PRUN_SCHEDULED'
         BigDecimal quantity = 5.0
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Timestamp productionRunStartDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 1)
@@ -205,7 +209,7 @@ class ProductionRunTests implements JupiterTestHelper {
         String productionRunId = serviceResult.productionRunId
 
         Map scheduleResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_SCHEDULED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: scheduledStatusId])
         assert ServiceUtil.isSuccess(scheduleResult)
         Map cancelResult = dispatcher.runSync('cancelProductionRun', [userLogin: userLogin, productionRunId: productionRunId])
         assert ServiceUtil.isSuccess(cancelResult)
@@ -239,8 +243,12 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(8)
     void testProductionRunQuickIssueAndProduce() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
-        String productId = 'PROD_MANUF'
-        String facilityId = 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String printedStatusId = testParams.printedStatusId ?: 'PRUN_DOC_PRINTED'
+        String completedStatusId = testParams.completedStatusId ?: 'PRUN_COMPLETED'
+        String inventoryItemTypeId = testParams.inventoryItemTypeId ?: 'NON_SERIAL_INV_ITEM'
+        String lotId = testParams.lotId ?: 'LOT12345'
         BigDecimal quantity = 2.0
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Timestamp productionRunStartDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 1)
@@ -257,7 +265,7 @@ class ProductionRunTests implements JupiterTestHelper {
         String productionRunId = serviceResult.productionRunId
 
         Map printResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_DOC_PRINTED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: printedStatusId])
         assert ServiceUtil.isSuccess(printResult)
         Map startResult = dispatcher.runSync('quickStartAllProductionRunTasks', [userLogin: userLogin, productionRunId: productionRunId])
         assert ServiceUtil.isSuccess(startResult)
@@ -279,8 +287,8 @@ class ProductionRunTests implements JupiterTestHelper {
         Map issueAndProduceCtx = [
             userLogin: userLogin,
             workEffortId: productionRunId,
-            inventoryItemTypeId: 'NON_SERIAL_INV_ITEM',
-            lotId: 'LOT12345',
+            inventoryItemTypeId: inventoryItemTypeId,
+            lotId: lotId,
             componentsLocationMap: componentsLocationMap,
             quantity: 1.0
         ]
@@ -321,7 +329,7 @@ class ProductionRunTests implements JupiterTestHelper {
         Map produceResult2 = dispatcher.runSync('productionRunDeclareAndProduce', issueAndProduceCtx)
         assert ServiceUtil.isSuccess(produceResult2)
         Map completeResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_COMPLETED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: completedStatusId])
         assert ServiceUtil.isSuccess(completeResult)
 
         productionRunHeader = from('WorkEffort').where('workEffortId', productionRunId).queryOne()
@@ -366,8 +374,10 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(9)
     void testQuickRunProductionRun() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
-        String productId = 'PROD_MANUF'
-        String facilityId = 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String printedStatusId = testParams.printedStatusId ?: 'PRUN_DOC_PRINTED'
+        String completedStatusId = testParams.completedStatusId ?: 'PRUN_COMPLETED'
         BigDecimal quantity = 1.0
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Timestamp productionRunStartDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 1)
@@ -384,10 +394,10 @@ class ProductionRunTests implements JupiterTestHelper {
         String productionRunId = serviceResult.productionRunId
 
         Map printResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_DOC_PRINTED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: printedStatusId])
         assert ServiceUtil.isSuccess(printResult)
         Map completeResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_COMPLETED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: completedStatusId])
         assert ServiceUtil.isSuccess(completeResult)
 
         GenericValue productionRunHeader = from('WorkEffort').where('workEffortId', productionRunId).queryOne()
@@ -406,8 +416,10 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(6)
     void testQuickCloseProductionRun() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestManufAdmin').queryOne()
-        String productId = 'PROD_MANUF'
-        String facilityId = 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String printedStatusId = testParams.printedStatusId ?: 'PRUN_DOC_PRINTED'
+        String closedStatusId = testParams.closedStatusId ?: 'PRUN_CLOSED'
         BigDecimal quantity = 1.0
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Timestamp productionRunStartDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 1)
@@ -424,10 +436,10 @@ class ProductionRunTests implements JupiterTestHelper {
         String productionRunId = serviceResult.productionRunId
 
         Map printResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_DOC_PRINTED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: printedStatusId])
         assert ServiceUtil.isSuccess(printResult)
         Map closeResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_CLOSED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: closedStatusId])
         assert ServiceUtil.isSuccess(closeResult)
 
         GenericValue productionRunHeader = from('WorkEffort').where('workEffortId', productionRunId).queryOne()
@@ -447,7 +459,9 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(4)
     void testCreateProductionRunForOrder() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'admin').queryOne()
-        String productId = 'PROD_MANUF'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String printedStatusId = testParams.printedStatusId ?: 'PRUN_DOC_PRINTED'
+        String closedStatusId = testParams.closedStatusId ?: 'PRUN_CLOSED'
 
         Map serviceResult = dispatcher.runSync('createTestSalesOrderSingle', [userLogin: userLogin, productId: productId])
         assert ServiceUtil.isSuccess(serviceResult)
@@ -497,10 +511,10 @@ class ProductionRunTests implements JupiterTestHelper {
         assert workOrderItemFulfillment.orderItemSeqId
 
         Map printResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_DOC_PRINTED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: printedStatusId])
         assert ServiceUtil.isSuccess(printResult)
         Map closeResult = dispatcher.runSync('quickChangeProductionRunStatus',
-                [userLogin: userLogin, productionRunId: productionRunId, statusId: 'PRUN_CLOSED'])
+                [userLogin: userLogin, productionRunId: productionRunId, statusId: closedStatusId])
         assert ServiceUtil.isSuccess(closeResult)
 
         GenericValue producedMaterial = from('WorkEffortAndInventoryProduced').where('workEffortId', productionRunHeader.workEffortId).queryFirst()
@@ -518,22 +532,25 @@ class ProductionRunTests implements JupiterTestHelper {
     @Order(3)
     void testCreateProductionRunForRequirement() {
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'TestSupplyAdmin').queryOne()
-        String productId = 'PROD_MANUF'
+        String productId = testParams.productId ?: 'PROD_MANUF'
+        String requirementTypeId = testParams.requirementTypeId ?: 'INTERNAL_REQUIREMENT'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String approvedStatusId = testParams.approvedStatusId ?: 'REQ_APPROVED'
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
         Timestamp startDate = UtilDateTime.addDaysToTimestamp(nowTimestamp, 1)
 
         Map reqCtx = [
             userLogin: userLogin,
             productId: productId,
-            requirementTypeId: 'INTERNAL_REQUIREMENT',
-            facilityId: 'WebStoreWarehouse',
+            requirementTypeId: requirementTypeId,
+            facilityId: facilityId,
             requirementStartDate: startDate
         ]
         Map reqResult = dispatcher.runSync('createRequirement', reqCtx)
         assert ServiceUtil.isSuccess(reqResult)
         String requirementId = reqResult.requirementId
 
-        Map updateResult = dispatcher.runSync('updateRequirement', [userLogin: userLogin, requirementId: requirementId, statusId: 'REQ_APPROVED'])
+        Map updateResult = dispatcher.runSync('updateRequirement', [userLogin: userLogin, requirementId: requirementId, statusId: approvedStatusId])
         assert ServiceUtil.isSuccess(updateResult)
 
         // Manually trigger the ECA service because tests run in an uncommitted transaction

--- a/applications/marketing/src/test/groovy/org/apache/ofbiz/marketing/marketing/test/MarketingTests.groovy
+++ b/applications/marketing/src/test/groovy/org/apache/ofbiz/marketing/marketing/test/MarketingTests.groovy
@@ -48,11 +48,17 @@ class MarketingTests implements JupiterTestHelper {
         Post condition: Contact list should be created and updated successfully
         */
 
+        String contactListTypeId = testParams.contactListTypeId ?: 'ANNOUNCEMENT'
+        String contactListName = testParams.contactListName ?: 'Announcement List'
+        String contactMechTypeId = testParams.contactMechTypeId ?: 'EMAIL_ADDRESS'
+        String updatedContactListName = testParams.updatedContactListName ?: 'Announcement Records'
+        String updatedContactMechTypeId = testParams.updatedContactMechTypeId ?: 'POSTAL_ADDRESS'
+
         //create contact list
         Map serviceCtx = [
-                contactListTypeId: 'ANNOUNCEMENT',
-                contactListName: 'Announcement List',
-                contactMechTypeId: 'EMAIL_ADDRESS',
+                contactListTypeId: contactListTypeId,
+                contactListName: contactListName,
+                contactMechTypeId: contactMechTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createContactList', serviceCtx)
@@ -61,13 +67,13 @@ class MarketingTests implements JupiterTestHelper {
 
         GenericValue contactList = from('ContactList').where('contactListId', contactListId).queryOne()
         assert contactList != null
-        assert contactList.contactMechTypeId == 'EMAIL_ADDRESS'
+        assert contactList.contactMechTypeId == contactMechTypeId
 
         //update contact list
         serviceCtx = [
-                contactListTypeId: 'ANNOUNCEMENT',
-                contactListName: 'Announcement Records',
-                contactMechTypeId: 'POSTAL_ADDRESS',
+                contactListTypeId: contactListTypeId,
+                contactListName: updatedContactListName,
+                contactMechTypeId: updatedContactMechTypeId,
                 contactListId: contactListId,
                 userLogin: userLogin
         ]
@@ -77,7 +83,7 @@ class MarketingTests implements JupiterTestHelper {
         contactList.refresh()
 
         assert contactList != null
-        assert contactList.contactMechTypeId == 'POSTAL_ADDRESS'
+        assert contactList.contactMechTypeId == updatedContactMechTypeId
     }
 
 }

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/CustRequestTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/CustRequestTests.groovy
@@ -45,24 +45,27 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testUpdateCustRequest() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String custRequestName = testParams.custRequestName ?: 'Updated Test Request'
         Map serviceCtx = [
-                custRequestId: '9000',
-                custRequestName: 'Updated Test Request',
+                custRequestId: custRequestId,
+                custRequestName: custRequestName,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('updateCustRequest', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue custRequest = from('CustRequest').where('custRequestId', '9000').queryOne()
+        GenericValue custRequest = from('CustRequest').where('custRequestId', custRequestId).queryOne()
         assert custRequest
-        assert custRequest.custRequestName == 'Updated Test Request'
+        assert custRequest.custRequestName == custRequestName
     }
 
     @Test
     @Order(3)
     void testCreateCustRequestItem() {
+        String custRequestId = testParams.custRequestId ?: '9000'
         Map serviceCtx = [
-                custRequestId: '9000',
+                custRequestId: custRequestId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createCustRequestItem', serviceCtx)
@@ -74,10 +77,13 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testCreateCustRequestItemNote() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String custRequestItemSeqId = testParams.custRequestItemSeqId ?: '00001'
+        String note = testParams.note ?: 'Test'
         Map serviceCtx = [
-                custRequestId: '9000',
-                custRequestItemSeqId: '00001',
-                note: 'Test',
+                custRequestId: custRequestId,
+                custRequestItemSeqId: custRequestItemSeqId,
+                note: note,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createCustRequestItemNote', serviceCtx)
@@ -89,9 +95,11 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testCreateCustRequestNote() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String noteInfo = testParams.noteInfo ?: 'Test'
         Map serviceCtx = [
-                custRequestId: '9000',
-                noteInfo: 'Test',
+                custRequestId: custRequestId,
+                noteInfo: noteInfo,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createCustRequestNote', serviceCtx)
@@ -104,17 +112,20 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testCreateCustRequestParty() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String partyId = testParams.partyId ?: 'Company'
+        String roleTypeId = testParams.roleTypeId ?: 'OWNER'
         Map serviceCtx = [
-                custRequestId: '9000',
-                partyId: 'Company',
-                roleTypeId: 'OWNER',
+                custRequestId: custRequestId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createCustRequestParty', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue custRequestParty = from('CustRequestParty')
-                .where('custRequestId', '9000', 'partyId', 'Company', 'roleTypeId', 'OWNER')
+                .where('custRequestId', custRequestId, 'partyId', partyId, 'roleTypeId', roleTypeId)
                 .filterByDate().queryFirst()
         assert custRequestParty
     }
@@ -122,10 +133,13 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testCreateCustRequestStatus() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String custRequestItemSeqId = testParams.custRequestItemSeqId ?: '00001'
+        String statusId = testParams.statusId ?: 'CRQ_ACCEPTED'
         Map serviceCtx = [
-                custRequestId: '9000',
-                custRequestItemSeqId: '00001',
-                statusId: 'CRQ_ACCEPTED',
+                custRequestId: custRequestId,
+                custRequestItemSeqId: custRequestItemSeqId,
+                statusId: statusId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createCustRequestStatus', serviceCtx)
@@ -137,9 +151,11 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testSetCustRequestStatus() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String statusId = testParams.statusId ?: 'CRQ_ACCEPTED'
         Map serviceCtx = [
-                custRequestId: '9000',
-                statusId: 'CRQ_ACCEPTED',
+                custRequestId: custRequestId,
+                statusId: statusId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('setCustRequestStatus', serviceCtx)
@@ -151,8 +167,9 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(9)
     void testGetCustRequestsByRole() {
+        String roleTypeId = testParams.roleTypeId ?: 'OWNER'
         Map serviceCtx = [
-                roleTypeId: 'OWNER',
+                roleTypeId: roleTypeId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('getCustRequestsByRole', serviceCtx)
@@ -164,16 +181,18 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testCreateCustRequestContent() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String contentId = testParams.contentId ?: '100-ALT'
         Map serviceCtx = [
-                custRequestId: '9000',
-                contentId: '100-ALT',
+                custRequestId: custRequestId,
+                contentId: contentId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createCustRequestContent', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue custRequestContent = from('CustRequestContent')
-                .where('custRequestId', '9000', 'contentId', '100-ALT')
+                .where('custRequestId', custRequestId, 'contentId', contentId)
                 .filterByDate().queryFirst()
         assert custRequestContent
     }
@@ -181,34 +200,39 @@ class CustRequestTests implements JupiterTestHelper {
     @Test
     @Order(11)
     void testCreateCustRequestAttribute() {
+        String attrName = testParams.attrName ?: 'Test Name'
+        String attrValue = testParams.attrValue ?: 'Test Value'
+        String custRequestId = testParams.custRequestId ?: '9000'
         Map serviceCtx = [
-                attrName: 'Test Name',
-                attrValue: 'Test Value',
-                custRequestId: '9000',
+                attrName: attrName,
+                attrValue: attrValue,
+                custRequestId: custRequestId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createCustRequestAttribute', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue custRequestAttribute = from('CustRequestAttribute')
-                .where('custRequestId', '9000', 'attrName', 'Test Name')
+                .where('custRequestId', custRequestId, 'attrName', attrName)
                 .queryOne()
         assert custRequestAttribute
-        assert custRequestAttribute.attrValue == 'Test Value'
+        assert custRequestAttribute.attrValue == attrValue
     }
 
     @Test
     @Order(12)
     void testCopyCustRequestItem() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String custRequestItemSeqId = testParams.custRequestItemSeqId ?: '00001'
         Map serviceCtx = [
-                custRequestId: '9000',
-                custRequestItemSeqId: '00001',
+                custRequestId: custRequestId,
+                custRequestItemSeqId: custRequestItemSeqId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('copyCustRequestItem', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        List<GenericValue> custRequestItems = from('CustRequestItem').where('custRequestId', '9000').queryList()
+        List<GenericValue> custRequestItems = from('CustRequestItem').where('custRequestId', custRequestId).queryList()
         assert custRequestItems.size() > 1
     }
 

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderRequirementTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderRequirementTests.groovy
@@ -31,9 +31,11 @@ class OrderRequirementTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCheckCreateProductRequirementForFacility() {
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String defaultRequirementMethodId = testParams.defaultRequirementMethodId ?: 'PRODRQM_STOCK'
         Map serviceCtx = [
-            facilityId: 'WebStoreWarehouse',
-            defaultRequirementMethodId: 'PRODRQM_STOCK',
+            facilityId: facilityId,
+            defaultRequirementMethodId: defaultRequirementMethodId,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('checkCreateProductRequirementForFacility', serviceCtx)
@@ -42,12 +44,17 @@ class OrderRequirementTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testCheckCreateStockRequirementQoh() {
+        String orderId = testParams.orderId ?: 'TEST_DEMO10090'
+        String orderItemSeqId = testParams.orderItemSeqId ?: '00001'
+        String shipGroupSeqId = testParams.shipGroupSeqId ?: '00001'
+        String itemIssuanceId = testParams.itemIssuanceId ?: '9006'
+        String quantity = testParams.quantity ?: '300'
         Map serviceCtx = [
-            orderId: 'TEST_DEMO10090',
-            orderItemSeqId: '00001',
-            shipGroupSeqId: '00001',
-            itemIssuanceId: '9006',
-            quantity: '300',
+            orderId: orderId,
+            orderItemSeqId: orderItemSeqId,
+            shipGroupSeqId: shipGroupSeqId,
+            itemIssuanceId: itemIssuanceId,
+            quantity: quantity,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('checkCreateStockRequirementQoh', serviceCtx)
@@ -56,12 +63,17 @@ class OrderRequirementTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testCheckCreateStockRequirementAtp() {
+        String orderId = testParams.orderId ?: 'TEST_DEMO10091'
+        String orderItemSeqId = testParams.orderItemSeqId ?: '00001'
+        String shipGroupSeqId = testParams.shipGroupSeqId ?: '00001'
+        String inventoryItemId = testParams.inventoryItemId ?: '9028'
+        String quantity = testParams.quantity ?: '20'
         Map serviceCtx = [
-            orderId: 'TEST_DEMO10091',
-            orderItemSeqId: '00001',
-            shipGroupSeqId: '00001',
-            inventoryItemId: '9028',
-            quantity: '20',
+            orderId: orderId,
+            orderItemSeqId: orderItemSeqId,
+            shipGroupSeqId: shipGroupSeqId,
+            inventoryItemId: inventoryItemId,
+            quantity: quantity,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('checkCreateStockRequirementAtp', serviceCtx)
@@ -70,9 +82,11 @@ class OrderRequirementTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testCheckCreateOrderRequirement() {
+        String orderId = testParams.orderId ?: 'TEST_DEMO10090'
+        String orderItemSeqId = testParams.orderItemSeqId ?: '00001'
         Map serviceCtx = [
-            orderId: 'TEST_DEMO10090',
-            orderItemSeqId: '00001',
+            orderId: orderId,
+            orderItemSeqId: orderItemSeqId,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('checkCreateOrderRequirement', serviceCtx)
@@ -81,8 +95,9 @@ class OrderRequirementTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testAutoAssignRequirementToSupplier() {
+        String requirementId = testParams.requirementId ?: '1000'
         Map serviceCtx = [
-            requirementId: '1000',
+            requirementId: requirementId,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('autoAssignRequirementToSupplier', serviceCtx)
@@ -91,10 +106,13 @@ class OrderRequirementTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testCreateRequirementCustRequest() {
+        String requirementId = testParams.requirementId ?: '1000'
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String custRequestItemSeqId = testParams.custRequestItemSeqId ?: '00001'
         Map serviceCtx = [
-            requirementId: '1000',
-            custRequestId: '9000',
-            custRequestItemSeqId: '00001',
+            requirementId: requirementId,
+            custRequestId: custRequestId,
+            custRequestItemSeqId: custRequestItemSeqId,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createRequirementCustRequest', serviceCtx)
@@ -103,9 +121,11 @@ class OrderRequirementTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testAddRequirementTask() {
+        String requirementId = testParams.requirementId ?: '1000'
+        String workEffortId = testParams.workEffortId ?: '9000'
         Map serviceCtx = [
-            requirementId: '1000',
-            workEffortId: '9000',
+            requirementId: requirementId,
+            workEffortId: workEffortId,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createWorkRequirementFulfillment', serviceCtx)

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderReturnTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderReturnTests.groovy
@@ -30,9 +30,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testQuickReturnOrder() {
+        String orderId = testParams.orderId ?: 'TEST_DEMO10090'
+        String returnHeaderTypeId = testParams.returnHeaderTypeId ?: 'CUSTOMER_RETURN'
         Map serviceCtx = [
-            orderId: 'TEST_DEMO10090',
-            returnHeaderTypeId: 'CUSTOMER_RETURN',
+            orderId: orderId,
+            returnHeaderTypeId: returnHeaderTypeId,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('quickReturnOrder', serviceCtx)
@@ -42,8 +44,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testProcessCreditReturn() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processCreditReturn', serviceCtx)
@@ -52,8 +55,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testProcessCrossShipReplacementReturn() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processCrossShipReplacementReturn', serviceCtx)
@@ -62,8 +66,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testProcessRefundImmediatelyReturn() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processRefundImmediatelyReturn', serviceCtx)
@@ -72,9 +77,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testGetReturnItemInitialCost() {
+        String returnId = testParams.returnId ?: '1009'
+        String returnItemSeqId = testParams.returnItemSeqId ?: '00001'
         Map serviceCtx = [
-                returnId: '1009',
-                returnItemSeqId: '00001',
+                returnId: returnId,
+                returnItemSeqId: returnItemSeqId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getReturnItemInitialCost', serviceCtx)
@@ -84,9 +91,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testProcessRefundReturn() {
+        String returnId = testParams.returnId ?: '1009'
+        String returnTypeId = testParams.returnTypeId ?: 'RTN_REFUND'
         Map serviceCtx = [
-                returnId: '1009',
-                returnTypeId: 'RTN_REFUND',
+                returnId: returnId,
+                returnTypeId: returnTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processRefundReturn', serviceCtx)
@@ -95,9 +104,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testProcessReplacementReturn() {
+        String returnId = testParams.returnId ?: '1009'
+        String returnTypeId = testParams.returnTypeId ?: 'RTN_REFUND'
         Map serviceCtx = [
-                returnId: '1009',
-                returnTypeId: 'RTN_REFUND',
+                returnId: returnId,
+                returnTypeId: returnTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processReplacementReturn', serviceCtx)
@@ -106,9 +117,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testProcessReplaceImmediatelyReturn() {
+        String returnId = testParams.returnId ?: '1009'
+        String orderItemSeqId = testParams.orderItemSeqId ?: '00001'
         Map serviceCtx = [
-                returnId: '1009',
-                orderItemSeqId: '00001',
+                returnId: returnId,
+                orderItemSeqId: orderItemSeqId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processReplaceImmediatelyReturn', serviceCtx)
@@ -117,8 +130,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(9)
     void testProcessRefundOnlyReturn() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processRefundOnlyReturn', serviceCtx)
@@ -127,8 +141,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testProcessWaitReplacementReturn() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processWaitReplacementReturn', serviceCtx)
@@ -137,8 +152,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(11)
     void testProcessWaitReplacementReservedReturn() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processWaitReplacementReservedReturn', serviceCtx)
@@ -148,8 +164,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(12)
     void testProcessSubscriptionReturn() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processSubscriptionReturn', serviceCtx)
@@ -158,9 +175,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(13)
     void testCreateReturnAndItemOrAdjustment() {
+        String orderId = testParams.orderId ?: 'DEMO10090'
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                orderId: 'DEMO10090',
-                returnId: '1009',
+                orderId: orderId,
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createReturnAndItemOrAdjustment', serviceCtx)
@@ -170,9 +189,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(14)
     void testCreateReturnAdjustment() {
+        String amount = testParams.amount ?: '2.0000'
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                amount: '2.0000',
-                returnId: '1009',
+                amount: amount,
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createReturnAdjustment', serviceCtx)
@@ -182,9 +203,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(15)
     void testCheckReturnComplete() {
+        String amount = testParams.amount ?: '2.0000'
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                amount: '2.0000',
-                returnId: '1009',
+                amount: amount,
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('checkReturnComplete', serviceCtx)
@@ -194,8 +217,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(16)
     void testCheckPaymentAmountForRefund() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('checkPaymentAmountForRefund', serviceCtx)
@@ -204,11 +228,15 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(17)
     void testCreateReturnItemShipment() {
+        String shipmentId = testParams.shipmentId ?: '1014'
+        String shipmentItemSeqId = testParams.shipmentItemSeqId ?: '00001'
+        String returnId = testParams.returnId ?: '1009'
+        String returnItemSeqId = testParams.returnItemSeqId ?: '00001'
         Map serviceCtx = [
-                shipmentId: '1014',
-                shipmentItemSeqId: '00001',
-                returnId: '1009',
-                returnItemSeqId: '00001',
+                shipmentId: shipmentId,
+                shipmentItemSeqId: shipmentItemSeqId,
+                returnId: returnId,
+                returnItemSeqId: returnItemSeqId,
                 quantity: 2.0000,
                 userLogin: userLogin
         ]
@@ -218,8 +246,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(18)
     void testCreateReturnStatus() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createReturnStatus', serviceCtx)
@@ -228,8 +257,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(19)
     void testGetReturnAmountByOrder() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getReturnAmountByOrder', serviceCtx)
@@ -238,9 +268,11 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(20)
     void testCreateReturnHeader() {
+        String toPartyId = testParams.toPartyId ?: 'Company'
+        String returnHeaderTypeId = testParams.returnHeaderTypeId ?: 'CUSTOMER_RETURN'
         Map serviceCtx = [
-                toPartyId: 'Company',
-                returnHeaderTypeId: 'CUSTOMER_RETURN',
+                toPartyId: toPartyId,
+                returnHeaderTypeId: returnHeaderTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createReturnHeader', serviceCtx)
@@ -250,8 +282,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(21)
     void testProcessRefundReturnForReplacement() {
+        String orderId = testParams.orderId ?: 'TEST_DEMO10090'
         Map serviceCtx = [
-                orderId: 'TEST_DEMO10090',
+                orderId: orderId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processRefundReturnForReplacement', serviceCtx)
@@ -260,8 +293,9 @@ class OrderReturnTests implements JupiterTestHelper {
     @Test
     @Order(22)
     void testProcessRepairReplacementReturn() {
+        String returnId = testParams.returnId ?: '1009'
         Map serviceCtx = [
-                returnId: '1009',
+                returnId: returnId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('processRepairReplacementReturn', serviceCtx)

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/OrderTests.groovy
@@ -30,8 +30,9 @@ class OrderTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateOrderDeliverySchedule() {
+        String orderId = testParams.orderId ?: 'TEST_DEMO10090'
         Map serviceCtx = [
-                orderId: 'TEST_DEMO10090',
+                orderId: orderId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createOrderDeliverySchedule', serviceCtx)
@@ -41,10 +42,13 @@ class OrderTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testCreateOrderItemChange() {
+        String changeTypeEnumId = testParams.changeTypeEnumId ?: 'ODR_ITM_APPEND'
+        String orderId = testParams.orderId ?: 'TEST_DEMO10090'
+        String orderItemSeqId = testParams.orderItemSeqId ?: '00001'
         Map serviceCtx = [
-                changeTypeEnumId: 'ODR_ITM_APPEND',
-                orderId: 'TEST_DEMO10090',
-                orderItemSeqId: '00001',
+                changeTypeEnumId: changeTypeEnumId,
+                orderId: orderId,
+                orderItemSeqId: orderItemSeqId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createOrderItemChange', serviceCtx)
@@ -55,8 +59,9 @@ class OrderTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testCreateOrderPaymentApplication() {
+        String paymentId = testParams.paymentId ?: '1014'
         Map serviceCtx = [
-                paymentId: '1014',
+                paymentId: paymentId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createOrderPaymentApplication', serviceCtx)
@@ -66,9 +71,11 @@ class OrderTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testCreateRequirement() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String requirementTypeId = testParams.requirementTypeId ?: 'CUSTOMER_REQUIREMENT'
         Map serviceCtx = [
-                custRequestId: '9000',
-                requirementTypeId: 'CUSTOMER_REQUIREMENT',
+                custRequestId: custRequestId,
+                requirementTypeId: requirementTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createRequirement', serviceCtx)
@@ -78,8 +85,9 @@ class OrderTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testGetRequirementsForSupplier() {
+        String partyId = testParams.partyId ?: 'Company'
         Map serviceCtx = [
-                partyId: 'Company',
+                partyId: partyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getRequirementsForSupplier', serviceCtx)
@@ -89,10 +97,13 @@ class OrderTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testCreateRequirementRole() {
+        String requirementId = testParams.requirementId ?: '1000'
+        String partyId = testParams.partyId ?: 'Company'
+        String roleTypeId = testParams.roleTypeId ?: 'OWNER'
         Map serviceCtx = [
-                requirementId: '1000',
-                partyId: 'Company',
-                roleTypeId: 'OWNER',
+                requirementId: requirementId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createRequirementRole', serviceCtx)
@@ -102,8 +113,9 @@ class OrderTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testCreateAutoRequirementsForOrder() {
+        String orderId = testParams.orderId ?: 'TEST_DEMO10090'
         Map serviceCtx = [
-                orderId: 'TEST_DEMO10090',
+                orderId: orderId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createAutoRequirementsForOrder', serviceCtx)
@@ -113,8 +125,9 @@ class OrderTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testCreateATPRequirementsForOrder() {
+        String orderId = testParams.orderId ?: 'TEST_DEMO10090'
         Map serviceCtx = [
-                orderId: 'TEST_DEMO10090',
+                orderId: orderId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createATPRequirementsForOrder', serviceCtx)

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/QuoteTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/QuoteTests.groovy
@@ -86,14 +86,15 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testCheckUpdateQuotestatus() {
+        String quoteId = testParams.quoteId ?: '9001'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9001',
+                quoteId: quoteId,
         ]
 
         Map serviceResult = dispatcher.runSync('checkUpdateQuoteStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quote = from('Quote').where(quoteId: '9001').queryOne()
+        GenericValue quote = from('Quote').where(quoteId: quoteId).queryOne()
         assert quote.statusId == 'QUO_ORDERED'
     }
 
@@ -102,15 +103,19 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testCreateWorkEffortAndQuoteWorkEffort() {
+        String currentStatusId = testParams.currentStatusId ?: 'ROU_ACTIVE'
+        String workEffortName = testParams.workEffortName ?: 'Test WorkEffort'
+        String workEffortTypeId = testParams.workEffortTypeId ?: 'ROUTING'
+        String quoteId = testParams.quoteId ?: '9000'
         GenericValue userLogin = getUserLogin('system')
 
         // Use the bare minimum inputs necessary to create the work effort as we
         // aren't testing that service, only that it plays well as an ECA.
         Map serviceCtx = [
-            currentStatusId: 'ROU_ACTIVE',
-            workEffortName: 'Test WorkEffort',
-            workEffortTypeId: 'ROUTING',
-            quoteId: '9000',
+            currentStatusId: currentStatusId,
+            workEffortName: workEffortName,
+            workEffortTypeId: workEffortTypeId,
+            quoteId: quoteId,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('ensureWorkEffortAndCreateQuoteWorkEffort', serviceCtx)
@@ -135,9 +140,10 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testCreateQuote() {
+        String partyId = testParams.partyId ?: 'Company'
         Map serviceCtx = [
                 userLogin: userLogin,
-                partyId: 'Company'
+                partyId: partyId
         ]
         Map serviceResult = dispatcher.runSync('createQuote', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
@@ -149,15 +155,17 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testUpdateQuote() {
+        String quoteId = testParams.quoteId ?: '9000'
+        String statusId = testParams.statusId ?: 'QUO_APPROVED'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9000',
-                statusId: 'QUO_APPROVED'
+                quoteId: quoteId,
+                statusId: statusId
         ]
         Map serviceResult = dispatcher.runSync('updateQuote', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quote = from('Quote').where(quoteId: '9000').queryOne()
-        assert quote.statusId == 'QUO_APPROVED'
+        GenericValue quote = from('Quote').where(quoteId: quoteId).queryOne()
+        assert quote.statusId == statusId
 
         serviceCtx.statusId = 'QUO_CREATED'
         serviceResult = dispatcher.runSync('updateQuote', serviceCtx)
@@ -167,9 +175,10 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testCopyQuote() {
+        String quoteId = testParams.quoteId ?: '9000'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9000'
+                quoteId: quoteId
         ]
         Map serviceResult = dispatcher.runSync('copyQuote', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
@@ -179,31 +188,37 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testCreateQuoteItem() {
+        String quoteId = testParams.quoteId ?: '9000'
+        String quoteItemSeqId = testParams.quoteItemSeqId ?: '00004'
+        String productId = testParams.productId ?: 'GZ-1001'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9000',
-                quoteItemSeqId: '00004',
-                productId: 'GZ-1001'
+                quoteId: quoteId,
+                quoteItemSeqId: quoteItemSeqId,
+                productId: productId
         ]
         Map serviceResult = dispatcher.runSync('createQuoteItem', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00004').queryOne()
+        GenericValue quoteItem = from('QuoteItem').where(quoteId: quoteId, quoteItemSeqId: quoteItemSeqId).queryOne()
         assert quoteItem.quoteUnitPrice
     }
 
     @Test
     @Order(9)
     void testUpdateQuoteItem() {
+        String quoteId = testParams.quoteId ?: '9000'
+        String quoteItemSeqId = testParams.quoteItemSeqId ?: '00002'
+        String productId = testParams.productId ?: 'GZ-1001'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9000',
-                quoteItemSeqId: '00002',
-                productId: 'GZ-1001'
+                quoteId: quoteId,
+                quoteItemSeqId: quoteItemSeqId,
+                productId: productId
         ]
         Map serviceResult = dispatcher.runSync('updateQuoteItem', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00002').queryOne()
-        assert quoteItem.productId == 'GZ-1001'
+        GenericValue quoteItem = from('QuoteItem').where(quoteId: quoteId, quoteItemSeqId: quoteItemSeqId).queryOne()
+        assert quoteItem.productId == productId
     }
 
     @Test
@@ -212,36 +227,44 @@ class QuoteTests implements JupiterTestHelper {
     // ("Value not found, cannot update") if it no longer exists.
     @Order(12)
     void testRemoveQuoteItem() {
+        String quoteId = testParams.quoteId ?: '9000'
+        String quoteItemSeqId = testParams.quoteItemSeqId ?: '00002'
+        String termTypeId = testParams.termTypeId ?: 'FIN_PAYMENT_DISC'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9000',
-                quoteItemSeqId: '00002'
+                quoteId: quoteId,
+                quoteItemSeqId: quoteItemSeqId
         ]
         Map serviceResult = dispatcher.runSync('removeQuoteItem', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = from('QuoteItem').where(quoteId: '9000', quoteItemSeqId: '00002').queryOne()
+        GenericValue quoteItem = from('QuoteItem').where(quoteId: quoteId, quoteItemSeqId: quoteItemSeqId).queryOne()
         assert !quoteItem
-        GenericValue quoteTerm = from('QuoteTerm').where(quoteId: '9000', quoteItemSeqId: '00002', termTypeId: 'FIN_PAYMENT_DISC').queryOne()
+        GenericValue quoteTerm = from('QuoteTerm').where(quoteId: quoteId, quoteItemSeqId: quoteItemSeqId, termTypeId: termTypeId).queryOne()
         assert !quoteTerm
     }
 
     @Test
     @Order(11)
     void testCreateQuoteTerm() {
+        String termTypeId = testParams.termTypeId ?: 'FIN_PAYMENT_DISC'
+        String quoteId = testParams.quoteId ?: '9000'
+        String quoteItemSeqId = testParams.quoteItemSeqId ?: '00001'
+        String uomId = testParams.uomId ?: 'CNY'
+        String description = testParams.description ?: 'create quoteTerm'
         Map serviceCtx = [
                 userLogin: userLogin,
-                termTypeId: 'FIN_PAYMENT_DISC',
-                quoteId: '9000',
-                quoteItemSeqId: '00001',
+                termTypeId: termTypeId,
+                quoteId: quoteId,
+                quoteItemSeqId: quoteItemSeqId,
                 termValue: 40L,
                 termDays: 4L,
-                uomId: 'CNY',
-                description: 'create quoteTerm'
+                uomId: uomId,
+                description: description
         ]
 
         Map serviceResult = dispatcher.runSync('createQuoteTerm', serviceCtx)
         List<GenericValue> terms = from('QuoteTerm')
-                .where(termTypeId: 'FIN_PAYMENT_DISC', quoteId: '9000', quoteItemSeqId: '00001').queryList()
+                .where(termTypeId: termTypeId, quoteId: quoteId, quoteItemSeqId: quoteItemSeqId).queryList()
 
         assert ServiceUtil.isSuccess(serviceResult)
         assert terms
@@ -256,14 +279,19 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testUpdateQuoteTerm() {
+        String termTypeId = testParams.termTypeId ?: 'FIN_PAYMENT_DISC'
+        String quoteId = testParams.quoteId ?: '9000'
+        String quoteItemSeqId = testParams.quoteItemSeqId ?: '00002'
+        String uomId = testParams.uomId ?: 'CNY'
+        String description = testParams.description ?: 'update quoteterm'
         Map serviceCtx = [
-            termTypeId: 'FIN_PAYMENT_DISC',
-            quoteId: '9000',
-            quoteItemSeqId: '00002',
+            termTypeId: termTypeId,
+            quoteId: quoteId,
+            quoteItemSeqId: quoteItemSeqId,
             termValue: 30L,
             termDays: 3L,
-            uomId: 'CNY',
-            description: 'update quoteterm',
+            uomId: uomId,
+            description: description,
             userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateQuoteTerm', serviceCtx)
@@ -288,11 +316,14 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(13)
     void testDeleteQuoteTerm() {
+        String termTypeId = testParams.termTypeId ?: 'FIN_PAYMENT_DISC'
+        String quoteId = testParams.quoteId ?: '9000'
+        String quoteItemSeqId = testParams.quoteItemSeqId ?: '00003'
         Map serviceCtx = [
                 userLogin: userLogin,
-                termTypeId: 'FIN_PAYMENT_DISC',
-                quoteId: '9000',
-                quoteItemSeqId: '00003'
+                termTypeId: termTypeId,
+                quoteId: quoteId,
+                quoteItemSeqId: quoteItemSeqId
         ]
 
         Map serviceResult = dispatcher.runSync('deleteQuoteTerm', serviceCtx)
@@ -305,10 +336,12 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(14)
     void testCreateQuoteAttribute() {
+        String quoteId = testParams.quoteId ?: '9001'
+        String attrName = testParams.attrName ?: 'Test'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9001',
-                attrName: 'Test'
+                quoteId: quoteId,
+                attrName: attrName
         ]
 
         Map serviceResult = dispatcher.runSync('createQuoteAttribute', serviceCtx)
@@ -318,10 +351,12 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(15)
     void testCreateQuoteCoefficient() {
+        String quoteId = testParams.quoteId ?: '9001'
+        String coeffName = testParams.coeffName ?: 'Test'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9001',
-                coeffName: 'Test'
+                quoteId: quoteId,
+                coeffName: coeffName
         ]
 
         Map serviceResult = dispatcher.runSync('createQuoteCoefficient', serviceCtx)
@@ -331,9 +366,10 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(16)
     void testGetNextQuoteId() {
+        String partyId = testParams.partyId ?: 'DemoCustomer-1'
         Map serviceCtx = [
                 userLogin: userLogin,
-                partyId: 'DemoCustomer-1'
+                partyId: partyId
         ]
 
         Map serviceResult = dispatcher.runSync('getNextQuoteId', serviceCtx)
@@ -344,12 +380,13 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(17)
     void testQuoteSequenceEnforced() {
-        GenericValue partyAcctgPreference = from('PartyAcctgPreference').where('partyId', 'DemoCustomer').queryOne()
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        GenericValue partyAcctgPreference = from('PartyAcctgPreference').where('partyId', partyId).queryOne()
         Long lastQuoteNumber = partyAcctgPreference.lastQuoteNumber ?: 0
 
         Map serviceCtx = [
                 userLogin: userLogin,
-                partyId: 'DemoCustomer',
+                partyId: partyId,
                 partyAcctgPreference: partyAcctgPreference
         ]
 
@@ -361,33 +398,40 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(18)
     void testCopyQuoteItem() {
+        String quoteId = testParams.quoteId ?: '9001'
+        String quoteItemSeqId = testParams.quoteItemSeqId ?: '00001'
+        String quoteIdTo = testParams.quoteIdTo ?: '9001'
+        String quoteItemSeqIdTo = testParams.quoteItemSeqIdTo ?: '00002'
+        String copyQuoteAdjustments = testParams.copyQuoteAdjustments ?: 'Y'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9001',
-                quoteItemSeqId: '00001',
-                quoteIdTo: '9001',
-                quoteItemSeqIdTo: '00002',
-                copyQuoteAdjustments: 'Y'
+                quoteId: quoteId,
+                quoteItemSeqId: quoteItemSeqId,
+                quoteIdTo: quoteIdTo,
+                quoteItemSeqIdTo: quoteItemSeqIdTo,
+                copyQuoteAdjustments: copyQuoteAdjustments
         ]
 
         Map serviceResult = dispatcher.runSync('copyQuoteItem', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         GenericValue quoteAdjustment = from('QuoteAdjustment')
-                .where('quoteId', '9001', 'quoteItemSeqId', '00002', 'quoteAdjustmentTypeId', 'SALES_TAX').queryFirst()
+                .where('quoteId', quoteId, 'quoteItemSeqId', quoteItemSeqIdTo, 'quoteAdjustmentTypeId', 'SALES_TAX').queryFirst()
         assert quoteAdjustment
     }
 
     @Test
     @Order(19)
     void testCreateQuoteAndQuoteItemForRequest() {
+        String custRequestId = testParams.custRequestId ?: '9000'
+        String custRequestItemSeqId = testParams.custRequestItemSeqId ?: '00001'
         Map serviceCtx = [
                 userLogin: userLogin,
-                custRequestId: '9000',
-                custRequestItemSeqId: '00001'
+                custRequestId: custRequestId,
+                custRequestItemSeqId: custRequestItemSeqId
         ]
         Map serviceResult = dispatcher.runSync('createQuoteAndQuoteItemForRequest', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = from('QuoteItem').where('quoteId', serviceResult.quoteId, 'custRequestItemSeqId', '00001').queryFirst()
+        GenericValue quoteItem = from('QuoteItem').where('quoteId', serviceResult.quoteId, 'custRequestItemSeqId', custRequestItemSeqId).queryFirst()
         assert quoteItem
     }
 
@@ -395,6 +439,7 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(20)
     void testCreateQuoteFromCart() {
+        String applyStorePromotions = testParams.applyStorePromotions ?: 'Y'
         String productId = 'SV-1001'
         String partyId = 'DemoCustomer'
 
@@ -414,7 +459,7 @@ class QuoteTests implements JupiterTestHelper {
         Map serviceCtx = [
             userLogin: userLogin,
             cart: cart,
-            applyStorePromotions: 'Y'
+            applyStorePromotions: applyStorePromotions
         ]
         Map serviceResult = dispatcher.runSync('createQuoteFromCart', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
@@ -427,10 +472,12 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(21)
     void testCreateQuoteFromShoppingList() {
+        String shoppingListId = testParams.shoppingListId ?: '9000'
+        String applyStorePromotions = testParams.applyStorePromotions ?: 'Y'
         Map serviceCtx = [
             userLogin: userLogin,
-            shoppingListId: '9000',
-            applyStorePromotions: 'Y'
+            shoppingListId: shoppingListId,
+            applyStorePromotions: applyStorePromotions
         ]
         Map serviceResult = dispatcher.runSync('createQuoteFromShoppingList', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
@@ -443,53 +490,60 @@ class QuoteTests implements JupiterTestHelper {
     @Test
     @Order(22)
     void testAutoUpdateQuotePrice() {
+        String quoteId = testParams.quoteId ?: '9000'
+        String quoteItemSeqId = testParams.quoteItemSeqId ?: '00001'
         Map serviceCtx = [
             userLogin: userLogin,
-            quoteId: '9000',
-            quoteItemSeqId: '00001',
+            quoteId: quoteId,
+            quoteItemSeqId: quoteItemSeqId,
             defaultQuoteUnitPrice: BigDecimal.valueOf(12)
         ]
         Map serviceResult = dispatcher.runSync('autoUpdateQuotePrice', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = from('QuoteItem').where('quoteId', '9000', 'quoteItemSeqId', '00001').queryOne()
+        GenericValue quoteItem = from('QuoteItem').where('quoteId', quoteId, 'quoteItemSeqId', quoteItemSeqId).queryOne()
         assert quoteItem.quoteUnitPrice == 12
     }
 
     @Test
     @Order(23)
     void testCreateQuoteFromCustRequest() {
+        String custRequestId = testParams.custRequestId ?: '9000'
         Map serviceCtx = [
                 userLogin: userLogin,
-                custRequestId: '9000'
+                custRequestId: custRequestId
         ]
         Map serviceResult = dispatcher.runSync('createQuoteFromCustRequest', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        GenericValue quoteItem = from('QuoteItem').where('quoteId', serviceResult.quoteId, 'custRequestId', '9000').queryFirst()
+        GenericValue quoteItem = from('QuoteItem').where('quoteId', serviceResult.quoteId, 'custRequestId', custRequestId).queryFirst()
         assert quoteItem
     }
 
     @Test
     @Order(24)
     void testAutoCreateQuoteAdjustments() {
+        String quoteId = testParams.quoteId ?: '9001'
         Map serviceCtx = [
             userLogin: userLogin,
-            quoteId: '9001'
+            quoteId: quoteId
         ]
         Map serviceResult = dispatcher.runSync('autoCreateQuoteAdjustments', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         GenericValue promoQuoteAdjustment = from('QuoteAdjustment')
-                .where('quoteId', '9001', 'quoteAdjustmentTypeId', 'PROMOTION_ADJUSTMENT').queryFirst()
+                .where('quoteId', quoteId, 'quoteAdjustmentTypeId', 'PROMOTION_ADJUSTMENT').queryFirst()
         assert promoQuoteAdjustment
     }
 
     @Test
     @Order(25)
     void testCreateQuoteNote() {
+        String quoteId = testParams.quoteId ?: '9001'
+        String noteName = testParams.noteName ?: 'Test Note'
+        String noteInfo = testParams.noteInfo ?: 'This is a test'
         Map serviceCtx = [
                 userLogin: userLogin,
-                quoteId: '9001',
-                noteName: 'Test Note',
-                noteInfo: 'This is a test'
+                quoteId: quoteId,
+                noteName: noteName,
+                noteInfo: noteInfo
         ]
 
         Map serviceResult = dispatcher.runSync('createQuoteNote', serviceCtx)

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/RequirementStatusEcaTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/RequirementStatusEcaTests.groovy
@@ -30,6 +30,8 @@ class RequirementStatusEcaTests implements JupiterTestHelper {
 
     @Test
     void testCreateRequirementStatusAfterOuterTransactionCommit() {
+        String requirementTypeId = testParams.requirementTypeId ?: 'CUSTOMER_REQUIREMENT'
+        String statusId = testParams.statusId ?: 'REQ_PROPOSED'
         ensureRequirementReferenceData()
         GenericValue userLogin = ensureUserLogin('mrpRequirementStatusTest')
         assert userLogin
@@ -40,8 +42,8 @@ class RequirementStatusEcaTests implements JupiterTestHelper {
         try {
             beganTransaction = TransactionUtil.begin()
             Map serviceCtx = [
-                requirementTypeId: 'CUSTOMER_REQUIREMENT',
-                statusId: 'REQ_PROPOSED',
+                requirementTypeId: requirementTypeId,
+                statusId: statusId,
                 userLogin: userLogin
             ]
             Map serviceResult = dispatcher.runSync('createRequirement', serviceCtx)
@@ -52,7 +54,7 @@ class RequirementStatusEcaTests implements JupiterTestHelper {
             assert from('Requirement').where('requirementId', requirementId).queryCount() == 1
 
             sleep(500L)
-            assert from('RequirementStatus').where('requirementId', requirementId, 'statusId', 'REQ_PROPOSED').queryCount() == 0
+            assert from('RequirementStatus').where('requirementId', requirementId, 'statusId', statusId).queryCount() == 0
 
             TransactionUtil.commit(beganTransaction)
             beganTransaction = false
@@ -62,7 +64,7 @@ class RequirementStatusEcaTests implements JupiterTestHelper {
             }
         }
 
-        assert waitForRequirementStatus(requirementId, 'REQ_PROPOSED')
+        assert waitForRequirementStatus(requirementId, statusId)
     }
 
     private boolean waitForRequirementStatus(String requirementId, String statusId) {

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/ShoppingListTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/order/test/ShoppingListTests.groovy
@@ -31,14 +31,21 @@ class ShoppingListTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateShoppingList() {
-        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
+        String userLoginId = testParams.userLoginId ?: 'DemoCustomer'
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        String shoppingListTypeId = testParams.shoppingListTypeId ?: 'SLT_WISH_LIST'
+        String productStoreId = testParams.productStoreId ?: '9000'
+        String listName = testParams.listName ?: 'Demo Wish List 1'
+        String isActive = testParams.isActive ?: 'Y'
+        String currencyUom = testParams.currencyUom ?: 'USD'
+        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: userLoginId], false)
         Map serviceCtx = [
-                partyId: 'DemoCustomer',
-                shoppingListTypeId: 'SLT_WISH_LIST',
-                productStoreId: '9000',
-                listName: 'Demo Wish List 1',
-                isActive: 'Y',
-                currencyUom: 'USD',
+                partyId: partyId,
+                shoppingListTypeId: shoppingListTypeId,
+                productStoreId: productStoreId,
+                listName: listName,
+                isActive: isActive,
+                currencyUom: currencyUom,
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('createShoppingList', serviceCtx, 600, true)
@@ -46,20 +53,23 @@ class ShoppingListTests implements JupiterTestHelper {
         GenericValue shoppingList = delegator.findOne('ShoppingList', [shoppingListId: shoppingListId], false)
         assert ServiceUtil.isSuccess(resultMap)
         assert shoppingList
-        assert shoppingList.partyId == 'DemoCustomer'
-        assert shoppingList.listName == 'Demo Wish List 1'
+        assert shoppingList.partyId == partyId
+        assert shoppingList.listName == listName
     }
 
     @Test
     @Order(2)
     void testCreateShoppingListItem() {
-        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
+        String userLoginId = testParams.userLoginId ?: 'DemoCustomer'
+        String productId = testParams.productId ?: 'GZ-8544'
+        String productStoreId = testParams.productStoreId ?: '9000'
+        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: userLoginId], false)
         String shoppingListId = 'DemoWishList'
         Map serviceCtx = [
                 shoppingListId: shoppingListId,
-                productId: 'GZ-8544',
+                productId: productId,
                 quantity: new BigDecimal(3),
-                productStoreId: '9000',
+                productStoreId: productStoreId,
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('createShoppingListItem', serviceCtx)
@@ -67,20 +77,23 @@ class ShoppingListTests implements JupiterTestHelper {
         GenericValue shoppingListItem = from('ShoppingListItem').where('shoppingListItemSeqId', shoppingListItemSeqId).queryOne()
         assert ServiceUtil.isSuccess(resultMap)
         assert shoppingListItem
-        assert shoppingListItem.productId == 'GZ-8544'
+        assert shoppingListItem.productId == productId
         assert shoppingListItem.quantity == 3
     }
 
     @Test
     @Order(3)
     void testCreateShoppingListItemWithSameProduct() {
-        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
+        String userLoginId = testParams.userLoginId ?: 'DemoCustomer'
+        String productId = testParams.productId ?: 'GZ-2644'
+        String productStoreId = testParams.productStoreId ?: '9000'
+        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: userLoginId], false)
         String shoppingListId = 'DemoWishList'
         Map serviceCtx = [
                 shoppingListId: shoppingListId,
-                productId: 'GZ-2644',
+                productId: productId,
                 quantity: new BigDecimal(2),
-                productStoreId: '9000',
+                productStoreId: productStoreId,
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('createShoppingListItem', serviceCtx)
@@ -94,32 +107,38 @@ class ShoppingListTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testUpdateShoppingList() {
-        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
+        String userLoginId = testParams.userLoginId ?: 'DemoCustomer'
+        String shoppingListId = testParams.shoppingListId ?: 'DemoWishList'
+        String listName = testParams.listName ?: 'New Demo Wish List'
+        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: userLoginId], false)
         Map serviceCtx = [
-                shoppingListId: 'DemoWishList',
-                listName: 'New Demo Wish List',
+                shoppingListId: shoppingListId,
+                listName: listName,
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('updateShoppingList', serviceCtx)
         GenericValue shoppingList = delegator.findOne('ShoppingList', [shoppingListId: serviceCtx.shoppingListId], false)
         assert ServiceUtil.isSuccess(resultMap)
         assert shoppingList
-        assert shoppingList.listName == 'New Demo Wish List'
+        assert shoppingList.listName == listName
     }
 
     @Test
     @Order(5)
     void testUpdateShoppingListItem() {
-        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
+        String userLoginId = testParams.userLoginId ?: 'DemoCustomer'
+        String shoppingListId = testParams.shoppingListId ?: 'DemoWishList'
+        String shoppingListItemSeqId = testParams.shoppingListItemSeqId ?: '00002'
+        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: userLoginId], false)
         Map serviceCtx = [
-                shoppingListId: 'DemoWishList',
-                shoppingListItemSeqId: '00002',
+                shoppingListId: shoppingListId,
+                shoppingListItemSeqId: shoppingListItemSeqId,
                 quantity: new BigDecimal(4),
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('updateShoppingListItem', serviceCtx)
         GenericValue shoppingListItem = delegator.findOne('ShoppingListItem',
-                [shoppingListId: serviceCtx.shoppingListId, 'shoppingListItemSeqId': '00002'], false)
+                [shoppingListId: serviceCtx.shoppingListId, 'shoppingListItemSeqId': shoppingListItemSeqId], false)
         assert ServiceUtil.isSuccess(resultMap)
         assert shoppingListItem
         assert shoppingListItem.quantity == 4
@@ -128,16 +147,19 @@ class ShoppingListTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testUpdateShoppingListItemWithZeroQty() {
-        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
+        String userLoginId = testParams.userLoginId ?: 'DemoCustomer'
+        String shoppingListId = testParams.shoppingListId ?: 'DemoWishList'
+        String shoppingListItemSeqId = testParams.shoppingListItemSeqId ?: '00003'
+        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: userLoginId], false)
         Map serviceCtx = [
-                shoppingListId: 'DemoWishList',
-                shoppingListItemSeqId: '00003',
+                shoppingListId: shoppingListId,
+                shoppingListItemSeqId: shoppingListItemSeqId,
                 quantity: new BigDecimal(0),
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('updateShoppingListItem', serviceCtx)
         GenericValue shoppingListItem = delegator.findOne('ShoppingListItem',
-                [shoppingListId: serviceCtx.shoppingListId, 'shoppingListItemSeqId': '00003'], false)
+                [shoppingListId: serviceCtx.shoppingListId, 'shoppingListItemSeqId': shoppingListItemSeqId], false)
         assert ServiceUtil.isSuccess(resultMap)
         assert shoppingListItem
     }
@@ -145,15 +167,18 @@ class ShoppingListTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testRemoveShoppingListItem() {
-        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: 'DemoCustomer'], false)
+        String userLoginId = testParams.userLoginId ?: 'DemoCustomer'
+        String shoppingListId = testParams.shoppingListId ?: 'DemoWishList'
+        String shoppingListItemSeqId = testParams.shoppingListItemSeqId ?: '00002'
+        GenericValue userLogin = delegator.findOne('UserLogin', [userLoginId: userLoginId], false)
         Map serviceCtx = [
-                shoppingListId: 'DemoWishList',
-                shoppingListItemSeqId: '00002',
+                shoppingListId: shoppingListId,
+                shoppingListItemSeqId: shoppingListItemSeqId,
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('removeShoppingListItem', serviceCtx)
         GenericValue shoppingListItem = delegator.findOne('ShoppingListItem',
-                [shoppingListId: serviceCtx.shoppingListId, 'shoppingListItemSeqId': '00002'], false)
+                [shoppingListId: serviceCtx.shoppingListId, 'shoppingListItemSeqId': shoppingListItemSeqId], false)
         assert ServiceUtil.isSuccess(resultMap)
         assert !shoppingListItem
     }

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/shoppingcart/test/ShoppingCartTests.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/shoppingcart/test/ShoppingCartTests.groovy
@@ -110,18 +110,32 @@ class ShoppingCartTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testLoadCartFromQuote() {
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        String currencyUomId = testParams.currencyUomId ?: 'USD'
+        String description = testParams.description ?: 'Test quote'
+        String productStoreId = testParams.productStoreId ?: '9000'
+        String quoteName = testParams.quoteName ?: 'Test quote'
+        String quoteTypeId = testParams.quoteTypeId ?: 'PRODUCT_QUOTE'
+        String statusId = testParams.statusId ?: 'QUO_APPROVED'
+        String productId = testParams.productId ?: 'GZ-1000'
+        String includeInShipping = testParams.includeInShipping ?: 'N'
+        String includeInTax = testParams.includeInTax ?: 'Y'
+        String quoteAdjustmentTypeId = testParams.quoteAdjustmentTypeId ?: 'SALES_TAX'
+        String taxAuthGeoId = testParams.taxAuthGeoId ?: 'UT'
+        String taxAuthPartyId = testParams.taxAuthPartyId ?: 'UT_TAXMAN'
+        String applyQuoteAdjustments = testParams.applyQuoteAdjustments ?: 'true'
         GenericValue systemLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
 
         Map createQuoteMap = [
                 userLogin: systemLogin,
-                partyId: 'DemoCustomer',
-                currencyUomId: 'USD',
-                description: 'Test quote',
+                partyId: partyId,
+                currencyUomId: currencyUomId,
+                description: description,
                 issueDate: UtilDateTime.toTimestamp('11/01/2011 10:00:00'),
-                productStoreId: '9000',
-                quoteName: 'Test quote',
-                quoteTypeId: 'PRODUCT_QUOTE',
-                statusId: 'QUO_APPROVED',
+                productStoreId: productStoreId,
+                quoteName: quoteName,
+                quoteTypeId: quoteTypeId,
+                statusId: statusId,
                 validFromDate: UtilDateTime.toTimestamp('11/01/2011 10:00:00')
         ]
         Map createQuoteResult = dispatcher.runSync('createQuote', createQuoteMap)
@@ -130,7 +144,7 @@ class ShoppingCartTests implements JupiterTestHelper {
         Map createQuoteItemMap = [
                 userLogin: systemLogin,
                 quoteId: quoteId,
-                productId: 'GZ-1000',
+                productId: productId,
                 quantity: 10,
                 quoteUnitPrice: 15.00
         ]
@@ -142,18 +156,18 @@ class ShoppingCartTests implements JupiterTestHelper {
                 quoteId: quoteId,
                 quoteItemSeqId: quoteItemSeqId,
                 amount: 15.00,
-                includeInShipping: 'N',
-                includeInTax: 'Y',
-                quoteAdjustmentTypeId: 'SALES_TAX',
-                taxAuthGeoId: 'UT',
-                taxAuthPartyId: 'UT_TAXMAN'
+                includeInShipping: includeInShipping,
+                includeInTax: includeInTax,
+                quoteAdjustmentTypeId: quoteAdjustmentTypeId,
+                taxAuthGeoId: taxAuthGeoId,
+                taxAuthPartyId: taxAuthPartyId
         ]
         dispatcher.runSync('createQuoteAdjustment', createQuoteAdjustmentMap)
 
         Map loadCartFromQuoteMap = [
                 userLogin: systemLogin,
                 quoteId: quoteId,
-                applyQuoteAdjustments: 'true'
+                applyQuoteAdjustments: applyQuoteAdjustments
         ]
         Map loadCartResult = dispatcher.runSync('loadCartFromQuote', loadCartFromQuoteMap)
         ShoppingCart shoppingCart = (ShoppingCart) loadCartResult.shoppingCart
@@ -213,6 +227,11 @@ class ShoppingCartTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testOrderMoveItemBetweenShipGoups() {
+        String contactMechId = testParams.contactMechId ?: '9015'
+        String carrierPartyId = testParams.carrierPartyId ?: 'UPS'
+        String shipmentMethodTypeId = testParams.shipmentMethodTypeId ?: 'NEXT_DAY'
+        String fromGroupIndex = testParams.fromGroupIndex ?: '00001'
+        String toGroupIndex = testParams.toGroupIndex ?: '00002'
         GenericValue userLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         Locale locale = Locale.getDefault()
         Map orderMap = createShoppinCartAndOrder(userLogin, locale)
@@ -224,9 +243,9 @@ class ShoppingCartTests implements JupiterTestHelper {
         Map createShipGroupMap = [
                 userLogin: userLogin,
                 orderId: orderId,
-                contactMechId: '9015',
-                carrierPartyId: 'UPS',
-                shipmentMethodTypeId: 'NEXT_DAY'
+                contactMechId: contactMechId,
+                carrierPartyId: carrierPartyId,
+                shipmentMethodTypeId: shipmentMethodTypeId
         ]
         dispatcher.runSync('createOrderItemShipGroup', createShipGroupMap)
 
@@ -234,8 +253,8 @@ class ShoppingCartTests implements JupiterTestHelper {
                 userLogin: userLogin,
                 orderId: orderId,
                 orderItemSeqId: orderItem.orderItemSeqId,
-                fromGroupIndex: '00001',
-                toGroupIndex: '00002',
+                fromGroupIndex: fromGroupIndex,
+                toGroupIndex: toGroupIndex,
                 quantity: 2
         ]
         dispatcher.runSync('moveItemBetweenShipGroups', moveItemMap)
@@ -245,7 +264,7 @@ class ShoppingCartTests implements JupiterTestHelper {
                                                                                       'orderItemSeqId',
                                                                                       orderItem.orderItemSeqId,
                                                                                       'shipGroupSeqId',
-                                                                                      '00001').queryOne()
+                                                                                      fromGroupIndex).queryOne()
         assert orderItemShipGroupAssoc1.quantity == 3
 
         GenericValue orderItemShipGroupAssoc2 = from('OrderItemShipGroupAssoc').where('orderId',
@@ -253,15 +272,15 @@ class ShoppingCartTests implements JupiterTestHelper {
                                                                                       'orderItemSeqId',
                                                                                       orderItem.orderItemSeqId,
                                                                                       'shipGroupSeqId',
-                                                                                      '00002').queryOne()
+                                                                                      toGroupIndex).queryOne()
         assert orderItemShipGroupAssoc2.quantity == 2
 
         dispatcher.runSync('deleteOrderItemShipGroupAssoc',
                             [userLogin: userLogin,
                             orderId: orderId,
                             orderItemSeqId: orderItem.orderItemSeqId,
-                            shipGroupSeqId: '00002'])
-        dispatcher.runSync('deleteOrderItemShipGroup', [userLogin: userLogin, orderId: orderId, shipGroupSeqId: '00002'])
+                            shipGroupSeqId: toGroupIndex])
+        dispatcher.runSync('deleteOrderItemShipGroup', [userLogin: userLogin, orderId: orderId, shipGroupSeqId: toGroupIndex])
 
         long orderItemShipGroupCount = from('OrderItemShipGroup').where('orderId', orderId).queryCount()
         assert orderItemShipGroupCount == 1

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/test/OrderTest.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/test/OrderTest.groovy
@@ -30,7 +30,8 @@ class OrderTest implements JupiterTestHelper {
     @Test
     @Order(1)
     void testAdminGetNextOrderSeqId() {
-        Map serviceCtx = [partyId: 'admin'] // party with no AcctgPref prefix
+        String partyId = testParams.partyId ?: 'admin'
+        Map serviceCtx = [partyId: partyId] // party with no AcctgPref prefix
         Map resp = dispatcher.runSync('getNextOrderId', serviceCtx)
         if (ServiceUtil.isError(resp)) {
             logError(ServiceUtil.getErrorMessage(resp))
@@ -44,7 +45,8 @@ class OrderTest implements JupiterTestHelper {
     @Test
     @Order(2)
     void testCompanyGetNextOrderSeqId() {
-        Map serviceCtx = [partyId: 'Company'] // party with AcctgPref prefix : CO
+        String partyId = testParams.partyId ?: 'Company'
+        Map serviceCtx = [partyId: partyId] // party with AcctgPref prefix : CO
         Map resp = dispatcher.runSync('getNextOrderId', serviceCtx)
         if (ServiceUtil.isError(resp)) {
             logError(ServiceUtil.getErrorMessage(resp))
@@ -58,9 +60,11 @@ class OrderTest implements JupiterTestHelper {
     @Test
     @Order(3)
     void testCompleteGetNextOrderSeqId() {
+        String partyId = testParams.partyId ?: 'Company'
+        String productStoreId = testParams.productStoreId ?: '9000'
         Map serviceCtx = [
-                partyId: 'Company', // party with AcctgPref prefix : CO
-                productStoreId: '9000' // prefix WS
+                partyId: partyId, // party with AcctgPref prefix : CO
+                productStoreId: productStoreId // prefix WS
         ]
         Map resp = dispatcher.runSync('getNextOrderId', serviceCtx)
         if (ServiceUtil.isError(resp)) {

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/test/PurchaseOrderTest.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/test/PurchaseOrderTest.groovy
@@ -29,55 +29,75 @@ class PurchaseOrderTest implements JupiterTestHelper {
 
     @Test
     void testCreatePurchaseOrder() {
+        String orderItemSeqId = testParams.orderItemSeqId ?: '00001'
+        String orderItemTypeId = testParams.orderItemTypeId ?: 'PRODUCT_ORDER_ITEM'
+        String prodCatalogId = testParams.prodCatalogId ?: 'DemoCatalog'
+        String productId = testParams.productId ?: 'GZ-1000'
+        String isPromo = testParams.isPromo ?: 'N'
+        String contactMechPurposeTypeId = testParams.contactMechPurposeTypeId ?: 'SHIPPING_LOCATION'
+        String contactMechId = testParams.contactMechId ?: '9000'
+        String carrierPartyId = testParams.carrierPartyId ?: 'UPS'
+        String isGift = testParams.isGift ?: 'N'
+        String maySplit = testParams.maySplit ?: 'N'
+        String shipGroupSeqId = testParams.shipGroupSeqId ?: '00001'
+        String shipmentMethodTypeId = testParams.shipmentMethodTypeId ?: 'NEXT_DAY'
+        String partyId = testParams.partyId ?: 'Company'
+        String orderTypeId = testParams.orderTypeId ?: 'PURCHASE_ORDER'
+        String currencyUom = testParams.currencyUom ?: 'USD'
+        String productStoreId = testParams.productStoreId ?: '9000'
+        String billToCustomerPartyId = testParams.billToCustomerPartyId ?: 'Company'
+        String billFromVendorPartyId = testParams.billFromVendorPartyId ?: 'DemoSupplier'
+        String shipFromVendorPartyId = testParams.shipFromVendorPartyId ?: 'Company'
+        String supplierAgentPartyId = testParams.supplierAgentPartyId ?: 'DemoSupplier'
         GenericValue orderItem = delegator.makeValue('OrderItem', [
-                orderItemSeqId: '00001',
-                orderItemTypeId: 'PRODUCT_ORDER_ITEM',
-                prodCatalogId: 'DemoCatalog',
-                productId: 'GZ-1000',
+                orderItemSeqId: orderItemSeqId,
+                orderItemTypeId: orderItemTypeId,
+                prodCatalogId: prodCatalogId,
+                productId: productId,
                 quantity: new BigDecimal('2'),
-                isPromo: 'N'
+                isPromo: isPromo
         ])
         orderItem.unitPrice = 1399.5
         orderItem.unitListPrice = BigDecimal.ZERO
-        orderItem.isModifiedPrice = 'N'
+        orderItem.isModifiedPrice = isPromo
         orderItem.statusId = 'ITEM_CREATED'
 
         GenericValue orderContactMech = delegator.makeValue('OrderContactMech', [
-                contactMechPurposeTypeId: 'SHIPPING_LOCATION',
-                contactMechId: '9000'
+                contactMechPurposeTypeId: contactMechPurposeTypeId,
+                contactMechId: contactMechId
         ])
 
         GenericValue orderItemContactMech = delegator.makeValue('OrderItemContactMech', [
-                contactMechPurposeTypeId: 'SHIPPING_LOCATION',
-                contactMechId: '9000',
-                orderItemSeqId: '00001'
+                contactMechPurposeTypeId: contactMechPurposeTypeId,
+                contactMechId: contactMechId,
+                orderItemSeqId: orderItemSeqId
         ])
 
         GenericValue orderItemShipGroup = delegator.makeValue('OrderItemShipGroup', [
-                carrierPartyId: 'UPS',
-                contactMechId: '9000',
-                isGift: 'N',
-                maySplit: 'N',
-                shipGroupSeqId: '00001',
-                shipmentMethodTypeId: 'NEXT_DAY'
+                carrierPartyId: carrierPartyId,
+                contactMechId: contactMechId,
+                isGift: isGift,
+                maySplit: maySplit,
+                shipGroupSeqId: shipGroupSeqId,
+                shipmentMethodTypeId: shipmentMethodTypeId
         ])
         orderItemShipGroup.carrierRoleTypeId = 'CARRIER'
 
         Map serviceCtx = [
-                partyId: 'Company',
-                orderTypeId: 'PURCHASE_ORDER',
-                currencyUom: 'USD',
-                productStoreId: '9000',
+                partyId: partyId,
+                orderTypeId: orderTypeId,
+                currencyUom: currencyUom,
+                productStoreId: productStoreId,
                 orderItems: [orderItem],
                 orderContactMechs: [orderContactMech],
                 orderItemContactMechs: [orderItemContactMech],
                 orderItemShipGroupInfo: [orderItemShipGroup],
                 orderTerms: [],
                 orderAdjustments: [],
-                billToCustomerPartyId: 'Company',
-                billFromVendorPartyId: 'DemoSupplier',
-                shipFromVendorPartyId: 'Company',
-                supplierAgentPartyId: 'DemoSupplier',
+                billToCustomerPartyId: billToCustomerPartyId,
+                billFromVendorPartyId: billFromVendorPartyId,
+                shipFromVendorPartyId: shipFromVendorPartyId,
+                supplierAgentPartyId: supplierAgentPartyId,
                 userLogin: userLogin
         ]
 

--- a/applications/order/src/test/groovy/org/apache/ofbiz/order/test/SalesOrderTest.groovy
+++ b/applications/order/src/test/groovy/org/apache/ofbiz/order/test/SalesOrderTest.groovy
@@ -29,25 +29,56 @@ class SalesOrderTest implements JupiterTestHelper {
 
     @Test
     void testCreateSalesOrder() {
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        String orderTypeId = testParams.orderTypeId ?: 'SALES_ORDER'
+        String currencyUom = testParams.currencyUom ?: 'USD'
+        String productStoreId = testParams.productStoreId ?: '9000'
+        String contactMechId = testParams.contactMechId ?: '9015'
+        String contactMechPurposeTypeId = testParams.contactMechPurposeTypeId ?: 'BILLING_LOCATION'
+        String paymentMethodId = testParams.paymentMethodId ?: '9015'
+        String paymentMethodTypeId = testParams.paymentMethodTypeId ?: 'CREDIT_CARD'
+        String statusId = testParams.statusId ?: 'PAYMENT_NOT_AUTH'
+        String overflowFlag = testParams.overflowFlag ?: 'N'
+        String carrierPartyId = testParams.carrierPartyId ?: 'UPS'
+        String isGift = testParams.isGift ?: 'N'
+        String shipGroupSeqId = testParams.shipGroupSeqId ?: '00001'
+        String shipmentMethodTypeId = testParams.shipmentMethodTypeId ?: 'NEXT_DAY'
+        String orderItemSeqId = testParams.orderItemSeqId ?: '00001'
+        String orderAdjustmentTypeId = testParams.orderAdjustmentTypeId ?: 'SHIPPING_CHARGES'
+        String orderAdjustmentTypeId1 = testParams.orderAdjustmentTypeId1 ?: 'SALES_TAX'
+        String overrideGlAccountId = testParams.overrideGlAccountId ?: '224153'
+        String primaryGeoId = testParams.primaryGeoId ?: 'UT'
+        String primaryGeoId1 = testParams.primaryGeoId1 ?: 'UT-UTAH'
+        String overrideGlAccountId1 = testParams.overrideGlAccountId1 ?: '224000'
+        String primaryGeoId2 = testParams.primaryGeoId2 ?: '_NA_'
+        String orderAdjustmentTypeId4 = testParams.orderAdjustmentTypeId4 ?: 'PROMOTION_ADJUSTMENT'
+        String productPromoActionSeqId = testParams.productPromoActionSeqId ?: '01'
+        String productPromoId = testParams.productPromoId ?: '9011'
+        String productPromoRuleId = testParams.productPromoRuleId ?: '01'
+        String orderItemTypeId = testParams.orderItemTypeId ?: 'PRODUCT_ORDER_ITEM'
+        String prodCatalogId = testParams.prodCatalogId ?: 'DemoCatalog'
+        String productId = testParams.productId ?: 'GZ-2644'
+        String orderItemSeqId1 = testParams.orderItemSeqId1 ?: '00002'
+        String productId1 = testParams.productId1 ?: 'GZ-1006-1'
         Map serviceCtx = [
-                partyId: 'DemoCustomer',
-                orderTypeId: 'SALES_ORDER',
-                currencyUom: 'USD',
-                productStoreId: '9000'
+                partyId: partyId,
+                orderTypeId: orderTypeId,
+                currencyUom: currencyUom,
+                productStoreId: productStoreId
         ]
 
         List orderPaymentInfo = []
         GenericValue orderContactMech = delegator.makeValue('OrderContactMech', [
-                contactMechId: '9015',
-                contactMechPurposeTypeId: 'BILLING_LOCATION'
+                contactMechId: contactMechId,
+                contactMechPurposeTypeId: contactMechPurposeTypeId
         ])
         orderPaymentInfo << orderContactMech
 
         GenericValue orderPaymentPreference = delegator.makeValue('OrderPaymentPreference', [
-                paymentMethodId: '9015',
-                paymentMethodTypeId: 'CREDIT_CARD',
-                statusId: 'PAYMENT_NOT_AUTH',
-                overflowFlag: 'N',
+                paymentMethodId: paymentMethodId,
+                paymentMethodTypeId: paymentMethodTypeId,
+                statusId: statusId,
+                overflowFlag: overflowFlag,
                 maxAmount: 49.26
         ])
         orderPaymentInfo << orderPaymentPreference
@@ -58,37 +89,37 @@ class SalesOrderTest implements JupiterTestHelper {
         orderItemShipGroupInfo << orderContactMech
 
         GenericValue orderItemShipGroup = delegator.makeValue('OrderItemShipGroup', [
-                carrierPartyId: 'UPS',
-                contactMechId: '9015',
-                isGift: 'N',
-                shipGroupSeqId: '00001',
-                shipmentMethodTypeId: 'NEXT_DAY'
+                carrierPartyId: carrierPartyId,
+                contactMechId: contactMechId,
+                isGift: isGift,
+                shipGroupSeqId: shipGroupSeqId,
+                shipmentMethodTypeId: shipmentMethodTypeId
         ])
         orderItemShipGroupInfo << orderItemShipGroup
 
         GenericValue orderItemShipGroupAssoc = delegator.makeValue('OrderItemShipGroupAssoc', [
-                orderItemSeqId: '00001',
+                orderItemSeqId: orderItemSeqId,
                 quantity: BigDecimal.ONE,
-                shipGroupSeqId: '00001'
+                shipGroupSeqId: shipGroupSeqId
         ])
         orderItemShipGroupInfo << orderItemShipGroupAssoc
 
         GenericValue shippingCharges = delegator.makeValue('OrderAdjustment', [
-                orderAdjustmentTypeId: 'SHIPPING_CHARGES',
-                shipGroupSeqId: '00001',
+                orderAdjustmentTypeId: orderAdjustmentTypeId,
+                shipGroupSeqId: shipGroupSeqId,
                 amount: 12.45
         ])
         orderItemShipGroupInfo << shippingCharges
 
         GenericValue salesTaxUt = delegator.makeValue('OrderAdjustment', [
-                orderAdjustmentTypeId: 'SALES_TAX',
-                orderItemSeqId: '00001',
-                overrideGlAccountId: '224153',
-                primaryGeoId: 'UT',
-                shipGroupSeqId: '00001',
+                orderAdjustmentTypeId: orderAdjustmentTypeId1,
+                orderItemSeqId: orderItemSeqId,
+                overrideGlAccountId: overrideGlAccountId,
+                primaryGeoId: primaryGeoId,
+                shipGroupSeqId: shipGroupSeqId,
                 sourcePercentage: BigDecimal.valueOf(4.7)
         ])
-        salesTaxUt.taxAuthGeoId = 'UT'
+        salesTaxUt.taxAuthGeoId = primaryGeoId
         salesTaxUt.taxAuthPartyId = 'UT_TAXMAN'
         salesTaxUt.taxAuthorityRateSeqId = '9004'
         salesTaxUt.amount = BigDecimal.valueOf(1.824)
@@ -96,14 +127,14 @@ class SalesOrderTest implements JupiterTestHelper {
         orderItemShipGroupInfo << salesTaxUt
 
         GenericValue salesTaxUtahCounty = delegator.makeValue('OrderAdjustment', [
-                orderAdjustmentTypeId: 'SALES_TAX',
-                orderItemSeqId: '00001',
-                overrideGlAccountId: '224153',
-                primaryGeoId: 'UT-UTAH',
-                shipGroupSeqId: '00001',
+                orderAdjustmentTypeId: orderAdjustmentTypeId1,
+                orderItemSeqId: orderItemSeqId,
+                overrideGlAccountId: overrideGlAccountId,
+                primaryGeoId: primaryGeoId1,
+                shipGroupSeqId: shipGroupSeqId,
                 sourcePercentage: BigDecimal.valueOf(0.1)
         ])
-        salesTaxUtahCounty.taxAuthGeoId = 'UT-UTAH'
+        salesTaxUtahCounty.taxAuthGeoId = primaryGeoId1
         salesTaxUtahCounty.taxAuthPartyId = 'UT_UTAH_TAXMAN'
         salesTaxUtahCounty.taxAuthorityRateSeqId = '9005'
         salesTaxUtahCounty.amount = BigDecimal.valueOf(0.039)
@@ -111,16 +142,16 @@ class SalesOrderTest implements JupiterTestHelper {
         orderItemShipGroupInfo << salesTaxUtahCounty
 
         GenericValue ofbTax = delegator.makeValue('OrderAdjustment', [
-                orderAdjustmentTypeId: 'SALES_TAX',
-                orderItemSeqId: '00001',
-                overrideGlAccountId: '224000',
-                primaryGeoId: '_NA_',
-                shipGroupSeqId: '00001',
+                orderAdjustmentTypeId: orderAdjustmentTypeId1,
+                orderItemSeqId: orderItemSeqId,
+                overrideGlAccountId: overrideGlAccountId1,
+                primaryGeoId: primaryGeoId2,
+                shipGroupSeqId: shipGroupSeqId,
                 sourcePercentage: BigDecimal.valueOf(1)
         ])
-        ofbTax.taxAuthGeoId = '_NA_'
-        ofbTax.taxAuthPartyId = '_NA_'
-        ofbTax.taxAuthorityRateSeqId = '9000'
+        ofbTax.taxAuthGeoId = primaryGeoId2
+        ofbTax.taxAuthPartyId = primaryGeoId2
+        ofbTax.taxAuthorityRateSeqId = productStoreId
         ofbTax.amount = BigDecimal.valueOf(0.384)
         ofbTax.comments = '1% OFB _NA_ Tax'
         orderItemShipGroupInfo << ofbTax
@@ -128,38 +159,38 @@ class SalesOrderTest implements JupiterTestHelper {
         serviceCtx.orderItemShipGroupInfo = orderItemShipGroupInfo
 
         GenericValue promoAdjustment = delegator.makeValue('OrderAdjustment', [
-                orderAdjustmentTypeId: 'PROMOTION_ADJUSTMENT',
-                productPromoActionSeqId: '01',
-                productPromoId: '9011',
-                productPromoRuleId: '01',
+                orderAdjustmentTypeId: orderAdjustmentTypeId4,
+                productPromoActionSeqId: productPromoActionSeqId,
+                productPromoId: productPromoId,
+                productPromoRuleId: productPromoRuleId,
                 amount: BigDecimal.valueOf(-3.84)
         ])
         serviceCtx.orderAdjustments = [promoAdjustment]
 
         GenericValue orderItem1 = delegator.makeValue('OrderItem', [
-                orderItemSeqId: '00001',
-                orderItemTypeId: 'PRODUCT_ORDER_ITEM',
-                prodCatalogId: 'DemoCatalog',
-                productId: 'GZ-2644',
+                orderItemSeqId: orderItemSeqId,
+                orderItemTypeId: orderItemTypeId,
+                prodCatalogId: prodCatalogId,
+                productId: productId,
                 quantity: BigDecimal.ONE,
                 selectedAmount: BigDecimal.ZERO
         ])
-        orderItem1.isPromo = 'N'
-        orderItem1.isModifiedPrice = 'N'
+        orderItem1.isPromo = overflowFlag
+        orderItem1.isModifiedPrice = overflowFlag
         orderItem1.unitPrice = 38.4
         orderItem1.unitListPrice = 48.0
         orderItem1.statusId = 'ITEM_CREATED'
 
         GenericValue orderItem2 = delegator.makeValue('OrderItem', [
-                orderItemSeqId: '00002',
-                orderItemTypeId: 'PRODUCT_ORDER_ITEM',
-                prodCatalogId: 'DemoCatalog',
-                productId: 'GZ-1006-1',
+                orderItemSeqId: orderItemSeqId1,
+                orderItemTypeId: orderItemTypeId,
+                prodCatalogId: prodCatalogId,
+                productId: productId1,
                 quantity: BigDecimal.ONE,
                 selectedAmount: BigDecimal.ZERO
         ])
-        orderItem2.isPromo = 'N'
-        orderItem2.isModifiedPrice = 'N'
+        orderItem2.isPromo = overflowFlag
+        orderItem2.isModifiedPrice = overflowFlag
         orderItem2.unitPrice = 1.99
         orderItem2.unitListPrice = 5.99
         orderItem2.statusId = 'ITEM_CREATED'
@@ -167,10 +198,10 @@ class SalesOrderTest implements JupiterTestHelper {
         serviceCtx.orderItems = [orderItem1, orderItem2]
         serviceCtx.orderTerms = []
 
-        serviceCtx.placingCustomerPartyId = 'DemoCustomer'
-        serviceCtx.endUserCustomerPartyId = 'DemoCustomer'
-        serviceCtx.shipToCustomerPartyId = 'DemoCustomer'
-        serviceCtx.billToCustomerPartyId = 'DemoCustomer'
+        serviceCtx.placingCustomerPartyId = partyId
+        serviceCtx.endUserCustomerPartyId = partyId
+        serviceCtx.shipToCustomerPartyId = partyId
+        serviceCtx.billToCustomerPartyId = partyId
         serviceCtx.billFromVendorPartyId = 'Company'
         serviceCtx.userLogin = userLogin
 

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyAddressTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyAddressTests.groovy
@@ -31,25 +31,29 @@ class PartyAddressTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateContactMech() {
+        String contactMechId = testParams.contactMechId ?: 'TestEmailConactMech'
+        String contactMechTypeId = testParams.contactMechTypeId ?: 'EMAIL_ADDRESS'
+        String infoString = testParams.infoString ?: 'test_email@example.com'
         Map serviceCtx = [
-                contactMechId: 'TestEmailConactMech',
-                contactMechTypeId: 'EMAIL_ADDRESS',
-                infoString: 'test_email@example.com',
+                contactMechId: contactMechId,
+                contactMechTypeId: contactMechTypeId,
+                infoString: infoString,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createContactMech', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue contactMech = from('ContactMech').where('contactMechId', 'TestEmailConactMech').queryOne()
+        GenericValue contactMech = from('ContactMech').where('contactMechId', contactMechId).queryOne()
         assert contactMech
-        assert contactMech.infoString == 'test_email@example.com'
+        assert contactMech.infoString == infoString
     }
 
     @Test
     @Order(2)
     void testCreateEmailAddress() {
+        String emailAddress = testParams.emailAddress ?: 'test.email123@example.com'
         Map serviceCtx = [
-                emailAddress: 'test.email123@example.com',
+                emailAddress: emailAddress,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createEmailAddress', serviceCtx)
@@ -57,24 +61,28 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue contactMech = from('ContactMech').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert contactMech
-        assert contactMech.infoString == 'test.email123@example.com'
+        assert contactMech.infoString == emailAddress
     }
 
     @Test
     @Order(3)
     void testCreatePartyContactMech() {
+        String contactMechId = testParams.contactMechId ?: 'TestContactMech3'
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String contactMechPurposeTypeId = testParams.contactMechPurposeTypeId ?: 'PRIMARY_EMAIL'
+        String contactMechTypeId = testParams.contactMechTypeId ?: 'EMAIL_ADDRESS'
         Map serviceCtx = [
-                contactMechId: 'TestContactMech3',
-                partyId: 'TestCustomer',
-                contactMechPurposeTypeId: 'PRIMARY_EMAIL',
-                contactMechTypeId: 'EMAIL_ADDRESS',
+                contactMechId: contactMechId,
+                partyId: partyId,
+                contactMechPurposeTypeId: contactMechPurposeTypeId,
+                contactMechTypeId: contactMechTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyContactMech', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyContactMech = from('PartyContactMech')
-            .where('contactMechId', 'TestContactMech3', 'partyId', 'TestCustomer')
+            .where('contactMechId', contactMechId, 'partyId', partyId)
             .queryFirst()
         assert partyContactMech
     }
@@ -85,10 +93,13 @@ class PartyAddressTests implements JupiterTestHelper {
     // otherwise createPartyContactMechPurpose fails ("a purpose with that type already exists").
     @Order(9)
     void testCreatePartyContactMechPurpose() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String contactMechId = testParams.contactMechId ?: 'TestContactMech'
+        String contactMechPurposeTypeId = testParams.contactMechPurposeTypeId ?: 'PRIMARY_EMAIL'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                contactMechId: 'TestContactMech',
-                contactMechPurposeTypeId: 'PRIMARY_EMAIL',
+                partyId: partyId,
+                contactMechId: contactMechId,
+                contactMechPurposeTypeId: contactMechPurposeTypeId,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 01:01:01'),
                 userLogin: userLogin
         ]
@@ -97,11 +108,11 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue partyContactMechPurpose = from('PartyContactMechPurpose')
             .where('partyId',
-                   'TestCustomer',
+                   partyId,
                    'contactMechId',
-                   'TestContactMech',
+                   contactMechId,
                    'contactMechPurposeTypeId',
-                   'PRIMARY_EMAIL',
+                   contactMechPurposeTypeId,
                    'fromDate',
                    java.sql.Timestamp.valueOf('2009-09-09 01:01:01'))
             .queryOne()
@@ -111,9 +122,11 @@ class PartyAddressTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testCreatePartyDataSource() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String dataSourceId = testParams.dataSourceId ?: 'MY_PORTAL'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                dataSourceId: 'MY_PORTAL',
+                partyId: partyId,
+                dataSourceId: dataSourceId,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 01:01:01'),
                 userLogin: userLogin
         ]
@@ -121,7 +134,7 @@ class PartyAddressTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyDataSource = from('PartyDataSource')
-            .where('partyId', 'TestCustomer', 'dataSourceId', 'MY_PORTAL', 'fromDate', java.sql.Timestamp.valueOf('2009-09-09 01:01:01'))
+            .where('partyId', partyId, 'dataSourceId', dataSourceId, 'fromDate', java.sql.Timestamp.valueOf('2009-09-09 01:01:01'))
             .queryOne()
         assert partyDataSource
     }
@@ -129,9 +142,11 @@ class PartyAddressTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testCreatePartyEmailAddress() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String emailAddress = testParams.emailAddress ?: 'test.email1234@example.com'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                emailAddress: 'test.email1234@example.com',
+                partyId: partyId,
+                emailAddress: emailAddress,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyEmailAddress', serviceCtx)
@@ -139,19 +154,25 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue contactMech = from('ContactMech').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert contactMech
-        assert contactMech.infoString == 'test.email1234@example.com'
+        assert contactMech.infoString == emailAddress
     }
 
     @Test
     @Order(7)
     void testCreatePostalAddress() {
+        String toName = testParams.toName ?: 'Test Address'
+        String address1 = testParams.address1 ?: '2004 Factory Blvd'
+        String city = testParams.city ?: 'City of Industry'
+        String countryGeoId = testParams.countryGeoId ?: 'USA'
+        String stateProvinceGeoId = testParams.stateProvinceGeoId ?: 'CA'
+        String postalCode = testParams.postalCode ?: '90000'
         Map serviceCtx = [
-                toName: 'Test Address',
-                address1: '2004 Factory Blvd',
-                city: 'City of Industry',
-                countryGeoId: 'USA',
-                stateProvinceGeoId: 'CA',
-                postalCode: '90000',
+                toName: toName,
+                address1: address1,
+                city: city,
+                countryGeoId: countryGeoId,
+                stateProvinceGeoId: stateProvinceGeoId,
+                postalCode: postalCode,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPostalAddress', serviceCtx)
@@ -159,18 +180,21 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue postalAddress = from('PostalAddress').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert postalAddress
-        assert postalAddress.address1 == '2004 Factory Blvd'
-        assert postalAddress.city == 'City of Industry'
-        assert postalAddress.postalCode == '90000'
+        assert postalAddress.address1 == address1
+        assert postalAddress.city == city
+        assert postalAddress.postalCode == postalCode
     }
 
     @Test
     @Order(8)
     void testCreateTelecomNumber() {
+        String contactMechId = testParams.contactMechId ?: 'TestTelecomNumber'
+        String areaCode = testParams.areaCode ?: '801'
+        String contactNumber = testParams.contactNumber ?: '1111111'
         Map serviceCtx = [
-                contactMechId: 'TestTelecomNumber',
-                areaCode: '801',
-                contactNumber: '1111111',
+                contactMechId: contactMechId,
+                areaCode: areaCode,
+                contactNumber: contactNumber,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createTelecomNumber', serviceCtx)
@@ -178,17 +202,20 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue telecomNumber = from('TelecomNumber').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert telecomNumber
-        assert telecomNumber.areaCode == '801'
-        assert telecomNumber.contactNumber == '1111111'
+        assert telecomNumber.areaCode == areaCode
+        assert telecomNumber.contactNumber == contactNumber
     }
 
     @Test
     @Order(4)
     void testExpirePartyContactMechPurpose() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String contactMechId = testParams.contactMechId ?: 'TestContactMech'
+        String contactMechPurposeTypeId = testParams.contactMechPurposeTypeId ?: 'PRIMARY_EMAIL'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                contactMechId: 'TestContactMech',
-                contactMechPurposeTypeId: 'PRIMARY_EMAIL',
+                partyId: partyId,
+                contactMechId: contactMechId,
+                contactMechPurposeTypeId: contactMechPurposeTypeId,
                 fromDate: java.sql.Timestamp.valueOf('2000-01-01 00:00:00'),
                 userLogin: userLogin
         ]
@@ -197,11 +224,11 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue partyContactMechPurpose = from('PartyContactMechPurpose')
             .where('partyId',
-                   'TestCustomer',
+                   partyId,
                    'contactMechId',
-                   'TestContactMech',
+                   contactMechId,
                    'contactMechPurposeTypeId',
-                   'PRIMARY_EMAIL',
+                   contactMechPurposeTypeId,
                    'fromDate',
                    java.sql.Timestamp.valueOf('2000-01-01 00:00:00'))
             .queryOne()
@@ -212,8 +239,9 @@ class PartyAddressTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testGetPartyEmail() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
+                partyId: partyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getPartyEmail', serviceCtx)
@@ -226,8 +254,9 @@ class PartyAddressTests implements JupiterTestHelper {
     @Test
     @Order(11)
     void testGetPartyPostalAddress() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
+                partyId: partyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getPartyPostalAddress', serviceCtx)
@@ -241,8 +270,9 @@ class PartyAddressTests implements JupiterTestHelper {
     @Test
     @Order(12)
     void testGetPartyTelephone() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
+                partyId: partyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getPartyTelephone', serviceCtx)
@@ -255,10 +285,13 @@ class PartyAddressTests implements JupiterTestHelper {
     @Test
     @Order(13)
     void testUpdateContactMech() {
+        String contactMechId = testParams.contactMechId ?: 'TestContactMech'
+        String contactMechTypeId = testParams.contactMechTypeId ?: 'EMAIL_ADDRESS'
+        String infoString = testParams.infoString ?: 'demo_email@example.com'
         Map serviceCtx = [
-                contactMechId: 'TestContactMech',
-                contactMechTypeId: 'EMAIL_ADDRESS',
-                infoString: 'demo_email@example.com',
+                contactMechId: contactMechId,
+                contactMechTypeId: contactMechTypeId,
+                infoString: infoString,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateContactMech', serviceCtx)
@@ -266,15 +299,17 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue contactMech = from('ContactMech').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert contactMech
-        assert contactMech.infoString == 'demo_email@example.com'
+        assert contactMech.infoString == infoString
     }
 
     @Test
     @Order(14)
     void testUpdateEmailAddress() {
+        String contactMechId = testParams.contactMechId ?: 'TestContactMech'
+        String emailAddress = testParams.emailAddress ?: 'test.email123@example.com'
         Map serviceCtx = [
-                contactMechId: 'TestContactMech',
-                emailAddress: 'test.email123@example.com',
+                contactMechId: contactMechId,
+                emailAddress: emailAddress,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateEmailAddress', serviceCtx)
@@ -282,16 +317,19 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue contactMech = from('ContactMech').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert contactMech
-        assert contactMech.infoString == 'test.email123@example.com'
+        assert contactMech.infoString == emailAddress
     }
 
     @Test
     @Order(15)
     void testUpdatePartyEmailAddress() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String contactMechId = testParams.contactMechId ?: 'TestContactMech'
+        String emailAddress = testParams.emailAddress ?: 'test.email12345@example.com'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                contactMechId: 'TestContactMech',
-                emailAddress: 'test.email12345@example.com',
+                partyId: partyId,
+                contactMechId: contactMechId,
+                emailAddress: emailAddress,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyEmailAddress', serviceCtx)
@@ -299,39 +337,50 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue contactMech = from('ContactMech').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert contactMech
-        assert contactMech.infoString == 'test.email12345@example.com'
+        assert contactMech.infoString == emailAddress
     }
 
     @Test
     @Order(16)
     void testUpdatePartyGroup() {
+        String partyId = testParams.partyId ?: 'TestGroup-1'
+        String groupName = testParams.groupName ?: 'Test Party Group'
+        String logoImageUrl = testParams.logoImageUrl ?: '/images/ofbiz_logo.png'
         Map serviceCtx = [
-                partyId: 'TestGroup-1',
-                groupName: 'Test Party Group',
-                logoImageUrl: '/images/ofbiz_logo.png',
+                partyId: partyId,
+                groupName: groupName,
+                logoImageUrl: logoImageUrl,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyGroup', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyGroup = from('PartyGroup').where('partyId', 'TestGroup-1').queryOne()
+        GenericValue partyGroup = from('PartyGroup').where('partyId', partyId).queryOne()
         assert partyGroup
-        assert partyGroup.groupName == 'Test Party Group'
-        assert partyGroup.logoImageUrl == '/images/ofbiz_logo.png'
+        assert partyGroup.groupName == groupName
+        assert partyGroup.logoImageUrl == logoImageUrl
     }
 
     @Test
     @Order(17)
     void testUpdatePartyPostalAddress() {
+        String contactMechId = testParams.contactMechId ?: 'TestPostalAdd2'
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String toName = testParams.toName ?: 'Test Address'
+        String address1 = testParams.address1 ?: '2004 Factory Blvd'
+        String city = testParams.city ?: 'City of Industry'
+        String countryGeoId = testParams.countryGeoId ?: 'USA'
+        String stateProvinceGeoId = testParams.stateProvinceGeoId ?: 'CA'
+        String postalCode = testParams.postalCode ?: '90000'
         Map serviceCtx = [
-                contactMechId: 'TestPostalAdd2',
-                partyId: 'TestCustomer',
-                toName: 'Test Address',
-                address1: '2004 Factory Blvd',
-                city: 'City of Industry',
-                countryGeoId: 'USA',
-                stateProvinceGeoId: 'CA',
-                postalCode: '90000',
+                contactMechId: contactMechId,
+                partyId: partyId,
+                toName: toName,
+                address1: address1,
+                city: city,
+                countryGeoId: countryGeoId,
+                stateProvinceGeoId: stateProvinceGeoId,
+                postalCode: postalCode,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyPostalAddress', serviceCtx)
@@ -339,19 +388,23 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue postalAddress = from('PostalAddress').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert postalAddress
-        assert postalAddress.address1 == '2004 Factory Blvd'
-        assert postalAddress.city == 'City of Industry'
-        assert postalAddress.postalCode == '90000'
+        assert postalAddress.address1 == address1
+        assert postalAddress.city == city
+        assert postalAddress.postalCode == postalCode
     }
 
     @Test
     @Order(18)
     void testUpdatePartyTelecomNumber() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String contactMechId = testParams.contactMechId ?: 'TestContactMech1'
+        String areaCode = testParams.areaCode ?: '801'
+        String contactNumber = testParams.contactNumber ?: '1111111'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                contactMechId: 'TestContactMech1',
-                areaCode: '801',
-                contactNumber: '1111111',
+                partyId: partyId,
+                contactMechId: contactMechId,
+                areaCode: areaCode,
+                contactNumber: contactNumber,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyTelecomNumber', serviceCtx)
@@ -359,39 +412,49 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue telecomNumber = from('TelecomNumber').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert telecomNumber
-        assert telecomNumber.areaCode == '801'
-        assert telecomNumber.contactNumber == '1111111'
+        assert telecomNumber.areaCode == areaCode
+        assert telecomNumber.contactNumber == contactNumber
     }
 
     @Test
     @Order(19)
     void testUpdatePerson() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String firstName = testParams.firstName ?: 'New Test'
+        String lastName = testParams.lastName ?: 'Person'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                firstName: 'New Test',
-                lastName: 'Person',
+                partyId: partyId,
+                firstName: firstName,
+                lastName: lastName,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePerson', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue person = from('Person').where('partyId', 'TestCustomer').queryOne()
+        GenericValue person = from(lastName).where('partyId', partyId).queryOne()
         assert person
-        assert person.firstName == 'New Test'
-        assert person.lastName == 'Person'
+        assert person.firstName == firstName
+        assert person.lastName == lastName
     }
 
     @Test
     @Order(20)
     void testUpdatePostalAddress() {
+        String contactMechId = testParams.contactMechId ?: 'TestPostalAdd1'
+        String toName = testParams.toName ?: 'Test Address'
+        String address1 = testParams.address1 ?: '2004 Factory Blvd'
+        String city = testParams.city ?: 'City of Industry'
+        String countryGeoId = testParams.countryGeoId ?: 'USA'
+        String stateProvinceGeoId = testParams.stateProvinceGeoId ?: 'CA'
+        String postalCode = testParams.postalCode ?: '90000'
         Map serviceCtx = [
-                contactMechId: 'TestPostalAdd1',
-                toName: 'Test Address',
-                address1: '2004 Factory Blvd',
-                city: 'City of Industry',
-                countryGeoId: 'USA',
-                stateProvinceGeoId: 'CA',
-                postalCode: '90000',
+                contactMechId: contactMechId,
+                toName: toName,
+                address1: address1,
+                city: city,
+                countryGeoId: countryGeoId,
+                stateProvinceGeoId: stateProvinceGeoId,
+                postalCode: postalCode,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePostalAddress', serviceCtx)
@@ -399,24 +462,32 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue postalAddress = from('PostalAddress').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert postalAddress
-        assert postalAddress.address1 == '2004 Factory Blvd'
-        assert postalAddress.city == 'City of Industry'
-        assert postalAddress.postalCode == '90000'
+        assert postalAddress.address1 == address1
+        assert postalAddress.city == city
+        assert postalAddress.postalCode == postalCode
         assert serviceResult.contactMechId != serviceResult.oldContactMechId
     }
 
     @Test
     @Order(21)
     void testUpdatePostalAddressAndPurposes() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String contactMechId = testParams.contactMechId ?: 'TestPostalAdd3'
+        String toName = testParams.toName ?: 'Test Address'
+        String address1 = testParams.address1 ?: '2004 Factory Blvd'
+        String city = testParams.city ?: 'City of Industry'
+        String countryGeoId = testParams.countryGeoId ?: 'USA'
+        String stateProvinceGeoId = testParams.stateProvinceGeoId ?: 'CA'
+        String postalCode = testParams.postalCode ?: '90000'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                contactMechId: 'TestPostalAdd3',
-                toName: 'Test Address',
-                address1: '2004 Factory Blvd',
-                city: 'City of Industry',
-                countryGeoId: 'USA',
-                stateProvinceGeoId: 'CA',
-                postalCode: '90000',
+                partyId: partyId,
+                contactMechId: contactMechId,
+                toName: toName,
+                address1: address1,
+                city: city,
+                countryGeoId: countryGeoId,
+                stateProvinceGeoId: stateProvinceGeoId,
+                postalCode: postalCode,
                 fromDate: java.sql.Timestamp.valueOf('2001-05-13 00:00:00.000'),
                 userLogin: userLogin
         ]
@@ -425,18 +496,21 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue postalAddress = from('PostalAddress').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert postalAddress
-        assert postalAddress.address1 == '2004 Factory Blvd'
-        assert postalAddress.city == 'City of Industry'
-        assert postalAddress.postalCode == '90000'
+        assert postalAddress.address1 == address1
+        assert postalAddress.city == city
+        assert postalAddress.postalCode == postalCode
     }
 
     @Test
     @Order(22)
     void testUpdateTelecomNumber() {
+        String contactMechId = testParams.contactMechId ?: 'TestContactMech1'
+        String areaCode = testParams.areaCode ?: '801'
+        String contactNumber = testParams.contactNumber ?: '1111111'
         Map serviceCtx = [
-                contactMechId: 'TestContactMech1',
-                areaCode: '801',
-                contactNumber: '1111111',
+                contactMechId: contactMechId,
+                areaCode: areaCode,
+                contactNumber: contactNumber,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateTelecomNumber', serviceCtx)
@@ -444,8 +518,8 @@ class PartyAddressTests implements JupiterTestHelper {
 
         GenericValue telecomNumber = from('TelecomNumber').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert telecomNumber
-        assert telecomNumber.areaCode == '801'
-        assert telecomNumber.contactNumber == '1111111'
+        assert telecomNumber.areaCode == areaCode
+        assert telecomNumber.contactNumber == contactNumber
         assert serviceResult.contactMechId != serviceResult.oldContactMechId
     }
 

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyCommunicationEventTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyCommunicationEventTests.groovy
@@ -31,95 +31,123 @@ class PartyCommunicationEventTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateCommunicationEvent() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-3'
+        String communicationEventTypeId = testParams.communicationEventTypeId ?: 'EMAIL_COMMUNICATION'
+        String statusId = testParams.statusId ?: 'COM_COMPLETE'
+        String fromString = testParams.fromString ?: 'send@example.com'
+        String toString = testParams.toString ?: 'receive@example.com'
+        String subject = testParams.subject ?: 'Why i would use the OFBiz system'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-3',
-                communicationEventTypeId: 'EMAIL_COMMUNICATION',
-                statusId: 'COM_COMPLETE',
-                fromString: 'send@example.com',
-                toString: 'receive@example.com',
-                subject: 'Why i would use the OFBiz system',
+                communicationEventId: communicationEventId,
+                communicationEventTypeId: communicationEventTypeId,
+                statusId: statusId,
+                fromString: fromString,
+                toString: toString,
+                subject: subject,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createCommunicationEvent', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', 'TestEvent-3').queryOne()
+        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', communicationEventId).queryOne()
         assert communicationEvent
-        assert communicationEvent.statusId == 'COM_COMPLETE'
-        assert communicationEvent.subject == 'Why i would use the OFBiz system'
+        assert communicationEvent.statusId == statusId
+        assert communicationEvent.subject == subject
     }
 
     @Test
     @Order(2)
     void testCreateCommunicationEventRole() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-6'
+        String partyId = testParams.partyId ?: 'TestCompany'
+        String roleTypeId = testParams.roleTypeId ?: 'ADDRESSEE'
+        String statusId = testParams.statusId ?: 'COM_ROLE_CREATED'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-6',
-                partyId: 'TestCompany',
-                roleTypeId: 'ADDRESSEE',
-                statusId: 'COM_ROLE_CREATED',
+                communicationEventId: communicationEventId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createCommunicationEventRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue communicationEventRole = from('CommunicationEventRole')
-            .where('communicationEventId', 'TestEvent-6', 'roleTypeId', 'ADDRESSEE', 'partyId', 'TestCompany')
+            .where('communicationEventId', communicationEventId, 'roleTypeId', roleTypeId, 'partyId', partyId)
             .queryOne()
 
         assert communicationEventRole
-        assert communicationEventRole.statusId == 'COM_ROLE_CREATED'
+        assert communicationEventRole.statusId == statusId
     }
 
     @Test
     @Order(3)
     void testCreateCommunicationEventRoleWithoutPermission() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-6'
+        String partyId = testParams.partyId ?: 'TestCompany'
+        String roleTypeId = testParams.roleTypeId ?: 'INTERNAL_ORGANIZATIO'
+        String statusId = testParams.statusId ?: 'COM_ROLE_CREATED'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-6',
-                partyId: 'TestCompany',
-                roleTypeId: 'INTERNAL_ORGANIZATIO',
-                statusId: 'COM_ROLE_CREATED',
+                communicationEventId: communicationEventId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createCommunicationEventRoleWithoutPermission', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue communicationEventRole = from('CommunicationEventRole')
-            .where('communicationEventId', 'TestEvent-6', 'roleTypeId', 'INTERNAL_ORGANIZATIO', 'partyId', 'TestCompany')
+            .where('communicationEventId', communicationEventId, 'roleTypeId', roleTypeId, 'partyId', partyId)
             .queryOne()
 
         assert communicationEventRole
-        assert communicationEventRole.statusId == 'COM_ROLE_CREATED'
+        assert communicationEventRole.statusId == statusId
     }
 
     @Test
     @Order(4)
     void testCreateCommunicationEventWithoutPermission() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-4'
+        String communicationEventTypeId = testParams.communicationEventTypeId ?: 'EMAIL_COMMUNICATION'
+        String statusId = testParams.statusId ?: 'COM_COMPLETE'
+        String fromString = testParams.fromString ?: 'send@example.com'
+        String toString = testParams.toString ?: 'receive@example.com'
+        String subject = testParams.subject ?: 'Why i would use the OFBiz system'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-4',
-                communicationEventTypeId: 'EMAIL_COMMUNICATION',
-                statusId: 'COM_COMPLETE',
-                fromString: 'send@example.com',
-                toString: 'receive@example.com',
-                subject: 'Why i would use the OFBiz system',
+                communicationEventId: communicationEventId,
+                communicationEventTypeId: communicationEventTypeId,
+                statusId: statusId,
+                fromString: fromString,
+                toString: toString,
+                subject: subject,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createCommunicationEventWithoutPermission', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', 'TestEvent-4').queryOne()
+        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', communicationEventId).queryOne()
         assert communicationEvent
-        assert communicationEvent.statusId == 'COM_COMPLETE'
-        assert communicationEvent.subject == 'Why i would use the OFBiz system'
+        assert communicationEvent.statusId == statusId
+        assert communicationEvent.subject == subject
     }
 
     @Test
     @Order(5)
     void testCreateNewCommEvent() {
+        String communicationEventTypeId = testParams.communicationEventTypeId ?: 'EMAIL_COMMUNICATION'
+        String statusId = testParams.statusId ?: 'COM_ENTERED'
+        String partyIdFrom = testParams.partyIdFrom ?: 'DemoCustomer'
+        String contactMechTypeId = testParams.contactMechTypeId ?: 'EMAIL_ADDRESS'
+        String communicationEventTypeId1 = testParams.communicationEventTypeId1 ?: 'AUTO_EMAIL_COMM'
+        String statusId1 = testParams.statusId1 ?: 'COM_COMPLETE'
+        String partyIdFrom1 = testParams.partyIdFrom1 ?: 'admin'
+        String contactMechTypeId1 = testParams.contactMechTypeId1 ?: 'ELECTRONIC_ADDRESS'
         Map createNewCommEventMap = [
-                communicationEventTypeId: 'EMAIL_COMMUNICATION',
-                statusId: 'COM_ENTERED',
-                partyIdFrom: 'DemoCustomer',
-                contactMechTypeId: 'EMAIL_ADDRESS',
+                communicationEventTypeId: communicationEventTypeId,
+                statusId: statusId,
+                partyIdFrom: partyIdFrom,
+                contactMechTypeId: contactMechTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createCommunicationEvent', createNewCommEventMap)
@@ -128,10 +156,10 @@ class PartyCommunicationEventTests implements JupiterTestHelper {
 
         Map updateCommEventMap = [
                 communicationEventId: communicationEventId,
-                communicationEventTypeId: 'AUTO_EMAIL_COMM',
-                statusId: 'COM_COMPLETE',
-                partyIdFrom: 'admin',
-                contactMechTypeId: 'ELECTRONIC_ADDRESS',
+                communicationEventTypeId: communicationEventTypeId1,
+                statusId: statusId1,
+                partyIdFrom: partyIdFrom1,
+                contactMechTypeId: contactMechTypeId1,
                 userLogin: userLogin
         ]
         Map serviceResult2 = dispatcher.runSync('updateCommunicationEvent', updateCommEventMap)
@@ -148,49 +176,57 @@ class PartyCommunicationEventTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testDeleteCommunicationEvent() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-1'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-1',
+                communicationEventId: communicationEventId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('deleteCommunicationEvent', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', 'TestEvent-1').queryOne()
+        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', communicationEventId).queryOne()
         assert !communicationEvent
     }
 
     @Test
     @Order(7)
     void testDeleteCommunicationEventWorkEffort() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-5'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-5',
+                communicationEventId: communicationEventId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('deleteCommunicationEventWorkEffort', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', 'TestEvent-5').queryOne()
+        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', communicationEventId).queryOne()
         assert !communicationEvent
 
-        List<GenericValue> communicationEventWorkEff = from('CommunicationEventWorkEff').where('communicationEventId', 'TestEvent-5').queryList()
+        List<GenericValue> communicationEventWorkEff = from('CommunicationEventWorkEff')
+                .where('communicationEventId', communicationEventId)
+                .queryList()
         assert !communicationEventWorkEff
     }
 
     @Test
     @Order(8)
     void testRemoveCommunicationEventRole() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-5'
+        String partyId = testParams.partyId ?: 'TestCompany'
+        String roleTypeId = testParams.roleTypeId ?: 'ADDRESSEE'
+        String statusId = testParams.statusId ?: 'COM_ROLE_CREATED'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-5',
-                partyId: 'TestCompany',
-                roleTypeId: 'ADDRESSEE',
-                statusId: 'COM_ROLE_CREATED',
+                communicationEventId: communicationEventId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('removeCommunicationEventRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue communicationEventRole = from('CommunicationEventRole')
-            .where('communicationEventId', 'TestEvent-5', 'partyId', 'TestCompany', 'roleTypeId', 'ADDRESSEE')
+            .where('communicationEventId', communicationEventId, 'partyId', partyId, 'roleTypeId', roleTypeId)
             .queryOne()
         assert !communicationEventRole
     }
@@ -198,14 +234,15 @@ class PartyCommunicationEventTests implements JupiterTestHelper {
     @Test
     @Order(9)
     void testSetCommEventComplete() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-6'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-6',
+                communicationEventId: communicationEventId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('setCommEventComplete', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', 'TestEvent-6').queryOne()
+        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', communicationEventId).queryOne()
         assert communicationEvent
         assert communicationEvent.statusId == 'COM_COMPLETE'
     }
@@ -213,17 +250,20 @@ class PartyCommunicationEventTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testSetCommEventRoleToRead() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-7'
+        String partyId = testParams.partyId ?: 'TestCompany'
+        String roleTypeId = testParams.roleTypeId ?: 'ADDRESSEE'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-7',
-                partyId: 'TestCompany',
-                roleTypeId: 'ADDRESSEE',
+                communicationEventId: communicationEventId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('setCommEventRoleToRead', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue communicationEventRole = from('CommunicationEventRole')
-            .where('communicationEventId', 'TestEvent-7', 'partyId', 'TestCompany', 'roleTypeId', 'ADDRESSEE', 'statusId', 'COM_ROLE_READ')
+            .where('communicationEventId', communicationEventId, 'partyId', partyId, 'roleTypeId', roleTypeId, 'statusId', 'COM_ROLE_READ')
             .queryOne()
         assert communicationEventRole
     }
@@ -234,18 +274,22 @@ class PartyCommunicationEventTests implements JupiterTestHelper {
     // valid transition, which is what testUpdateCommunicationEventRole needs to do to that role.
     @Order(14)
     void testSetCommunicationEventRoleStatus() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-2'
+        String partyId = testParams.partyId ?: 'TestCompany'
+        String roleTypeId = testParams.roleTypeId ?: 'ADDRESSEE'
+        String statusId = testParams.statusId ?: 'COM_ROLE_COMPLETED'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-2',
-                partyId: 'TestCompany',
-                roleTypeId: 'ADDRESSEE',
-                statusId: 'COM_ROLE_COMPLETED',
+                communicationEventId: communicationEventId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('setCommunicationEventRoleStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue communicationEventRole = from('CommunicationEventRole')
-            .where('communicationEventId', 'TestEvent-2', 'partyId', 'TestCompany', 'roleTypeId', 'ADDRESSEE', 'statusId', 'COM_ROLE_COMPLETED')
+            .where('communicationEventId', communicationEventId, 'partyId', partyId, 'roleTypeId', roleTypeId, 'statusId', statusId)
             .queryOne()
         assert communicationEventRole
     }
@@ -253,53 +297,61 @@ class PartyCommunicationEventTests implements JupiterTestHelper {
     @Test
     @Order(12)
     void testSetCommunicationEventStatus() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-6'
+        String statusId = testParams.statusId ?: 'COM_COMPLETE'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-6',
-                statusId: 'COM_COMPLETE',
+                communicationEventId: communicationEventId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('setCommunicationEventStatus', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', 'TestEvent-6').queryOne()
+        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', communicationEventId).queryOne()
         assert communicationEvent
-        assert communicationEvent.statusId == 'COM_COMPLETE'
+        assert communicationEvent.statusId == statusId
     }
 
     @Test
     @Order(13)
     void testUpdateCommunicationEvent() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-7'
+        String statusId = testParams.statusId ?: 'COM_COMPLETE'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-7',
-                statusId: 'COM_COMPLETE',
+                communicationEventId: communicationEventId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateCommunicationEvent', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', 'TestEvent-7').queryOne()
+        GenericValue communicationEvent = from('CommunicationEvent').where('communicationEventId', communicationEventId).queryOne()
         assert communicationEvent
-        assert communicationEvent.statusId == 'COM_COMPLETE'
+        assert communicationEvent.statusId == statusId
     }
 
     @Test
     @Order(11)
     void testUpdateCommunicationEventRole() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-2'
+        String partyId = testParams.partyId ?: 'TestCompany'
+        String roleTypeId = testParams.roleTypeId ?: 'ADDRESSEE'
+        String statusId = testParams.statusId ?: 'COM_ROLE_READ'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-2',
-                partyId: 'TestCompany',
-                roleTypeId: 'ADDRESSEE',
-                statusId: 'COM_ROLE_READ',
+                communicationEventId: communicationEventId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateCommunicationEventRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue communicationEventRole = from('CommunicationEventRole')
-            .where('communicationEventId', 'TestEvent-2', 'partyId', 'TestCompany', 'roleTypeId', 'ADDRESSEE')
+            .where('communicationEventId', communicationEventId, 'partyId', partyId, 'roleTypeId', roleTypeId)
             .queryOne()
         assert communicationEventRole
-        assert communicationEventRole.statusId == 'COM_ROLE_READ'
+        assert communicationEventRole.statusId == statusId
     }
 
 }

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyContactMechTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyContactMechTests.groovy
@@ -33,6 +33,7 @@ class PartyContactMechTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testUpdatePartyEmailAddress() {
+        String contactMechIdParam = testParams.contactMechIdParam ?: '9026'
         String partyId = 'DemoCustomer'
         String contactMechTypeId = 'EMAIL_ADDRESS'
         String emailAddress = 'ofbiztest@example.com'
@@ -42,7 +43,7 @@ class PartyContactMechTests implements JupiterTestHelper {
                 partyId: partyId,
                 contactMechTypeId: contactMechTypeId,
                 emailAddress: emailAddress,
-                contactMechId: '9026',
+                contactMechId: contactMechIdParam,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyEmailAddress', serviceCtx)
@@ -77,15 +78,19 @@ class PartyContactMechTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testUpdatePartyTelecomNumber() {
+        String contactMechIdParam = testParams.contactMechIdParam ?: '9025'
+        String countryCode = testParams.countryCode ?: '1'
+        String areaCode = testParams.areaCode ?: '801'
+        String contactNumber = testParams.contactNumber ?: '555-5555'
         String partyId = 'DemoCustomer'
 
         // first try with just updating without changing the email address
         Map serviceCtx = [
                 partyId: partyId,
-                contactMechId: '9025',
-                countryCode: '1',
-                areaCode: '801',
-                contactNumber: '555-5555',
+                contactMechId: contactMechIdParam,
+                countryCode: countryCode,
+                areaCode: areaCode,
+                contactNumber: contactNumber,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyTelecomNumber', serviceCtx)
@@ -321,6 +326,7 @@ class PartyContactMechTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testCreateUpdatePartyTelecomNumberWithUpdate() {
+        String contactMechIdParam = testParams.contactMechIdParam ?: '9125'
         String partyId = 'DemoCustomer'
         String contactMechPurposeTypeId = 'PHONE_HOME'
         String areaCode = '802'
@@ -328,7 +334,7 @@ class PartyContactMechTests implements JupiterTestHelper {
 
         Map serviceCtx = [
                 partyId: partyId,
-                contactMechId: '9125',
+                contactMechId: contactMechIdParam,
                 contactMechPurposeTypeId: contactMechPurposeTypeId,
                 areaCode: areaCode,
                 contactNumber: contactNumber,
@@ -337,10 +343,10 @@ class PartyContactMechTests implements JupiterTestHelper {
         Map serviceResult = dispatcher.runSync('createUpdatePartyTelecomNumber', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         String contactMechId = serviceResult.contactMechId
-        assert contactMechId != '9125'
+        assert contactMechId != contactMechIdParam
 
         GenericValue partyContactMechPurpose = from('PartyContactMechPurpose')
-                .where('contactMechId', '9125')
+                .where('contactMechId', contactMechIdParam)
                 .queryFirst()
         assert partyContactMechPurpose
         assert partyContactMechPurpose.thruDate
@@ -408,13 +414,14 @@ class PartyContactMechTests implements JupiterTestHelper {
     @Test
     @Order(9)
     void testCreateUpdatePartyEmailAddressWithUpdate() {
+        String contactMechIdParam = testParams.contactMechIdParam ?: '9126'
         String partyId = 'DemoCustomer'
         String contactMechPurposeTypeId = 'PRIMARY_EMAIL'
         String emailAddress = 'demo.customer@foo.com'
 
         Map serviceCtx = [
                 partyId: partyId,
-                contactMechId: '9126',
+                contactMechId: contactMechIdParam,
                 contactMechPurposeTypeId: contactMechPurposeTypeId,
                 emailAddress: emailAddress,
                 userLogin: userLogin
@@ -423,11 +430,11 @@ class PartyContactMechTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
         String contactMechId = serviceResult.contactMechId
         assert contactMechId
-        assert contactMechId != '9126'
+        assert contactMechId != contactMechIdParam
         assert emailAddress == serviceResult.emailAddress
 
         GenericValue partyContactMechPurpose = from('PartyContactMechPurpose')
-                .where('contactMechId', '9126')
+                .where('contactMechId', contactMechIdParam)
                 .queryFirst()
         assert partyContactMechPurpose
         assert partyContactMechPurpose.thruDate != null

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyMiscTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyMiscTests.groovy
@@ -48,24 +48,28 @@ class PartyMiscTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateAddressMatchMap() {
+        String mapKey = testParams.mapKey ?: 'TEST_KEY'
+        String mapValue = testParams.mapValue ?: 'TEST VALUE'
         Map serviceCtx = [
-                mapKey: 'TEST_KEY',
-                mapValue: 'TEST VALUE',
+                mapKey: mapKey,
+                mapValue: mapValue,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createAddressMatchMap', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue addressMatchMap = from('AddressMatchMap').where('mapKey', 'TEST_KEY', 'mapValue', 'TEST VALUE').queryOne()
+        GenericValue addressMatchMap = from('AddressMatchMap').where('mapKey', mapKey, 'mapValue', mapValue).queryOne()
         assert addressMatchMap
     }
 
     @Test
     @Order(2)
     void testCreateAffiliate() {
+        String partyId = testParams.partyId ?: 'TestCompany'
+        String affiliateName = testParams.affiliateName ?: 'Test Affiliate'
         Map serviceCtx = [
-                partyId: 'TestCompany',
-                affiliateName: 'Test Affiliate',
+                partyId: partyId,
+                affiliateName: affiliateName,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createAffiliate', serviceCtx)
@@ -73,20 +77,21 @@ class PartyMiscTests implements JupiterTestHelper {
 
         GenericValue affiliate = from('Affiliate').where('partyId', serviceResult.partyId).queryOne()
         assert affiliate
-        assert affiliate.affiliateName == 'Test Affiliate'
+        assert affiliate.affiliateName == affiliateName
     }
 
     @Test
     @Order(3)
     void testCreateEmailAddressVerification() {
+        String emailAddress = testParams.emailAddress ?: 'test_email@example.com'
         Map serviceCtx = [
-                emailAddress: 'test_email@example.com',
+                emailAddress: emailAddress,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createEmailAddressVerification', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue emailAddressVerification = from('EmailAddressVerification').where('emailAddress', 'test_email@example.com').queryOne()
+        GenericValue emailAddressVerification = from('EmailAddressVerification').where('emailAddress', emailAddress).queryOne()
         assert emailAddressVerification
         assert emailAddressVerification.verifyHash == serviceResult.verifyHash
     }
@@ -94,11 +99,14 @@ class PartyMiscTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testCreatePartyIdentifications() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String partyIdentificationTypeId = testParams.partyIdentificationTypeId ?: 'CARD_ID'
+        String idValue = testParams.idValue ?: '123456789'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
+                partyId: partyId,
                 identifications: [
-                partyIdentificationTypeId: 'CARD_ID',
-                CARD_ID: '123456789'
+                partyIdentificationTypeId: partyIdentificationTypeId,
+                (partyIdentificationTypeId): idValue
             ],
             userLogin: userLogin
         ]
@@ -106,19 +114,22 @@ class PartyMiscTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyIdentification = from('PartyIdentification')
-            .where('partyId', 'TestCustomer', 'partyIdentificationTypeId', 'CARD_ID')
+            .where('partyId', partyId, 'partyIdentificationTypeId', partyIdentificationTypeId)
             .queryOne()
         assert partyIdentification
-        assert partyIdentification.idValue == '123456789'
+        assert partyIdentification.idValue == idValue
     }
 
     @Test
     @Order(5)
     void testCreatePartyInvitation() {
+        String partyIdFrom = testParams.partyIdFrom ?: 'TestCompany'
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String emailAddress = testParams.emailAddress ?: 'test_email@example.com'
         Map serviceCtx = [
-                partyIdFrom: 'TestCompany',
-                partyId: 'TestCustomer',
-                emailAddress: 'test_email@example.com',
+                partyIdFrom: partyIdFrom,
+                partyId: partyId,
+                emailAddress: emailAddress,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyInvitation', serviceCtx)
@@ -126,168 +137,188 @@ class PartyMiscTests implements JupiterTestHelper {
 
         GenericValue partyInvitation = from('PartyInvitation').where('partyInvitationId', serviceResult.partyInvitationId).queryOne()
         assert partyInvitation
-        assert partyInvitation.emailAddress == 'test_email@example.com'
+        assert partyInvitation.emailAddress == emailAddress
     }
 
     @Test
     @Order(6)
     void testCreatePartyInvitationGroupAssoc() {
+        String partyInvitationId = testParams.partyInvitationId ?: 'TEST_INVITE'
+        String partyIdTo = testParams.partyIdTo ?: 'TestCompany'
         Map serviceCtx = [
-                partyInvitationId: 'TEST_INVITE',
-                partyIdTo: 'TestCompany',
+                partyInvitationId: partyInvitationId,
+                partyIdTo: partyIdTo,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyInvitationGroupAssoc', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyInvitationGroupAssoc = from('PartyInvitationGroupAssoc').where('partyInvitationId',
-                                                                                         'TEST_INVITE',
+                                                                                         partyInvitationId,
                                                                                          'partyIdTo',
-                                                                                         'TestCompany').queryOne()
+                                                                                         partyIdTo).queryOne()
         assert partyInvitationGroupAssoc
     }
 
     @Test
     @Order(7)
     void testCreatePartyInvitationRoleAssoc() {
+        String partyInvitationId = testParams.partyInvitationId ?: 'TEST_INVITE'
+        String roleTypeId = testParams.roleTypeId ?: 'COMMEVENT_ROLE'
         Map serviceCtx = [
-                partyInvitationId: 'TEST_INVITE',
-                roleTypeId: 'COMMEVENT_ROLE',
+                partyInvitationId: partyInvitationId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyInvitationRoleAssoc', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyInvitationRoleAssoc = from('PartyInvitationRoleAssoc').where('partyInvitationId',
-                                                                                       'TEST_INVITE',
+                                                                                       partyInvitationId,
                                                                                        'roleTypeId',
-                                                                                       'COMMEVENT_ROLE').queryOne()
+                                                                                       roleTypeId).queryOne()
         assert partyInvitationRoleAssoc
     }
 
     @Test
     @Order(8)
     void testCreatePartyNote() {
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        String noteName = testParams.noteName ?: 'Demo Note'
+        String note = testParams.note ?: 'This is demo note to test createPartyNote service'
         Map serviceCtx = [
-                partyId: 'DemoCustomer',
-                noteName: 'Demo Note',
-                note: 'This is demo note to test createPartyNote service',
+                partyId: partyId,
+                noteName: noteName,
+                note: note,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyNote', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyNote = from('PartyNote').where('partyId', 'DemoCustomer', 'noteId', serviceResult.noteId).queryOne()
+        GenericValue partyNote = from('PartyNote').where('partyId', partyId, 'noteId', serviceResult.noteId).queryOne()
         assert partyNote
 
         GenericValue noteData = from('NoteData').where('noteId', serviceResult.noteId).queryOne()
         assert noteData
-        assert noteData.noteName == 'Demo Note'
-        assert noteData.noteInfo == 'This is demo note to test createPartyNote service'
+        assert noteData.noteName == noteName
+        assert noteData.noteInfo == note
     }
 
     @Test
     @Order(9)
     void testDeletePartyInvitation() {
+        String partyInvitationId = testParams.partyInvitationId ?: 'TEST_INVITE-1'
         Map serviceCtx = [
-                partyInvitationId: 'TEST_INVITE-1',
+                partyInvitationId: partyInvitationId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('deletePartyInvitation', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyInvitation = from('PartyInvitation').where('partyInvitationId', 'TEST_INVITE-1').queryOne()
+        GenericValue partyInvitation = from('PartyInvitation').where('partyInvitationId', partyInvitationId).queryOne()
         assert !partyInvitation
     }
 
     @Test
     @Order(10)
     void testDeletePartyInvitationGroupAssoc() {
+        String partyInvitationId = testParams.partyInvitationId ?: 'TEST_INVITE-2'
+        String partyIdTo = testParams.partyIdTo ?: 'TestCompany'
         Map serviceCtx = [
-                partyInvitationId: 'TEST_INVITE-2',
-                partyIdTo: 'TestCompany',
+                partyInvitationId: partyInvitationId,
+                partyIdTo: partyIdTo,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('deletePartyInvitationGroupAssoc', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyInvitationGroupAssoc = from('PartyInvitationGroupAssoc').where('partyInvitationId',
-                                                                                         'TEST_INVITE-2',
+                                                                                         partyInvitationId,
                                                                                          'partyIdTo',
-                                                                                         'TestCompany').queryOne()
+                                                                                         partyIdTo).queryOne()
         assert !partyInvitationGroupAssoc
     }
 
     @Test
     @Order(11)
     void testDeletePartyInvitationRoleAssoc() {
+        String partyInvitationId = testParams.partyInvitationId ?: 'TEST_INVITE-2'
+        String roleTypeId = testParams.roleTypeId ?: 'COMMEVENT_ROLE'
         Map serviceCtx = [
-                partyInvitationId: 'TEST_INVITE-2',
-                roleTypeId: 'COMMEVENT_ROLE',
+                partyInvitationId: partyInvitationId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('deletePartyInvitationRoleAssoc', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyInvitationRoleAssoc = from('PartyInvitationRoleAssoc').where('partyInvitationId',
-                                                                                       'TEST_INVITE-2',
+                                                                                       partyInvitationId,
                                                                                        'roleTypeId',
-                                                                                       'COMMEVENT_ROLE').queryOne()
+                                                                                       roleTypeId).queryOne()
         assert !partyInvitationRoleAssoc
     }
 
     @Test
     @Order(12)
     void testRemoveAddressMatchMap() {
+        String mapKey = testParams.mapKey ?: 'TESTKEY-1'
+        String mapValue = testParams.mapValue ?: 'Test Value 1'
         // Create the record first so this test is independent of seed data and execution order
-        dispatcher.runSync('createAddressMatchMap', [mapKey: 'TESTKEY-1', mapValue: 'Test Value 1', userLogin: userLogin])
+        dispatcher.runSync('createAddressMatchMap', [mapKey: mapKey, mapValue: mapValue, userLogin: userLogin])
 
         Map serviceCtx = [
-                mapKey: 'TESTKEY-1',
-                mapValue: 'Test Value 1',
+                mapKey: mapKey,
+                mapValue: mapValue,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('removeAddressMatchMap', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue addressMatchMap = from('AddressMatchMap').where('mapKey', 'TESTKEY-1', 'mapValue', 'Test Value 1').queryOne()
+        GenericValue addressMatchMap = from('AddressMatchMap').where('mapKey', mapKey, 'mapValue', mapValue).queryOne()
         assert !addressMatchMap
     }
 
     @Test
     @Order(13)
     void testUpdateAffiliate() {
+        String partyId = testParams.partyId ?: 'TestGroup-1'
+        String affiliateName = testParams.affiliateName ?: 'Test Affiliate'
+        String siteType = testParams.siteType ?: 'Main Site'
+        String siteVisitors = testParams.siteVisitors ?: '2000'
         Map serviceCtx = [
-                partyId: 'TestGroup-1',
-                affiliateName: 'Test Affiliate',
-                siteType: 'Main Site',
-                siteVisitors: '2000',
+                partyId: partyId,
+                affiliateName: affiliateName,
+                siteType: siteType,
+                siteVisitors: siteVisitors,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateAffiliate', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue affiliate = from('Affiliate').where('partyId', 'TestGroup-1').queryOne()
+        GenericValue affiliate = from('Affiliate').where('partyId', partyId).queryOne()
         assert affiliate
-        assert affiliate.affiliateName == 'Test Affiliate'
-        assert affiliate.siteType == 'Main Site'
-        assert affiliate.siteVisitors == '2000'
+        assert affiliate.affiliateName == affiliateName
+        assert affiliate.siteType == siteType
+        assert affiliate.siteVisitors == siteVisitors
     }
 
     @Test
     @Order(14)
     void testUpdatePartyInvitation() {
+        String partyInvitationId = testParams.partyInvitationId ?: 'TEST_INVITE'
+        String emailAddress = testParams.emailAddress ?: 'test_email@example.com'
         Map serviceCtx = [
-                partyInvitationId: 'TEST_INVITE',
-                emailAddress: 'test_email@example.com',
+                partyInvitationId: partyInvitationId,
+                emailAddress: emailAddress,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyInvitation', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyInvitation = from('PartyInvitation').where('partyInvitationId', 'TEST_INVITE').queryOne()
+        GenericValue partyInvitation = from('PartyInvitation').where('partyInvitationId', partyInvitationId).queryOne()
         assert partyInvitation
-        assert partyInvitation.emailAddress == 'test_email@example.com'
+        assert partyInvitation.emailAddress == emailAddress
     }
 
 }

--- a/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyTests.groovy
+++ b/applications/party/src/test/groovy/org/apache/ofbiz/party/party/test/PartyTests.groovy
@@ -31,26 +31,32 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCopyPartyContactMechs() {
+        String partyIdFrom = testParams.partyIdFrom ?: 'TestCustomer'
+        String partyIdTo = testParams.partyIdTo ?: 'TestParty'
         Map serviceCtx = [
-                partyIdFrom: 'TestCustomer',
-                partyIdTo: 'TestParty',
+                partyIdFrom: partyIdFrom,
+                partyIdTo: partyIdTo,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('copyPartyContactMechs', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        List<GenericValue> partyContactMechList = from('PartyContactMech').where('partyId', 'TestParty').queryList()
+        List<GenericValue> partyContactMechList = from('PartyContactMech').where('partyId', partyIdTo).queryList()
         assert partyContactMechList
     }
 
     @Test
     @Order(2)
     void testCreatePartyGroup() {
+        String partyId = testParams.partyId ?: 'DemoGroup1'
+        String groupName = testParams.groupName ?: 'Demo Group'
+        String partyTypeId = testParams.partyTypeId ?: 'PARTY_GROUP'
+        String statusId = testParams.statusId ?: 'PARTY_ENABLED'
         Map serviceCtx = [
-                partyId: 'DemoGroup1',
-                groupName: 'Demo Group',
-                partyTypeId: 'PARTY_GROUP',
-                statusId: 'PARTY_ENABLED',
+                partyId: partyId,
+                groupName: groupName,
+                partyTypeId: partyTypeId,
+                statusId: statusId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyGroup', serviceCtx)
@@ -59,22 +65,30 @@ class PartyTests implements JupiterTestHelper {
         GenericValue partyGroup = from('PartyGroup').where('partyId', serviceResult.partyId).queryOne()
 
         assert partyGroup
-        assert partyGroup.partyId == 'DemoGroup1'
-        assert partyGroup.groupName == 'Demo Group'
+        assert partyGroup.partyId == partyId
+        assert partyGroup.groupName == groupName
     }
 
     @Test
     @Order(3)
     void testCreatePartyPostalAddress() {
+        String contactMechId = testParams.contactMechId ?: 'TestPostalAddress'
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String toName = testParams.toName ?: 'Test Address'
+        String address1 = testParams.address1 ?: '2004 Factory Blvd'
+        String city = testParams.city ?: 'City of Industry'
+        String countryGeoId = testParams.countryGeoId ?: 'USA'
+        String stateProvinceGeoId = testParams.stateProvinceGeoId ?: 'CA'
+        String postalCode = testParams.postalCode ?: '90000'
         Map serviceCtx = [
-                contactMechId: 'TestPostalAddress',
-                partyId: 'TestCustomer',
-                toName: 'Test Address',
-                address1: '2004 Factory Blvd',
-                city: 'City of Industry',
-                countryGeoId: 'USA',
-                stateProvinceGeoId: 'CA',
-                postalCode: '90000',
+                contactMechId: contactMechId,
+                partyId: partyId,
+                toName: toName,
+                address1: address1,
+                city: city,
+                countryGeoId: countryGeoId,
+                stateProvinceGeoId: stateProvinceGeoId,
+                postalCode: postalCode,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyPostalAddress', serviceCtx)
@@ -82,17 +96,21 @@ class PartyTests implements JupiterTestHelper {
 
         GenericValue postalAddress = from('PostalAddress').where('contactMechId', serviceResult.contactMechId).queryOne()
         assert postalAddress != null
-        assert postalAddress.city == 'City of Industry'
+        assert postalAddress.city == city
     }
 
     @Test
     @Order(4)
     void testCreatePartyRelationship() {
+        String partyIdFrom = testParams.partyIdFrom ?: 'TestCompany'
+        String partyIdTo = testParams.partyIdTo ?: 'TestCustomer'
+        String roleTypeIdFrom = testParams.roleTypeIdFrom ?: 'INTERNAL_ORGANIZATIO'
+        String roleTypeIdTo = testParams.roleTypeIdTo ?: 'CONTACT'
         Map serviceCtx = [
-                partyIdFrom: 'TestCompany',
-                partyIdTo: 'TestCustomer',
-                roleTypeIdFrom: 'INTERNAL_ORGANIZATIO',
-                roleTypeIdTo: 'CONTACT',
+                partyIdFrom: partyIdFrom,
+                partyIdTo: partyIdTo,
+                roleTypeIdFrom: roleTypeIdFrom,
+                roleTypeIdTo: roleTypeIdTo,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 01:01:01'),
                 userLogin: userLogin
         ]
@@ -101,13 +119,13 @@ class PartyTests implements JupiterTestHelper {
 
         GenericValue partyRelationship = from('PartyRelationship')
             .where('partyIdFrom',
-                   'TestCompany',
+                   partyIdFrom,
                    'partyIdTo',
-                   'TestCustomer',
+                   partyIdTo,
                    'roleTypeIdFrom',
-                   'INTERNAL_ORGANIZATIO',
+                   roleTypeIdFrom,
                    'roleTypeIdTo',
-                   'CONTACT',
+                   roleTypeIdTo,
                    'fromDate',
                    java.sql.Timestamp.valueOf('2009-09-09 01:01:01'))
             .queryOne()
@@ -117,29 +135,33 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testCreatePartyRelationshipAndRole() {
+        String partyIdFrom = testParams.partyIdFrom ?: 'TestCompany'
+        String partyIdTo = testParams.partyIdTo ?: 'TestCustomer'
+        String roleTypeIdFrom = testParams.roleTypeIdFrom ?: 'BUYER'
+        String roleTypeIdTo = testParams.roleTypeIdTo ?: 'ACCOUNT_LEAD'
         Map serviceCtx = [
-                partyIdFrom: 'TestCompany',
-                partyIdTo: 'TestCustomer',
-                roleTypeIdFrom: 'BUYER',
-                roleTypeIdTo: 'ACCOUNT_LEAD',
+                partyIdFrom: partyIdFrom,
+                partyIdTo: partyIdTo,
+                roleTypeIdFrom: roleTypeIdFrom,
+                roleTypeIdTo: roleTypeIdTo,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 01:01:01'),
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyRelationshipAndRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyRole = from('PartyRole').where('partyId', 'TestCompany', 'roleTypeId', 'BUYER').queryOne()
+        GenericValue partyRole = from('PartyRole').where('partyId', partyIdFrom, 'roleTypeId', roleTypeIdFrom).queryOne()
         assert partyRole
 
         GenericValue partyRelationship = from('PartyRelationship')
             .where('partyIdFrom',
-                   'TestCompany',
+                   partyIdFrom,
                    'partyIdTo',
-                   'TestCustomer',
+                   partyIdTo,
                    'roleTypeIdFrom',
-                   'BUYER',
+                   roleTypeIdFrom,
                    'roleTypeIdTo',
-                   'ACCOUNT_LEAD',
+                   roleTypeIdTo,
                    'fromDate',
                    java.sql.Timestamp.valueOf('2009-09-09 01:01:01'))
             .queryOne()
@@ -149,17 +171,20 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testCreatePartyRelationshipContactAccount() {
+        String accountPartyId = testParams.accountPartyId ?: 'TestParty'
+        String contactPartyId = testParams.contactPartyId ?: 'TestCustomer'
+        String comments = testParams.comments ?: 'This is a test party contact account relationship'
         Map serviceCtx = [
-                accountPartyId: 'TestParty',
-                contactPartyId: 'TestCustomer',
-                comments: 'This is a test party contact account relationship',
+                accountPartyId: accountPartyId,
+                contactPartyId: contactPartyId,
+                comments: comments,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyRelationshipContactAccount', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         List<GenericValue> partyRelationshipList = from('PartyRelationship')
-            .where('partyIdFrom', 'TestParty', 'partyIdTo', 'TestCustomer', 'roleTypeIdFrom', 'ACCOUNT', 'roleTypeIdTo', 'CONTACT')
+            .where('partyIdFrom', accountPartyId, 'partyIdTo', contactPartyId, 'roleTypeIdFrom', 'ACCOUNT', 'roleTypeIdTo', 'CONTACT')
             .queryList()
         assert partyRelationshipList
     }
@@ -167,32 +192,39 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testCreatePartyRole() {
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        String roleTypeId = testParams.roleTypeId ?: 'CLIENT'
         Map serviceCtx = [
-                partyId: 'DemoCustomer',
-                roleTypeId: 'CLIENT',
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyRole = from('PartyRole')
-            .where('partyId', 'DemoCustomer', 'roleTypeId', 'CLIENT')
+            .where('partyId', partyId, 'roleTypeId', roleTypeId)
             .queryOne()
 
         assert partyRole
-        assert partyRole.partyId == 'DemoCustomer'
-        assert partyRole.roleTypeId == 'CLIENT'
+        assert partyRole.partyId == partyId
+        assert partyRole.roleTypeId == roleTypeId
     }
 
     @Test
     @Order(8)
     void testCreatePartyTelecomNumber() {
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        String contactMechPurposeTypeId = testParams.contactMechPurposeTypeId ?: 'PRIMARY_PHONE'
+        String countryCode = testParams.countryCode ?: '1'
+        String areaCode = testParams.areaCode ?: '801'
+        String contactNumber = testParams.contactNumber ?: '888-8888'
         Map serviceCtx = [
-                partyId: 'DemoCustomer',
-                contactMechPurposeTypeId: 'PRIMARY_PHONE',
-                countryCode: '1',
-                areaCode: '801',
-                contactNumber: '888-8888',
+                partyId: partyId,
+                contactMechPurposeTypeId: contactMechPurposeTypeId,
+                countryCode: countryCode,
+                areaCode: areaCode,
+                contactNumber: contactNumber,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPartyTelecomNumber', serviceCtx)
@@ -205,32 +237,34 @@ class PartyTests implements JupiterTestHelper {
 
         GenericValue telecomNumber = from('TelecomNumber').where('contactMechId', contactMechId).queryOne()
         assert telecomNumber
-        assert telecomNumber.countryCode == '1'
-        assert telecomNumber.areaCode == '801'
-        assert telecomNumber.contactNumber == '888-8888'
+        assert telecomNumber.countryCode == countryCode
+        assert telecomNumber.areaCode == areaCode
+        assert telecomNumber.contactNumber == contactNumber
 
         List<GenericValue> pcmList = from('PartyContactMech')
-            .where('partyId', 'DemoCustomer', 'contactMechId', contactMechId)
+            .where('partyId', partyId, 'contactMechId', contactMechId)
             .filterByDate()
             .queryList()
         assert pcmList
 
         List<GenericValue> pcmpList = from('PartyContactMechPurpose')
-            .where('partyId', 'DemoCustomer', 'contactMechId', contactMechId)
+            .where('partyId', partyId, 'contactMechId', contactMechId)
             .filterByDate()
             .queryList()
         assert pcmpList
 
         GenericValue pcmp = pcmpList.first()
-        assert pcmp.contactMechPurposeTypeId == 'PRIMARY_PHONE'
+        assert pcmp.contactMechPurposeTypeId == contactMechPurposeTypeId
     }
 
     @Test
     @Order(9)
     void testCreatePerson() {
+        String firstName = testParams.firstName ?: 'Demo'
+        String lastName = testParams.lastName ?: 'Person'
         Map serviceCtx = [
-                firstName: 'Demo',
-                lastName: 'Person',
+                firstName: firstName,
+                lastName: lastName,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPerson', serviceCtx)
@@ -241,22 +275,28 @@ class PartyTests implements JupiterTestHelper {
         assert party
         assert party.partyTypeId == 'PERSON'
 
-        GenericValue person = from('Person').where('partyId', partyId).queryOne()
+        GenericValue person = from(lastName).where('partyId', partyId).queryOne()
         assert person
-        assert person.firstName == 'Demo'
-        assert person.lastName == 'Person'
+        assert person.firstName == firstName
+        assert person.lastName == lastName
     }
 
     @Test
     @Order(10)
     void testCreatePersonAndUserLogin() {
+        String partyId = testParams.partyId ?: 'DemoPerson'
+        String firstName = testParams.firstName ?: 'Demo'
+        String lastName = testParams.lastName ?: 'Person'
+        String userLoginId = testParams.userLoginId ?: 'demo.person'
+        String currentPassword = testParams.currentPassword ?: 'ofbiz'
+        String currentPasswordVerify = testParams.currentPasswordVerify ?: 'ofbiz'
         Map serviceCtx = [
-                partyId: 'DemoPerson',
-                firstName: 'Demo',
-                lastName: 'Person',
-                userLoginId: 'demo.person',
-                currentPassword: 'ofbiz',
-                currentPasswordVerify: 'ofbiz',
+                partyId: partyId,
+                firstName: firstName,
+                lastName: lastName,
+                userLoginId: userLoginId,
+                currentPassword: currentPassword,
+                currentPasswordVerify: currentPasswordVerify,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPersonAndUserLogin', serviceCtx)
@@ -264,78 +304,90 @@ class PartyTests implements JupiterTestHelper {
 
         GenericValue newUserLogin = serviceResult.newUserLogin
         assert newUserLogin
-        assert newUserLogin.partyId == 'DemoPerson'
-        assert newUserLogin.userLoginId == 'demo.person'
+        assert newUserLogin.partyId == partyId
+        assert newUserLogin.userLoginId == userLoginId
 
-        GenericValue person = from('Person').where('partyId', 'DemoPerson').queryOne()
+        GenericValue person = from(lastName).where('partyId', partyId).queryOne()
         assert person
-        assert person.firstName == 'Demo'
-        assert person.lastName == 'Person'
+        assert person.firstName == firstName
+        assert person.lastName == lastName
     }
 
     @Test
     @Order(11)
     void testCreateUpdatePartyRelationshipAndRoles() {
+        String partyId = testParams.partyId ?: 'TestCompany'
+        String partyIdFrom = testParams.partyIdFrom ?: 'TestCompany'
+        String partyIdTo = testParams.partyIdTo ?: 'TestCustomer'
+        String roleTypeIdFrom = testParams.roleTypeIdFrom ?: 'BUYER'
+        String roleTypeIdTo = testParams.roleTypeIdTo ?: 'ACCOUNT_LEAD'
+        String partyRelationshipTypeId = testParams.partyRelationshipTypeId ?: 'AGENT'
         Map serviceCtx = [
-                partyId: 'TestCompany',
-                partyIdFrom: 'TestCompany',
-                partyIdTo: 'TestCustomer',
-                roleTypeIdFrom: 'BUYER',
-                roleTypeIdTo: 'ACCOUNT_LEAD',
+                partyId: partyId,
+                partyIdFrom: partyIdFrom,
+                partyIdTo: partyIdTo,
+                roleTypeIdFrom: roleTypeIdFrom,
+                roleTypeIdTo: roleTypeIdTo,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 01:01:01'),
-                partyRelationshipTypeId: 'AGENT',
+                partyRelationshipTypeId: partyRelationshipTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createUpdatePartyRelationshipAndRoles', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyRole = from('PartyRole').where('partyId', 'TestCompany', 'roleTypeId', 'BUYER').queryOne()
+        GenericValue partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', roleTypeIdFrom).queryOne()
         assert partyRole
 
         GenericValue partyRelationship = from('PartyRelationship')
             .where('partyIdFrom',
-                   'TestCompany',
+                   partyIdFrom,
                    'partyIdTo',
-                   'TestCustomer',
+                   partyIdTo,
                    'roleTypeIdFrom',
-                   'BUYER',
+                   roleTypeIdFrom,
                    'roleTypeIdTo',
-                   'ACCOUNT_LEAD',
+                   roleTypeIdTo,
                    'fromDate',
                    java.sql.Timestamp.valueOf('2009-09-09 01:01:01'))
             .queryOne()
         assert partyRelationship
-        assert serviceCtx.partyRelationshipTypeId == 'AGENT'
+        assert serviceCtx.partyRelationshipTypeId == partyRelationshipTypeId
     }
 
     @Test
     @Order(12)
     void testCreateUpdatePersonWithCreate() {
+        String partyId = testParams.partyId ?: 'DemoPerson1'
+        String firstName = testParams.firstName ?: 'Demo'
+        String lastName = testParams.lastName ?: 'Person1'
         Map serviceCtx = [
-                partyId: 'DemoPerson1',
-                firstName: 'Demo',
-                lastName: 'Person1',
+                partyId: partyId,
+                firstName: firstName,
+                lastName: lastName,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createUpdatePerson', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue party = from('Party').where('partyId', 'DemoPerson1').queryOne()
+        GenericValue party = from('Party').where('partyId', partyId).queryOne()
         assert party
 
-        GenericValue person = from('Person').where('partyId', 'DemoPerson1').queryOne()
+        GenericValue person = from('Person').where('partyId', partyId).queryOne()
         assert person
-        assert person.firstName == 'Demo'
-        assert person.lastName == 'Person1'
+        assert person.firstName == firstName
+        assert person.lastName == lastName
     }
 
     @Test
     @Order(13)
     void testCreateUpdatePersonWithUpdate() {
+        String partyId = testParams.partyId ?: 'DemoPerson1'
+        String firstName = testParams.firstName ?: 'Demo'
+        String lastName = testParams.lastName ?: 'Person2'
         Map serviceCtx = [
-                partyId: 'DemoPerson1',
-                firstName: 'Demo',
-                lastName: 'Person2',
+                partyId: partyId,
+                firstName: firstName,
+                lastName: lastName,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createUpdatePerson', serviceCtx)
@@ -346,18 +398,22 @@ class PartyTests implements JupiterTestHelper {
 
         assert party
         assert person
-        assert person.firstName == 'Demo'
-        assert person.lastName == 'Person2'
+        assert person.firstName == firstName
+        assert person.lastName == lastName
     }
 
     @Test
     @Order(14)
     void testDeletePartyRelationship() {
+        String partyIdFrom = testParams.partyIdFrom ?: 'TestCompany'
+        String partyIdTo = testParams.partyIdTo ?: 'TestCustomer'
+        String roleTypeIdFrom = testParams.roleTypeIdFrom ?: '_NA_'
+        String roleTypeIdTo = testParams.roleTypeIdTo ?: 'CONTACT'
         Map serviceCtx = [
-                partyIdFrom: 'TestCompany',
-                partyIdTo: 'TestCustomer',
-                roleTypeIdFrom: '_NA_',
-                roleTypeIdTo: 'CONTACT',
+                partyIdFrom: partyIdFrom,
+                partyIdTo: partyIdTo,
+                roleTypeIdFrom: roleTypeIdFrom,
+                roleTypeIdTo: roleTypeIdTo,
                 fromDate: java.sql.Timestamp.valueOf('2000-01-01 00:00:00'),
                 userLogin: userLogin
         ]
@@ -366,13 +422,13 @@ class PartyTests implements JupiterTestHelper {
 
         GenericValue partyRelationship = from('PartyRelationship')
             .where('partyIdFrom',
-                   'TestCompany',
+                   partyIdFrom,
                    'partyIdTo',
-                   'TestCustomer',
+                   partyIdTo,
                    'roleTypeIdFrom',
-                   '_NA_',
+                   roleTypeIdFrom,
                    'roleTypeIdTo',
-                   'CONTACT',
+                   roleTypeIdTo,
                    'fromDate',
                    java.sql.Timestamp.valueOf('2000-01-01 00:00:00'))
             .queryOne()
@@ -382,74 +438,83 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(15)
     void testDeletePartyRole() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
+        String roleTypeId = testParams.roleTypeId ?: 'ACCOUNTANT'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
-                roleTypeId: 'ACCOUNTANT',
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('deletePartyRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyRole = from('PartyRole').where('partyId', 'TestCustomer', 'roleTypeId', 'ACCOUNTANT').queryOne()
+        GenericValue partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', roleTypeId).queryOne()
         assert !partyRole
     }
 
     @Test
     @Order(16)
     void testEnsurePartyRole() {
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        String roleTypeId = testParams.roleTypeId ?: 'VENDOR'
+        String partyIdFrom = testParams.partyIdFrom ?: 'DemoCustomer'
+        String roleTypeIdFrom = testParams.roleTypeIdFrom ?: 'CONTRACTOR'
+        String partyIdTo = testParams.partyIdTo ?: 'DemoCustomer'
+        String roleTypeIdTo = testParams.roleTypeIdTo ?: 'MANUFACTURER'
         Map serviceCtx = [
-                partyId: 'DemoCustomer',
-                roleTypeId: 'VENDOR',
+                partyId: partyId,
+                roleTypeId: roleTypeId,
                 userLogin: userLogin
         ]
 
         Map serviceResult = dispatcher.runSync('ensurePartyRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyRole = from('PartyRole').where('partyId', 'DemoCustomer', 'roleTypeId', 'VENDOR').queryOne()
+        GenericValue partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', roleTypeId).queryOne()
         assert partyRole
 
         serviceCtx.roleTypeId = 'EMPLOYEE'
-        partyRole = from('PartyRole').where('partyId', 'DemoCustomer', 'roleTypeId', 'EMPLOYEE').queryOne()
+        partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', 'EMPLOYEE').queryOne()
         assert !partyRole
 
         serviceResult = dispatcher.runSync('ensurePartyRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        partyRole = from('PartyRole').where('partyId', 'DemoCustomer', 'roleTypeId', 'EMPLOYEE').queryOne()
+        partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', 'EMPLOYEE').queryOne()
         assert partyRole
 
         Map ensurePartyRoleFromCtx = [
-                partyIdFrom: 'DemoCustomer',
-                roleTypeIdFrom: 'CONTRACTOR',
+                partyIdFrom: partyIdFrom,
+                roleTypeIdFrom: roleTypeIdFrom,
                 userLogin: userLogin
         ]
-        partyRole = from('PartyRole').where('partyId', 'DemoCustomer', 'roleTypeId', 'CONTRACTOR').queryOne()
+        partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', roleTypeIdFrom).queryOne()
         assert !partyRole
 
         serviceResult = dispatcher.runSync('ensurePartyRoleFrom', ensurePartyRoleFromCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        partyRole = from('PartyRole').where('partyId', 'DemoCustomer', 'roleTypeId', 'CONTRACTOR').queryOne()
+        partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', roleTypeIdFrom).queryOne()
         assert partyRole
 
         Map ensurePartyRoleToCtx = [
-                partyIdTo: 'DemoCustomer',
-                roleTypeIdTo: 'MANUFACTURER',
+                partyIdTo: partyIdTo,
+                roleTypeIdTo: roleTypeIdTo,
                 userLogin: userLogin
         ]
-        partyRole = from('PartyRole').where('partyId', 'DemoCustomer', 'roleTypeId', 'MANUFACTURER').queryOne()
+        partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', roleTypeIdTo).queryOne()
         assert !partyRole
 
         serviceResult = dispatcher.runSync('ensurePartyRoleTo', ensurePartyRoleToCtx)
         assert ServiceUtil.isSuccess(serviceResult)
-        partyRole = from('PartyRole').where('partyId', 'DemoCustomer', 'roleTypeId', 'MANUFACTURER').queryOne()
+        partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', roleTypeIdTo).queryOne()
         assert partyRole
     }
 
     @Test
     @Order(17)
     void testFindPartiesById() {
+        String idToFind = testParams.idToFind ?: 'TestCustomer'
         Map serviceCtx = [
-                idToFind: 'TestCustomer',
+                idToFind: idToFind,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('findPartiesById', serviceCtx)
@@ -457,14 +522,15 @@ class PartyTests implements JupiterTestHelper {
 
         GenericValue party = serviceResult.party
         assert party
-        assert party.partyId == 'TestCustomer'
+        assert party.partyId == idToFind
     }
 
     @Test
     @Order(18)
     void testFindPartyFromEmailAddress() {
+        String address = testParams.address ?: 'newtest_email@example.com'
         Map serviceCtx = [
-                address: 'newtest_email@example.com',
+                address: address,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('findPartyFromEmailAddress', serviceCtx)
@@ -479,8 +545,9 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(19)
     void testFindPartyFromTelephone() {
+        String telno = testParams.telno ?: '801555-5555'
         Map serviceCtx = [
-                telno: '801555-5555',
+                telno: telno,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('findPartyFromTelephone', serviceCtx)
@@ -493,8 +560,9 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(20)
     void testFindPartyFromTelephoneComplete() {
+        String telno = testParams.telno ?: '801555-5555'
         Map serviceCtx = [
-                telno: '801555-5555',
+                telno: telno,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('findPartyFromTelephoneComplete', serviceCtx)
@@ -507,8 +575,9 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(21)
     void testFindPartyWithNoSearchParameters() {
+        String lookupFlag = testParams.lookupFlag ?: 'Y'
         Map serviceCtx = [
-                lookupFlag: 'Y',
+                lookupFlag: lookupFlag,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('findParty', serviceCtx)
@@ -525,17 +594,20 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(22)
     void testFindPartyWithSearchParameters() {
+        String partyId = testParams.partyId ?: 'DemoCustomer'
+        String roleTypeId = testParams.roleTypeId ?: 'CUSTOMER'
+        String lookupFlag = testParams.lookupFlag ?: 'Y'
         Map serviceCtx = [
-                partyId: 'DemoCustomer',
-                roleTypeId: 'CUSTOMER',
-                lookupFlag: 'Y',
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                lookupFlag: lookupFlag,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('findParty', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue partyRoleDetailAndPartyDetail = from('PartyRoleDetailAndPartyDetail')
-            .where('partyId', 'DemoCustomer', 'roleTypeId', 'CUSTOMER')
+            .where('partyId', partyId, 'roleTypeId', roleTypeId)
             .queryOne()
 
         try {
@@ -554,22 +626,24 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(23)
     void testGetPartyMainRole() {
+        String partyId = testParams.partyId ?: 'TestCustomer'
         Map serviceCtx = [
-                partyId: 'TestCustomer',
+                partyId: partyId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getPartyMainRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue partyRole = from('PartyRole').where('partyId', 'TestCustomer', 'roleTypeId', serviceResult.roleTypeId).queryOne()
+        GenericValue partyRole = from('PartyRole').where('partyId', partyId, 'roleTypeId', serviceResult.roleTypeId).queryOne()
         assert partyRole
     }
 
     @Test
     @Order(24)
     void testLookupParty() {
+        String firstName = testParams.firstName ?: 'Test'
         Map serviceCtx = [
-                firstName: 'Test',
+                firstName: firstName,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('lookupParty', serviceCtx)
@@ -581,10 +655,13 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(25)
     void testQuickCreateCustomer() {
+        String firstName = testParams.firstName ?: 'Test'
+        String lastName = testParams.lastName ?: 'Customer'
+        String emailAddress = testParams.emailAddress ?: 'test.customer@example.com'
         Map serviceCtx = [
-                firstName: 'Test',
-                lastName: 'Customer',
-                emailAddress: 'test.customer@example.com',
+                firstName: firstName,
+                lastName: lastName,
+                emailAddress: emailAddress,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('quickCreateCustomer', serviceCtx)
@@ -592,8 +669,8 @@ class PartyTests implements JupiterTestHelper {
 
         GenericValue person = from('Person').where('partyId', serviceResult.partyId).queryOne()
         assert person
-        assert person.firstName == 'Test'
-        assert person.lastName == 'Customer'
+        assert person.firstName == firstName
+        assert person.lastName == lastName
 
         GenericValue partyRole = from('PartyRole').where('partyId', serviceResult.partyId, 'roleTypeId', 'CUSTOMER').queryOne()
         assert partyRole
@@ -602,12 +679,13 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(26)
     void testUpdatePartyCreditCard() {
+        String partyId = testParams.partyId ?: 'DemoCustomer'
         Map serviceCtx = [
-                partyId: 'DemoCustomer',
+                partyId: partyId,
                 userLogin: userLogin
         ]
         List<GenericValue> paymentMethodAndCreditCards = from('PaymentMethodAndCreditCard')
-            .where('partyId', 'DemoCustomer')
+            .where('partyId', partyId)
             .filterByDate()
             .queryList()
         GenericValue paymentMethodAndCreditCard = paymentMethodAndCreditCards.first()
@@ -649,13 +727,18 @@ class PartyTests implements JupiterTestHelper {
     @Test
     @Order(27)
     void testUpdatePartyRelationship() {
+        String partyIdFrom = testParams.partyIdFrom ?: 'TestCompany'
+        String partyIdTo = testParams.partyIdTo ?: 'TestParty'
+        String roleTypeIdFrom = testParams.roleTypeIdFrom ?: '_NA_'
+        String roleTypeIdTo = testParams.roleTypeIdTo ?: 'CONTACT'
+        String partyRelationshipTypeId = testParams.partyRelationshipTypeId ?: 'AGENT'
         Map serviceCtx = [
-                partyIdFrom: 'TestCompany',
-                partyIdTo: 'TestParty',
-                roleTypeIdFrom: '_NA_',
-                roleTypeIdTo: 'CONTACT',
+                partyIdFrom: partyIdFrom,
+                partyIdTo: partyIdTo,
+                roleTypeIdFrom: roleTypeIdFrom,
+                roleTypeIdTo: roleTypeIdTo,
                 fromDate: java.sql.Timestamp.valueOf('2000-01-01 00:00:00'),
-                partyRelationshipTypeId: 'AGENT',
+                partyRelationshipTypeId: partyRelationshipTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updatePartyRelationship', serviceCtx)
@@ -663,18 +746,18 @@ class PartyTests implements JupiterTestHelper {
 
         GenericValue partyRelationship = from('PartyRelationship')
             .where('partyIdFrom',
-                   'TestCompany',
+                   partyIdFrom,
                    'partyIdTo',
-                   'TestParty',
+                   partyIdTo,
                    'roleTypeIdFrom',
-                   '_NA_',
+                   roleTypeIdFrom,
                    'roleTypeIdTo',
-                   'CONTACT',
+                   roleTypeIdTo,
                    'fromDate',
                    java.sql.Timestamp.valueOf('2000-01-01 00:00:00'))
             .queryOne()
         assert partyRelationship
-        assert partyRelationship.partyRelationshipTypeId == 'AGENT'
+        assert partyRelationship.partyRelationshipTypeId == partyRelationshipTypeId
     }
 
     @Test

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/CategoryTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/CategoryTests.groovy
@@ -32,9 +32,11 @@ class CategoryTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testAddProductCategoryToCategory() {
+        String productCategoryId = testParams.productCategoryId ?: 'TPC'
+        String parentProductCategoryId = testParams.parentProductCategoryId ?: 'TPCP'
         Map serviceCtx = [
-                productCategoryId: 'TPC',
-                parentProductCategoryId: 'TPCP',
+                productCategoryId: productCategoryId,
+                parentProductCategoryId: parentProductCategoryId,
                 fromDate: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -42,16 +44,20 @@ class CategoryTests implements JupiterTestHelper {
         Map serviceResult = dispatcher.runSync('addProductCategoryToCategory', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue prodCategory = from('ProductCategoryRollup').where('productCategoryId', 'TPC', 'parentProductCategoryId', 'TPCP').queryFirst()
+        GenericValue prodCategory = from('ProductCategoryRollup')
+                .where('productCategoryId', productCategoryId, 'parentProductCategoryId', parentProductCategoryId)
+                .queryFirst()
         assert prodCategory != null
     }
 
     @Test
     @Order(2)
     void testGetProductCategoryAndLimitedMembers() {
+        String productCategoryId = testParams.productCategoryId ?: '101'
+        String prodCatalogId = testParams.prodCatalogId ?: 'DemoCatalog'
         Map serviceCtx = [
-                productCategoryId: '101',
-                prodCatalogId: 'DemoCatalog',
+                productCategoryId: productCategoryId,
+                prodCatalogId: prodCatalogId,
                 defaultViewSize: 10,
                 limitView: true,
                 userLogin: userLogin
@@ -62,9 +68,9 @@ class CategoryTests implements JupiterTestHelper {
 
         assert serviceResult.productCategoryMembers != null
         assert serviceResult.productCategory != null
-        assert serviceResult.productCategory.productCategoryId == '101'
+        assert serviceResult.productCategory.productCategoryId == productCategoryId
 
-        List<GenericValue> productCategoryMemberList = from('ProductCategoryMember').where('productCategoryId', '101').queryList()
+        List<GenericValue> productCategoryMemberList = from('ProductCategoryMember').where('productCategoryId', productCategoryId).queryList()
         assert productCategoryMemberList.containsAll(serviceResult.productCategoryMembers)
     }
 

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/CostTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/CostTests.groovy
@@ -31,11 +31,13 @@ class CostTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCalculateProductStandardCosts() {
+        String currencyUomId = testParams.currencyUomId ?: 'USD'
+        String costComponentTypePrefix = testParams.costComponentTypePrefix ?: 'EST_STD'
         String productId = 'PROD_MANUF'
         Map serviceCtx = [
                 productId: productId,
-                currencyUomId: 'USD',
-                costComponentTypePrefix: 'EST_STD',
+                currencyUomId: currencyUomId,
+                costComponentTypePrefix: costComponentTypePrefix,
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('calculateProductCosts', serviceCtx)
@@ -45,7 +47,7 @@ class CostTests implements JupiterTestHelper {
         BigDecimal costTotalAmount = BigDecimal.ZERO
 
         for (GenericValue costComponent : costComponents) {
-            assert costComponent.costUomId == 'USD'
+            assert costComponent.costUomId == currencyUomId
             switch (costComponent.costComponentTypeId) {
                 case 'EST_STD_ROUTE_COST':
                     assert costComponent.cost == 10
@@ -68,11 +70,13 @@ class CostTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testGetProductCost() {
+        String currencyUomId = testParams.currencyUomId ?: 'USD'
+        String costComponentTypePrefix = testParams.costComponentTypePrefix ?: 'EST_STD'
         String productId = 'PROD_MANUF'
         Map serviceCtx = [
                 productId: productId,
-                currencyUomId: 'USD',
-                costComponentTypePrefix: 'EST_STD',
+                currencyUomId: currencyUomId,
+                costComponentTypePrefix: costComponentTypePrefix,
                 userLogin: userLogin
         ]
         Map resultMap = dispatcher.runSync('getProductCost', serviceCtx)

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/GroupOrderTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/GroupOrderTests.groovy
@@ -34,6 +34,8 @@ class GroupOrderTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testGroupOrderLimitReached() {
+        String productId = testParams.productId ?: 'GZ-1000'
+        String statusId = testParams.statusId ?: 'GO_CREATED'
         GenericValue systemUserLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         GenericValue adminUserLogin = from('UserLogin').where('userLoginId', 'admin').queryOne()
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
@@ -41,10 +43,10 @@ class GroupOrderTests implements JupiterTestHelper {
 
         Map createGroupOrderCtx = [
                 userLogin: systemUserLogin,
-                productId: 'GZ-1000',
+                productId: productId,
                 fromDate: nowTimestamp,
                 thruDate: thruDate,
-                statusId: 'GO_CREATED',
+                statusId: statusId,
                 reqOrderQty: 1.0,
                 soldOrderQty: 0.0
         ]
@@ -54,7 +56,7 @@ class GroupOrderTests implements JupiterTestHelper {
         assert groupOrderId
 
         // Create an order using the createTestSalesOrderSingle service
-        Map orderResult = dispatcher.runSync('createTestSalesOrderSingle', [userLogin: adminUserLogin, productId: 'GZ-1000'])
+        Map orderResult = dispatcher.runSync('createTestSalesOrderSingle', [userLogin: adminUserLogin, productId: productId])
         assert ServiceUtil.isSuccess(orderResult)
 
         GenericValue productGroupOrder = from('ProductGroupOrder').where('groupOrderId', groupOrderId).queryOne()
@@ -78,6 +80,8 @@ class GroupOrderTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testGroupOrderLimitNotReached() {
+        String productId = testParams.productId ?: 'GZ-1001'
+        String statusId = testParams.statusId ?: 'GO_CREATED'
         GenericValue systemUserLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         GenericValue adminUserLogin = from('UserLogin').where('userLoginId', 'admin').queryOne()
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
@@ -85,10 +89,10 @@ class GroupOrderTests implements JupiterTestHelper {
 
         Map createGroupOrderCtx = [
                 userLogin: systemUserLogin,
-                productId: 'GZ-1001',
+                productId: productId,
                 fromDate: nowTimestamp,
                 thruDate: thruDate,
-                statusId: 'GO_CREATED',
+                statusId: statusId,
                 reqOrderQty: 2.0,
                 soldOrderQty: 0.0
         ]
@@ -98,7 +102,7 @@ class GroupOrderTests implements JupiterTestHelper {
         assert groupOrderId
 
         // Create an order using the createTestSalesOrderSingle service
-        Map orderResult = dispatcher.runSync('createTestSalesOrderSingle', [userLogin: adminUserLogin, productId: 'GZ-1001'])
+        Map orderResult = dispatcher.runSync('createTestSalesOrderSingle', [userLogin: adminUserLogin, productId: productId])
         assert ServiceUtil.isSuccess(orderResult)
 
         GenericValue productGroupOrder = from('ProductGroupOrder').where('groupOrderId', groupOrderId).queryOne()

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/InventoryTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/InventoryTests.groovy
@@ -30,9 +30,11 @@ class InventoryTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testGetInventoryAvailableByFacility() {
+        String productId = testParams.productId ?: 'GZ-2644'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
         Map serviceCtx = [
-                productId: 'GZ-2644',
-                facilityId: 'WebStoreWarehouse',
+                productId: productId,
+                facilityId: facilityId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('getInventoryAvailableByFacility', serviceCtx)
@@ -45,9 +47,11 @@ class InventoryTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testCreatePhysicalInventoryAndVariance() {
+        String inventoryItemId = testParams.inventoryItemId ?: '9024'
+        String varianceReasonId = testParams.varianceReasonId ?: 'VAR_LOST'
         Map serviceCtx = [
-                inventoryItemId: '9024',
-                varianceReasonId: 'VAR_LOST',
+                inventoryItemId: inventoryItemId,
+                varianceReasonId: varianceReasonId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createPhysicalInventoryAndVariance', serviceCtx)

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductPromoCondTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductPromoCondTests.groovy
@@ -66,12 +66,13 @@ class ProductPromoCondTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testNewACCTPromo() {
+        String partyId = testParams.partyId ?: 'FrenchCustomer'
         String condValue = '1095'
-        GenericValue frenchCustomer = delegator.makeValue('Party', [partyId: 'FrenchCustomer', createdDate: Timestamp.valueOf('2010-01-01 00:00:00')])
+        GenericValue frenchCustomer = delegator.makeValue('Party', [partyId: partyId, createdDate: Timestamp.valueOf('2010-01-01 00:00:00')])
         frenchCustomer.store()
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
         Timestamp nowTimestamp = UtilDateTime.nowTimestamp()
-        cart.setOrderPartyId('FrenchCustomer')
+        cart.setOrderPartyId(partyId)
         cart.getPartyDaysSinceCreated(nowTimestamp)
         Map<String, Object> serviceContext = prepareConditionMap(cart, condValue)
         Map<String, Object> serviceResult = dispatcher.runSync('productPromoCondNewACCT', serviceContext)
@@ -97,16 +98,17 @@ class ProductPromoCondTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testPartyClassPromo() {
+        String partyId = testParams.partyId ?: 'FrenchCustomer'
         String condValue = 'PROMO_TEST'
         GenericValue partyClassGroup = delegator.makeValue('PartyClassificationGroup', [partyClassificationGroupId: condValue])
         delegator.createOrStore(partyClassGroup)
         GenericValue partyClassification = delegator.makeValue('PartyClassification',
-                [partyId: 'FrenchCustomer', partyClassificationGroupId: condValue,
+                [partyId: partyId, partyClassificationGroupId: condValue,
                  fromDate: Timestamp.valueOf('2010-01-01 00:00:00'),
                  thruDate: null])
         delegator.createOrStore(partyClassification)
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
-        cart.setOrderPartyId('FrenchCustomer')
+        cart.setOrderPartyId(partyId)
 
         // call service promo
         Map<String, Object> serviceContext = prepareConditionMap(cart, condValue)
@@ -133,17 +135,23 @@ class ProductPromoCondTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testPartyGMPromo() {
+        String partyId = testParams.partyId ?: 'FrenchCustomer'
+        String roleTypeId = testParams.roleTypeId ?: '_NA_'
+        String partyIdFrom = testParams.partyIdFrom ?: 'FrenchCustomer'
+        String roleTypeIdFrom = testParams.roleTypeIdFrom ?: '_NA_'
+        String roleTypeIdTo = testParams.roleTypeIdTo ?: '_NA_'
+        String partyRelationshipTypeId = testParams.partyRelationshipTypeId ?: 'GROUP_ROLLUP'
         String condValue = 'HUMAN_RES'
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
         cart.setOrderPartyId(condValue)
-        GenericValue partyRole = delegator.makeValue('PartyRole', [partyId: 'FrenchCustomer', roleTypeId: '_NA_'])
+        GenericValue partyRole = delegator.makeValue('PartyRole', [partyId: partyId, roleTypeId: roleTypeId])
         delegator.createOrStore(partyRole)
         partyRole.partyId = condValue
         delegator.createOrStore(partyRole)
-        GenericValue relation = delegator.makeValue('PartyRelationship', [partyIdFrom: 'FrenchCustomer', roleTypeIdFrom: '_NA_',
-                                               partyIdTo: condValue, roleTypeIdTo: '_NA_',
+        GenericValue relation = delegator.makeValue('PartyRelationship', [partyIdFrom: partyIdFrom, roleTypeIdFrom: roleTypeIdFrom,
+                                               partyIdTo: condValue, roleTypeIdTo: roleTypeIdTo,
                                                fromDate: Timestamp.valueOf('2010-01-01 00:00:00'),
-                                               partyRelationshipTypeId: 'GROUP_ROLLUP'])
+                                               partyRelationshipTypeId: partyRelationshipTypeId])
         delegator.createOrStore(relation)
 
         // call service promo
@@ -169,10 +177,11 @@ class ProductPromoCondTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testRoleTypePromo() {
+        String partyId = testParams.partyId ?: 'FrenchCustomer'
         String condValue = 'APPROVER'
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
-        cart.setOrderPartyId('FrenchCustomer')
-        GenericValue partyRole = delegator.makeValue('PartyRole', [partyId: 'FrenchCustomer', roleTypeId: condValue])
+        cart.setOrderPartyId(partyId)
+        GenericValue partyRole = delegator.makeValue('PartyRole', [partyId: partyId, roleTypeId: condValue])
         delegator.createOrStore(partyRole)
 
         // call service promo
@@ -252,10 +261,12 @@ class ProductPromoCondTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testRecurrencePromo() {
+        String frequency = testParams.frequency ?: 'DAILY'
+        String byDayList = testParams.byDayList ?: 'MO,TU,WE,TH,FR,SA,SU'
         String condValue = 'TEST_PROMO'
         ShoppingCart cart = new ShoppingCart(delegator, '9000', Locale.getDefault(), 'EUR')
-        GenericValue reccurenceRule = delegator.makeValue('RecurrenceRule', [recurrenceRuleId: condValue, frequency: 'DAILY', intervalNumber: 1L,
-                                                                       countNumber: -1L, byDayList: 'MO,TU,WE,TH,FR,SA,SU'])
+        GenericValue reccurenceRule = delegator.makeValue('RecurrenceRule', [recurrenceRuleId: condValue, frequency: frequency, intervalNumber: 1L,
+                                                                       countNumber: -1L, byDayList: byDayList])
         delegator.createOrStore(reccurenceRule)
         GenericValue reccurenceInfo = delegator.makeValue('RecurrenceInfo',
                 [recurrenceInfoId: condValue, startDateTime: Timestamp.valueOf('2008-01-01 00:00:00.000'),
@@ -315,6 +326,12 @@ class ProductPromoCondTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testProductAmountPromo() {
+        String productPromoId = testParams.productPromoId ?: 'TEST'
+        String productPromoRuleId = testParams.productPromoRuleId ?: '01'
+        String productPromoCondSeqId = testParams.productPromoCondSeqId ?: '01'
+        String productId = testParams.productId ?: 'GZ-2644'
+        String productPromoApplEnumId = testParams.productPromoApplEnumId ?: 'PPPA_INCLUDE'
+        String productPromoActionSeqId = testParams.productPromoActionSeqId ?: '_NA_'
         String condValue = '30'
         String orderId = 'DEMO10090'
         ShoppingCart cart = loadOrder(orderId)
@@ -322,8 +339,8 @@ class ProductPromoCondTests implements JupiterTestHelper {
         // call service promo
         Map<String, Object> serviceContext = prepareConditionMap(cart, condValue, true)
         GenericValue productPromoProduct = delegator.makeValue('ProductPromoProduct',
-                [productPromoId: 'TEST', productPromoRuleId: '01', productPromoCondSeqId: '01',
-                 productId: 'GZ-2644', productPromoApplEnumId: 'PPPA_INCLUDE', productPromoActionSeqId: '_NA_'])
+                [productPromoId: productPromoId, productPromoRuleId: productPromoRuleId, productPromoCondSeqId: productPromoCondSeqId,
+                 productId: productId, productPromoApplEnumId: productPromoApplEnumId, productPromoActionSeqId: productPromoActionSeqId])
         delegator.createOrStore(productPromoProduct)
         Map<String, Object> serviceResult = dispatcher.runSync('productPromoCondProductAmount', serviceContext)
 
@@ -347,14 +364,20 @@ class ProductPromoCondTests implements JupiterTestHelper {
     @Test
     @Order(11)
     void testProductTotalPromo() {
+        String productPromoId = testParams.productPromoId ?: 'TEST'
+        String productPromoRuleId = testParams.productPromoRuleId ?: '01'
+        String productPromoCondSeqId = testParams.productPromoCondSeqId ?: '01'
+        String productId = testParams.productId ?: 'WG-1111'
+        String productPromoApplEnumId = testParams.productPromoApplEnumId ?: 'PPPA_INCLUDE'
+        String productPromoActionSeqId = testParams.productPromoActionSeqId ?: '_NA_'
         String orderId = 'Demo1002'
         ShoppingCart cart = loadOrder(orderId)
 
         // call service promo
         Map<String, Object> serviceContext = prepareConditionMap(cart, '50', true)
         GenericValue productPromoProduct = delegator.makeValue('ProductPromoProduct',
-            [productPromoId: 'TEST', productPromoRuleId: '01', productPromoCondSeqId: '01',
-             productId: 'WG-1111', productPromoApplEnumId: 'PPPA_INCLUDE', productPromoActionSeqId: '_NA_'])
+            [productPromoId: productPromoId, productPromoRuleId: productPromoRuleId, productPromoCondSeqId: productPromoCondSeqId,
+             productId: productId, productPromoApplEnumId: productPromoApplEnumId, productPromoActionSeqId: productPromoActionSeqId])
         delegator.createOrStore(productPromoProduct)
         Map<String, Object> serviceResult = dispatcher.runSync('productPromoCondProductTotal', serviceContext)
 

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTagTest.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTagTest.groovy
@@ -32,6 +32,10 @@ class ProductTagTest implements JupiterTestHelper {
 
     @Test
     void testProductTag() {
+        String productId = testParams.productId ?: 'GZ-1000'
+        String keyword = testParams.keyword ?: 'test'
+        String keywordTypeId = testParams.keywordTypeId ?: 'KWT_TAG'
+        String statusId = testParams.statusId ?: 'KW_APPROVED'
         /*Test Product Tag
         Step 1) Create a product tag.
         Step 2) Check a product tag is created.
@@ -48,62 +52,64 @@ class ProductTagTest implements JupiterTestHelper {
         request.setAttribute('delegator', delegator)
         request.setAttribute('dispatcher', dispatcher)
         // Step 1
-        request.setParameter('productId', 'GZ-1000')
-        request.setParameter('productTags', 'test')
+        request.setParameter('productId', productId)
+        request.setParameter('productTags', keyword)
         ProductEvents.addProductTags(request, response)
 
         // Step 2
-        GenericValue productKeyword = from('ProductKeyword').where('productId', 'GZ-1000', 'keyword', 'test', 'keywordTypeId', 'KWT_TAG').queryOne()
+        GenericValue productKeyword = from('ProductKeyword')
+                .where('productId', productId, 'keyword', keyword, 'keywordTypeId', keywordTypeId)
+                .queryOne()
         assert productKeyword != null
         assert productKeyword.statusId == 'KW_PENDING'
         // Step 3
         Map updateProductKeywordMap = [
                 userLogin: systemUserLogin,
-                productId: 'GZ-1000',
-                keyword: 'test',
-                keywordTypeId: 'KWT_TAG',
-                statusId: 'KW_APPROVED',
+                productId: productId,
+                keyword: keyword,
+                keywordTypeId: keywordTypeId,
+                statusId: statusId,
         ]
         Map resultMap = dispatcher.runSync('updateProductKeyword', updateProductKeywordMap)
         assert ServiceUtil.isSuccess(resultMap)
 
         // Step 4
         GenericValue checkProductKeywordApprove = from('ProductKeyword')
-                .where('productId', 'GZ-1000', 'keyword', 'test', 'keywordTypeId', 'KWT_TAG').queryOne()
+                .where('productId', productId, 'keyword', keyword, 'keywordTypeId', keywordTypeId).queryOne()
         assert checkProductKeywordApprove != null
-        assert checkProductKeywordApprove.statusId == 'KW_APPROVED'
+        assert checkProductKeywordApprove.statusId == statusId
 
         // Step 5
-        request.setParameter('productId', 'GZ-1000')
+        request.setParameter('productId', productId)
         request.setParameter('productTags', '\'rock and roll\' t-shirt red')
         ProductEvents.addProductTags(request, response)
 
         // Step 6
         GenericValue checkProductKeyword1 = from('ProductKeyword')
-                .where('productId', 'GZ-1000', 'keyword', 'rock and roll', 'keywordTypeId', 'KWT_TAG').queryOne()
+                .where('productId', productId, 'keyword', 'rock and roll', 'keywordTypeId', keywordTypeId).queryOne()
         assert checkProductKeyword1 != null
         assert checkProductKeyword1.statusId == 'KW_PENDING'
 
         GenericValue checkProductKeyword2 = from('ProductKeyword')
-                .where('productId', 'GZ-1000', 'keyword', 't-shirt', 'keywordTypeId', 'KWT_TAG').queryOne()
+                .where('productId', productId, 'keyword', 't-shirt', 'keywordTypeId', keywordTypeId).queryOne()
         assert checkProductKeyword2 != null
         assert checkProductKeyword2.statusId == 'KW_PENDING'
 
         GenericValue checkProductKeyword3 = from('ProductKeyword')
-                .where('productId', 'GZ-1000', 'keyword', 'red', 'keywordTypeId', 'KWT_TAG').queryOne()
+                .where('productId', productId, 'keyword', 'red', 'keywordTypeId', keywordTypeId).queryOne()
         assert checkProductKeyword3 != null
         assert checkProductKeyword3.statusId == 'KW_PENDING'
 
         // Step 7
         List<GenericValue> checkAllProductKeywordApproveList = from('ProductKeyword')
-                .where('productId', 'GZ-1000', 'statusId', 'KW_PENDING', 'keywordTypeId', 'KWT_TAG').queryList()
+                .where('productId', productId, 'statusId', 'KW_PENDING', 'keywordTypeId', keywordTypeId).queryList()
         for (GenericValue checkAllProductKeywordApprove : checkAllProductKeywordApproveList) {
             updateProductKeywordMap = [
                     userLogin: systemUserLogin,
                     productId: checkAllProductKeywordApprove.productId,
                     keyword: checkAllProductKeywordApprove.keyword,
                     keywordTypeId: checkAllProductKeywordApprove.keywordTypeId,
-                    statusId: 'KW_APPROVED',
+                    statusId: statusId,
             ]
             resultMap = dispatcher.runSync('updateProductKeyword', updateProductKeywordMap)
             assert ServiceUtil.isSuccess(resultMap)
@@ -111,19 +117,19 @@ class ProductTagTest implements JupiterTestHelper {
 
         // Step 8
         GenericValue checkProductKeywordApprove1 = from('ProductKeyword')
-                .where('productId', 'GZ-1000', 'keyword', 'rock and roll', 'keywordTypeId', 'KWT_TAG').queryOne()
+                .where('productId', productId, 'keyword', 'rock and roll', 'keywordTypeId', keywordTypeId).queryOne()
         assert checkProductKeywordApprove1 != null
-        assert checkProductKeywordApprove1.statusId == 'KW_APPROVED'
+        assert checkProductKeywordApprove1.statusId == statusId
 
         GenericValue checkProductKeywordApprove2 = from('ProductKeyword')
-                .where('productId', 'GZ-1000', 'keyword', 't-shirt', 'keywordTypeId', 'KWT_TAG').queryOne()
+                .where('productId', productId, 'keyword', 't-shirt', 'keywordTypeId', keywordTypeId).queryOne()
         assert checkProductKeywordApprove2 != null
-        assert checkProductKeywordApprove2.statusId == 'KW_APPROVED'
+        assert checkProductKeywordApprove2.statusId == statusId
 
         GenericValue checkProductKeywordApprove3 = from('ProductKeyword')
-                .where('productId', 'GZ-1000', 'keyword', 'red', 'keywordTypeId', 'KWT_TAG').queryOne()
+                .where('productId', productId, 'keyword', 'red', 'keywordTypeId', keywordTypeId).queryOne()
         assert checkProductKeywordApprove3 != null
-        assert checkProductKeywordApprove3.statusId == 'KW_APPROVED'
+        assert checkProductKeywordApprove3.statusId == statusId
     }
 
 }

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTest.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTest.groovy
@@ -239,8 +239,9 @@ class ProductTest implements JupiterTestHelper {
     @Test
     @Order(9)
     void testFindProductById() {
+        String idToFind = testParams.idToFind ?: 'Test_product_C'
         Map serviceCtx = [
-                idToFind: 'Test_product_C',
+                idToFind: idToFind,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('findProductById', serviceCtx)
@@ -287,6 +288,8 @@ class ProductTest implements JupiterTestHelper {
     @Test
     @Order(11)
     void testUpdateProductPrice() {
+        String internalName = testParams.internalName ?: 'Test update product price'
+        String productTypeId = testParams.productTypeId ?: 'Test_type'
         String productId = 'Test_prod_price_up'
         String productPriceTypeId = 'AVERAGE_COST'
         String productPricePurposeId = 'COMPONENT_PRICE'
@@ -297,8 +300,8 @@ class ProductTest implements JupiterTestHelper {
 
         Map serviceCtx = [
                 productId: productId,
-                internalName: 'Test update product price',
-                productTypeId: 'Test_type',
+                internalName: internalName,
+                productTypeId: productTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createProduct', serviceCtx)

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ProductTests.groovy
@@ -29,20 +29,24 @@ class ProductTests implements JupiterTestHelper {
 
     @Test
     void testUpdateProductCategory() {
+        String categoryName = testParams.categoryName ?: 'Updated Test Product Category'
+        String longDescription = testParams.longDescription ?: 'Updated Long Test Product Category Description'
+        String productCategoryId = testParams.productCategoryId ?: 'CATALOG1_BEST_SELL'
+        String productCategoryTypeId = testParams.productCategoryTypeId ?: 'BEST_SELL_CATEGORY'
         Map serviceCtx = [
-                categoryName: 'Updated Test Product Category',
-                longDescription: 'Updated Long Test Product Category Description',
-                productCategoryId: 'CATALOG1_BEST_SELL',
-                productCategoryTypeId: 'BEST_SELL_CATEGORY',
+                categoryName: categoryName,
+                longDescription: longDescription,
+                productCategoryId: productCategoryId,
+                productCategoryTypeId: productCategoryTypeId,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('updateProductCategory', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue prodCategory = from('ProductCategory').where('productCategoryId', 'CATALOG1_BEST_SELL').queryOne()
+        GenericValue prodCategory = from('ProductCategory').where('productCategoryId', productCategoryId).queryOne()
         if (prodCategory) { // fails in framework integration tests only, data is in ecommerce
-            assert prodCategory.categoryName == 'Updated Test Product Category'
-            assert prodCategory.productCategoryTypeId == 'BEST_SELL_CATEGORY'
+            assert prodCategory.categoryName == categoryName
+            assert prodCategory.productCategoryTypeId == productCategoryTypeId
         }
     }
 

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ShipmentTests.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/product/test/ShipmentTests.groovy
@@ -33,15 +33,20 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testPackingServices() {
+        String productId = testParams.productId ?: 'GZ-2644'
+        String orderId = testParams.orderId ?: 'DEMO10090'
+        String shipGroupSeqId = testParams.shipGroupSeqId ?: '00001'
+        String pickerPartyId = testParams.pickerPartyId ?: 'DemoCustomer'
+        String handlingInstructions = testParams.handlingInstructions ?: 'Handle with care'
         PackingSession packingSession = new PackingSession(dispatcher, userLogin)
         Map serviceCtx = [
-                productId: 'GZ-2644',
-                orderId: 'DEMO10090',
-                shipGroupSeqId: '00001',
+                productId: productId,
+                orderId: orderId,
+                shipGroupSeqId: shipGroupSeqId,
                 quantity: new BigDecimal('2'),
                 packageSeq: 1,
-                pickerPartyId: 'DemoCustomer',
-                handlingInstructions: 'Handle with care',
+                pickerPartyId: pickerPartyId,
+                handlingInstructions: handlingInstructions,
                 packingSession: packingSession,
                 userLogin: userLogin
         ]
@@ -53,10 +58,10 @@ class ShipmentTests implements JupiterTestHelper {
         serviceResult.clear()
         serviceCtx = [
                 updateQuantity: true,
-                orderId: 'DEMO10090',
-                shipGroupSeqId: '00001',
-                pickerPartyId: 'DemoCustomer',
-                handlingInstructions: 'Handle with care',
+                orderId: orderId,
+                shipGroupSeqId: shipGroupSeqId,
+                pickerPartyId: pickerPartyId,
+                handlingInstructions: handlingInstructions,
                 nextPackageSeq: 1,
                 packingSession: packingSession,
                 userLogin: userLogin
@@ -67,9 +72,9 @@ class ShipmentTests implements JupiterTestHelper {
         serviceCtx.clear()
         serviceResult.clear()
         serviceCtx = [
-                orderId: 'DEMO10090',
-                pickerPartyId: 'DemoCustomer',
-                handlingInstructions: 'Handle with care',
+                orderId: orderId,
+                pickerPartyId: pickerPartyId,
+                handlingInstructions: handlingInstructions,
                 packingSession: packingSession,
                 additionalShippingCharge: new BigDecimal('10'),
                 forceComplete: true,
@@ -107,12 +112,18 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(2)
     void testShipmentServices() {
+        String shipmentTypeId = testParams.shipmentTypeId ?: 'SALES_SHIPMENT'
+        String statusId = testParams.statusId ?: 'SHIPMENT_INPUT'
+        String primaryOrderId = testParams.primaryOrderId ?: 'DEMO10090'
+        String partyIdTo = testParams.partyIdTo ?: 'DemoCustomer'
+        String originFacilityId = testParams.originFacilityId ?: 'WebStoreWarehouse'
+        String statusId1 = testParams.statusId1 ?: 'SHIPMENT_PACKED'
         Map serviceCtx = [
-                shipmentTypeId: 'SALES_SHIPMENT',
-                statusId: 'SHIPMENT_INPUT',
-                primaryOrderId: 'DEMO10090',
-                partyIdTo: 'DemoCustomer',
-                originFacilityId: 'WebStoreWarehouse',
+                shipmentTypeId: shipmentTypeId,
+                statusId: statusId,
+                primaryOrderId: primaryOrderId,
+                partyIdTo: partyIdTo,
+                originFacilityId: originFacilityId,
                 userLogin: userLogin
         ]
 
@@ -125,7 +136,7 @@ class ShipmentTests implements JupiterTestHelper {
         serviceResult.clear()
         serviceCtx = [
                 shipmentId: shipmentId,
-                statusId: 'SHIPMENT_PACKED',
+                statusId: statusId1,
                 userLogin: userLogin
         ]
         serviceResult = dispatcher.runSync('updateShipment', serviceCtx)
@@ -145,13 +156,16 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(3)
     void testReceiveInventoryNonSerialized() {
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'GZ-2644'
+        String inventoryItemTypeId = testParams.inventoryItemTypeId ?: 'NON_SERIAL_INV_ITEM'
         Map serviceCtx = [
-                facilityId: 'WebStoreWarehouse',
-                productId: 'GZ-2644',
+                facilityId: facilityId,
+                productId: productId,
                 quantityAccepted: new BigDecimal('2'),
                 quantityRejected: BigDecimal.ZERO,
                 unitCost: new BigDecimal('24'),
-                inventoryItemTypeId: 'NON_SERIAL_INV_ITEM',
+                inventoryItemTypeId: inventoryItemTypeId,
                 datetimeReceived: UtilDateTime.nowTimestamp(),
                 userLogin: userLogin
         ]
@@ -186,8 +200,14 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testIssueOrderItemShipGrpInvResToShipmentRejectsMixedDestinations() {
+        String productId = testParams.productId ?: 'GZ-2644'
+        String shipmentTypeId = testParams.shipmentTypeId ?: 'SALES_SHIPMENT'
+        String statusId = testParams.statusId ?: 'SHIPMENT_INPUT'
+        String primaryShipGroupSeqId = testParams.primaryShipGroupSeqId ?: '00001'
+        String originFacilityId = testParams.originFacilityId ?: 'WebStoreWarehouse'
+        String shipGroupSeqId = testParams.shipGroupSeqId ?: '00002'
         Map orderResult = dispatcher.runSync('createTestSalesOrderSingle',
-                [userLogin: userLogin, productId: 'GZ-2644'])
+                [userLogin: userLogin, productId: productId])
         assert ServiceUtil.isSuccess(orderResult)
         String orderId = orderResult.orderId
         assert orderId
@@ -197,17 +217,17 @@ class ShipmentTests implements JupiterTestHelper {
         String orderItemSeqId = orderItem.orderItemSeqId
 
         GenericValue shipGroup1 = from('OrderItemShipGroup')
-                .where('orderId', orderId, 'shipGroupSeqId', '00001')
+                .where('orderId', orderId, 'shipGroupSeqId', primaryShipGroupSeqId)
                 .queryOne()
         assert shipGroup1
         assert shipGroup1.contactMechId
 
         Map createShipmentCtx = [
-                shipmentTypeId: 'SALES_SHIPMENT',
-                statusId: 'SHIPMENT_INPUT',
+                shipmentTypeId: shipmentTypeId,
+                statusId: statusId,
                 primaryOrderId: orderId,
-                primaryShipGroupSeqId: '00001',
-                originFacilityId: 'WebStoreWarehouse',
+                primaryShipGroupSeqId: primaryShipGroupSeqId,
+                originFacilityId: originFacilityId,
                 userLogin: userLogin
         ]
         Map createShipmentResult = dispatcher.runSync('createShipment', createShipmentCtx)
@@ -220,15 +240,15 @@ class ShipmentTests implements JupiterTestHelper {
 
         String differentContactMechId = resolveDifferentDestinationAddress('789 Different St')
         assert differentContactMechId != shipGroup1.contactMechId
-        addShipGroup(orderId, '00002', differentContactMechId)
+        addShipGroup(orderId, shipGroupSeqId, differentContactMechId)
         GenericValue inventoryItem = findGz2644InventoryItem()
-        associateItemWithShipGroup(orderId, orderItemSeqId, '00002', new BigDecimal('1'))
-        reserveInventoryToShipGroup(orderId, orderItemSeqId, '00002', inventoryItem.inventoryItemId, new BigDecimal('1'))
+        associateItemWithShipGroup(orderId, orderItemSeqId, shipGroupSeqId, new BigDecimal('1'))
+        reserveInventoryToShipGroup(orderId, orderItemSeqId, shipGroupSeqId, inventoryItem.inventoryItemId, new BigDecimal('1'))
 
         Map issueCtx = [
                 shipmentId: shipmentId,
                 orderId: orderId,
-                shipGroupSeqId: '00002',
+                shipGroupSeqId: shipGroupSeqId,
                 orderItemSeqId: orderItemSeqId,
                 inventoryItemId: inventoryItem.inventoryItemId,
                 quantity: new BigDecimal('1'),
@@ -242,24 +262,30 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testIssueOrderItemShipGrpInvResToShipmentRejectsMixedDestinationsAcrossOrders() {
+        String productId = testParams.productId ?: 'GZ-2644'
+        String shipmentTypeId = testParams.shipmentTypeId ?: 'SALES_SHIPMENT'
+        String statusId = testParams.statusId ?: 'SHIPMENT_INPUT'
+        String primaryShipGroupSeqId = testParams.primaryShipGroupSeqId ?: '00001'
+        String originFacilityId = testParams.originFacilityId ?: 'WebStoreWarehouse'
+        String contactMechPurposeTypeId = testParams.contactMechPurposeTypeId ?: 'SHIPPING_LOCATION'
         Map orderResult1 = dispatcher.runSync('createTestSalesOrderSingle',
-                [userLogin: userLogin, productId: 'GZ-2644'])
+                [userLogin: userLogin, productId: productId])
         assert ServiceUtil.isSuccess(orderResult1)
         String orderId1 = orderResult1.orderId
         assert orderId1
 
         GenericValue shipGroup1 = from('OrderItemShipGroup')
-                .where('orderId', orderId1, 'shipGroupSeqId', '00001')
+                .where('orderId', orderId1, 'shipGroupSeqId', primaryShipGroupSeqId)
                 .queryOne()
         assert shipGroup1
         assert shipGroup1.contactMechId
 
         Map createShipmentCtx = [
-                shipmentTypeId: 'SALES_SHIPMENT',
-                statusId: 'SHIPMENT_INPUT',
+                shipmentTypeId: shipmentTypeId,
+                statusId: statusId,
                 primaryOrderId: orderId1,
-                primaryShipGroupSeqId: '00001',
-                originFacilityId: 'WebStoreWarehouse',
+                primaryShipGroupSeqId: primaryShipGroupSeqId,
+                originFacilityId: originFacilityId,
                 userLogin: userLogin
         ]
         Map createShipmentResult = dispatcher.runSync('createShipment', createShipmentCtx)
@@ -267,9 +293,9 @@ class ShipmentTests implements JupiterTestHelper {
         String shipmentId = createShipmentResult.shipmentId
         assert shipmentId
 
-        // second, independent order; also uses shipGroupSeqId '00001' but a different destination
+        // second, independent order; also uses shipGroupSeqId primaryShipGroupSeqId but a different destination
         Map orderResult2 = dispatcher.runSync('createTestSalesOrderSingle',
-                [userLogin: userLogin, productId: 'GZ-2644'])
+                [userLogin: userLogin, productId: productId])
         assert ServiceUtil.isSuccess(orderResult2)
         String orderId2 = orderResult2.orderId
         assert orderId2
@@ -284,9 +310,9 @@ class ShipmentTests implements JupiterTestHelper {
 
         Map updateShipGroupCtx = [
                 orderId: orderId2,
-                shipGroupSeqId: '00001',
+                shipGroupSeqId: primaryShipGroupSeqId,
                 contactMechId: differentContactMechId,
-                contactMechPurposeTypeId: 'SHIPPING_LOCATION',
+                contactMechPurposeTypeId: contactMechPurposeTypeId,
                 userLogin: userLogin
         ]
         Map updateShipGroupResult = dispatcher.runSync('updateOrderItemShipGroup', updateShipGroupCtx)
@@ -294,12 +320,12 @@ class ShipmentTests implements JupiterTestHelper {
 
         // order2's item is already associated with ship group 00001 from checkout; only reserve
         GenericValue inventoryItem = findGz2644InventoryItem()
-        reserveInventoryToShipGroup(orderId2, orderItemSeqId2, '00001', inventoryItem.inventoryItemId, new BigDecimal('1'))
+        reserveInventoryToShipGroup(orderId2, orderItemSeqId2, primaryShipGroupSeqId, inventoryItem.inventoryItemId, new BigDecimal('1'))
 
         Map issueCtx = [
                 shipmentId: shipmentId,
                 orderId: orderId2,
-                shipGroupSeqId: '00001',
+                shipGroupSeqId: primaryShipGroupSeqId,
                 orderItemSeqId: orderItemSeqId2,
                 inventoryItemId: inventoryItem.inventoryItemId,
                 quantity: new BigDecimal('1'),
@@ -313,8 +339,12 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testPackingSessionRejectsMixedShipGroupDestinations() {
+        String productId = testParams.productId ?: 'GZ-2644'
+        String shipGroupSeqId = testParams.shipGroupSeqId ?: '00001'
+        String pickerPartyId = testParams.pickerPartyId ?: 'DemoCustomer'
+        String shipGroupSeqId1 = testParams.shipGroupSeqId1 ?: '00002'
         Map orderResult = dispatcher.runSync('createTestSalesOrderSingle',
-                [userLogin: userLogin, productId: 'GZ-2644'])
+                [userLogin: userLogin, productId: productId])
         assert ServiceUtil.isSuccess(orderResult)
         String orderId = orderResult.orderId
         assert orderId
@@ -324,20 +354,20 @@ class ShipmentTests implements JupiterTestHelper {
         String orderItemSeqId = orderItem.orderItemSeqId
 
         String differentContactMechId = resolveDifferentDestinationAddress('456 Other Ave')
-        addShipGroup(orderId, '00002', differentContactMechId)
+        addShipGroup(orderId, shipGroupSeqId1, differentContactMechId)
         GenericValue inventoryItem = findGz2644InventoryItem()
-        associateItemWithShipGroup(orderId, orderItemSeqId, '00002', new BigDecimal('1'))
-        reserveInventoryToShipGroup(orderId, orderItemSeqId, '00002', inventoryItem.inventoryItemId, new BigDecimal('1'))
+        associateItemWithShipGroup(orderId, orderItemSeqId, shipGroupSeqId1, new BigDecimal('1'))
+        reserveInventoryToShipGroup(orderId, orderItemSeqId, shipGroupSeqId1, inventoryItem.inventoryItemId, new BigDecimal('1'))
 
         PackingSession packingSession = new PackingSession(dispatcher, userLogin)
 
         Map packLine1Ctx = [
-                productId: 'GZ-2644',
+                productId: productId,
                 orderId: orderId,
-                shipGroupSeqId: '00001',
+                shipGroupSeqId: shipGroupSeqId,
                 quantity: new BigDecimal('1'),
                 packageSeq: 1,
-                pickerPartyId: 'DemoCustomer',
+                pickerPartyId: pickerPartyId,
                 packingSession: packingSession,
                 userLogin: userLogin
         ]
@@ -345,12 +375,12 @@ class ShipmentTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(packLine1Result)
 
         Map packLine2Ctx = [
-                productId: 'GZ-2644',
+                productId: productId,
                 orderId: orderId,
-                shipGroupSeqId: '00002',
+                shipGroupSeqId: shipGroupSeqId1,
                 quantity: new BigDecimal('1'),
                 packageSeq: 1,
-                pickerPartyId: 'DemoCustomer',
+                pickerPartyId: pickerPartyId,
                 packingSession: packingSession,
                 userLogin: userLogin
         ]
@@ -359,7 +389,7 @@ class ShipmentTests implements JupiterTestHelper {
 
         Map completeCtx = [
                 orderId: orderId,
-                pickerPartyId: 'DemoCustomer',
+                pickerPartyId: pickerPartyId,
                 packingSession: packingSession,
                 forceComplete: true,
                 userLogin: userLogin
@@ -372,6 +402,7 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testCreateShipmentRouteSegment() {
+        String shipmentRouteSegmentIdParam = testParams.shipmentRouteSegmentIdParam ?: '0001'
         GenericValue shipment = from('Shipment')
                 .where('shipmentId', '9998')
                 .queryOne()
@@ -379,7 +410,7 @@ class ShipmentTests implements JupiterTestHelper {
 
         Map serviceCtx = [
                 shipmentId: shipment.shipmentId,
-                shipmentRouteSegmentId: '0001',
+                shipmentRouteSegmentId: shipmentRouteSegmentIdParam,
                 userLogin: userLogin
         ]
         Map serviceResult = dispatcher.runSync('createShipmentRouteSegment', serviceCtx)
@@ -398,8 +429,9 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(8)
     void testQuickShipEntireOrderDoesNotMixShipGroupDestinations() {
+        String productId = testParams.productId ?: 'GZ-2644'
         Map orderResult = dispatcher.runSync('createTestSalesOrderSingle',
-                [userLogin: userLogin, productId: 'GZ-2644'])
+                [userLogin: userLogin, productId: productId])
         assert ServiceUtil.isSuccess(orderResult)
         String orderId = orderResult.orderId
         assert orderId
@@ -431,8 +463,9 @@ class ShipmentTests implements JupiterTestHelper {
     @Test
     @Order(9)
     void testQuickShipEntireOrderSkipsShipGroupWithNothingToShip() {
+        String productId = testParams.productId ?: 'GZ-2644'
         Map orderResult = dispatcher.runSync('createTestSalesOrderSingle',
-                [userLogin: userLogin, productId: 'GZ-2644'])
+                [userLogin: userLogin, productId: productId])
         assert ServiceUtil.isSuccess(orderResult)
         String orderId = orderResult.orderId
         assert orderId

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/test/InventoryItemTransferTest.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/test/InventoryItemTransferTest.groovy
@@ -28,14 +28,19 @@ class InventoryItemTransferTest implements JupiterTestHelper {
 
     @Test
     void testCreateInventoryItemsTransfer() {
+        String inventoryItemId = testParams.inventoryItemId ?: '9005'
+        String statusId = testParams.statusId ?: 'IXF_REQUESTED'
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String facilityIdTo = testParams.facilityIdTo ?: 'WebStoreWarehouse'
+        String statusId1 = testParams.statusId1 ?: 'IXF_COMPLETE'
         BigDecimal transferQty = BigDecimal.ONE
 
         // create
         Map createCtx = [
-                inventoryItemId: '9005',
-                statusId: 'IXF_REQUESTED',
-                facilityId: 'WebStoreWarehouse',
-                facilityIdTo: 'WebStoreWarehouse',
+                inventoryItemId: inventoryItemId,
+                statusId: statusId,
+                facilityId: facilityId,
+                facilityIdTo: facilityIdTo,
                 receiveDate: UtilDateTime.nowTimestamp(),
                 xferQty: transferQty,
                 userLogin: userLogin
@@ -47,8 +52,8 @@ class InventoryItemTransferTest implements JupiterTestHelper {
         // transfer
         Map updateCtx = [
                 inventoryTransferId: inventoryTransferId,
-                inventoryItemId: '9005',
-                statusId: 'IXF_COMPLETE',
+                inventoryItemId: inventoryItemId,
+                statusId: statusId1,
                 userLogin: userLogin
         ]
         Map updateResp = dispatcher.runSync('updateInventoryTransfer', updateCtx)

--- a/applications/product/src/test/groovy/org/apache/ofbiz/product/test/StockMovesTest.groovy
+++ b/applications/product/src/test/groovy/org/apache/ofbiz/product/test/StockMovesTest.groovy
@@ -30,8 +30,12 @@ class StockMovesTest implements JupiterTestHelper {
 
     @Test
     void testStockMoves() {
+        String facilityId = testParams.facilityId ?: 'WebStoreWarehouse'
+        String productId = testParams.productId ?: 'GZ-2644'
+        String locationSeqId = testParams.locationSeqId ?: 'TLTLTLUL01'
+        String targetLocationSeqId = testParams.targetLocationSeqId ?: 'TLTLTLLL01'
         Map fsmnCtx = [
-                facilityId: 'WebStoreWarehouse',
+                facilityId: facilityId,
                 userLogin: userLogin
         ]
         Map respMap1 = dispatcher.runSync('findStockMovesNeeded', fsmnCtx)
@@ -44,10 +48,10 @@ class StockMovesTest implements JupiterTestHelper {
         assert !respMap2.warningMessageList
 
         Map ppsmCtx = [
-                productId: 'GZ-2644',
-                facilityId: 'WebStoreWarehouse',
-                locationSeqId: 'TLTLTLUL01',
-                targetLocationSeqId: 'TLTLTLLL01',
+                productId: productId,
+                facilityId: facilityId,
+                locationSeqId: locationSeqId,
+                targetLocationSeqId: targetLocationSeqId,
                 quantityMoved: new BigDecimal('5'),
                 userLogin: userLogin
         ]

--- a/applications/workeffort/src/test/groovy/org/apache/ofbiz/workeffort/workeffort/test/WorkEffortTests.groovy
+++ b/applications/workeffort/src/test/groovy/org/apache/ofbiz/workeffort/workeffort/test/WorkEffortTests.groovy
@@ -31,15 +31,23 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(1)
     void testCreateWorkEffortAndPartyAssign() {
+        String partyId = testParams.partyId ?: 'TestParty-1'
+        String roleTypeId = testParams.roleTypeId ?: 'CAL_OWNER'
+        String statusId = testParams.statusId ?: 'PRTYASGN_ASSIGNED'
+        String workEffortId = testParams.workEffortId ?: 'TestWorkEffort-99'
+        String partyTypeId = testParams.partyTypeId ?: 'PARTY_GROUP'
+        String workEffortName = testParams.workEffortName ?: 'Test WorkEffort Event'
+        String workEffortTypeId = testParams.workEffortTypeId ?: 'TASK'
+        String currentStatusId = testParams.currentStatusId ?: 'CAL_ACCEPTED'
         Map serviceCtx = [
-                partyId: 'TestParty-1',
-                roleTypeId: 'CAL_OWNER',
-                statusId: 'PRTYASGN_ASSIGNED',
-                workEffortId: 'TestWorkEffort-99',
-                partyTypeId: 'PARTY_GROUP',
-                workEffortName: 'Test WorkEffort Event',
-                workEffortTypeId: 'TASK',
-                currentStatusId: 'CAL_ACCEPTED',
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                statusId: statusId,
+                workEffortId: workEffortId,
+                partyTypeId: partyTypeId,
+                workEffortName: workEffortName,
+                workEffortTypeId: workEffortTypeId,
+                currentStatusId: currentStatusId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createWorkEffortAndPartyAssign', serviceCtx)
@@ -49,46 +57,51 @@ class WorkEffortTests implements JupiterTestHelper {
         List<GenericValue> workEffortPartyAssignmentList = from('WorkEffortPartyAssignment').where('workEffortId',
                                                                                                    serviceResult.workEffortId,
                                                                                                    'partyId',
-                                                                                                   'TestParty-1',
+                                                                                                   partyId,
                                                                                                    'roleTypeId',
-                                                                                                   'CAL_OWNER').queryList()
+                                                                                                   roleTypeId).queryList()
         GenericValue workEffortPartyAssignment = workEffortPartyAssignmentList ? workEffortPartyAssignmentList[0] : null
         GenericValue workEffort = from('WorkEffort').where('workEffortId', serviceResult.workEffortId).queryOne()
         assert workEffort
         assert workEffortPartyAssignment
-        assert workEffort.workEffortTypeId == 'TASK'
-        assert workEffort.currentStatusId == 'CAL_ACCEPTED'
-        assert workEffortPartyAssignment.statusId == 'PRTYASGN_ASSIGNED'
+        assert workEffort.workEffortTypeId == workEffortTypeId
+        assert workEffort.currentStatusId == currentStatusId
+        assert workEffortPartyAssignment.statusId == statusId
     }
 
     @Test
     @Order(2)
     void testDeleteWorkEffort() {
+        String workEffortId = testParams.workEffortId ?: 'TestWorkEffort-98'
+        String workEffortName = testParams.workEffortName ?: 'Delete Me'
+        String workEffortTypeId = testParams.workEffortTypeId ?: 'TASK'
+        String currentStatusId = testParams.currentStatusId ?: 'CAL_TENTATIVE'
         Map createCtx = [
-                workEffortId: 'TestWorkEffort-98',
-                workEffortName: 'Delete Me',
-                workEffortTypeId: 'TASK',
-                currentStatusId: 'CAL_TENTATIVE',
+                workEffortId: workEffortId,
+                workEffortName: workEffortName,
+                workEffortTypeId: workEffortTypeId,
+                currentStatusId: currentStatusId,
                 userLogin: userLogin,
         ]
         dispatcher.runSync('createWorkEffort', createCtx)
 
         Map serviceCtx = [
-                workEffortId: 'TestWorkEffort-98',
+                workEffortId: workEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('deleteWorkEffort', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue workEffort = from('WorkEffort').where('workEffortId', 'TestWorkEffort-98').queryOne()
+        GenericValue workEffort = from('WorkEffort').where('workEffortId', workEffortId).queryOne()
         assert !workEffort
     }
 
     @Test
     @Order(3)
     void testCopyWorkEffort() {
+        String sourceWorkEffortId = testParams.sourceWorkEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                sourceWorkEffortId: 'TestWorkeffort-3',
+                sourceWorkEffortId: sourceWorkEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('copyWorkEffort', serviceCtx)
@@ -103,8 +116,9 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(4)
     void testDuplicateWorkEffort() {
+        String oldWorkEffortId = testParams.oldWorkEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                oldWorkEffortId: 'TestWorkeffort-3',
+                oldWorkEffortId: oldWorkEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('duplicateWorkEffort', serviceCtx)
@@ -119,9 +133,11 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(5)
     void testMakeCommunicationEventWorkEffort() {
+        String communicationEventId = testParams.communicationEventId ?: 'TestEvent-1'
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                communicationEventId: 'TestEvent-1',
-                workEffortId: 'TestWorkeffort-3',
+                communicationEventId: communicationEventId,
+                workEffortId: workEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('makeCommunicationEventWorkEffort', serviceCtx)
@@ -139,11 +155,15 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(6)
     void testAssignPartyToWorkEffort() {
+        String partyId = testParams.partyId ?: 'TestParty'
+        String roleTypeId = testParams.roleTypeId ?: 'CONTENT_AUTHOR'
+        String statusId = testParams.statusId ?: 'PRTYASGN_ASSIGNED'
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                partyId: 'TestParty',
-                roleTypeId: 'CONTENT_AUTHOR',
-                statusId: 'PRTYASGN_ASSIGNED',
-                workEffortId: 'TestWorkeffort-3',
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                statusId: statusId,
+                workEffortId: workEffortId,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 01:01:01'),
                 userLogin: userLogin,
         ]
@@ -152,11 +172,11 @@ class WorkEffortTests implements JupiterTestHelper {
         assert serviceResult.fromDate
 
         GenericValue workEffortPartyAssignment = from('WorkEffortPartyAssignment').where('partyId',
-                                                                                         'TestParty',
+                                                                                         partyId,
                                                                                          'roleTypeId',
-                                                                                         'CONTENT_AUTHOR',
+                                                                                         roleTypeId,
                                                                                          'workEffortId',
-                                                                                         'TestWorkeffort-3',
+                                                                                         workEffortId,
                                                                                          'fromDate',
                                                                                          serviceResult.fromDate).queryOne()
         assert workEffortPartyAssignment
@@ -165,11 +185,15 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(7)
     void testUpdatePartyToWorkEffortAssignment() {
+        String partyId = testParams.partyId ?: 'TestParty'
+        String roleTypeId = testParams.roleTypeId ?: 'CUSTOMER'
+        String statusId = testParams.statusId ?: 'PRTYASGN_ASSIGNED'
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                partyId: 'TestParty',
-                roleTypeId: 'CUSTOMER',
-                statusId: 'PRTYASGN_ASSIGNED',
-                workEffortId: 'TestWorkeffort-3',
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                statusId: statusId,
+                workEffortId: workEffortId,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 02:02:02'),
                 userLogin: userLogin,
         ]
@@ -177,24 +201,27 @@ class WorkEffortTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue workEffortPartyAssignment = from('WorkEffortPartyAssignment').where('partyId',
-                                                                                         'TestParty',
+                                                                                         partyId,
                                                                                          'roleTypeId',
-                                                                                         'CUSTOMER',
+                                                                                         roleTypeId,
                                                                                          'workEffortId',
-                                                                                         'TestWorkeffort-3',
+                                                                                         workEffortId,
                                                                                          'fromDate',
                                                                                          java.sql.Timestamp.valueOf('2009-09-09 02:02:02')).queryOne()
         assert workEffortPartyAssignment
-        assert workEffortPartyAssignment.statusId == 'PRTYASGN_ASSIGNED'
+        assert workEffortPartyAssignment.statusId == statusId
     }
 
     @Test
     @Order(8)
     void testDeletePartyToWorkEffortAssignment() {
+        String partyId = testParams.partyId ?: 'TestParty'
+        String roleTypeId = testParams.roleTypeId ?: 'ACCOUNTANT'
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                partyId: 'TestParty',
-                roleTypeId: 'ACCOUNTANT',
-                workEffortId: 'TestWorkeffort-3',
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                workEffortId: workEffortId,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 02:02:02'),
                 userLogin: userLogin,
         ]
@@ -202,11 +229,11 @@ class WorkEffortTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue workEffortPartyAssignment = from('WorkEffortPartyAssignment').where('partyId',
-                                                                                         'TestParty',
+                                                                                         partyId,
                                                                                          'roleTypeId',
-                                                                                         'ACCOUNTANT',
+                                                                                         roleTypeId,
                                                                                          'workEffortId',
-                                                                                         'TestWorkeffort-3',
+                                                                                         workEffortId,
                                                                                          'fromDate',
                                                                                          java.sql.Timestamp.valueOf('2009-09-09 02:02:02')).queryOne()
         assert workEffortPartyAssignment
@@ -216,18 +243,20 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(9)
     void testQuickAssignPartyToWorkEffort() {
+        String quickAssignPartyId = testParams.quickAssignPartyId ?: 'TestCompany'
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                quickAssignPartyId: 'TestCompany',
-                workEffortId: 'TestWorkeffort-3',
+                quickAssignPartyId: quickAssignPartyId,
+                workEffortId: workEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('quickAssignPartyToWorkEffort', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         List<GenericValue> workEffortPartyAssignmentList = from('WorkEffortPartyAssignment').where('workEffortId',
-                                                                                                   'TestWorkeffort-3',
+                                                                                                   workEffortId,
                                                                                                    'partyId',
-                                                                                                   'TestCompany').queryList()
+                                                                                                   quickAssignPartyId).queryList()
         GenericValue workEffortPartyAssignment = workEffortPartyAssignmentList ? workEffortPartyAssignmentList[0] : null
         assert workEffortPartyAssignment
     }
@@ -235,21 +264,24 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(10)
     void testQuickAssignPartyToWorkEffortWithRole() {
+        String quickAssignPartyId = testParams.quickAssignPartyId ?: 'TestParty-1'
+        String roleTypeId = testParams.roleTypeId ?: 'BILL_FROM_VENDOR'
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                quickAssignPartyId: 'TestParty-1',
-                roleTypeId: 'BILL_FROM_VENDOR',
-                workEffortId: 'TestWorkeffort-3',
+                quickAssignPartyId: quickAssignPartyId,
+                roleTypeId: roleTypeId,
+                workEffortId: workEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('quickAssignPartyToWorkEffortWithRole', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
         List<GenericValue> workEffortPartyAssignmentList = from('WorkEffortPartyAssignment').where('workEffortId',
-                                                                                                   'TestWorkeffort-3',
+                                                                                                   workEffortId,
                                                                                                    'partyId',
-                                                                                                   'TestParty-1',
+                                                                                                   quickAssignPartyId,
                                                                                                    'roleTypeId',
-                                                                                                   'BILL_FROM_VENDOR').queryList()
+                                                                                                   roleTypeId).queryList()
         GenericValue workEffortPartyAssignment = workEffortPartyAssignmentList ? workEffortPartyAssignmentList[0] : null
         assert workEffortPartyAssignment
     }
@@ -257,47 +289,54 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(11)
     void testCreateWorkEffortNote() {
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
+        String noteInfo = testParams.noteInfo ?: 'This is test note.'
         Map serviceCtx = [
-                workEffortId: 'TestWorkeffort-3',
-                noteInfo: 'This is test note.',
+                workEffortId: workEffortId,
+                noteInfo: noteInfo,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createWorkEffortNote', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
         assert serviceResult.noteId
 
-        GenericValue workEffortNote = from('WorkEffortNote').where('workEffortId', 'TestWorkeffort-3', 'noteId', serviceResult.noteId).queryOne()
+        GenericValue workEffortNote = from('WorkEffortNote').where('workEffortId', workEffortId, 'noteId', serviceResult.noteId).queryOne()
         GenericValue noteData = from('NoteData').where('noteId', serviceResult.noteId).queryOne()
         assert workEffortNote
         assert noteData
-        assert noteData.noteInfo == 'This is test note.'
+        assert noteData.noteInfo == noteInfo
     }
 
     @Test
     @Order(12)
     void testUpdateWorkEffortNote() {
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
+        String noteId = testParams.noteId ?: 'TestNote-1'
+        String internalNote = testParams.internalNote ?: 'Y'
+        String noteInfo = testParams.noteInfo ?: 'This is updated test note.'
         Map serviceCtx = [
-                workEffortId: 'TestWorkeffort-3',
-                noteId: 'TestNote-1',
-                internalNote: 'Y',
-                noteInfo: 'This is updated test note.',
+                workEffortId: workEffortId,
+                noteId: noteId,
+                internalNote: internalNote,
+                noteInfo: noteInfo,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('updateWorkEffortNote', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue workEffortNote = from('WorkEffortNote').where('workEffortId', 'TestWorkeffort-3', 'noteId', 'TestNote-1').queryOne()
-        GenericValue noteData = from('NoteData').where('noteId', 'TestNote-1').queryOne()
+        GenericValue workEffortNote = from('WorkEffortNote').where('workEffortId', workEffortId, 'noteId', noteId).queryOne()
+        GenericValue noteData = from('NoteData').where('noteId', noteId).queryOne()
         assert workEffortNote
         assert noteData
-        assert noteData.noteInfo == 'This is updated test note.'
+        assert noteData.noteInfo == noteInfo
     }
 
     @Test
     @Order(13)
     void testGetWorkEffort() {
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
         Map serviceCtx = [
-                workEffortId: 'TestWorkeffort-3',
+                workEffortId: workEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('getWorkEffort', serviceCtx)
@@ -308,10 +347,13 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(14)
     void testCreateWorkEffortAssoc() {
+        String workEffortIdFrom = testParams.workEffortIdFrom ?: 'TestWorkeffort-2'
+        String workEffortIdTo = testParams.workEffortIdTo ?: 'TestWorkeffort-3'
+        String workEffortAssocTypeId = testParams.workEffortAssocTypeId ?: 'ROUTING_COMPONENT'
         Map serviceCtx = [
-                workEffortIdFrom: 'TestWorkeffort-2',
-                workEffortIdTo: 'TestWorkeffort-3',
-                workEffortAssocTypeId: 'ROUTING_COMPONENT',
+                workEffortIdFrom: workEffortIdFrom,
+                workEffortIdTo: workEffortIdTo,
+                workEffortAssocTypeId: workEffortAssocTypeId,
                 fromDate: java.sql.Timestamp.valueOf('2009-09-09 02:02:02'),
                 userLogin: userLogin,
         ]
@@ -319,11 +361,11 @@ class WorkEffortTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue workEffortAssoc = from('WorkEffortAssoc').where('workEffortIdFrom',
-                                                                     'TestWorkeffort-2',
+                                                                     workEffortIdFrom,
                                                                      'workEffortIdTo',
-                                                                     'TestWorkeffort-3',
+                                                                     workEffortIdTo,
                                                                      'workEffortAssocTypeId',
-                                                                     'ROUTING_COMPONENT',
+                                                                     workEffortAssocTypeId,
                                                                      'fromDate',
                                                                      java.sql.Timestamp.valueOf('2009-09-09 02:02:02')).queryOne()
         assert workEffortAssoc
@@ -332,24 +374,28 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(15)
     void testCopyWorkEffortAssocs() {
+        String sourceWorkEffortId = testParams.sourceWorkEffortId ?: 'TestWorkeffort-2'
+        String targetWorkEffortId = testParams.targetWorkEffortId ?: 'TestWorkeffort-4'
         Map serviceCtx = [
-                sourceWorkEffortId: 'TestWorkeffort-2',
-                targetWorkEffortId: 'TestWorkeffort-4',
+                sourceWorkEffortId: sourceWorkEffortId,
+                targetWorkEffortId: targetWorkEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('copyWorkEffortAssocs', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        List<GenericValue> workEffortAssocList = from('WorkEffortAssoc').where('workEffortIdFrom', 'TestWorkeffort-4').queryList()
+        List<GenericValue> workEffortAssocList = from('WorkEffortAssoc').where('workEffortIdFrom', targetWorkEffortId).queryList()
         assert workEffortAssocList
     }
 
     @Test
     @Order(16)
     void testCreateWorkEffortKeyword() {
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-2'
+        String keyword = testParams.keyword ?: 'new test keyword for workeffort'
         Map serviceCtx = [
-                workEffortId: 'TestWorkeffort-2',
-                keyword: 'new test keyword for workeffort',
+                workEffortId: workEffortId,
+                keyword: keyword,
                 relevancyWeight: 1L,
                 userLogin: userLogin,
         ]
@@ -357,48 +403,54 @@ class WorkEffortTests implements JupiterTestHelper {
         assert ServiceUtil.isSuccess(serviceResult)
 
         GenericValue workEffortKeyword = from('WorkEffortKeyword').where('workEffortId',
-                                                                         'TestWorkeffort-2',
+                                                                         workEffortId,
                                                                          'keyword',
-                                                                         'new test keyword for workeffort').queryOne()
+                                                                         keyword).queryOne()
         assert workEffortKeyword
     }
 
     @Test
     @Order(17)
     void testDeleteWorkEffortKeyword() {
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-3'
+        String keyword = testParams.keyword ?: 'test keyword'
         Map serviceCtx = [
-                workEffortId: 'TestWorkeffort-3',
-                keyword: 'test keyword',
+                workEffortId: workEffortId,
+                keyword: keyword,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('deleteWorkEffortKeyword', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue workEffortKeyword = from('WorkEffortKeyword').where('workEffortId', 'TestWorkeffort-3', 'keyword', 'test keyword').queryOne()
+        GenericValue workEffortKeyword = from('WorkEffortKeyword').where('workEffortId', workEffortId, 'keyword', keyword).queryOne()
         assert !workEffortKeyword
     }
 
     @Test
     @Order(18)
     void testDeleteWorkEffortKeywords() {
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-2'
         Map serviceCtx = [
-                workEffortId: 'TestWorkeffort-2',
+                workEffortId: workEffortId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('deleteWorkEffortKeywords', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        List<GenericValue> workEffortKeywordList = from('WorkEffortKeyword').where('workEffortId', 'TestWorkeffort-2').queryList()
+        List<GenericValue> workEffortKeywordList = from('WorkEffortKeyword').where('workEffortId', workEffortId).queryList()
         assert !workEffortKeywordList
     }
 
     @Test
     @Order(19)
     void testCreateTimesheet() {
+        String partyId = testParams.partyId ?: 'TestParty'
+        String comments = testParams.comments ?: 'Test timesheet'
+        String statusId = testParams.statusId ?: 'TIMESHEET_IN_PROCESS'
         Map serviceCtx = [
-                partyId: 'TestParty',
-                comments: 'Test timesheet',
-                statusId: 'TIMESHEET_IN_PROCESS',
+                partyId: partyId,
+                comments: comments,
+                statusId: statusId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createTimesheet', serviceCtx)
@@ -407,50 +459,55 @@ class WorkEffortTests implements JupiterTestHelper {
 
         GenericValue timesheet = from('Timesheet').where('timesheetId', serviceResult.timesheetId).queryOne()
         assert timesheet
-        assert timesheet.partyId == 'TestParty'
-        assert timesheet.statusId == 'TIMESHEET_IN_PROCESS'
-        assert timesheet.comments == 'Test timesheet'
+        assert timesheet.partyId == partyId
+        assert timesheet.statusId == statusId
+        assert timesheet.comments == comments
     }
 
     @Test
     @Order(20)
     void testUpdateTimesheet() {
+        String timesheetId = testParams.timesheetId ?: 'TestTimesheet-2'
+        String clientPartyId = testParams.clientPartyId ?: 'TestParty'
+        String statusId = testParams.statusId ?: 'TIMESHEET_COMPLETED'
         Map serviceCtx = [
-                timesheetId: 'TestTimesheet-2',
-                clientPartyId: 'TestParty',
-                statusId: 'TIMESHEET_COMPLETED',
+                timesheetId: timesheetId,
+                clientPartyId: clientPartyId,
+                statusId: statusId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('updateTimesheet', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue timesheet = from('Timesheet').where('timesheetId', 'TestTimesheet-2').queryOne()
+        GenericValue timesheet = from('Timesheet').where('timesheetId', timesheetId).queryOne()
         assert timesheet
-        assert timesheet.clientPartyId == 'TestParty'
-        assert timesheet.statusId == 'TIMESHEET_COMPLETED'
+        assert timesheet.clientPartyId == clientPartyId
+        assert timesheet.statusId == statusId
     }
 
     @Test
     @Order(21)
     void testDeleteTimesheet() {
+        String timesheetId = testParams.timesheetId ?: 'TestTimesheet-3'
         Map serviceCtx = [
-                timesheetId: 'TestTimesheet-3',
+                timesheetId: timesheetId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('deleteTimesheet', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue timesheet = from('Timesheet').where('timesheetId', 'TestTimesheet-3').queryOne()
+        GenericValue timesheet = from('Timesheet').where('timesheetId', timesheetId).queryOne()
         assert !timesheet
     }
 
     @Test
     @Order(22)
     void testCreateTimesheets() {
+        String comments = testParams.comments ?: 'Test timesheet for test parties'
         List partyIdList = ['TestParty', 'TestParty-1']
         Map serviceCtx = [
                 partyIdList: partyIdList,
-                comments: 'Test timesheet for test parties',
+                comments: comments,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createTimesheets', serviceCtx)
@@ -458,7 +515,7 @@ class WorkEffortTests implements JupiterTestHelper {
 
         for (String partyId : partyIdList) {
             List<GenericValue> timesheetList = from('Timesheet')
-                .where('partyId', partyId, 'comments', 'Test timesheet for test parties')
+                .where('partyId', partyId, 'comments', comments)
                 .queryList()
             assert timesheetList
         }
@@ -467,9 +524,11 @@ class WorkEffortTests implements JupiterTestHelper {
     @Test
     @Order(23)
     void testCreateTimesheetForThisWeek() {
+        String partyId = testParams.partyId ?: 'TestParty-1'
+        String comments = testParams.comments ?: 'Test timesheet'
         Map serviceCtx = [
-                partyId: 'TestParty-1',
-                comments: 'Test timesheet',
+                partyId: partyId,
+                comments: comments,
                 requiredDate: java.sql.Timestamp.valueOf('2009-09-06 00:00:00.0'),
                 userLogin: userLogin,
         ]
@@ -479,17 +538,20 @@ class WorkEffortTests implements JupiterTestHelper {
 
         GenericValue timesheet = from('Timesheet').where('timesheetId', serviceResult.timesheetId).queryOne()
         assert timesheet
-        assert timesheet.partyId == 'TestParty-1'
+        assert timesheet.partyId == partyId
         assert timesheet.fromDate == java.sql.Timestamp.valueOf('2009-09-06 00:00:00.0')
     }
 
     @Test
     @Order(24)
     void testAddTimesheetToNewInvoice() {
+        String partyId = testParams.partyId ?: 'TestParty-1'
+        String partyIdFrom = testParams.partyIdFrom ?: 'TestCompany'
+        String timesheetId = testParams.timesheetId ?: 'TestTimesheet-2'
         Map serviceCtx = [
-                partyId: 'TestParty-1',
-                partyIdFrom: 'TestCompany',
-                timesheetId: 'TestTimesheet-2',
+                partyId: partyId,
+                partyIdFrom: partyIdFrom,
+                timesheetId: timesheetId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('addTimesheetToNewInvoice', serviceCtx)
@@ -498,15 +560,17 @@ class WorkEffortTests implements JupiterTestHelper {
 
         GenericValue invoice = from('Invoice').where('invoiceId', serviceResult.invoiceId).queryOne()
         assert invoice
-        assert invoice.partyId == 'TestParty-1'
+        assert invoice.partyId == partyId
     }
 
     @Test
     @Order(25)
     void testCreateTimeEntry() {
+        String workEffortId = testParams.workEffortId ?: 'TestWorkeffort-2'
+        String comments = testParams.comments ?: 'Test Time Entry'
         Map serviceCtx = [
-                workEffortId: 'TestWorkeffort-2',
-                comments: 'Test Time Entry',
+                workEffortId: workEffortId,
+                comments: comments,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('createTimeEntry', serviceCtx)
@@ -515,49 +579,58 @@ class WorkEffortTests implements JupiterTestHelper {
 
         GenericValue timeEntry = from('TimeEntry').where('timeEntryId', serviceResult.timeEntryId).queryOne()
         assert timeEntry
-        assert timeEntry.workEffortId == 'TestWorkeffort-2'
-        assert timeEntry.comments == 'Test Time Entry'
+        assert timeEntry.workEffortId == workEffortId
+        assert timeEntry.comments == comments
     }
 
     @Test
     @Order(26)
     void testUpdateTimeEntry() {
+        String timeEntryId = testParams.timeEntryId ?: 'TestTimeEntry-1'
+        String timesheetId = testParams.timesheetId ?: 'TestTimesheet-4'
         Map serviceCtx = [
-                timeEntryId: 'TestTimeEntry-1',
-                timesheetId: 'TestTimesheet-4',
+                timeEntryId: timeEntryId,
+                timesheetId: timesheetId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('updateTimeEntry', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue timeEntry = from('TimeEntry').where('timeEntryId', 'TestTimeEntry-1').queryOne()
+        GenericValue timeEntry = from('TimeEntry').where('timeEntryId', timeEntryId).queryOne()
         assert timeEntry
-        assert timeEntry.timesheetId == 'TestTimesheet-4'
+        assert timeEntry.timesheetId == timesheetId
     }
 
     @Test
     @Order(27)
     void testDeleteTimeEntry() {
+        String timeEntryId = testParams.timeEntryId ?: 'TestTimeEntry-2'
         Map serviceCtx = [
-                timeEntryId: 'TestTimeEntry-2',
+                timeEntryId: timeEntryId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('deleteTimeEntry', serviceCtx)
         assert ServiceUtil.isSuccess(serviceResult)
 
-        GenericValue timeEntry = from('TimeEntry').where('timeEntryId', 'TestTimeEntry-2').queryOne()
+        GenericValue timeEntry = from('TimeEntry').where('timeEntryId', timeEntryId).queryOne()
         assert !timeEntry
     }
 
     @Test
     @Order(28)
     void testCreateEventService() {
+        String workEffortTypeId = testParams.workEffortTypeId ?: 'EVENT'
+        String quickAssignPartyId = testParams.quickAssignPartyId ?: 'DemoCustomer'
+        String workEffortName = testParams.workEffortName ?: 'Create Work Effort'
+        String currentStatusId = testParams.currentStatusId ?: 'CAL_TENTATIVE'
+        String workEffortName1 = testParams.workEffortName1 ?: 'Update an event'
+        String currentStatusId1 = testParams.currentStatusId1 ?: 'CAL_ACCEPTED'
         GenericValue systemLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         Map createCtx = [
-                workEffortTypeId: 'EVENT',
-                quickAssignPartyId: 'DemoCustomer',
-                workEffortName: 'Create Work Effort',
-                currentStatusId: 'CAL_TENTATIVE',
+                workEffortTypeId: workEffortTypeId,
+                quickAssignPartyId: quickAssignPartyId,
+                workEffortName: workEffortName,
+                currentStatusId: currentStatusId,
                 userLogin: systemLogin,
         ]
         Map createResult = dispatcher.runSync('createWorkEffort', createCtx)
@@ -567,9 +640,9 @@ class WorkEffortTests implements JupiterTestHelper {
 
         Map updateCtx = [
                 workEffortId: workEffortId,
-                workEffortTypeId: 'EVENT',
-                workEffortName: 'Update an event',
-                currentStatusId: 'CAL_ACCEPTED',
+                workEffortTypeId: workEffortTypeId,
+                workEffortName: workEffortName1,
+                currentStatusId: currentStatusId1,
                 userLogin: systemLogin,
         ]
         Map updateResult = dispatcher.runSync('updateWorkEffort', updateCtx)
@@ -577,20 +650,28 @@ class WorkEffortTests implements JupiterTestHelper {
 
         GenericValue workEffort = from('WorkEffort').where('workEffortId', workEffortId).queryOne()
         assert workEffort
-        assert workEffort.workEffortTypeId == 'EVENT'
-        assert workEffort.workEffortName == 'Update an event'
-        assert workEffort.currentStatusId == 'CAL_ACCEPTED'
+        assert workEffort.workEffortTypeId == workEffortTypeId
+        assert workEffort.workEffortName == workEffortName1
+        assert workEffort.currentStatusId == currentStatusId1
     }
 
     @Test
     @Order(29)
     void testCreateProjectService() {
+        String workEffortTypeId = testParams.workEffortTypeId ?: 'PROJECT'
+        String quickAssignPartyId = testParams.quickAssignPartyId ?: 'DemoCustomer'
+        String workEffortName = testParams.workEffortName ?: 'Create a project'
+        String currentStatusId = testParams.currentStatusId ?: 'CAL_TENTATIVE'
+        String workEffortName1 = testParams.workEffortName1 ?: 'Update a project'
+        String currentStatusId1 = testParams.currentStatusId1 ?: 'CAL_ACCEPTED'
+        String noteParty = testParams.noteParty ?: 'DemoCustomer'
+        String noteInfo = testParams.noteInfo ?: "This is a note for party '${noteParty}'"
         GenericValue systemLogin = from('UserLogin').where('userLoginId', 'system').queryOne()
         Map createCtx = [
-                workEffortTypeId: 'PROJECT',
-                quickAssignPartyId: 'DemoCustomer',
-                workEffortName: 'Create a project',
-                currentStatusId: 'CAL_TENTATIVE',
+                workEffortTypeId: workEffortTypeId,
+                quickAssignPartyId: quickAssignPartyId,
+                workEffortName: workEffortName,
+                currentStatusId: currentStatusId,
                 userLogin: systemLogin,
         ]
         Map createResult = dispatcher.runSync('createWorkEffort', createCtx)
@@ -600,9 +681,9 @@ class WorkEffortTests implements JupiterTestHelper {
 
         Map updateCtx = [
                 workEffortId: workEffortId,
-                workEffortTypeId: 'PROJECT',
-                workEffortName: 'Update a project',
-                currentStatusId: 'CAL_ACCEPTED',
+                workEffortTypeId: workEffortTypeId,
+                workEffortName: workEffortName1,
+                currentStatusId: currentStatusId1,
                 userLogin: systemLogin,
         ]
         Map updateResult = dispatcher.runSync('updateWorkEffort', updateCtx)
@@ -610,8 +691,8 @@ class WorkEffortTests implements JupiterTestHelper {
 
         Map noteCtx = [
                 workEffortId: workEffortId,
-                noteParty: 'DemoCustomer',
-                noteInfo: "This is a note for party 'DemoCustomer'",
+                noteParty: noteParty,
+                noteInfo: noteInfo,
                 userLogin: systemLogin,
         ]
         Map noteResult = dispatcher.runSync('createWorkEffortNote', noteCtx)
@@ -619,22 +700,24 @@ class WorkEffortTests implements JupiterTestHelper {
 
         GenericValue workEffort = from('WorkEffort').where('workEffortId', workEffortId).queryOne()
         assert workEffort
-        assert workEffort.workEffortTypeId == 'PROJECT'
-        assert workEffort.workEffortName == 'Update a project'
-        assert workEffort.currentStatusId == 'CAL_ACCEPTED'
+        assert workEffort.workEffortTypeId == workEffortTypeId
+        assert workEffort.workEffortName == workEffortName1
+        assert workEffort.currentStatusId == currentStatusId1
 
         GenericValue noteData = from('NoteData').where('noteId', noteResult.noteId).queryOne()
         assert noteData
-        assert noteData.noteParty == 'DemoCustomer'
-        assert noteData.noteInfo == "This is a note for party 'DemoCustomer'"
+        assert noteData.noteParty == noteParty
+        assert noteData.noteInfo == noteInfo
     }
 
     @Test
     @Order(30)
     void testGetTimeEntryRate() {
+        String timeEntryId = testParams.timeEntryId ?: 'TestTimeEntry-3'
+        String currencyUomId = testParams.currencyUomId ?: 'USD'
         Map serviceCtx = [
-                timeEntryId: 'TestTimeEntry-3',
-                currencyUomId: 'USD',
+                timeEntryId: timeEntryId,
+                currencyUomId: currencyUomId,
                 userLogin: userLogin,
         ]
         Map serviceResult = dispatcher.runSync('getTimeEntryRate', serviceCtx)
@@ -646,7 +729,7 @@ class WorkEffortTests implements JupiterTestHelper {
                                                                      'rateTypeId',
                                                                      'STANDARD',
                                                                      'rateCurrencyUomId',
-                                                                     'USD').queryList()
+                                                                     currencyUomId).queryList()
         GenericValue rateAmount = rateAmountList ? rateAmountList[0] : null
         assert rateAmount
     }


### PR DESCRIPTION
This migrates the Jupiter test classes under applications/* (accounting, content,
manufacturing, marketing, order, party, product, workeffort) so their fixture values
can be overridden via testParams when a run is driven through the test-run REST API,
instead of only ever running with their hardcoded defaults.

Existing hardcoded literals remain the default for every test method, so current
behavior (gradle test, testIntegration, ofbiz --test) is unchanged unless a caller
explicitly supplies testParams.

No new files added - this is test-source changes only, across the 8 components
listed above.