### PR TITLE
Fixed: CheckoutServices anonymous-checkout party reattachment and createUpdatePerson new-party-id regressions (OFBIZ-13544)

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/order/CheckoutServices.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/order/CheckoutServices.groovy
@@ -60,7 +60,7 @@ Map createUpdateCustomerAndShippingAddress() {
 
     Map partyRoleCtx = [partyId: partyId, roleTypeId: 'CUSTOMER']
     if (userLogin) {
-        if (userLogin.userLoginId == 'anonymos') {
+        if (userLogin.userLoginId == 'anonymous') {
             userLogin.partyId = partyId
         }
         partyRoleCtx.userLogin = userLogin

--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyServicesScript.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyServicesScript.groovy
@@ -693,7 +693,10 @@ Map createUpdatePerson() {
        .where(partyId: partyId)
        .queryOne()
     String serviceName = (party ? 'update' : 'create') + 'Person'
-    run service: serviceName, with: personContext
+    Map serviceResult = run service: serviceName, with: personContext
+    if (!party) {
+        partyId = serviceResult.partyId
+    }
     resultMap.partyId = partyId
     return resultMap
 }


### PR DESCRIPTION
- createUpdateCustomerAndShippingAddress's anonymous-user check is corrected from the misspelled 'anonymos' to 'anonymous', so a first-time guest checkout's shopping-cart userLogin is actually attached to the newly created party, rather than the branch silently never running.
- createUpdatePerson now captures the newly-generated partyId from createPerson's result when creating a brand-new person, instead of always returning the (often empty) partyId it was originally called with. This was discovered while verifying the fix above: it's the only production caller of createUpdatePerson, and without this fix a genuine first-time anonymous checkout would crash at the very next step (ensurePartyRole) with a "Required Field Missing: Party Id" error, so both fixes are needed together to actually restore working anonymous checkout.