### PR TITLE
Fixed: updateBlogEntry checks the wrong field for existing article text (OFBIZ-13545)

### DIFF
--- a/applications/content/src/main/groovy/org/apache/ofbiz/content/BlogServices.groovy
+++ b/applications/content/src/main/groovy/org/apache/ofbiz/content/BlogServices.groovy
@@ -168,7 +168,7 @@ Map updateBlogEntry() {
         }
     }
 
-    if (!blog.articleText && parameters.articleData) {
+    if (!blog.articleData && parameters.articleData) {
         run service: 'createTextContent',
                 with: [
                         dataResourceTypeId: 'ELECTRONIC_TEXT',


### PR DESCRIPTION
Backported from trunk (#1883).