### PR TITLE
Fixed: Legacy jQuery.noConflict() in imagemanagement templates breaks common-theme JS (OFBIZ-13513)

### DIFF
--- a/applications/product/template/imagemanagement/ImageCrop.ftl
+++ b/applications/product/template/imagemanagement/ImageCrop.ftl
@@ -20,7 +20,6 @@ under the License.
 <script type="text/javascript" src="<@ofbizContentUrl>/common/js/plugins/imagemanagement/jquery.Jcrop.min.js</@ofbizContentUrl>"></script>
 <link rel="stylesheet" href="<@ofbizContentUrl>/common/js/plugins/imagemanagement/jquery.Jcrop.css</@ofbizContentUrl>" type="text/css" />
 <script type="text/javascript">
-jQuery.noConflict();
 jQuery(document).ready(function(){
     jQuery('td.cropbox img').Jcrop({
         onChange: showPreview,

--- a/applications/product/template/imagemanagement/ImageFrame.ftl
+++ b/applications/product/template/imagemanagement/ImageFrame.ftl
@@ -17,7 +17,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 <script type="text/javascript">
-    jQuery.noConflict();
     var host = document.location.host;
     jQuery(document).ready(function() {
         var productId = jQuery('#ImageFrames_productId').val();

--- a/applications/product/template/imagemanagement/ImageRotating.ftl
+++ b/applications/product/template/imagemanagement/ImageRotating.ftl
@@ -29,7 +29,6 @@ under the License.
     }
 </style>
 <script type="text/javascript">
-jQuery.noConflict();
 jQuery(document).ready(function(){
     var angleHold = 0;
     if((jQuery.browser.mozilla) || (jQuery.browser.msie)) {

--- a/applications/product/template/imagemanagement/ResizeImage.ftl
+++ b/applications/product/template/imagemanagement/ResizeImage.ftl
@@ -18,7 +18,6 @@ under the License.
 -->
 <script type="text/javascript" src="<@ofbizContentUrl>/common/js/plugins/imagemanagement/sizzle.min.js</@ofbizContentUrl>"></script>
 <script type="text/javascript">
-jQuery.noConflict();
 jQuery(document).ready(function(){
     jQuery('img').attr('id',"previewImage");
     

--- a/applications/product/template/imagemanagement/ShowPeopleApprove.ftl
+++ b/applications/product/template/imagemanagement/ShowPeopleApprove.ftl
@@ -18,7 +18,6 @@ under the License.
 -->
 <script type="text/javascript" src="<@ofbizContentUrl>/common/js/plugins/imagemanagement/sizzle.min.js</@ofbizContentUrl>"></script>
 <script type="text/javascript">
-jQuery.noConflict();
 jQuery(document).ready(function(){
     jQuery('input:radio').click(function(){
         var elementVal = jQuery(this).val();


### PR DESCRIPTION
Five imagemanagement templates called jQuery.noConflict() since 2010, resetting the global $ alias even though nothing in the theme needs it. This broke OfbizUtil.js's initializeEvents() and importLibrary, which both rely on bare $ after page load, causing checkbox select-all, dialogs, and importLibrary-loaded widgets like the category tree to fail. Removed the noConflict() calls.