### PR TITLE
Improved: add permission and path checks to XmlDsDump.groovy (#1712)

### DIFF
--- a/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/XmlDsDump.groovy
+++ b/framework/webtools/src/main/groovy/org/apache/ofbiz/webtools/entity/XmlDsDump.groovy
@@ -19,6 +19,7 @@
 package org.apache.ofbiz.webtools.entity
 
 import org.apache.ofbiz.base.util.Debug
+import org.apache.ofbiz.base.util.GeneralException
 import org.apache.ofbiz.base.util.UtilFormatOut
 import org.apache.ofbiz.entity.condition.EntityComparisonOperator
 import org.apache.ofbiz.entity.condition.EntityCondition
@@ -26,6 +27,15 @@ import org.apache.ofbiz.entity.condition.EntityJoinOperator
 import org.apache.ofbiz.entity.model.ModelViewEntity
 import org.apache.ofbiz.entity.transaction.TransactionUtil
 import org.apache.ofbiz.entity.util.EntityFindOptions
+import org.apache.ofbiz.security.SecurityUtil
+
+// Kept in sync with the permission check the page's own decorator and template already
+// perform (CommonScreens.xml#CommonImportExportDecorator, XmlDsDump.ftl); this script must
+// not run its logic -- especially the file/directory writes further down -- ahead of that
+// check, since screen actions run unconditionally, before any widget-level permission gate.
+if (!security.hasPermission('ENTITY_MAINT', session)) {
+    return
+}
 
 outpath = parameters.outpath
 filename = parameters.filename
@@ -198,7 +208,18 @@ if (passedEntityNames) {
             if (outpath && !(filename.contains('/') && filename.contains('\\'))) {
                 filename = outpath + File.separator + filename
             }
-            writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(filename), 'UTF-8')))
+            File outfile = new File(filename)
+            allowedPath = true
+            try {
+                SecurityUtil.checkOfbizFileAllowList(outfile)
+            } catch (GeneralException e) {
+                context.errorMessage = e.getMessage()
+                allowedPath = false
+            }
+            if (!allowedPath) {
+                return
+            }
+            writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outfile), 'UTF-8')))
             writer.println('<?xml version="1.0" encoding="UTF-8"?>')
             writer.println('<entity-engine-xml>')
 
@@ -250,6 +271,16 @@ if (passedEntityNames) {
         context.results = results
         if (outpath && !filename) {
             outdir = new File(outpath)
+            allowedPath = true
+            try {
+                SecurityUtil.checkOfbizFileAllowList(outdir)
+            } catch (GeneralException e) {
+                context.errorMessage = e.getMessage()
+                allowedPath = false
+            }
+            if (!allowedPath) {
+                return
+            }
             if (!outdir.exists()) {
                 outdir.mkdir()
             }


### PR DESCRIPTION
- Added a permission check at the top of the script, matching the pattern used by sibling scripts and the equivalent Java export service in this package.

- Added destination path validation (via SecurityUtil.checkOfbizFileAllowList) for both the single-file and directory export branches, before any file/directory write happens.

Cherry-picked from trunk commit c9a27ad03a44262adf46667152cb2fa244177573, adjusted for the EntityFindOptions-based query code still on this branch (trunk's copy of this file has since moved to the EntityQuery API, unrelated to this fix).

Thank you Krishna Uprit for your contribution.