### PR TITLE
Improved: escape link parameter values in MacroScreenRenderer.renderLink (#1711)

### DIFF
--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroScreenRenderer.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/renderer/macro/MacroScreenRenderer.java
@@ -125,7 +125,7 @@ public class MacroScreenRenderer implements ScreenStringRenderer {
                 Object value = parameter.getValue();
                 if (value instanceof String) {
                     sb.append('"');
-                    sb.append(((String) value).replace("\\", "\\\\").replace("\"", "\\\"").replace("$", "\\$"));
+                    sb.append(((String) value).replace("\\", "\\\\").replace("\"", "\\\"").replace("{", "\\{"));
                     sb.append('"');
                 } else {
                     sb.append(value);
@@ -134,6 +134,10 @@ public class MacroScreenRenderer implements ScreenStringRenderer {
         }
         sb.append(" />");
         executeMacro(writer, sb.toString());
+    }
+
+    private static String escapeFtlSingleQuoted(String value) {
+        return value == null ? "" : value.replace("\\", "\\\\").replace("'", "\\'").replace("{", "\\{");
     }
 
     private Environment getEnvironment(Appendable writer) throws TemplateException, IOException {
@@ -298,10 +302,10 @@ public class MacroScreenRenderer implements ScreenStringRenderer {
                     parameters.append(",");
                 }
                 parameters.append("{'name':'");
-                parameters.append(parameter.getKey());
+                parameters.append(escapeFtlSingleQuoted(parameter.getKey()));
                 parameters.append("'");
                 parameters.append(",'value':'");
-                parameters.append(parameter.getValue());
+                parameters.append(escapeFtlSingleQuoted(parameter.getValue()));
                 parameters.append("'}");
             }
             parameters.append("]");


### PR DESCRIPTION
- Parameter names and values were appended to the generated FTL macro call without escaping. Added escapeFtlSingleQuoted() to escape these values before they are embedded in the macro string, consistent with escaping already used elsewhere in this class.

- Corrected existing escaping in the other executeMacro overload, which escaped a lone dollar sign with a backslash - not a valid FTL string escape, and one that failed to parse for any value containing a plain "$". Escaping the following brace instead is sufficient and valid syntax.

Cherry-picked from trunk commit 9d096f9af85db998f028643a0b169fa6b84349e4.

Thank you Krishna Uprit for your contribution.
