### PR TITLE
Fixed: jGrowl notifications never display due to dead jQuery-plugin paths (OFBIZ-13506)

### DIFF
--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -1319,27 +1319,23 @@ function showjGrowlMessage(errMessage, classEvent, stickyValue, showAllLabel, co
         if (!hideAllLabel) hideAllLabel = jGrowlLabelObject[0];
     }
 
-    var libraryFiles = ["/common/js/jquery/plugins/Readmore.js-master/readmore.js",
-        "/common/js/jquery/plugins/jquery-jgrowl/jquery.jgrowl-1.4.6.min.js"];
-    importLibrary(libraryFiles, function () {
-        $.jGrowl.defaults.closerTemplate = '<div class="closeAllJGrowl">' + hideAllLabel + '</div>';
-        if (jGrowlPosition !== null && jGrowlPosition !== undefined) $.jGrowl.defaults.position = jGrowlPosition;
-        $.jGrowl(errMessage, {
-            theme: classEvent, sticky: stickyValue,
-            beforeOpen: function (e, m, o) {
-                if (jGrowlWidth !== null && jGrowlWidth !== undefined) $(e).width(jGrowlWidth + 'px');
-                if (jGrowlHeight !== null && jGrowlHeight !== undefined) $(e).height(jGrowlHeight + 'px');
-            },
-            afterOpen: function (e, m) {
-                jQuery(".jGrowl-message").readmore({
-                    moreLink: '<a href="#" style="display: block; width: auto; padding: 0px;text-align: right; margin-top: 10px; color: #ffffff; font-size: 0.8em">' + showAllLabel + '</a>',
-                    lessLink: '<a href="#" style="display: block; width: auto; padding: 0px;text-align: right; margin-top: 10px; color: #ffffff; font-size: 0.8em">' + collapseLabel + '</a>',
+    $.jGrowl.defaults.closerTemplate = '<div class="closeAllJGrowl">' + hideAllLabel + '</div>';
+    if (jGrowlPosition !== null && jGrowlPosition !== undefined) $.jGrowl.defaults.position = jGrowlPosition;
+    $.jGrowl(errMessage, {
+        theme: classEvent, sticky: stickyValue,
+        beforeOpen: function (e, m, o) {
+            if (jGrowlWidth !== null && jGrowlWidth !== undefined) $(e).width(jGrowlWidth + 'px');
+            if (jGrowlHeight !== null && jGrowlHeight !== undefined) $(e).height(jGrowlHeight + 'px');
+        },
+        afterOpen: function (e, m) {
+            jQuery(".jGrowl-message").readmore({
+                moreLink: '<a href="#" style="display: block; width: auto; padding: 0px;text-align: right; margin-top: 10px; color: #ffffff; font-size: 0.8em">' + showAllLabel + '</a>',
+                lessLink: '<a href="#" style="display: block; width: auto; padding: 0px;text-align: right; margin-top: 10px; color: #ffffff; font-size: 0.8em">' + collapseLabel + '</a>',
 
-                    maxHeight: 75
-                });
-            },
-            speed: jGrowlSpeed
-        });
+                maxHeight: 75
+            });
+        },
+        speed: jGrowlSpeed
     });
 }
 

--- a/themes/common-theme/widget/Theme.xml
+++ b/themes/common-theme/widget/Theme.xml
@@ -68,6 +68,8 @@ under the License.
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/daterangepicker/daterangepicker.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/trumbowyg/dist/trumbowyg.min.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/trumbowyg/dist/plugins/indent/trumbowyg.indent.min.js"/>
+        <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/jgrowl/jquery.jgrowl.min.js"/>
+        <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/node_modules/readmore-js/readmore.min.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/util/OfbizUtil.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/util/fieldlookup.js"/>
         <property name="VT_HDR_JAVASCRIPT['add']" value="/common/js/plugins/date/date.timezone-min.js"/>


### PR DESCRIPTION
showjGrowlMessage() in themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js dynamically loaded jGrowl and Readmore.js from vendor paths under js/jquery/plugins/ that no longer exist, since those two plugins were migrated to npm-managed packages while only jGrowl's CSS was updated to the new location at the time; the resulting 404s made the internal importLibrary() loader's promise reject and fall into its default catch handler, which just logs a console error, so the success callback that actually shows the jGrowl toast never ran. This fix statically includes jgrowl's and readmore-js's JS in Theme.xml alongside the other npm-migrated plugins, the same way their CSS and Trumbowyg's JS are already wired in, and drops the now-dead importLibrary call from showjGrowlMessage. Verified live in a browser that the from/thru-date validation toast (triggered via plugins/date/FromThruDateCheck.js) now renders correctly, and confirmed this doesn't affect release24.09 since that branch still has the vendored plugin files in place at the paths the code references.