### PR TITLE
Fixed: Bump ant-junit from 1.10.15 to 1.10.17 in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ dependencies {
     }
 
     junitReport 'junit:junit:4.13.2'
-    junitReport 'org.apache.ant:ant-junit:1.10.15'
+    junitReport 'org.apache.ant:ant-junit:1.10.17'
 
     // Libraries downloaded manually
     implementation fileTree(dir: file("${rootDir}/lib"), include: '**/*.jar')


### PR DESCRIPTION
The version 1.10.17 is the one already declared in dependencies.gradle.