### PR TITLE
Fixed: lookupParty crashes on empty search criteria (OFBIZ-13556)

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/LookupServices.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/LookupServices.groovy
@@ -18,14 +18,26 @@
 */
 package org.apache.ofbiz.party.party
 
+import org.apache.ofbiz.entity.util.EntityListIterator
+
 /*
  * lookupParty is deprecated, and only present for backward compatibility during the deprecation time
  */
 Map lookupParty() {
     Map serviceResult = run service: 'performFindParty', with: parameters
     List lookupResult = []
-    serviceResult.listIt.getCompleteList().each {
-        lookupResult << [label: it.firstName, value: it.partyId]
+    EntityListIterator listIt = serviceResult.listIt
+    if (listIt) {
+        try {
+            listIt.getCompleteList().each {
+                lookupResult << [label: it.firstName, value: it.partyId]
+            }
+        } finally {
+            listIt.close()
+        }
+    }
+    if (!lookupResult) {
+        lookupResult << [label: 'No match', value: '']
     }
     Map result = success()
     result.lookupResult = lookupResult


### PR DESCRIPTION
lookupParty crashed with a NullPointerException on empty search criteria, since performFindParty (the shared service it now delegates to, replacing minilang's self-contained <find-by-and>) only populates its listIt result under certain input conditions, and no null-check was added for the remaining case. Also restores minilang's explicit "No match" placeholder entry on a zero-match search, which the conversion silently dropped in favor of an empty result list. The EntityListIterator is also explicitly closed after use to release its underlying database cursor.