### PR TITLE
Improved: Retry testIntegration once on non-graceful failure (OFBIZ-13514)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1023,8 +1023,41 @@ def createOfbizCommandTask(taskName, arguments) {
             // with stale ones from an earlier run into what looks like one coherent run. Clearing
             // the directory before the run starts guarantees every report reflects exactly this
             // run's suites, nothing left over from before.
+            def completionMarker = file('./runtime/logs/test-results/run-completed.marker')
             doFirst {
                 delete fileTree('./runtime/logs/test-results') { include '*.xml' }
+                delete completionMarker
+            }
+            // Mitigates sporadic CI-worker contention failures on BuildBot, not a general
+            // flaky-test policy. completionMarker (written by TestRunContainer once every suite
+            // finishes) marks a graceful test failure - fail immediately, no retry - apart from a
+            // crash/hang before that point, which retries once.
+            ignoreExitValue = true
+            doLast {
+                if (executionResult.get().exitValue != 0) {
+                    if (completionMarker.exists()) {
+                        throw new GradleException("${taskName}: test run completed but one or more tests failed.")
+                    }
+                    logger.warn("${taskName}: did not complete gracefully (crash/hang/non-test startup "
+                            + "failure) - retrying once.")
+                    delete completionMarker
+                    def retry = javaexec {
+                        jvmArgs(application.applicationDefaultJvmArgs)
+                        classpath = sourceSets.main.runtimeClasspath + sourceSets.test.runtimeClasspath
+                        mainClass = application.mainClass
+                        args arguments
+                        ignoreExitValue = true
+                    }
+                    if (retry.exitValue != 0) {
+                        if (completionMarker.exists()) {
+                            throw new GradleException("${taskName}: retry completed but one or more tests "
+                                    + "still failed.")
+                        }
+                        throw new GradleException("${taskName}: failed on both the initial run and the "
+                                + "retry, and neither completed gracefully (exit ${retry.exitValue}) - this "
+                                + "points to a CI-worker/environment issue, not a test failure.")
+                    }
+                }
             }
             finalizedBy(createTestReports)
         }

--- a/framework/testtools/src/main/java/org/apache/ofbiz/testtools/TestRunContainer.java
+++ b/framework/testtools/src/main/java/org/apache/ofbiz/testtools/TestRunContainer.java
@@ -21,7 +21,10 @@ package org.apache.ofbiz.testtools;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -51,6 +54,8 @@ public class TestRunContainer implements Container {
 
     private static final String MODULE = TestRunContainer.class.getName();
     public static final String LOG_DIR = "runtime/logs/test-results/";
+    // build.gradle's testIntegration retry logic relies on this exact filename; keep them in sync.
+    static final String RUN_COMPLETED_MARKER = LOG_DIR + "run-completed.marker";
 
     private String name;
     private JunitSuiteWrapper jsWrapper;
@@ -97,10 +102,26 @@ public class TestRunContainer implements Container {
             failedRun = !results.wasSuccessful() ? true : failedRun;
         }
 
+        // Lets testIntegration's retry logic (build.gradle) tell a graceful test failure apart
+        // from a crash/hang before this point was reached.
+        markRunCompleted();
+
         if (failedRun) {
             throw new ContainerException("Test run was unsuccessful");
         }
         return true;
+    }
+
+    /**
+     * Writes {@link #RUN_COMPLETED_MARKER}. Best-effort - a failed write only means a caller
+     * can't distinguish a graceful failure from a crash, not that this run's outcome changes.
+     */
+    static void markRunCompleted() {
+        try {
+            Files.writeString(Path.of(RUN_COMPLETED_MARKER), "true");
+        } catch (IOException e) {
+            Debug.logWarning(e, "Unable to write test-run completion marker at " + RUN_COMPLETED_MARKER, MODULE);
+        }
     }
 
     @Override


### PR DESCRIPTION
Backported from trunk (#1836). TestRunContainer.java needed manual adaptation since release24.09 predates the Jupiter test-engine migration - the same completion-marker fix was applied to its plain JUnit3-based start() loop, and the accompanying unit test was dropped since this branch has no src/test/java tree for the testtools module.