### PR TITLE
Fixed: createOrderShipmentPlan leaks order items across ship groups (OFBIZ-13520)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentServices.groovy
@@ -1072,16 +1072,29 @@ Map createOrderShipmentPlan () {
     // get the product store entity
     GenericValue productStore = from('ProductStore').where(productStoreId: orderHeader.productStoreId).cache().queryOne()
     List orderItemShipGroupList = orderHeader.getRelated('OrderItemShipGroup', null, null, false)
+    // group OrderItemAndShipGroupAssoc records by shipGroupSeqId so that each shipment only gets
+    // the items actually associated with its own ship group, instead of every item on the order
+    List orderItemAndShipGroupAssocList = from('OrderItemAndShipGroupAssoc')
+            .where(orderId: orderHeader.orderId)
+            .queryList()
+    Map orderItemListByShGrpMap = [:]
+    for (GenericValue orderItemAndShipGroupAssoc : orderItemAndShipGroupAssocList) {
+        orderItemListByShGrpMap.computeIfAbsent(orderItemAndShipGroupAssoc.shipGroupSeqId) { [] } << orderItemAndShipGroupAssoc
+    }
     for (GenericValue orderItemShipGroup : orderItemShipGroupList) {
+        List perShipGroupItemList = orderItemListByShGrpMap[orderItemShipGroup.shipGroupSeqId] ?: []
+        // make sure we have something to ship for this ship group; if not, skip to the next one
+        if (!perShipGroupItemList) {
+            continue
+        }
         Map serviceResult = run service: 'createShipment', with: [primaryOrderId: orderHeader.orderId,
                                                                   primaryShipGroupSeqId: orderItemShipGroup.shipGroupSeqId,
                                                                   statusId: 'SHIPMENT_INPUT',
                                                                   originFacilityId: productStore.inventoryFacilityId]
         parameters.shipmentId = serviceResult.shipmentId
         GenericValue shipment = from('Shipment').where(parameters).queryOne()
-        List orderItems = orderHeader.getRelated('OrderItem', null, null, false)
-        orderItems.each { GenericValue orderItem ->
-            GenericValue itemProduct = from('Product').where(productId: orderItem.productId).cache().queryOne()
+        perShipGroupItemList.each { GenericValue orderItemAndShipGroupAssoc ->
+            GenericValue itemProduct = from('Product').where(productId: orderItemAndShipGroupAssoc.productId).cache().queryOne()
 
             // make sure the OrderItem is for a Product that has a ProductType with isPhysical=Y
             if (itemProduct) {
@@ -1089,10 +1102,10 @@ Map createOrderShipmentPlan () {
                 if (itemProductType.isPhysical == 'Y') {
                     // Create shipment item
                     run service: 'addOrderShipmentToShipment', with: [orderId: orderHeader.orderId,
-                                                                      orderItemSeqId: orderItem.orderItemSeqId,
+                                                                      orderItemSeqId: orderItemAndShipGroupAssoc.orderItemSeqId,
                                                                       shipmentId: shipment.shipmentId,
                                                                       shipGroupSeqId: orderItemShipGroup.shipGroupSeqId,
-                                                                      quantity: orderItem.quantity]
+                                                                      quantity: orderItemAndShipGroupAssoc.quantity]
                 }
             }
         }


### PR DESCRIPTION
createOrderShipmentPlan iterated every order item for each ship group instead of only the items associated with that ship group, so a multi-ship-group order got every item planned onto every shipment, tagged with a ship group it did not belong to. Scope the inner loop to OrderItemAndShipGroupAssoc records for the current ship group, use the assoc quantity instead of the order item's total quantity, and skip a ship group entirely when it has no associated items.