### PR TITLE
Improved: Allow testIntegration to run with --portoffset for concurrent test runs (OFBIZ-13518)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -364,7 +364,11 @@ task loadAll(group: ofbizServer) {
 }
 
 task testIntegration(group: ofbizServer) {
-    dependsOn 'ofbiz --test'
+    def command = 'ofbiz --test'
+    if (project.hasProperty('portOffset')) {
+        command += " --portoffset=${project.property('portOffset')}"
+    }
+    dependsOn command
     description = 'Run OFBiz integration tests; You must run loadAll before running this task'
 }
 

--- a/framework/widget/src/main/java/org/apache/ofbiz/widget/test/WidgetMacroLibraryTests.java
+++ b/framework/widget/src/main/java/org/apache/ofbiz/widget/test/WidgetMacroLibraryTests.java
@@ -34,7 +34,7 @@ import org.apache.tika.sax.BodyContentHandler;
 
 public class WidgetMacroLibraryTests extends OFBizTestCase {
 
-    private String screenUrl = "https://localhost:8443/webtools/control/WebtoolsLayoutDemo"; //use existing screen to present most of layout use case
+    private String screenUrl = buildScreenUrl();
     private final String authentificationQuery = "?USERNAME=admin&PASSWORD=ofbiz";
 
     public WidgetMacroLibraryTests(String name) {
@@ -53,15 +53,24 @@ public class WidgetMacroLibraryTests extends OFBizTestCase {
     }
 
     /**
+     * Build the demo layout screen URL, accounting for --portoffset since each
+     * test method runs against a fresh instance and can't share a mutated field.
+     */
+    private static String buildScreenUrl() {
+        String url = "https://localhost:8443/webtools/control/WebtoolsLayoutDemo"; //use existing screen to present most of layout use case
+        int portOffset = Start.getInstance().getConfig().getPortOffset();
+        if (portOffset != 0) {
+            url = url.replace("8443", String.valueOf(8443 + portOffset));
+        }
+        return url;
+    }
+
+    /**
      * Test html macro library.
      * @throws Exception the exception
      */
     public void testHtmlMacroLibrary() throws Exception {
         HttpClient http = initHttpClient();
-        if (Start.getInstance().getConfig().getPortOffset() != 0) {
-            Integer port = 8443 + Start.getInstance().getConfig().getPortOffset();
-            screenUrl = screenUrl.replace("8443", port.toString());
-        }
         http.setUrl(screenUrl.concat(authentificationQuery));
         String screenOutString = http.post();
         assertNotNull("Response failed from ofbiz", screenOutString);


### PR DESCRIPTION
Backported from trunk (#1842). OFBiz's Start entrypoint already supports --portoffset=<N>, which shifts every container's bound ports including the test Catalina container, but testIntegration had no way to pass it through since it hardcoded dependsOn 'ofbiz --test'. Added an optional -PportOffset Gradle property that appends --portoffset=<N> to the underlying command when set, with no change in behavior when omitted. Also fixed the same pre-existing WidgetMacroLibraryTests bug present on this branch: only one of six test methods self-corrected for a nonzero offset, so a hardcoded localhost:8443 URL broke the other five under --portoffset. Adapted rather than cherry-picked, since this branch predates the trunk test-code relocation and RestTestHttpRequest doesn't exist here.