### PR TITLE
Fixed: voidPayment throws on a non-invoice payment application (OFBIZ-13560)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/payment/PaymentServices.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/payment/PaymentServices.groovy
@@ -373,7 +373,7 @@ Map voidPayment() {
         .queryList()
         .each { it ->
             Map invoice = from('Invoice').where(invoiceId: it.invoiceId).queryOne()
-            if (invoice.statusId == 'INVOICE_PAID') {
+            if (invoice?.statusId == 'INVOICE_PAID') {
                 run service: 'setInvoiceStatus', with: [*: invoice.getAllFields(),
                                                         paidDate: null,
                                                         statusId: 'INVOICE_READY']


### PR DESCRIPTION
voidPayment threw a null-dereference crash when voiding a payment with any non-invoice-linked PaymentApplication (one applied to a billing account, another payment, a GL account, or a tax authority) - the query for the associated invoice legitimately returns nothing in that case, and the following status check dereferenced it unconditionally. Minilang's equivalent <get-related-one>/<if-compare> combination safely skipped this case; the Groovy version now does the same via a null-safe check.