### PR TITLE
Fixed: createUpdateCustomerAndShippingAddress leaves shipToAddressCtx.partyId stale after a new party is created (OFBIZ-13565)

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/order/CheckoutServices.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/order/CheckoutServices.groovy
@@ -57,6 +57,7 @@ Map createUpdateCustomerAndShippingAddress() {
     createUpdatePersonCtx.partyId = partyId
     Map serviceResultCUP = run service: 'createUpdatePerson', with: createUpdatePersonCtx
     partyId = serviceResultCUP.partyId
+    parameters.partyId = partyId
 
     Map partyRoleCtx = [partyId: partyId, roleTypeId: 'CUSTOMER']
     if (userLogin) {


### PR DESCRIPTION
Backported from trunk (#1889)