### PR TITLE
Fixed: jQuery 4.0 migration broke legacy API usage in common-theme (OFBIZ-13510)

### DIFF
--- a/applications/commonext/webapp/ordermgr-js/geoAutoCompleter.js
+++ b/applications/commonext/webapp/ordermgr-js/geoAutoCompleter.js
@@ -79,6 +79,9 @@ function setKeyAsParameter(event, ui) {
 
 //Generic function for fetching country's associated state list.
 function getAssociatedStateList(countryId, stateId, errorId, divId) {
+    if (!countryId || !stateId) {
+        return;
+    }
     var countryGeoId = jQuery("#" + countryId).val();
     jQuery.ajax({
         url: '/common-js/control/getAssociatedStateList',

--- a/applications/humanres/template/category/CategoryTree.ftl
+++ b/applications/humanres/template/category/CategoryTree.ftl
@@ -23,7 +23,7 @@ function unescapeHtmlText(text) {
     return jQuery('<div />').html(text).text()
 }
  
-jQuery(window).load(createTree());
+createTree();
 
 <#-- creating the JSON Data -->
 var rawdata = [

--- a/applications/product/template/category/CategoryTree.ftl
+++ b/applications/product/template/category/CategoryTree.ftl
@@ -22,8 +22,8 @@ under the License.
 function unescapeHtmlText(text) {
     return jQuery('<div />').html(text).text()
 }
- 
-jQuery(window).load(createTree());
+
+createTree();
 
 <#-- creating the JSON Data -->
 var rawdata = [

--- a/applications/product/template/imagemanagement/ImageFrame.ftl
+++ b/applications/product/template/imagemanagement/ImageFrame.ftl
@@ -23,7 +23,7 @@ under the License.
         var productId = jQuery('#ImageFrames_productId').val();
         var imageName = jQuery('#ImageFrames_imageName').val();
     });
-    jQuery(window).load(function() {
+    jQuery(window).on('load', function() {
         var width = jQuery('td.image-src img').width();
         var height = jQuery('td.image-src img').height();
         jQuery('td.image-src img').css("width", 200);

--- a/applications/product/template/store/ProductStoreGroupTree.ftl
+++ b/applications/product/template/store/ProductStoreGroupTree.ftl
@@ -23,7 +23,7 @@ function unescapeHtmlText(text) {
     return jQuery('<div />').html(text).text()
 }
 
-jQuery(window).load(createTree());
+createTree();
 
 <#-- creating the JSON Data -->
 <#if parentProductStoreGroup?has_content>

--- a/themes/common-theme/webapp/common-theme/js/plugins/myportal.js
+++ b/themes/common-theme/webapp/common-theme/js/plugins/myportal.js
@@ -151,7 +151,7 @@ function updatePortletOrder(currentItem, nextObjectToDroppedItem, mode, destinat
         url: "/myportal/control/updatePortalPagePortletSeqAjax",
         data: requestData,
         type: "POST",
-    }).success( function(data){ onCompleteRequest(); });
+    }).done( function(data){ onCompleteRequest(); });
 
 }
 

--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -467,7 +467,7 @@ function initDateTimePicker(self) {
 function addSelectAllObserver(action_checkbox) {
     var form_fields = jQuery(action_checkbox).getForm().getFormFields(),
         all_child = form_fields.filter(":checkbox:not(:disabled):not(.selectAll)"),
-        select_child = all_child.filter(".selectAllChild").size() > 0 ? all_child.filter(".selectAllChild") : all_child,
+        select_child = all_child.filter(".selectAllChild").length > 0 ? all_child.filter(".selectAllChild") : all_child,
         parent_checkbox = form_fields.filter(".selectAll"),
         is_parent = action_checkbox.is(".selectAll");
 
@@ -478,7 +478,7 @@ function addSelectAllObserver(action_checkbox) {
         });
     } else {
         // Check/ Uncheck parent checkbox when child checkboxes checked.
-        if (select_child.size() > 0) {
+        if (select_child.length > 0) {
             var all_checked = true;
 
             select_child.each(function () {
@@ -511,7 +511,7 @@ jQuery.fn.getFormFields = function () {
 jQuery.fn.getForm = function () {
     var form_id = jQuery(this).attr("form");
     // Get closest form if no form id specified else get the form using id.
-    if (form_id === undefined) {
+    if (!form_id) {
         return jQuery(this).closest("form");
     } else {
         return jQuery("#" + form_id);
@@ -933,6 +933,9 @@ function ajaxAutoCompleter(areaCsvString, showDescription, defaultMinLength, def
         else
             var url = initUrl + "?" + areaArray[i + 2];
         var div = areaArray[i];
+        if (!div) {
+            continue;
+        }
         // create a separated div where the result JSON Opbject will be placed
         if ((jQuery("#" + div + "_auto")).length < 1) {
             jQuery("<div id='" + div + "_auto'></div>").insertBefore("#" + areaArray[i]);
@@ -1010,6 +1013,9 @@ function ajaxAutoCompleter(areaCsvString, showDescription, defaultMinLength, def
 }
 
 function setLookDescription(textFieldId, description, params, formName, showDescription) {
+    if (!textFieldId) {
+        return;
+    }
     if (description) {
         var start = description.lastIndexOf(' [');
         if (start != -1) {
@@ -1221,6 +1227,9 @@ function toggleScreenlet(link, areaId, saveCollapsed, expandTxt, collapseTxt) {
  */
 
 function ajaxInPlaceEditDisplayField(element, url, options) {
+    if (!element) {
+        return;
+    }
     var jElement = jQuery("#" + element);
     jElement.mouseover(function () {
         jQuery(this).css('background-color', 'rgb(255, 255, 153)');

--- a/themes/common-theme/webapp/common-theme/js/util/application.js
+++ b/themes/common-theme/webapp/common-theme/js/util/application.js
@@ -33,7 +33,7 @@ var j = 1;
             
     this.each(function() {
         var settings = jQuery.extend(defaults, options);
-        var totalListElements = jQuery(this).children('li').size();
+        var totalListElements = jQuery(this).children('li').length;
         var baseColItems = Math.ceil(totalListElements / settings.colNumber);
         var listClass = jQuery(this).attr('class');
         
@@ -72,7 +72,7 @@ var j = 1;
             });
             
             jQuery('.listContainer'+j).find('ol,ul').each(function(){
-                if(jQuery(this).children().size() == 0) {
+                if(jQuery(this).children().length == 0) {
                 jQuery(this).remove();
                 }
             });    

--- a/themes/common-theme/webapp/common-theme/js/util/fieldlookup.js
+++ b/themes/common-theme/webapp/common-theme/js/util/fieldlookup.js
@@ -620,6 +620,9 @@ function lookupAjaxRequest(request) {
 }
 
 function lookupFormAjaxRequest(formAction, form) {
+    if (!form) {
+        return;
+    }
     var lookupId = GLOBAL_LOOKUP_REF.getReference(ACTIVATED_LOOKUP).lookupId;
     var data = jQuery("#" + form).serialize();
     data = data + "&presentation=" + GLOBAL_LOOKUP_REF.getReference(ACTIVATED_LOOKUP).presentation;

--- a/themes/common-theme/webapp/common-theme/js/util/miscAjaxFunctions.js
+++ b/themes/common-theme/webapp/common-theme/js/util/miscAjaxFunctions.js
@@ -35,6 +35,9 @@ function getDependentDropdownValues(request, paramKey, paramField, targetField, 
 //             this is to handle a specific case where an input field is needed instead of a drop-down when no values are returned by the request
 //             this will be maybe extended later to use an auto-completed drop-down or a lookup, instead of straight drop-down currently, when there are too much values to populate
 //             this is e.g. currently used in the Product Price Rules screen
+    if (!paramField) {
+        return;
+    }
     target = '#' + targetField;
     input = '#' + inputField;
     targetTitle = target + '_title'
@@ -49,6 +52,9 @@ function getDependentDropdownValues(request, paramKey, paramField, targetField, 
 
     	    // Both arrays should be the same length
     	    for (var i=0; i<paramKeyArr.length; i++) {
+    	        if (!paramFieldArr[i]) {
+    	            continue;
+    	        }
     	        paramData.push({name: paramKeyArr[i], value: jQuery('#' + paramFieldArr[i]).val()});
     	    }
     } else {

--- a/themes/common-theme/webapp/common-theme/js/util/selectMultipleRelatedValues.js
+++ b/themes/common-theme/webapp/common-theme/js/util/selectMultipleRelatedValues.js
@@ -27,6 +27,9 @@
 // responseName = result returned by the service (using a standard json response, ie chaining json request)
 
 function selectMultipleRelatedValues(request, paramKey, paramField, targetField, type, typeValue, responseName) {
+    if (!paramField || !targetField) {
+        return;
+    }
     data = [ { name: paramKey, value: jQuery('#' + paramField).val()}, { name: type, value: typeValue} ];  // get requested value from parent dropdown field 
     list = jQuery.post(request, data, function(result) {
         selectedOptions = result[responseName];

--- a/themes/helveticus/webapp/helveticus/js/OfbizUtil.js
+++ b/themes/helveticus/webapp/helveticus/js/OfbizUtil.js
@@ -20,6 +20,9 @@
 
 
 function setLookDescription(textFieldId, description, params, formName, showDescription) {
+    if (!textFieldId) {
+        return;
+    }
     if (description) {
         var start = description.lastIndexOf(' [');
         if (start != -1) {


### PR DESCRIPTION
Backported from trunk (#1829).

Bumping jquery to 4.0.0 and jquery-migrate to 4.0.2 dropped legacy shims that several call sites relied on: ImageFrame.ftl's window-load binding, myportal.js's chained jqXHR `.success()`, and four `.size()` calls in OfbizUtil.js and application.js all threw `TypeError` under the new versions, breaking the product image dimension display, My Portal's drag-and-drop reordering, and a handful of checkbox/list helpers. This also hardens roughly a dozen `jQuery("#" + var)` selectors against jQuery 4's stricter selector engine, which now throws instead of silently no-op'ing on an empty id. Verified live against a real OFBiz instance, including reproducing the image-frame and My-Portal bugs on their original code and confirming the fix on the actual screens with real interaction.

`OfbizUtil.js`'s `getForm` needed manual adaptation during the cherry-pick: release24.09 still has the pre-refactor jQuery-plugin-method shape (`jQuery.fn.getForm`, `form_id`) rather than trunk's standalone-function shape (`getForm(element)`, `formId`), so the same guard was applied to release24.09's actual code instead of pasting trunk's version verbatim.