### PR TITLE
Fix content visibility check in help screens

### DIFF
--- a/applications/content/src/main/groovy/org/apache/ofbiz/content/content/ResolveRenderedDataResource.groovy
+++ b/applications/content/src/main/groovy/org/apache/ofbiz/content/content/ResolveRenderedDataResource.groovy
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*/
+package org.apache.ofbiz.content.content
+
+import org.apache.ofbiz.base.util.GeneralException
+
+// A <content content-id="${contentId}"/> widget does not necessarily render contentId's own
+// DataResource: ContentWorker.findContentForRendering() can redirect a WEB_SITE_PUB_PT publish
+// point to its PUBLISH_LINK-ed target, or substitute an ALTERNATE_LOCALE sibling. Resolve the
+// same record here so a caller can check isPublic against what will actually be rendered.
+renderedDataResource = null
+if (contentId) {
+    try {
+        resolvedContent = ContentWorker.findContentForRendering(delegator, contentId, locale, null, null, true)
+        if (resolvedContent.dataResourceId) {
+            renderedDataResource = from('DataResource').where('dataResourceId', resolvedContent.dataResourceId).cache().queryOne()
+        }
+    } catch (GeneralException | IOException e) {
+        // contentId does not exist, or e.g. a publish point has no currently published target --
+        // leave renderedDataResource null so callers deny access by default
+        logVerbose("Could not resolve content for rendering [${contentId}]: ${e.message}")
+    }
+}
+context.renderedDataResource = renderedDataResource

--- a/themes/common-theme/widget/HelpScreens.xml
+++ b/themes/common-theme/widget/HelpScreens.xml
@@ -144,10 +144,12 @@ under the License.
                 <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="CommonExtUiLabels" map-name="uiLabelMap" global="true"/>
                 <set field="contentId" from-field="parameters.contentId" default-value="${contentId}"/>
-                <entity-one entity-name="Content" value-field="showDocumentHelpContent"/>
-                <entity-one entity-name="DataResource" value-field="showDocumentHelpDataResource" auto-field-map="false">
-                    <field-map field-name="dataResourceId" from-field="showDocumentHelpContent.dataResourceId"/>
-                </entity-one>
+                <!-- must check the DataResource that will actually be rendered below, not just contentId's
+                     own: content rendering can silently substitute a different record (WEB_SITE_PUB_PT
+                     publish-point redirection, ALTERNATE_LOCALE substitution); see
+                     ResolveRenderedDataResource.groovy -->
+                <script location="component://content/src/main/groovy/org/apache/ofbiz/content/content/ResolveRenderedDataResource.groovy"/>
+                <set field="showDocumentHelpDataResource" from-field="renderedDataResource"/>
             </actions>
             <widgets>
                 <!-- an unauthenticated caller (e.g. via showHelpPublic) must not be able to pull an arbitrary

--- a/themes/common-theme/widget/HelpScreens.xml
+++ b/themes/common-theme/widget/HelpScreens.xml
@@ -144,11 +144,30 @@ under the License.
                 <property-map resource="CommonUiLabels" map-name="uiLabelMap" global="true"/>
                 <property-map resource="CommonExtUiLabels" map-name="uiLabelMap" global="true"/>
                 <set field="contentId" from-field="parameters.contentId" default-value="${contentId}"/>
+                <entity-one entity-name="Content" value-field="showDocumentHelpContent"/>
+                <entity-one entity-name="DataResource" value-field="showDocumentHelpDataResource" auto-field-map="false">
+                    <field-map field-name="dataResourceId" from-field="showDocumentHelpContent.dataResourceId"/>
+                </entity-one>
             </actions>
             <widgets>
-                <container id="Document">
-                    <content content-id="${contentId}" />
-                </container>
+                <!-- an unauthenticated caller (e.g. via showHelpPublic) must not be able to pull an arbitrary
+                     contentId; only content whose DataResource is explicitly marked isPublic=Y may be shown -->
+                <section>
+                    <condition>
+                        <or>
+                            <not><if-empty field="userLogin"/></not>
+                            <if-compare field="showDocumentHelpDataResource.isPublic" operator="equals" value="Y"/>
+                        </or>
+                    </condition>
+                    <widgets>
+                        <container id="Document">
+                            <content content-id="${contentId}" />
+                        </container>
+                    </widgets>
+                    <fail-widgets>
+                        <label style="h3">${uiLabelMap.CommonPermissionError}</label>
+                    </fail-widgets>
+                </section>
             </widgets>
         </section>
     </screen>


### PR DESCRIPTION
`showDocumentHelp` now resolves the DataResource that will actually be rendered (accounting for publish-point redirection and locale-alternate substitution) before checking visibility, instead of checking the literally requested content ID. This keeps the visibility check consistent with what's actually shown, and corrects which help content is available to anonymous users versus logged-in users.