### PR TITLE
Improved: ServiceGroupReader.readConfig() lacks cache-hit guard, causing redundant XML re-parsing on every ServiceDispatcher construction (OFBIZ-13515)

### DIFF
--- a/framework/service/src/main/java/org/apache/ofbiz/service/group/ServiceGroupReader.java
+++ b/framework/service/src/main/java/org/apache/ofbiz/service/group/ServiceGroupReader.java
@@ -45,6 +45,9 @@ public final class ServiceGroupReader {
     protected ServiceGroupReader() { }
 
     public static void readConfig() {
+        if (!GROUPS_CACHE.isEmpty()) {
+            return;
+        }
         List<ServiceGroups> serviceGroupsList = null;
         try {
             serviceGroupsList = ServiceConfigUtil.getServiceEngine().getServiceGroups();


### PR DESCRIPTION
readConfig() had no cache-hit check, so it re-parsed every component's service-group XML on each call. Its sibling getGroupModel() already guards with an empty-cache check before calling it, but readConfig() itself didn't. It is called unconditionally from ServiceDispatcher's constructor on every dispatcher construction, so a full testIntegration run re-parsed this XML dozens of times for no reason. Added the same empty-cache guard inside readConfig() itself; GROUPS_CACHE is a plain ConcurrentHashMap and there is no evidence of a concurrent-mutation race here, so no locking is needed. While investigating, ServiceMcaUtil.getServiceMcaRules() was also checked for the same pattern: it already has an unsynchronized empty-cache guard, but it's only reached from JavaMailContainer (at startup and during mail-rule evaluation), not from ServiceDispatcher, so it isn't on the same hot path and was left unchanged.