### PR TITLE
Fixed: updateBlogEntry checks the wrong field for existing article text (OFBIZ-13545)

### DIFF
--- a/applications/content/src/main/groovy/org/apache/ofbiz/content/BlogServices.groovy
+++ b/applications/content/src/main/groovy/org/apache/ofbiz/content/BlogServices.groovy
@@ -168,7 +168,7 @@ Map updateBlogEntry() {
         }
     }
 
-    if (!blog.articleText && parameters.articleData) {
+    if (!blog.articleData && parameters.articleData) {
         run service: 'createTextContent',
                 with: [
                         dataResourceTypeId: 'ELECTRONIC_TEXT',


### PR DESCRIPTION
updateBlogEntry checked blog.articleText, a field getBlogEntry never populates on its result map (only a same-named local variable existed in minilang's shared-scope version, lost in the conversion to an isolated service call), instead of the correctly-populated blog.articleData. Since blog.articleText was always null, every edit to an existing blog post's article text created a duplicate "ARTICLE" sub-content instead of updating the original one's text in place, matching the parallel (and correct) summary-text check a few lines below.