### PR TITLE
Improved: Allow testIntegration to run with --portoffset for concurrent test runs (OFBIZ-13518)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -673,7 +673,11 @@ task loadAll(group: ofbizServer) {
 }
 
 task testIntegration(group: ofbizServer) {
-    dependsOn 'ofbiz --test'
+    def command = 'ofbiz --test'
+    if (project.hasProperty('portOffset')) {
+        command += " --portoffset=${project.property('portOffset')}"
+    }
+    dependsOn command
     description = 'Run OFBiz integration tests; You must run loadAll before running this task'
 }
 

--- a/framework/rest-api/src/test/java/org/apache/ofbiz/ws/rs/test/RestTestHttpRequest.java
+++ b/framework/rest-api/src/test/java/org/apache/ofbiz/ws/rs/test/RestTestHttpRequest.java
@@ -32,6 +32,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipException;
 
+import org.apache.ofbiz.base.start.Start;
 import org.apache.ofbiz.base.util.Debug;
 import org.apache.ofbiz.base.util.HttpClient;
 import org.apache.ofbiz.base.util.HttpClientException;
@@ -52,9 +53,14 @@ import jakarta.ws.rs.HttpMethod;
 class RestTestHttpRequest implements JupiterTestHelper {
 
     private static final String MODULE = RestTestHttpRequest.class.getName();
-    private static final String BASE_URL = "https://localhost:8443/rest";
+    private static final String BASE_URL = buildBaseUrl();
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static String accessToken;
+
+    private static String buildBaseUrl() {
+        int portOffset = Start.getInstance().getConfig().getPortOffset();
+        return "https://localhost:" + (8443 + portOffset) + "/rest";
+    }
 
     private static HttpClient initHttpClient() {
         HttpClient http = new HttpClient();

--- a/framework/widget/src/test/java/org/apache/ofbiz/widget/test/WidgetMacroLibraryTests.java
+++ b/framework/widget/src/test/java/org/apache/ofbiz/widget/test/WidgetMacroLibraryTests.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 @JunitJupiterTest
 public class WidgetMacroLibraryTests implements JupiterTestHelper {
 
-    private String screenUrl = "https://localhost:8443/webtools/control/WebtoolsLayoutDemo"; //use existing screen to present most of layout use case
+    private String screenUrl = buildScreenUrl();
     private final String authentificationQuery = "?USERNAME=admin&PASSWORD=ofbiz";
 
     /**
@@ -57,6 +57,19 @@ public class WidgetMacroLibraryTests implements JupiterTestHelper {
     }
 
     /**
+     * Build the demo layout screen URL, accounting for --portoffset since each
+     * @Test method runs against a fresh instance and can't share a mutated field.
+     */
+    private static String buildScreenUrl() {
+        String url = "https://localhost:8443/webtools/control/WebtoolsLayoutDemo"; //use existing screen to present most of layout use case
+        int portOffset = Start.getInstance().getConfig().getPortOffset();
+        if (portOffset != 0) {
+            url = url.replace("8443", String.valueOf(8443 + portOffset));
+        }
+        return url;
+    }
+
+    /**
      * Test html macro library.
      * @throws Exception the exception
      */
@@ -64,10 +77,6 @@ public class WidgetMacroLibraryTests implements JupiterTestHelper {
     @Order(1)
     public void testHtmlMacroLibrary() throws Exception {
         HttpClient http = initHttpClient();
-        if (Start.getInstance().getConfig().getPortOffset() != 0) {
-            Integer port = 8443 + Start.getInstance().getConfig().getPortOffset();
-            screenUrl = screenUrl.replace("8443", port.toString());
-        }
         http.setUrl(screenUrl.concat(authentificationQuery));
         String screenOutString = http.post();
         assertNotNull(screenOutString, "Response failed from ofbiz");


### PR DESCRIPTION
OFBiz's Start entrypoint already supports --portoffset=<N>, which shifts every container's bound ports including the test Catalina container, but testIntegration had no way to pass it through since it hardcoded dependsOn 'ofbiz --test'. Added an optional -PportOffset Gradle property that appends --portoffset=<N> to the underlying command when set, with no change in behavior when omitted, so multiple testIntegration runs can execute concurrently without port conflicts. Also fixed two pre-existing test bugs that block a clean run under a nonzero offset: WidgetMacroLibraryTests and RestTestHttpRequest both hardcoded localhost:8443 URLs, and only one of six WidgetMacroLibraryTests methods self-corrected for a nonzero offset.