### PR TITLE
Fixed: createInvoiceItemPayrol crashes on Deduction/Tax amount entry (OFBIZ-13561)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceEvents.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/invoice/InvoiceEvents.groovy
@@ -32,14 +32,20 @@ Map createInvoiceItemPayrol() {
                 if (payRol.parentTypeId == payRolGroup.invoiceItemTypeId) {
                     Map createInvoiceItem = [invoiceId: parameters.invoiceId,
                                              invoiceItemTypeId: payRol.invoiceItemTypeId,
-                                             description: "${payRolGroup.description}: ${payRol.description}",
-                                             quantity: parameters."${payRol.invoiceItemTypeId}_Quantity" ?: 1d,
-                                             amount: parameters."${payRol.invoiceItemTypeId}_Amount" ?: 0d]
+                                             description: "${payRolGroup.description} : ${payRol.description}"]
+                    String quantityParam = parameters."${payRol.invoiceItemTypeId}_Quantity"
+                    if (quantityParam) {
+                        createInvoiceItem.quantity = quantityParam
+                    }
+                    String amountParam = parameters."${payRol.invoiceItemTypeId}_Amount"
+                    if (amountParam) {
+                        createInvoiceItem.amount = amountParam
+                    }
 
-                    if (parameters."${payRol.invoiceItemTypeId}_Quantity" ||
-                            parameters."${payRol.invoiceItemTypeId}_Amount") {
+                    if (quantityParam || amountParam) {
                         if ('PAYROL_EARN_HOURS' != payRolGroup.invoiceItemTypeId) {
-                            createInvoiceItem.amount = createInvoiceItem.amount.negate()
+                            BigDecimal amountValue = amountParam ? new BigDecimal(amountParam) : BigDecimal.ZERO
+                            createInvoiceItem.amount = amountValue.negate()
                         }
                         Map serviceResult = run service: 'createInvoiceItem', with: createInvoiceItem
                         if (ServiceUtil.isError(serviceResult)) {


### PR DESCRIPTION
- Coerced the raw HTTP-string Amount parameter to BigDecimal before negating it (this event receives raw, unconverted request strings, unlike a service context) - fixes a crash on every Deduction/Tax line item entry
- Removed the ?: 1d/?: 0d defaults for blank Quantity/Amount to match minilang's null-skip behavior, restoring the original validation-rejects-blank-amount behavior for Earnings/Hours rows
- Restored the description separator's leading space ("X : Y", matching minilang) lost in the conversion