### PR TITLE
Fixed: addOrderShipmentToShipment/getQuantityForShipment broken since the minilang-to-Groovy conversion (OFBIZ-13521)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentServices.groovy
@@ -1342,7 +1342,7 @@ Map addOrderShipmentToShipment() {
         Map serviceResultCSI = run service: 'createShipmentItem', with: [shipmentId: parameters.shipmentId,
                                                                          productId: orderItem.productId,
                                                                          quantity: parameters.quantity]
-        parameters.shipmentItemSeqId = serviceResultCSI.shipemntItemSeqId
+        parameters.shipmentItemSeqId = serviceResultCSI.shipmentItemSeqId
         result.shipmentItemSeqId = serviceResultCSI.shipmentItemSeqId
         run service: 'createOrderShipment', with: parameters
     }
@@ -1374,7 +1374,7 @@ Map getQuantityForShipment() {
     BigDecimal totPlannedOrIssuedQuantity = issuedQuantity + plannedQuantity
     BigDecimal orderCancelQuantity = orderItem.cancelQuantity ?: BigDecimal.ZERO
 
-    result.remainingQuantity = orderCancelQuantity + totPlannedOrIssuedQuantity - orderItem.quantity
+    result.remainingQuantity = orderItem.quantity - orderCancelQuantity - totPlannedOrIssuedQuantity
     return result
 }
 


### PR DESCRIPTION
getQuantityForShipment computed the negative of the correct remaining quantity, so addOrderShipmentToShipment rejected almost any real quantity as "greater than the remaining quantity." Separately, a typo (shipemntItemSeqId) meant the shipment item sequence ID was never carried into the createOrderShipment call, so it always failed with a missing required parameter. Both left createOrderShipmentPlan, and anything else calling addOrderShipmentToShipment, unable to complete successfully.