### PR TITLE
Raise Groovy compile worker heap to fix docker image build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,16 @@ tasks.withType(JavaCompile) {
     }
 }
 
+// The Groovy compiler forks to an isolated worker process whose default heap (512m) is too
+// small to jointly compile the full framework + applications + plugins Groovy source set in one
+// pass; on Linux this reliably fails compileGroovy with a bare "parsing failed" (no further
+// detail) rather than an explicit OutOfMemoryError. Raise the worker heap to avoid it. See the
+// "Build and push framework with plugins docker image" job, which is the one that pulls in the
+// full plugins/ source tree and is where this was first observed.
+tasks.withType(GroovyCompile) {
+    groovyOptions.forkOptions.memoryMaximumSize = '2g'
+}
+
 // Enables Zip larger than 4 GB and more than 65535 entries
 tasks.withType(Zip) { zip64 = true }
 


### PR DESCRIPTION
## Problem

Trunk's "Build and push docker images" workflow has been failing on every run since commit 8312aec4 (unrelated to this PR's fix), specifically on the "Build and push framework with plugins docker image" step:

```
> Task :compileGroovy
parsing failed

> Task :compileGroovy FAILED
...
Execution failed for task ':compileGroovy'.
> Compilation failed; see the compiler error output for details.
```

No file, no line, no further detail is ever printed, which reads like a source syntax error but isn't one.

## Root cause

The `compileGroovy` task forks to an isolated Gradle worker process whose default heap (512m) is too small to jointly compile the full framework + applications + **plugins** Groovy source set in one pass. That step is the only one of the three docker builds in the workflow that pulls in the full `plugins/` source tree (via `pullAllPluginsSource.sh`), which is why only it fails while the runtime and demo image builds succeed.

On Linux, exhausting that heap during compilation surfaces as a bare `parsing failed` rather than an explicit `OutOfMemoryError`.

## Fix

Raise the Groovy compile worker's heap:

```groovy
tasks.withType(GroovyCompile) {
    groovyOptions.forkOptions.memoryMaximumSize = '2g'
}
```

## Verification

Reproduced the failure locally with the real `apache/ofbiz-plugins` trunk content (cloned the same way `pullAllPluginsSource.sh` does) via `docker build --target builder --no-cache .`, matching the failing CI step:
- **Without this change**: fails identically, `parsing failed`.
- **With this change**: `BUILD SUCCESSFUL in 5m 14s, 25 actionable tasks: 25 executed`, all the way through `generateSecretKeys distTar`.

Also confirmed standalone parsing of every individual `.groovy` file in `plugins/` succeeds, ruling out an actual syntax error in any single file and pointing at the joint-compilation resource limit instead.