### PR TITLE
Improved: Align survey template location resolution with other widget/template loaders (#1730)

### DIFF
--- a/applications/content/src/main/java/org/apache/ofbiz/content/survey/SurveyWrapper.java
+++ b/applications/content/src/main/java/org/apache/ofbiz/content/survey/SurveyWrapper.java
@@ -175,6 +175,11 @@ public class SurveyWrapper {
      * @throws SurveyWrapperException
      */
     public Writer render(String templatePath) throws SurveyWrapperException {
+        if (UtilValidate.isUrlInStringAndDoesNotStartByComponentProtocol(templatePath)) {
+            String errMsg = "Problem getting the template for Survey from URL: " + templatePath;
+            Debug.logError(errMsg, MODULE);
+            throw new IllegalArgumentException(errMsg);
+        }
         URL templateUrl = null;
         try {
             templateUrl = FlexibleLocation.resolveLocation(templatePath);


### PR DESCRIPTION
- SurveyWrapper currently resolves its template location on its own, separately from the other widget/template loaders in the codebase (screens, forms, grids, menus, themes).

- This change updates SurveyWrapper.render(String) to resolve its template location the same way those other loaders already do, so resolution is consistent across all loaders in the framework.

Thank you Krishna Uprit for the contribution.

(cherry picked from commit d20b0fd07e6387b5318f78d446458d3644a839ac)