### PR TITLE
Fixed: updatePartyInvitation crashes when auto-deriving the invitee name (OFBIZ-13553)

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyInvitationServices.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyInvitationServices.groovy
@@ -38,7 +38,7 @@ Map createPartyInvitation() {
 Map updatePartyInvitation() {
     GenericValue lookedUpValue = makeValue('PartyInvitation', parameters)
     if (! parameters.toName && parameters.partyId) {
-        newEntity.toName = PartyHelper.getPartyName(delegator, parameters.partyId, false)
+        lookedUpValue.toName = PartyHelper.getPartyName(delegator, parameters.partyId, false)
     }
     lookedUpValue.store()
     return success()


### PR DESCRIPTION
updatePartyInvitation referenced an undeclared newEntity variable, belonging to the sibling createPartyInvitation method, instead of its own lookedUpValue, throwing MissingPropertyException on every call that supplies partyId with an empty toName.