### PR TITLE
Remove unused static mock scope in TestRunServicesTest

### DIFF
--- a/framework/testtools/src/test/java/org/apache/ofbiz/testtools/TestRunServicesTest.java
+++ b/framework/testtools/src/test/java/org/apache/ofbiz/testtools/TestRunServicesTest.java
@@ -327,10 +327,7 @@ class TestRunServicesTest {
     @Test
     void isTestApiEnabledForComponentDefaultsToTrueWhenUnset() {
         Delegator delegator = mock(Delegator.class);
-        try (MockedStatic<EntityUtilProperties> entityUtilProperties =
-                Mockito.mockStatic(EntityUtilProperties.class, Mockito.CALLS_REAL_METHODS)) {
-            assertThat(TestRunServices.isTestApiEnabledForComponent(delegator, "example"), is(true));
-        }
+        assertThat(TestRunServices.isTestApiEnabledForComponent(delegator, "example"), is(true));
     }
 
     @Test


### PR DESCRIPTION
isTestApiEnabledForComponentDefaultsToTrueWhenUnset opened a MockedStatic for EntityUtilProperties with CALLS_REAL_METHODS but never stubbed it, which is a no-op wrapper (every call just falls through to the real method) and triggered a [try] compiler warning for an unreferenced resource. Dropped the wrapper; the real method still runs the same way without it.

I reproduced the warning using the following commands:

./gradlew test --tests "org.apache.ofbiz.testtools.TestRunServicesTest" --console=plain

./gradlew compileTestJava checkstyleTest --console=plain


> Task :classes

> Task :compileTestJava
/Users/ashish/ofbiz-dev/ofbiz-trunk/framework/testtools/src/test/java/org/apache/ofbiz/testtools/TestRunServicesTest.java:330: warning: [try] auto-closeable resource entityUtilProperties is never referenced in body of corresponding try statement
        try (MockedStatic<EntityUtilProperties> entityUtilProperties =
                                                ^
1 warning

> Task :compileTestGroovy
> Task :processTestResources
> Task :testClasses
> Task :checkstyleTest

[Incubating] Problems report is available at: file:///Users/ashish/ofbiz-dev/ofbiz-trunk/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.14.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 48s
25 actionable tasks: 25 executed

Thank you @jacopoc for letting me know about this. 