### PR TITLE
Fixed: javadoc build fails with connection timeout fetching Groovy external docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ javadoc {
         links(
             'https://docs.oracle.com/en/java/javase/17/docs/api/',
             'https://tomcat.apache.org/tomcat-10.1-doc/servletapi/',
-            'http://docs.groovy-lang.org/docs/groovy-4.0.22/html/api',
+            'https://docs.groovy-lang.org/docs/groovy-4.0.22/html/api',
             'https://commons.apache.org/proper/commons-cli/apidocs'
         )
     }


### PR DESCRIPTION
The javadoc task's links() config referenced the Groovy API docs over plain http, which is slow/unreliable and was timing out on CI while the same host responds quickly over https. Switched to https, matching the other external javadoc links already in this block.