### PR TITLE
Fixed: quickShipEntireOrder calls undefined errorMessage() instead of error() (OFBIZ-13564)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/shipment/ShipmentServices.groovy
@@ -776,7 +776,7 @@ Map quickShipEntireOrder() {
     }
     if (productStore.explodeOrderItems == 'Y') {
         // can't insert duplicate rows in shipmentPackageContent
-        return errorMessage(UtilProperties.getMessage('ProductUiLabels',
+        return error(UtilProperties.getMessage('ProductUiLabels',
                 'FacilityShipmentNotCreatedForExplodesOrderItems', [productStore: productStore], locale))
     }
     // locate shipping facilities associated with order item rez's


### PR DESCRIPTION
quickShipEntireOrder() called a non-existent errorMessage() method instead of the GroovyBaseScript-provided error(), throwing groovy.lang.MissingMethodException whenever productStore.explodeOrderItems == 'Y' instead of returning the intended service error.