### PR TITLE
Fixed: ContentServices status-transition and content-creation regressions (OFBIZ-13540)

### DIFF
--- a/applications/content/src/main/groovy/org/apache/ofbiz/content/content/ContentServicesScript.groovy
+++ b/applications/content/src/main/groovy/org/apache/ofbiz/content/content/ContentServicesScript.groovy
@@ -25,6 +25,7 @@ import org.apache.ofbiz.entity.GenericValue
 import org.apache.ofbiz.entity.condition.EntityCondition
 import org.apache.ofbiz.entity.condition.EntityConditionBuilder
 import org.apache.ofbiz.entity.condition.EntityOperator
+import org.apache.ofbiz.entity.util.EntityUtilProperties
 import org.apache.ofbiz.service.GenericServiceException
 import org.apache.ofbiz.service.ModelService
 import org.apache.ofbiz.service.ServiceUtil
@@ -32,13 +33,13 @@ import org.apache.ofbiz.service.ServiceUtil
 Map createTextAndUploadedContent() {
     Map result = success()
 
-    Map serviceResult = run service: 'createContent', with: parameters
+    Map serviceResult = run service: 'createTextContent', with: parameters
     parameters.parentContentId = serviceResult.contentId
 
     if (parameters.uploadedFile) {
         logInfo('Uploaded file found; processing sub-content')
         Map uploadContext = [*: parameters,
-                             ownerContentId: parentContentId,
+                             ownerContentId: parameters.parentContentId,
                              contentIdFrom: parameters.parentContentId,
                              contentAssocTypeId: 'SUB_CONTENT',
                              contentPurposeTypeId: 'SECTION']
@@ -126,9 +127,9 @@ Map createContentAlternativeUrl() {
     defaultLocaleString = parameters.locale ?: 'en'
 
     EntityCondition entryExprs
-    EntityCondition contentTypeExprs = EntityCondition.makeCondition(EntityOperator.OR,
-            'contentTypeId', 'DOCUMENT',
-            'contentTypeId', 'WEB_SITE_PUB_PT')
+    EntityCondition contentTypeExprs = EntityCondition.makeCondition([
+            EntityCondition.makeCondition('contentTypeId', 'DOCUMENT'),
+            EntityCondition.makeCondition('contentTypeId', 'WEB_SITE_PUB_PT')], EntityOperator.OR)
     if (parameters.contentId) {
         entryExprs = new EntityConditionBuilder().AND(contentTypeExprs) {
             NOT_EQUAL(contentName: null)
@@ -155,8 +156,7 @@ Map createContentAlternativeUrl() {
                         .filterByDate('caFromDate', 'caThruDate')
                         .queryList()
                 if (contentAssocDataResources) {
-                    if (contentAssocDataResources
-                            && contentAssocDataResources[0].drObjectInfo
+                    if (!contentAssocDataResources[0].drObjectInfo
                             && content.contentName) {
                         String uri = UrlServletHelper.invalidCharacter(content.contentName)
                         if (uri) {
@@ -171,6 +171,8 @@ Map createContentAlternativeUrl() {
                             }
                             contentCreated = 'Y'
                         }
+                    } else {
+                        contentCreated = 'N'
                     }
                 } else {
                     if (content.contentName) {
@@ -252,11 +254,8 @@ Map createArticleContent() {
     if (textData) {
         int textDataLen = textData.length()
         logInfo('textDataLen: ' + textDataLen)
-        int descriptLen = 0
-        if (parameters.descriptLen) {
-            descriptLen = (int) parameters.descriptLen
-            logInfo('descriptLen: ' + descriptLen)
-        }
+        int descriptLen = EntityUtilProperties.getPropertyValue('forum', 'descriptLen', '0', delegator) as Integer
+        logInfo('descriptLen: ' + descriptLen)
         int subStringLen = Math.min(descriptLen, textDataLen)
         logInfo('subStringLen: ' + subStringLen)
         subDescript = textData.substring(0, subStringLen)
@@ -368,8 +367,11 @@ Map setContentStatus() {
                 content.statusId = parameters.statusId
                 content.store()
             } else {
-                result.errorMessage = "Cannot change from ${oldStatusId} to ${parameters.statusId}"
-                logError(result.errorMessage)
+                String errorMessage = "Cannot change from ${oldStatusId} to ${parameters.statusId}"
+                logError(errorMessage)
+                result.responseMessage = 'error'
+                result.errorMessage = errorMessage
+                return result
             }
         }
     } else {


### PR DESCRIPTION
- setContentStatus now rejects an invalid status transition instead of silently reporting success, since the else-branch previously set an error message without ever returning it or marking the response as an error.
- createTextAndUploadedContent now calls createTextContent instead of createContent so a DataResource/ElectronicText is actually created for the text data, and no longer references the undefined bare parentContentId variable.
- createContentAlternativeUrl's contentTypeExprs condition is rebuilt as a proper OR of two separate EntityConditions instead of the makeCondition(EntityOperator, keysValues...) overload, which silently collapsed the repeated contentTypeId key and dropped DOCUMENT-type content from the query.
- createContentAlternativeUrl's inner drObjectInfo check regains its else branch so contentCreated is explicitly set to 'N' when nothing needs repairing.
- createArticleContent now reads its description length via EntityUtilProperties from the forum.properties descriptLen setting instead of leaving it hardcoded at 0, restoring the originally intended truncation behavior.