### PR TITLE
Fixed: createQuoteFromCart duplicates QuoteAdjustment records (OFBIZ-13525)

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/quote/QuoteServicesScript.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/quote/QuoteServicesScript.groovy
@@ -526,12 +526,12 @@ Map createQuoteFromCart() {
             //and the quoteItemSeqId is assigned to the shopping cart item (as orderItemSeqId)
             item.setOrderItemSeqId(serviceQuoteItemResult.quoteItemSeqId)
         }
-        if (parameters.applyStorePromotions != 'N') {
-            cart.makeAllQuoteAdjustments()?.each { GenericValue adjustment ->
-                adjustment.quoteId = quote.quoteId
-                adjustment.quoteAdjustmentId = delegator.getNextSeqId('QuoteAdjustment')
-                adjustment.create()
-            }
+    }
+    if (parameters.applyStorePromotions != 'N') {
+        cart.makeAllQuoteAdjustments()?.each { GenericValue adjustment ->
+            adjustment.quoteId = quote.quoteId
+            adjustment.quoteAdjustmentId = delegator.getNextSeqId('QuoteAdjustment')
+            adjustment.create()
         }
     }
     return [successMessage: null, quoteId: quote.quoteId]


### PR DESCRIPTION
The block that creates QuoteAdjustment records from the cart's store promotions was nested inside the per-cart-item loop instead of running once after it. Every store promotion recomputed by makeAllQuoteAdjustments() covers the whole cart, not a single item, so nesting it inside the loop persisted the same set of adjustments once per cart item instead of once per order, inflating quote totals for any cart with more than one item. Moving the block outside the loop restores the original minilang's once-per-cart behavior.