### PR TITLE
Improved: bind EntityFunction literal values as SQL parameters instead of inlining them (#1729)

### DIFF
--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityFunction.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/condition/EntityFunction.java
@@ -222,7 +222,7 @@ public abstract class EntityFunction<T extends Comparable<?>> extends EntityCond
         if (nested != null) {
             nested.addSqlValue(sql, tableAliases, modelEntity, entityConditionParams, includeTableNamePrefix, datasourceinfo);
         } else {
-            EntityConditionUtils.addValue(sql, null, value, entityConditionParams);
+            EntityConditionUtils.addValue(sql, field, value, entityConditionParams);
         }
         sql.append(')');
     }


### PR DESCRIPTION
EntityFunction.addSqlValue built the SQL for a wrapped literal value (used by ignore-case comparisons such as UPPER(...)) by always passing a null ModelField, even when the caller had already identified the field via setModelField. This caused the value to be inlined into the generated SQL text instead of bound as a JDBC parameter, unlike the field-bound path used everywhere else in the same class.

Use the ModelField that's already available instead of discarding it, so the value is bound the same way as any other condition value.

Test coverage from the original commit is omitted here: it targets test infrastructure (Groovy/JUnit test classes) not present on this branch.

Thank you Krishna Uprit for your help in reviewing the fix.

(cherry picked from commit 231b3cb3cd3aec32362b2f2c794f6222349f80af)