### PR TITLE
Fixed: jGrowl toast messages use wrong readmore-js option (OFBIZ-13512)

### DIFF
--- a/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
+++ b/themes/common-theme/webapp/common-theme/js/util/OfbizUtil.js
@@ -1347,7 +1347,7 @@ function showjGrowlMessage(errMessage, classEvent, stickyValue, showAllLabel, co
                     moreLink: '<a href="#" style="display: block; width: auto; padding: 0px;text-align: right; margin-top: 10px; color: #ffffff; font-size: 0.8em">' + showAllLabel + '</a>',
                     lessLink: '<a href="#" style="display: block; width: auto; padding: 0px;text-align: right; margin-top: 10px; color: #ffffff; font-size: 0.8em">' + collapseLabel + '</a>',
 
-                    maxHeight: 75
+                    collapsedHeight: 75
                 });
             },
             speed: jGrowlSpeed


### PR DESCRIPTION
Backported from trunk (#1831); adapted to release24.09's pre-OFBIZ-13506 code shape since a straight cherry-pick conflicted.