### PR TITLE
Improved: authorization checks on Catalog and Order Manager helper routes

### DIFF
--- a/applications/order/webapp/ordermgr/WEB-INF/controller.xml
+++ b/applications/order/webapp/ordermgr/WEB-INF/controller.xml
@@ -674,7 +674,7 @@ under the License.
         <response name="error" type="request" value="orderentry"/>
     </request-map>
     <request-map uri="quickadd">
-        <security https="false" auth="false"/>
+        <security https="true" auth="true"/>
         <response name="success" type="view" value="quickadd"/>
     </request-map>
 
@@ -2044,7 +2044,7 @@ under the License.
     <view-map name="category" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#category"/>
     <view-map name="product" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#product"/>
     <view-map name="compareProducts" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#compareProducts"/>
-    <view-map name="quickadd" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#quickadd" auth="false"/>
+    <view-map name="quickadd" type="screen" page="component://order/widget/ordermgr/OrderEntryCatalogScreens.xml#quickadd"/>
     <view-map name="AddGiftCertificate" type="screen" page="component://order/widget/ordermgr/OrderEntryCartScreens.xml#AddGiftCertificate"/>
 
     <view-map name="custsetting" type="screen" page="component://order/widget/ordermgr/OrderEntryOrderScreens.xml#CustSettings"/>

--- a/applications/product/config/ProductErrorUiLabels.xml
+++ b/applications/product/config/ProductErrorUiLabels.xml
@@ -1614,4 +1614,7 @@
     <property key="ProductRequiredFieldMissingTotalIssuedQty">
         <value xml:lang="en">Required Field Missing :Total Issued Qty. </value>
     </property>
+    <property key="CatalogViewPermissionError">
+        <value xml:lang="en">You do not have permission to view Catalog Manager category data.</value>
+    </property>
 </resource>

--- a/applications/product/src/main/java/org/apache/ofbiz/product/category/CategoryServices.java
+++ b/applications/product/src/main/java/org/apache/ofbiz/product/category/CategoryServices.java
@@ -32,6 +32,7 @@ import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.GeneralException;
 import org.apache.ofbiz.base.util.UtilDateTime;
 import org.apache.ofbiz.base.util.UtilGenerics;
+import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.base.util.UtilMisc;
 import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilValidate;
@@ -46,6 +47,7 @@ import org.apache.ofbiz.entity.util.EntityQuery;
 import org.apache.ofbiz.entity.util.EntityUtil;
 import org.apache.ofbiz.product.catalog.CatalogWorker;
 import org.apache.ofbiz.product.product.ProductWorker;
+import org.apache.ofbiz.security.Security;
 import org.apache.ofbiz.service.DispatchContext;
 import org.apache.ofbiz.service.LocalDispatcher;
 import org.apache.ofbiz.service.ServiceUtil;
@@ -461,6 +463,15 @@ public class CategoryServices {
     // Please note : the structure of map in this function is according to the JSON data map of the jsTree
     @SuppressWarnings("unchecked")
     public static String getChildCategoryTree(HttpServletRequest request, HttpServletResponse response) {
+        Security security = (Security) request.getAttribute("security");
+        if (security == null || !security.hasEntityPermission("CATALOG", "_VIEW", request.getSession())) {
+            String errMsg = UtilProperties.getMessage(RES_ERROR, "CatalogViewPermissionError", UtilHttp.getLocale(request));
+            request.setAttribute("_ERROR_MESSAGE_", errMsg);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            Debug.logWarning("Unauthorized attempt to access getChild by productCategoryId param [%s]", MODULE,
+                    request.getParameter("productCategoryId"));
+            return "error";
+        }
         Delegator delegator = (Delegator) request.getAttribute("delegator");
         String productCategoryId = request.getParameter("productCategoryId");
         String isCatalog = request.getParameter("isCatalog");

--- a/applications/product/src/main/java/org/apache/ofbiz/product/store/ProductStoreEvents.java
+++ b/applications/product/src/main/java/org/apache/ofbiz/product/store/ProductStoreEvents.java
@@ -27,19 +27,32 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.ofbiz.base.util.Debug;
+import org.apache.ofbiz.base.util.UtilHttp;
 import org.apache.ofbiz.base.util.UtilMisc;
+import org.apache.ofbiz.base.util.UtilProperties;
 import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.GenericEntityException;
 import org.apache.ofbiz.entity.GenericValue;
 import org.apache.ofbiz.entity.util.EntityQuery;
+import org.apache.ofbiz.security.Security;
 
 public class ProductStoreEvents {
 
     private static final String MODULE = ProductStoreWorker.class.getName();
+    private static final String RES_ERROR = "ProductErrorUiLabels";
 
     // Please note : the structure of map in this function is according to the JSON data map of the jsTree
     public static String getChildProductStoreGroupTree(HttpServletRequest request, HttpServletResponse response) {
+        Security security = (Security) request.getAttribute("security");
+        if (security == null || !security.hasEntityPermission("CATALOG", "_VIEW", request.getSession())) {
+            String errMsg = UtilProperties.getMessage(RES_ERROR, "CatalogViewPermissionError", UtilHttp.getLocale(request));
+            request.setAttribute("_ERROR_MESSAGE_", errMsg);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            Debug.logWarning("Unauthorized attempt to access getProductStoreGroupRollupHierarchy by parentGroupId param [%s]", MODULE,
+                    request.getParameter("parentGroupId"));
+            return "error";
+        }
         Delegator delegator = (Delegator) request.getAttribute("delegator");
         String parentGroupId = request.getParameter("parentGroupId");
         String onclickFunction = request.getParameter("onclickFunction");

--- a/applications/product/webapp/catalog/WEB-INF/controller.xml
+++ b/applications/product/webapp/catalog/WEB-INF/controller.xml
@@ -1467,7 +1467,7 @@ under the License.
         <response name="error" type="view" value="EditProductStoreGroup"/>
     </request-map>
     <request-map uri="getProductStoreGroupRollupHierarchy">
-        <security auth="false" https="true"/>
+        <security auth="true" https="true"/>
         <event type="java" path="org.apache.ofbiz.product.store.ProductStoreEvents" invoke="getChildProductStoreGroupTree"/>
         <response name="success" type="request" value="json"/>
         <response name="error" type="request" value="json"/>
@@ -3026,7 +3026,7 @@ under the License.
     </request-map>
 
     <request-map uri="getChild">
-        <security auth="false" https="true"/>
+        <security auth="true" https="true"/>
         <event type="java" path="org.apache.ofbiz.product.category.CategoryServices" invoke="getChildCategoryTree"/>
         <response name="success" type="request" value="json"/>
         <response name="error" type="request" value="json"/>


### PR DESCRIPTION
Improved: authorization checks on Catalog and Order Manager helper routes
- getChild and getProductStoreGroupRollupHierarchy in the Catalog Manager
  now require login and a CATALOG _VIEW permission check, matching the
  pattern used elsewhere in this package.
- Order Manager's quickadd request-map and view-map no longer carry a
  stray auth=false override, so it follows the webapp's normal login
  requirement like its sibling views.