### PR TITLE
Fixed: externalLoginKey enable flag never checked, cannot be changed live (OFBIZ-13519)

### DIFF
--- a/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ExternalLoginKeysManager.java
+++ b/framework/webapp/src/main/java/org/apache/ofbiz/webapp/control/ExternalLoginKeysManager.java
@@ -28,7 +28,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.apache.ofbiz.base.util.Debug;
-import org.apache.ofbiz.base.util.UtilValidate;
 import org.apache.ofbiz.entity.Delegator;
 import org.apache.ofbiz.entity.DelegatorFactory;
 import org.apache.ofbiz.entity.GenericValue;
@@ -53,9 +52,6 @@ public class ExternalLoginKeysManager {
     // app-switcher workflow (open two different apps from the same page) working while still
     // rejecting a second redemption against the same webapp.
     private static final Map<String, ExternalLoginTicket> EXTERNAL_LOGIN_KEYS = new ConcurrentHashMap<>();
-
-    // This variable is set to empty so we know need to read from the properties file.
-    private static String isExternalLoginKeyEnabled = "";
 
     /**
      * A minted external login key, bound to the UserLogin it authenticates and to a deadline.
@@ -164,6 +160,12 @@ public class ExternalLoginKeysManager {
         String externalKey = request.getParameter(EXTERNAL_LOGIN_KEY_ATTR);
         if (externalKey == null) return "success";
 
+        if (!isExternalLoginKeyEnabled(request)) {
+            // Feature disabled: don't even look up the ticket, so nothing about it is consumed.
+            LoginWorker.autoLoginSet(request, response);
+            return "success";
+        }
+
         // Look up without removing: the same key is shared across every cross-webapp link one
         // render emits, so it must stay valid for whichever *other* destination webapps the
         // user still hasn't visited yet. redeemFor(), below, is what actually stops replay --
@@ -239,12 +241,9 @@ public class ExternalLoginKeysManager {
      * @return
      */
     public static boolean isExternalLoginKeyEnabled(HttpServletRequest request) {
-        if (UtilValidate.isEmpty(isExternalLoginKeyEnabled)) {
-            isExternalLoginKeyEnabled = EntityUtilProperties.getPropertyValue("security",
-                    "security.login.externalLoginKey.enabled", "true",
-                    (Delegator) request.getAttribute("delegator"));
-        }
-        return "true".equals(isExternalLoginKeyEnabled);
+        return "true".equals(EntityUtilProperties.getPropertyValue("security",
+                "security.login.externalLoginKey.enabled", "true",
+                (Delegator) request.getAttribute("delegator")));
     }
 
 }


### PR DESCRIPTION
Backported from trunk (#1847). isExternalLoginKeyEnabled() cached the security.login.externalLoginKey.enabled property in a static field on first read and never re-read it, so any later change made no difference until a process restart. Separately, checkExternalLoginKey() -- the consumption path wired into the default preprocessor chain used by most controller.xml files -- never called isExternalLoginKeyEnabled() at all; the flag was only ever checked at the two key-generation call sites (RequestHandler.makeLink(), ScreenRenderer.java). Together this meant an admin disabling the property got no change in behavior on either the caching or the enforcement side. This removes the permanent caching so the property is re-read on every call, and adds the missing check to checkExternalLoginKey() so it short-circuits to success without touching the key when the feature is disabled. The production fix cherry-picked cleanly; the test file did not, since this branch's ExternalLoginKeysManagerTests predates the externalLoginKey hardening work and has no existing coverage of checkExternalLoginKey() to update, so no test changes were needed here.