### PR TITLE
Fixed: EntityEcaUtil cache-rebuild race under concurrent Delegator construction (OFBIZ-13517)

### DIFF
--- a/framework/entityext/src/main/java/org/apache/ofbiz/entityext/eca/EntityEcaUtil.java
+++ b/framework/entityext/src/main/java/org/apache/ofbiz/entityext/eca/EntityEcaUtil.java
@@ -52,15 +52,25 @@ public final class EntityEcaUtil {
     private static final UtilCache<String, Map<String, Map<String, List<EntityEcaRule>>>> ENTITY_ECA_READERS =
             UtilCache.createUtilCache("entity.EcaReaders", 0, 0, false);
 
+    // Guards getEntityEcaCache()'s check-then-build-then-publish sequence: concurrent Delegator
+    // construction (see GenericDelegator.initEntityEcaHandler()) can race a cache miss for the same
+    // reader name, each redundantly rebuilding before only one publish wins.
+    private static final Object CONFIG_LOCK = new Object();
+
     private EntityEcaUtil() { }
 
     public static Map<String, Map<String, List<EntityEcaRule>>> getEntityEcaCache(String entityEcaReaderName) {
         Map<String, Map<String, List<EntityEcaRule>>> ecaCache = ENTITY_ECA_READERS.get(entityEcaReaderName);
         if (ecaCache == null) {
-            // FIXME: Collections are not thread safe
-            ecaCache = new HashMap<>();
-            readConfig(entityEcaReaderName, ecaCache);
-            ecaCache = ENTITY_ECA_READERS.putIfAbsentAndGet(entityEcaReaderName, ecaCache);
+            synchronized (CONFIG_LOCK) {
+                // Re-check: another thread may have already published this while we waited for the lock.
+                ecaCache = ENTITY_ECA_READERS.get(entityEcaReaderName);
+                if (ecaCache == null) {
+                    ecaCache = new HashMap<>();
+                    readConfig(entityEcaReaderName, ecaCache);
+                    ecaCache = ENTITY_ECA_READERS.putIfAbsentAndGet(entityEcaReaderName, ecaCache);
+                }
+            }
         }
         return ecaCache;
     }


### PR DESCRIPTION
Backported from trunk (#1839). The regression test isn't included here: release24.09's plain unit-test JVM never bootstraps ComponentConfig (0 components loaded), so the trunk test's approach of racing real component-registered entity ECA resources doesn't apply in that environment. Verified via a full testIntegration run instead, which does boot the container and exercises the real race end-to-end.