### PR TITLE
Fixed: Bump js-yaml to 4.3.2 to resolve CVE-2026-84375

### DIFF
--- a/framework/rest-api/package-lock.json
+++ b/framework/rest-api/package-lock.json
@@ -483,9 +483,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "funding": [
                 {
                     "type": "github",

--- a/framework/rest-api/package.json
+++ b/framework/rest-api/package.json
@@ -8,7 +8,7 @@
         "redoc": "2.5.3"
     },
     "overrides": {
-        "js-yaml": "4.3.1",
+        "js-yaml": "4.3.2",
         "minimatch": "10.2.5",
         "brace-expansion": "5.0.9",
         "fast-xml-parser": "5.10.1",


### PR DESCRIPTION
js-yaml 4.0.0-4.3.1 is vulnerable to CVE-2026-84375 (GHSA-2883-xcg3-v3hh): maxTotalMergeKeys doesn't count empty mappings in a YAML merge key, letting an attacker consume disproportionate CPU with a small document. This is a transitive dependency pulled in via redoc/@redocly/openapi-core in framework/rest-api, pinned via an npm override. Bumping the override from 4.3.1 to 4.3.2, the version the advisory identifies as fixed. Not caused by any of the OFBIZ-13523 minilang-to-Groovy fixes — this is a whole-repo Scorecard dependency scan (see https://github.com/apache/ofbiz-framework/security/code-scanning/1865) that happened to attribute its latest instance to a recent trunk commit purely because that was HEAD when the CVE was published and the scan re-ran.