### PR TITLE
Fixed: jGrowl toast messages use wrong readmore-js option (OFBIZ-13512)

### DIFF
--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -1341,7 +1341,7 @@ function showjGrowlMessage(errMessage, classEvent, stickyValue, showAllLabel, co
                 moreLink: '<a href="#" style="display: block; width: auto; padding: 0px;text-align: right; margin-top: 10px; color: #ffffff; font-size: 0.8em">' + showAllLabel + '</a>',
                 lessLink: '<a href="#" style="display: block; width: auto; padding: 0px;text-align: right; margin-top: 10px; color: #ffffff; font-size: 0.8em">' + collapseLabel + '</a>',
 
-                maxHeight: 75
+                collapsedHeight: 75
             });
         },
         speed: jGrowlSpeed


### PR DESCRIPTION
showjGrowlMessage initialized the vendored readmore-js plugin with maxHeight, but readmore-js has no such option — the real option is collapsedHeight. jQuery.extend silently drops unrecognized keys, so the plugin fell back to its default collapsedHeight of 200px, meaning jGrowl messages under 200px never showed the truncation toggle and taller ones collapsed at 200px instead of the intended 75px. Renamed maxHeight to collapsedHeight in the readmore() call.