### PR TITLE
Fixed: checkContentOperationSecurity crashes when content has a purpose assigned (OFBIZ-13535)

### DIFF
--- a/applications/content/src/main/groovy/org/apache/ofbiz/content/permission/ContentPermissionServices.groovy
+++ b/applications/content/src/main/groovy/org/apache/ofbiz/content/permission/ContentPermissionServices.groovy
@@ -353,7 +353,7 @@ Map checkContentOperationSecurity(String contentOperationId, String contentPurpo
                         .orderBy('contentPurposeTypeId')
                         .cache()
                         .queryList()
-                operations << currentOperations
+                operations.addAll(currentOperations)
             }
         } else {
             operations = from('ContentPurposeOperation')
@@ -531,7 +531,7 @@ Map checkRoleSecurity(String roleEntity, String roleEntityField, String checkId,
 /**
  * Find all content purposes for the specified content
  */
-Map findAllContentPurposes(String checkId) {
+Object findAllContentPurposes(String checkId) {
     if (!checkId) {
         return error(label('ContentUiLabels', 'ContentRequiredField', [requiredField: 'checkId']))
     }


### PR DESCRIPTION
- Fixed operations << currentOperations nesting a sub-list instead of flattening it, which made the operations loop crash with MissingPropertyException on any content with a ContentPurpose assigned
- Fixed findAllContentPurposes's declared return type (Map, should never have been narrowed from def) crashing with GroovyCastException for the same trigger condition, earlier in the same call chain, before the bug above could even be reached