### PR TITLE
Fixed: In-place editor broken due to deleted jQuery-plugin file

### DIFF
--- a/themes/common-theme/webapp/common-theme/js/package-lock.json
+++ b/themes/common-theme/webapp/common-theme/js/package-lock.json
@@ -16,6 +16,7 @@
                 "inputmask": "^5.0.10",
                 "jgrowl": "^1.5.1",
                 "jquery": "^4.0.0",
+                "jquery-jeditable": "^2.0.19",
                 "jquery-migrate": "^4.0.2",
                 "jquery-ui-dist": "^1.13.3",
                 "jquery-validation": "^1.22.1",
@@ -103,6 +104,22 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
             "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
+            "license": "MIT"
+        },
+        "node_modules/jquery-jeditable": {
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/jquery-jeditable/-/jquery-jeditable-2.0.19.tgz",
+            "integrity": "sha512-eg3kgRO+2e/mzJ53aNn26TeOYOAjFEr2v6mR7jqeGKl2FqCat+N03GOBDqRlz9g5jdHvONsOVRM9/vab0Yb+Bw==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "license": "MIT",
+            "dependencies": {
+                "jquery": "^3.5.1"
+            }
+        },
+        "node_modules/jquery-jeditable/node_modules/jquery": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
             "license": "MIT"
         },
         "node_modules/jquery-migrate": {

--- a/themes/common-theme/webapp/common-theme/js/package.json
+++ b/themes/common-theme/webapp/common-theme/js/package.json
@@ -13,6 +13,7 @@
         "inputmask": "^5.0.10",
         "jquery": "^4.0.0",
         "jgrowl": "^1.5.1",
+        "jquery-jeditable": "^2.0.19",
         "jquery-migrate": "^4.0.2",
         "jquery-ui-dist": "^1.13.3",
         "jquery-validation": "^1.22.1",

--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -1227,13 +1227,13 @@ function ajaxInPlaceEditDisplayField(element, url, options) {
         jQuery(this).css('background-color', 'transparent');
     });
 
-    importLibrary(["/common/js/jquery/plugins/jeditable/jquery.jeditable-1.7.3.js"], function () {
+    importLibrary(["/common/js/node_modules/jquery-jeditable/dist/jquery.jeditable.min.js"], function () {
         jElement.editable(function (value, settings) {
             // removes all line breaks from the value param, because the parseJSON Function can't work with line breaks
             value = value.replace(/\n/g, " ");
             value = value.replace(/\"/g, "&quot;");
 
-            var resultField = jQuery.parseJSON('{"' + settings.name + '":"' + value + '"}');
+            var resultField = JSON.parse('{"' + settings.name + '":"' + value + '"}');
             // merge both parameter objects together
             jQuery.extend(settings.submitdata, resultField);
             jQuery.ajax({


### PR DESCRIPTION
A prior cleanup commit (3543919d6) deleted the vendored jquery.jeditable-1.7.3.js file while removing datepicker locale files, but OfbizUtil.js's ajaxInPlaceEditDisplayField still references it, silently breaking every in-place-editor field (Product Image Management's rename-image field, Portal Page's rename name/description fields) with a 404. This migrates jeditable to the npm-maintained jquery-jeditable package, matching the project's existing jgrowl/readmore-js npm migrations, and also replaces the same function's removed jQuery.parseJSON call with native JSON.parse, a follow-up to the jQuery 4 upgrade (#941) that this code path was missed by since the feature was already silently broken.