### PR TITLE
Fixed: updatePartyInvitation crashes when auto-deriving the invitee name (OFBIZ-13553)

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyInvitationServices.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyInvitationServices.groovy
@@ -40,7 +40,7 @@ Map createPartyInvitation() {
 Map updatePartyInvitation() {
     GenericValue lookedUpValue = makeValue('PartyInvitation', parameters)
     if (! parameters.toName && parameters.partyId) {
-        newEntity.toName = PartyHelper.getPartyName(delegator, parameters.partyId, false)
+        lookedUpValue.toName = PartyHelper.getPartyName(delegator, parameters.partyId, false)
     }
     lookedUpValue.store()
     return success()


### PR DESCRIPTION
Backported from trunk (#1885).