### PR TITLE
Fixed: duplicateCategoryEntities throws GroovyCastException (OFBIZ-13563)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/product/category/CategoryServicesScript.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/product/category/CategoryServicesScript.groovy
@@ -353,7 +353,7 @@ Map duplicateCategoryEntities() {
  * copies all entities of entityName with a productCategoryId to a new entity with a productCategoryIdTo,
  * filtering them by a timestamp passed in to validDate if necessary
  */
-Map copyCategoryEntities(String entityName, String productCategoryId, String productCategoryIdTo, Timestamp validDate) {
+void copyCategoryEntities(String entityName, String productCategoryId, String productCategoryIdTo, Timestamp validDate) {
     EntityQuery query = from(entityName).where('productCategoryId', productCategoryId)
     if (validDate) {
         query.filterByDate()


### PR DESCRIPTION
copyCategoryEntities() was declared with a Map return type, but its last statement (delegator.storeAll(entitiesToStore)) implicitly returns an int (the number of rows stored). Groovy coerces the returned value to the declared type, throwing a GroovyCastException. Since the return value is unused by all call sites, the method is declared void, which prevents Groovy from attempting the coercion.