### PR TITLE
Fixed: Dependabot repeatedly reopening a commons-imaging alpha-to-alpha bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,14 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # commons-imaging has been alpha-only since 2019 (alpha1..1.0.0-alpha6,
+      # see the version catalog comment) with no stable release in sight;
+      # we've deliberately deferred adapting to its post-alpha3 API changes
+      # until it ships an actual 1.0.0. This keeps Dependabot from reopening
+      # an alpha-to-alpha bump PR forever, while still surfacing a real 1.0.0
+      # (or later) release when one finally happens.
+      - dependency-name: "org.apache.commons:commons-imaging"
+        versions: ["< 1.0.0"]
 
   - package-ecosystem: "gradle"
     directory: "/"
@@ -48,6 +56,9 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # See the same rule in the trunk gradle block above.
+      - dependency-name: "org.apache.commons:commons-imaging"
+        versions: ["< 1.0.0"]
 
   - package-ecosystem: "npm"
     directory: "themes/common-theme/webapp/common-theme/js"


### PR DESCRIPTION
commons-imaging has been alpha-only since 2019 (currently 1.0.0-alpha6, spanning six years with no GA in sight), and its API changed starting with 1.0.0-alpha4 in a way that would require real adaptation work in OFBiz, so we're deliberately staying pinned to 1.0-alpha3 until a stable 1.0.0 ships (see the comment on the commons-imaging entry in gradle/libs.versions.toml). The existing dependabot.yml only ignores semver-major bumps, which doesn't catch alpha-to-alpha updates within the nominal 1.0.0 line, so Dependabot kept reopening a bump PR (most recently #1116, closed) proposing 1.0.0-alpha6. This adds a dependency-specific ignore rule scoped to versions below 1.0.0, so alpha bumps stop recurring while a genuine 1.0.0 (or later) release still surfaces normally.