### PR TITLE
Fixed: productPriceGenericPermission ignores its own sub-check result (OFBIZ-13538)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/product/product/ProductServicesScript.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/product/product/ProductServicesScript.groovy
@@ -621,7 +621,7 @@ Map productGenericPermission() {
     result.hasPermission = ServiceUtil.isSuccess(
             checkProductRelatedPermission(parameters.resourceDescription, parameters.mainAction))
     if (!result.hasPermission) {
-        result = fail(UtilProperties.getMessage('ProductUiLabels', 'ProductPermissionError', parameters.locale))
+        result = failure(UtilProperties.getMessage('ProductUiLabels', 'ProductPermissionError', parameters.locale))
     }
     return result
 }
@@ -641,9 +641,10 @@ Map productPriceGenericPermission() {
         result = error(UtilProperties.getMessage('ProductUiLabels',
                 'ProductPriceMaintPermissionError', parameters.locale))
     }
-    result.hasPermission = ServiceUtil.isSuccess(result) && checkProductRelatedPermission(parameters.resourceDescription, mainAction)
+    result.hasPermission = ServiceUtil.isSuccess(result) &&
+            ServiceUtil.isSuccess(checkProductRelatedPermission(parameters.resourceDescription, mainAction))
     if (!result.hasPermission) {
-        result = fail(UtilProperties.getMessage('ProductUiLabels', 'ProductPermissionError', parameters.locale))
+        result = failure(UtilProperties.getMessage('ProductUiLabels', 'ProductPermissionError', parameters.locale))
     }
     return result
 }


### PR DESCRIPTION
- productPriceGenericPermission ANDed the raw Map returned by checkProductRelatedPermission directly into hasPermission instead of wrapping it in ServiceUtil.isSuccess() first. Since a non-empty Map is always truthy in Groovy regardless of whether it represents success or failure, the product-scoped LTD_ADMIN/alternatePermissionRoot check was silently bypassed for any caller holding CATALOG_PRICE_MAINT.
- While verifying the fix, a second, previously undiscovered bug in the same file surfaced: both productGenericPermission and productPriceGenericPermission call a nonexistent fail(...) method instead of the real failure(...) helper on permission denial, present since the original 2018 conversion commit. Any actual permission denial from either service currently crashes with a GenericServiceException rather than returning a clean failure response. Both are fixed here since they're in the same method and the second bug blocked verifying the first.