### PR TITLE
Reject party/role combinations the party does not hold for BudgetRole (OFBIZ-12371)

### DIFF
--- a/applications/accounting/servicedef/secas.xml
+++ b/applications/accounting/servicedef/secas.xml
@@ -118,6 +118,13 @@ under the License.
     </eca>
 
     <!-- budget role ecas -->
+    <!-- reject an improbable party/role combination before it reaches ensurePartyRole below,
+         which would otherwise silently create a spurious PartyRole - OFBIZ-12371 -->
+    <eca service="createBudgetRole" event="in-validate">
+        <condition field-name="roleTypeId" operator="is-not-empty"/>
+        <condition field-name="partyId" operator="is-not-empty"/>
+        <action service="checkPartyRoleExists" mode="sync"/>
+    </eca>
     <eca service="createBudgetRole" event="invoke">
         <action service="ensurePartyRole" mode="sync" run-as-user="system"/>
     </eca>

--- a/applications/accounting/servicedef/secas.xml
+++ b/applications/accounting/servicedef/secas.xml
@@ -47,6 +47,19 @@ under the License.
         <action service="updatePaymentMethodAddress" mode="sync"/>
     </eca>
 
+    <!-- reject an improbable party/role combination (party does not already hold roleTypeId) before it
+         reaches ensurePartyRole below, which would otherwise silently create a spurious PartyRole - OFBIZ-12370/12372/12373 -->
+    <eca service="createInvoiceRole" event="in-validate">
+        <condition field-name="roleTypeId" operator="is-not-empty"/>
+        <condition field-name="partyId" operator="is-not-empty"/>
+        <action service="checkPartyRoleExists" mode="sync"/>
+    </eca>
+
+    <eca service="createBillingAccountRole" event="in-validate">
+        <condition field-name="roleTypeId" operator="is-not-empty"/>
+        <condition field-name="partyId" operator="is-not-empty"/>
+        <action service="checkPartyRoleExists" mode="sync"/>
+    </eca>
     <eca service="createBillingAccountRole" event="invoke">
         <condition field-name="roleTypeId" operator="is-not-empty"/>
         <condition field-name="partyId" operator="is-not-empty"/>
@@ -110,6 +123,13 @@ under the License.
     </eca>
 
     <!-- financial account role ecas -->
+    <!-- reject an improbable party/role combination before it reaches ensurePartyRole below,
+         which would otherwise silently create a spurious PartyRole - OFBIZ-12373 -->
+    <eca service="createFinAccountRole" event="in-validate">
+        <condition field-name="roleTypeId" operator="is-not-empty"/>
+        <condition field-name="partyId" operator="is-not-empty"/>
+        <action service="checkPartyRoleExists" mode="sync"/>
+    </eca>
     <eca service="createFinAccountRole" event="invoke">
         <action service="ensurePartyRole" mode="sync" run-as-user="system"/>
     </eca>

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBillingAccountTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBillingAccountTests.groovy
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
+package org.apache.ofbiz.accounting.accounting
+
+import org.apache.ofbiz.entity.GenericValue
+import org.apache.ofbiz.service.ServiceUtil
+import org.apache.ofbiz.testtools.JunitJupiterTest
+import org.apache.ofbiz.testtools.JupiterTestHelper
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+
+@JunitJupiterTest
+class AutoAcctgBillingAccountTests implements JupiterTestHelper {
+
+    private String billingAccountId
+
+    @Test
+    @Order(1)
+    void testCreateBillingAccount() {
+        Map serviceCtx = [
+                accountLimit: 1000,
+                description: 'AutoAcctgBillingAccountTests billing account',
+                userLogin: userLogin
+        ]
+        Map serviceResult = dispatcher.runSync('createBillingAccount', serviceCtx)
+        assert ServiceUtil.isSuccess(serviceResult)
+        billingAccountId = serviceResult.billingAccountId
+        assert billingAccountId
+
+        GenericValue billingAccount = from('BillingAccount').where('billingAccountId', billingAccountId).queryOne()
+        assert billingAccount
+    }
+
+    // DEMO_COMPANY already holds the INTERNAL_ORGANIZATIO role (see AccountingTestsData.xml), so this
+    // combination is legitimate and must still succeed after OFBIZ-12372's validation is in place.
+    @Test
+    @Order(2)
+    void testCreateBillingAccountRole() {
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        String roleTypeId = 'INTERNAL_ORGANIZATIO'
+        Map serviceCtx = [
+                billingAccountId: billingAccountId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                userLogin: userLogin
+        ]
+        Map serviceResult = dispatcher.runSync('createBillingAccountRole', serviceCtx)
+        assert ServiceUtil.isSuccess(serviceResult)
+
+        GenericValue billingAccountRole = from('BillingAccountRole')
+                .where('billingAccountId', billingAccountId, 'partyId', partyId, 'roleTypeId', roleTypeId)
+                .queryOne()
+        assert billingAccountRole
+    }
+
+    // OFBIZ-12372: DEMO_COMPANY does not hold the CARRIER role (only INTERNAL_ORGANIZATIO/SUPPLIER,
+    // see AccountingTestsData.xml), so this combination must be rejected instead of the
+    // createBillingAccountRole -> ensurePartyRole eca silently fabricating a PartyRole record for a
+    // role the party was never given.
+    @Test
+    @Order(3)
+    void testCreateBillingAccountRoleRejectsPartyWithoutRole() {
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        Map serviceCtx = [
+                billingAccountId: billingAccountId,
+                partyId: partyId,
+                roleTypeId: 'CARRIER',
+                userLogin: userLogin
+        ]
+        Map serviceResult = dispatcher.runSync('createBillingAccountRole', serviceCtx)
+        assert ServiceUtil.isError(serviceResult)
+
+        GenericValue billingAccountRole = from('BillingAccountRole')
+                .where('billingAccountId', billingAccountId, 'partyId', partyId, 'roleTypeId', 'CARRIER')
+                .queryOne()
+        assert !billingAccountRole
+
+        GenericValue spuriousPartyRole = from('PartyRole')
+                .where('partyId', partyId, 'roleTypeId', 'CARRIER')
+                .queryOne()
+        assert !spuriousPartyRole
+    }
+
+}

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBudgetTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBudgetTests.groovy
@@ -62,4 +62,56 @@ class AutoAcctgBudgetTests implements JupiterTestHelper {
         assert budgetStatuses[0].statusId == statusId
     }
 
+    // DEMO_COMPANY already holds the INTERNAL_ORGANIZATIO role (see AccountingTestsData.xml), so this
+    // combination is legitimate and must still succeed after OFBIZ-12371's validation is in place.
+    @Test
+    @Order(3)
+    void testCreateBudgetRole() {
+        String budgetId = testParams.budgetId ?: '9999'
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        String roleTypeId = 'INTERNAL_ORGANIZATIO'
+        Map serviceCtx = [
+                budgetId: budgetId,
+                partyId: partyId,
+                roleTypeId: roleTypeId,
+                userLogin: userLogin
+        ]
+        Map serviceResult = dispatcher.runSync('createBudgetRole', serviceCtx)
+        assert ServiceUtil.isSuccess(serviceResult)
+
+        GenericValue budgetRole = from('BudgetRole')
+                .where('budgetId', budgetId, 'partyId', partyId, 'roleTypeId', roleTypeId)
+                .queryOne()
+        assert budgetRole
+    }
+
+    // OFBIZ-12371: DEMO_COMPANY does not hold the CARRIER role (only INTERNAL_ORGANIZATIO/SUPPLIER,
+    // see AccountingTestsData.xml), so this combination must be rejected instead of the
+    // createBudgetRole -> ensurePartyRole eca silently fabricating a PartyRole record for a role
+    // the party was never given.
+    @Test
+    @Order(4)
+    void testCreateBudgetRoleRejectsPartyWithoutRole() {
+        String budgetId = testParams.budgetId ?: '9999'
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        Map serviceCtx = [
+                budgetId: budgetId,
+                partyId: partyId,
+                roleTypeId: 'CARRIER',
+                userLogin: userLogin
+        ]
+        Map serviceResult = dispatcher.runSync('createBudgetRole', serviceCtx)
+        assert ServiceUtil.isError(serviceResult)
+
+        GenericValue budgetRole = from('BudgetRole')
+                .where('budgetId', budgetId, 'partyId', partyId, 'roleTypeId', 'CARRIER')
+                .queryOne()
+        assert !budgetRole
+
+        GenericValue spuriousPartyRole = from('PartyRole')
+                .where('partyId', partyId, 'roleTypeId', 'CARRIER')
+                .queryOne()
+        assert !spuriousPartyRole
+    }
+
 }

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFinAccountTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgFinAccountTests.groovy
@@ -114,8 +114,38 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
         assert finAccountRole
     }
 
+    // OFBIZ-12373: DEMO_COMPANY does not hold the CARRIER role (only INTERNAL_ORGANIZATIO/SUPPLIER,
+    // see AccountingTestsData.xml), so this combination must be rejected instead of the createFinAccountRole
+    // -> ensurePartyRole eca silently fabricating a PartyRole record for a role the party was never given.
     @Test
     @Order(5)
+    void testCreateFinAccountRoleRejectsPartyWithoutRole() {
+        String finAccountId = testParams.finAccountId ?: '1003'
+        String partyId = testParams.partyId ?: 'DEMO_COMPANY'
+        Map serviceCtx = [
+                finAccountId: finAccountId,
+                partyId: partyId,
+                roleTypeId: 'CARRIER',
+                fromDate: UtilDateTime.nowTimestamp(),
+                currencyUomId: testParams.currencyUomId ?: 'USD',
+                userLogin: userLogin
+        ]
+        Map serviceResult = dispatcher.runSync('createFinAccountRole', serviceCtx)
+        assert ServiceUtil.isError(serviceResult)
+
+        GenericValue finAccountRole = from('FinAccountRole')
+                .where('finAccountId', finAccountId, 'partyId', partyId, 'roleTypeId', 'CARRIER')
+                .queryFirst()
+        assert !finAccountRole
+
+        GenericValue spuriousPartyRole = from('PartyRole')
+                .where('partyId', partyId, 'roleTypeId', 'CARRIER')
+                .queryOne()
+        assert !spuriousPartyRole
+    }
+
+    @Test
+    @Order(6)
     void testUpdateFinAccountRole() {
         String finAccountId = testParams.finAccountId ?: '1004'
         String partyId = testParams.partyId ?: 'DEMO_COMPANY'
@@ -139,7 +169,7 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     void testDeleteFinAccountRole() {
         String finAccountId = testParams.finAccountId ?: '1004'
         String partyId = testParams.partyId ?: 'DEMO_COMPANY'
@@ -161,7 +191,7 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void testCreateFinAccountTrans() {
         String finAccountId = testParams.finAccountId ?: '1003'
         String finAccountTransTypeId = testParams.finAccountTransTypeId ?: 'ADJUSTMENT'
@@ -180,7 +210,7 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void testCreateFinAccountStatus() {
         String finAccountId = testParams.finAccountId ?: '1003'
         String statusId = testParams.statusId ?: 'FNACT_ACTIVE'
@@ -200,7 +230,7 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void testCreateFinAccountAuth() {
         String finAccountId = testParams.finAccountId ?: '1004'
         String currencyUomId = testParams.currencyUomId ?: 'USD'
@@ -218,7 +248,7 @@ class AutoAcctgFinAccountTests implements JupiterTestHelper {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void testSetFinAccountTransStatus() {
         String finAccountTransId = testParams.finAccountTransId ?: '1010'
         String statusId = testParams.statusId ?: 'FINACT_TRNS_APPROVED'

--- a/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgInvoiceTests.groovy
+++ b/applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgInvoiceTests.groovy
@@ -217,8 +217,31 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
         assert invoiceRole
     }
 
+    // OFBIZ-12370: DEMO_COMPANY does not hold the CARRIER role (only INTERNAL_ORGANIZATIO/SUPPLIER,
+    // see AccountingTestsData.xml), so this combination must be rejected instead of hitting the
+    // InvoiceRole/PartyRole foreign key constraint with a raw SQL error.
     @Test
     @Order(11)
+    void testCreateInvoiceRoleRejectsPartyWithoutRole() {
+        Map serviceCtx = [
+                invoiceId: testParams.invoiceId ?: '1006',
+                partyId: testParams.partyId ?: 'DEMO_COMPANY',
+                roleTypeId: 'CARRIER',
+                userLogin: userLogin
+        ]
+        Map serviceResult = dispatcher.runSync('createInvoiceRole', serviceCtx)
+        assert ServiceUtil.isError(serviceResult)
+
+        GenericValue invoiceRole = from('InvoiceRole')
+                .where('invoiceId', serviceCtx.invoiceId,
+                        'partyId', serviceCtx.partyId,
+                        'roleTypeId', 'CARRIER')
+                .queryOne()
+        assert !invoiceRole
+    }
+
+    @Test
+    @Order(12)
     void testCreateInvoiceTerm() {
         Map serviceCtx = [
                 invoiceId: testParams.invoiceId ?: '1006',
@@ -239,7 +262,7 @@ class AutoAcctgInvoiceTests implements JupiterTestHelper {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void testCancelInvoice() {
         Map serviceCtx = [
                 invoiceId: testParams.invoiceId ?: '1007',

--- a/applications/accounting/testdef/accountingtests.xml
+++ b/applications/accounting/testdef/accountingtests.xml
@@ -42,6 +42,9 @@
     <test-case case-name="auto-accounting-agreement-tests">
         <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgAgreementTests"/>
     </test-case>
+    <test-case case-name="auto-accounting-billingaccount-tests">
+        <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgBillingAccountTests"/>
+    </test-case>
     <test-case case-name="auto-accounting-budget-tests">
         <jupiter-test-suite class-name="org.apache.ofbiz.accounting.accounting.AutoAcctgBudgetTests"/>
     </test-case>

--- a/applications/party/minilang/party/PartySimpleMethods.xml
+++ b/applications/party/minilang/party/PartySimpleMethods.xml
@@ -85,6 +85,19 @@ under the License.
         </if-not-empty>
     </simple-method>
 
+    <simple-method method-name="checkPartyRoleExists" short-description="Verify the party already holds the given role before a role-based association is created" login-required="false">
+        <set field="lookupPKMap.partyId" from-field="parameters.partyId"/>
+        <set field="lookupPKMap.roleTypeId" from-field="parameters.roleTypeId"/>
+        <find-by-primary-key entity-name="PartyRole" map="lookupPKMap" value-field="lookedUpValue" use-cache="true"/>
+        <if-empty field="lookedUpValue">
+            <entity-one entity-name="RoleType" value-field="roleType"/>
+            <add-error>
+                <fail-message message="${groovy: label('PartyErrorUiLabels', 'PartyRoleAssociationRequired', [partyId: parameters.partyId, roleDescription: roleType?.get('description', locale)], locale)}"/>
+            </add-error>
+            <check-errors/>
+        </if-empty>
+    </simple-method>
+
     <simple-method method-name="createPersonAndUserLogin" short-description="Creates a person and userlogin" login-required="false">
         <set-service-fields service-name="createUserLogin" map="parameters" to-map="createUlInMap"/>
 

--- a/applications/party/servicedef/services.xml
+++ b/applications/party/servicedef/services.xml
@@ -349,6 +349,21 @@ under the License.
             </type-validate>
         </attribute>
     </service>
+    <service name="checkPartyRoleExists" engine="simple"
+            location="component://party/minilang/party/PartySimpleMethods.xml" invoke="checkPartyRoleExists" auth="false">
+        <description>Reject the request with a friendly error if the party does not already hold the given role,
+        instead of letting a role-based association be created against a party/role combination that doesn't exist.</description>
+        <attribute name="partyId" type="String" mode="IN" optional="false">
+            <type-validate>
+                <fail-property resource="PartyErrorUiLabels" property="PartyRequiredFieldMissingPartyId"/>
+            </type-validate>
+        </attribute>
+        <attribute name="roleTypeId" type="String" mode="IN" optional="false">
+            <type-validate>
+                <fail-property resource="PartyErrorUiLabels" property="PartyRequiredFieldMissingRoleTypeId"/>
+            </type-validate>
+        </attribute>
+    </service>
     <service name="ensurePartyRoleFrom" engine="simple"
             location="component://party/minilang/party/PartySimpleMethods.xml" invoke="ensureNaPartyRole" auth="true">
         <description>Ensure that the party indicate by partyIdFrom is in the roleTypeIdFrom specifc role. If roleTypeIdFrom isn't present use _NA_</description>


### PR DESCRIPTION
### Jira ticket
https://issues.apache.org/jira/browse/OFBIZ-12371

### Depends on #1727

**This PR depends on #1727 and should be reviewed/merged after it.** It builds directly on top of that branch, which adds the `checkPartyRoleExists` service this PR wires up for `createBudgetRole`. Without #1727, the `checkPartyRoleExists` service referenced here doesn't exist yet.

### Purpose and Description

Same bug shape as OFBIZ-12370/12372/12373 (fixed in #1727), one ticket over in the same family Pierre Smits filed: `createBudgetRole` has an unconditional `ensurePartyRole` `invoke` eca that silently fabricates a `PartyRole` record for whatever `roleTypeId`/`partyId` is submitted on the Budget Role page, with no validation that the party actually holds (or should hold) that role.

This wires the `checkPartyRoleExists` service added in #1727 as an `in-validate` eca on `createBudgetRole`, mirroring the exact same pattern already used there for `createInvoiceRole`/`createBillingAccountRole`/`createFinAccountRole`. Since `in-validate` runs before `invoke`, an invalid party/role combination is rejected before the existing `ensurePartyRole` eca ever fires - that eca is left untouched and becomes reachable only for combinations that are already valid.

### Changes 🏗️

- `applications/accounting/servicedef/secas.xml`: adds an `in-validate` eca on `createBudgetRole` calling `checkPartyRoleExists`, right before the existing `invoke` eca.
- `applications/accounting/src/test/groovy/org/apache/ofbiz/accounting/accounting/AutoAcctgBudgetTests.groovy`: adds a positive-case test (`DEMO_COMPANY` + `INTERNAL_ORGANIZATIO`, a role the test party already legitimately holds per `AccountingTestsData.xml`) and a negative-case test (`DEMO_COMPANY` + `CARRIER`, a role it does not hold - must now be rejected, and must not fabricate a spurious `PartyRole`), following the exact pattern used for the other three role types in #1727.

### Testing

- Verified `applications/accounting/servicedef/secas.xml` against the real `service-eca.xsd` schema via `xmllint --schema` - validates cleanly.
- Ran `gradle compileTestGroovy` (JDK 21) - compiles clean, including the new test methods.
- This repo's pre-push hook (`checkstyleMain checkstyleTest codenarcMain codenarcTest`) ran clean on push - no violations.
- I don't have a running OFBiz instance with a live database in this environment, so I could not execute the Groovy test suite itself end-to-end (only compile it) - same disclosed limitation as #1727.

### Checklist
- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly (n/a - no user-facing docs for this internal validation)
- [x] I have read the CONTRIBUTING document
- [x] I have added tests to cover my changes