### PR TITLE
Fixed: TaxAuthorityServices tax-ID validation and update regressions (OFBIZ-13555)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/tax/TaxAuthorityServicesScript.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/tax/TaxAuthorityServicesScript.groovy
@@ -51,10 +51,11 @@ Map updatePartyTaxAuthInfo() {
         return error(errorMesg)
     }
     GenericValue partyAuthInfo = from('PartyTaxAuthInfo').where(parameters).queryOne()
-    if (partyAuthInfo) {
-        partyAuthInfo.setNonPKFields(parameters, false)
-        partyAuthInfo.store()
+    if (!partyAuthInfo) {
+        return error('PartyTaxAuthInfo not found for the given parameters')
     }
+    partyAuthInfo.setNonPKFields(parameters, false)
+    partyAuthInfo.store()
     return success()
 }
 
@@ -64,7 +65,7 @@ Map updatePartyTaxAuthInfo() {
 String validatePartyTaxIdInline() {
     GenericValue taxAuthority = from('TaxAuthority').where(parameters).queryOne()
     if (taxAuthority && taxAuthority.taxIdFormatPattern && parameters.partyTaxId &&
-            !Pattern.compile(taxAuthority.taxIdFormatPattern).matcher(parameters.partyTaxId).find()) {
+            !Pattern.compile(taxAuthority.taxIdFormatPattern).matcher(parameters.partyTaxId).matches()) {
         return label('AccountingErrorUiLabels', 'AccountingTaxIdInvalidFormat', [parameters: parameters, taxAuthority: taxAuthority])
     }
     return ''
@@ -75,9 +76,9 @@ String validatePartyTaxIdInline() {
  * @return Success, error response otherwise.
  */
 Map createCustomerTaxAuthInfo() {
-    List taxAuthPartyGeoIds = org.apache.ofbiz.base.util.StringUtil.split(parameters.taxAuthPartyGeoIds, '::')
-    parameters.taxAuthPartyId = taxAuthPartyGeoIds[0]
-    parameters.taxAuthGeoId = taxAuthPartyGeoIds[1]
+    String taxAuthPartyGeoIds = parameters.taxAuthPartyGeoIds
+    parameters.taxAuthPartyId = taxAuthPartyGeoIds.substring(0, taxAuthPartyGeoIds.indexOf('::'))
+    parameters.taxAuthGeoId = taxAuthPartyGeoIds.substring(taxAuthPartyGeoIds.indexOf('::') + 2)
     run service: 'createPartyTaxAuthInfo', with: parameters
     return success()
 }


### PR DESCRIPTION
- validatePartyTaxIdInline used Pattern.matcher(...).find() (partial match), silently accepting malformed tax IDs whenever they merely contain a valid-looking substring, instead of .matches() (full-string match, matching minilang's original <if-regexp> semantics).
- updatePartyTaxAuthInfo now returns an error instead of silently succeeding when the target PartyTaxAuthInfo record doesn't exist, matching minilang's <set-nonpk-fields>/<store-value> behavior against a missing lookup.
- createCustomerTaxAuthInfo now splits taxAuthPartyGeoIds using literal-substring semantics on :: (matching minilang's .indexOf("::")/.substring() logic) instead of StringUtil.split, whose StringTokenizer-based delimiter is a character set (:), not the literal two-character substring, and would incorrectly split on any embedded single colon.