### PR TITLE
Fixed: CommunicationEventServices sender/recipient and status regressions (OFBIZ-13542)

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/communication/CommunicationEventServicesScript.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/communication/CommunicationEventServicesScript.groovy
@@ -43,7 +43,7 @@ Map createCommunicationEvent() {
         newCommEvent.remove('communicationEventId')
         newCommEvent.remove('messageId')
         newCommEvent.remove('partyIdTo')
-        newCommEvent.partyIdFrom = parameters.partyIdTo
+        newCommEvent.partyIdFrom = parameters.partyIdFrom
         String forwardLabel = UtilProperties.getPropertyValue('PartyUiLabels', 'PartyForward')
         newCommEvent.subject = "${forwardLabel}: ${newCommEvent.subject}"
         newCommEvent.origCommEventId = parameters.origCommEventId
@@ -64,7 +64,7 @@ Map createCommunicationEvent() {
                 .where('communicationEventId', parameters.parentCommEventId)
                 .queryOne()
         GenericValue party = from('Party')
-                .where('partyId', parameters.partyIdFrom)
+                .where('partyId', parentCommEvent.partyIdFrom)
                 .queryOne()
         newCommEvent.communicationEventTypeId = parentCommEvent.communicationEventTypeId
         if (newCommEvent.communicationEventTypeId == 'AUTO_EMAIL_COMM') {
@@ -264,7 +264,7 @@ Map updateCommunicationEvent() {
         if (event.partyIdTo) {
             GenericValue roleTo = from('CommunicationEventRole')
                     .where([communicationEventId: event.communicationEventId,
-                            partyId: event.partyIdto,
+                            partyId: event.partyIdTo,
                             roleTypeId: 'ADDRESSEE'])
                     .queryOne()
             roleTo?.remove()
@@ -540,21 +540,21 @@ Map setCommunicationEventStatus() {
                         role.store()
                     }
                 }
-            }
-        } else { //make sure at least the senders role is set to complete
+            } else { //make sure at least the senders role is set to complete
 
-            GenericValue communicationEventRole =
-                    from('CommunicationEventRole').where(
-                            communicationEventId: communicationEvent.communicationEventId,
-                            partyId: communicationEvent.partyIdFrom,
-                            roleTypeId: 'ORIGINATOR')
-                            .queryOne()
-            //found a mispelling in minilang so ...
-            if (communicationEventRole
-                    && 'COM_ROLE_COMPLETED' != communicationEventRole.statusId) {
-                Map updateRoleMap = [*:communicationEventRole]
-                updateRoleMap.statusId = 'COM_ROLE_COMPLETED'
-                run service: 'updateCommunicationEventRole', with: updateRoleMap
+                GenericValue communicationEventRole =
+                        from('CommunicationEventRole').where(
+                                communicationEventId: communicationEvent.communicationEventId,
+                                partyId: communicationEvent.partyIdFrom,
+                                roleTypeId: 'ORIGINATOR')
+                                .queryOne()
+                //found a mispelling in minilang so ...
+                if (communicationEventRole
+                        && 'COM_ROLE_COMPLETED' != communicationEventRole.statusId) {
+                    Map updateRoleMap = [*:communicationEventRole]
+                    updateRoleMap.statusId = 'COM_ROLE_COMPLETED'
+                    run service: 'updateCommunicationEventRole', with: updateRoleMap
+                }
             }
         }
     }


### PR DESCRIPTION
- createCommunicationEvent's FORWARD path now attributes the forwarded message's sender to the forwarder (parameters.partyIdFrom) instead of silently reusing the new recipient (parameters.partyIdTo) when no explicit sender is supplied.
- createCommunicationEvent's REPLY/REPLYALL quote-attribution now looks up the original message's author (parentCommEvent.partyIdFrom) instead of the person replying (parameters.partyIdFrom), so the "X wrote:" quote correctly credits the original sender.
- updateCommunicationEvent fixes a lowercase field-name typo (event.partyIdto instead of event.partyIdTo) that threw an IllegalArgumentException whenever a caller reassigned an already-set recipient.
- setCommunicationEventStatus's else branch is reattached to the inner setRoleStatusToComplete == 'Y' check instead of the outer statusId == COM_COMPLETE check, so the sender's role is marked complete only on a complete-without-mark-all-roles transition, not on every non-complete status change.