### PR TITLE
Fixed: Complete Mustang 2.26 compatibility

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -49,14 +49,15 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.25.4' // the API of log4j 2
     implementation 'org.apache.logging.log4j:log4j-core:2.25.4' // Somehow needed by Buildbot to compile OFBizDynamicThresholdFilter.java
     implementation 'org.apache.poi:poi:4.1.2' // poi-ooxml-schemas-5.0.0.pom'. Received status code 401 from server
-    implementation 'org.apache.pdfbox:pdfbox:2.0.37' // 3.0.1 does not compile
+    implementation 'org.apache.pdfbox:pdfbox:3.0.8'
+    implementation 'org.apache.pdfbox:pdfbox-io:3.0.8'
     implementation 'org.apache.shiro:shiro-core:1.13.0'
     implementation 'org.apache.shiro:shiro-crypto-cipher:2.1.0'
     implementation 'org.apache.sshd:sshd-core:2.17.1'
     implementation 'org.apache.sshd:sshd-sftp:2.17.1'
-    implementation 'org.apache.tika:tika-core:2.9.4'
-    implementation 'org.apache.tika:tika-parsers:2.9.4'
-    implementation 'org.apache.tika:tika-parser-pdf-module:2.9.4'
+    implementation 'org.apache.tika:tika-core:3.3.2'
+    implementation 'org.apache.tika:tika-parsers:3.3.2'
+    implementation 'org.apache.tika:tika-parser-pdf-module:3.3.2'
     implementation 'org.apache.cxf:cxf-rt-frontend-jaxrs:3.6.12' // 4.0.3 does not compile
     implementation 'org.apache.tomcat:tomcat-catalina-ha:9.0.121' // Remember to change the version number (9 now) in javadoc block if needed.
     implementation 'org.apache.tomcat:tomcat-jasper:9.0.121'

--- a/framework/entity/src/main/java/org/apache/ofbiz/entity/serialize/XmlSerializer.java
+++ b/framework/entity/src/main/java/org/apache/ofbiz/entity/serialize/XmlSerializer.java
@@ -44,7 +44,7 @@ import java.util.TreeSet;
 import java.util.Vector;
 import java.util.WeakHashMap;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.ofbiz.base.util.Debug;

--- a/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
+++ b/framework/security/src/main/java/org/apache/ofbiz/security/SecuredUpload.java
@@ -93,6 +93,8 @@ import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.base.util.UtilXml;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.util.EntityUtilProperties;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBufferedFile;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
 import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
@@ -1019,7 +1021,7 @@ public class SecuredUpload {
             }
             // OK no JS code, pass to check 2: detect if the document has any embedded files
             PDEmbeddedFilesNameTreeNode efTree = null;
-            try (PDDocument pdDocument = PDDocument.load(file)) {
+            try (PDDocument pdDocument = Loader.loadPDF(new RandomAccessReadBufferedFile(fileName))) {
                 PDDocumentNameDictionary names = new PDDocumentNameDictionary(pdDocument.getDocumentCatalog());
                 efTree = names.getEmbeddedFiles();
             }


### PR DESCRIPTION
Companion fix for #1803.

Mustang 2.26 brings Tika 3/PDFBox 3 and Jakarta JAXB expectations that the release branch does not yet satisfy. This completes that upgrade by:

- aligning Tika and PDFBox with their compatible current lines, including `pdfbox-io`
- migrating the PDFBox load call to the 3.x `Loader` API
- using Jakarta `DatatypeConverter` for Mustang 2.26 compatibility

The PDFBox/Tika part follows the approach already accepted on the main line in #1255, updated to the versions resolved by this Dependabot branch.

Verification on Corretto JDK 17 with Gradle 8.14.5:

- `compileJava` passed
- `checkstyleMain` passed with no violations
- `codenarcMain` and `codenarcTest` passed
- `git diff --check`

JAIPilot Remote was also attempted with the exact worktree, but its Gradle plugin mirror could not resolve the repository-required Develocity 3.19.2 plugin, so no remote pass is claimed. The disposable workspace and source upload were deleted.