### PR TITLE
Fixed: Party permission-check helper methods use incorrect logic (OFBIZ-13541)

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyPermissionServices.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/party/PartyPermissionServices.groovy
@@ -97,7 +97,7 @@ Map partyStatusPermissionCheck() {
  */
 Map partyGroupPermissionCheck() {
     parameters.altPermission = 'PARTYMGR_GRP'
-    Map result = run service: 'partyStatusPermissionCheck', with: parameters
+    Map result = basePlusPartyIdPermissionCheck()
     return result
 }
 
@@ -117,7 +117,7 @@ Map partyDatasourcePermissionCheck() {
  */
 Map partyRolePermissionCheck() {
     parameters.altPermission = 'PARTYMGR_ROLE'
-    Map result = run service: 'partyStatusPermissionCheck', with: parameters
+    Map result = basePlusPartyIdPermissionCheck()
     return result
 }
 
@@ -259,9 +259,10 @@ Map cancelPartyInvitationPermissionCheck() {
  */
 Map partyCommunicationEventPermissionCheck() {
     Map result = success()
-    if (parameters.communicationEventTypeId == 'EMAIL_COMMUNICATION') {
+    String action = parameters.mainAction ?: parameters.action
+    if (parameters.communicationEventTypeId == 'EMAIL_COMMUNICATION' && action == 'CREATE') {
         parameters.altPermission = 'PARTYMGR_CME-EMAIL'
-    } else if (parameters.communicationEventTypeId == 'COMMENT_NOTE') {
+    } else if (parameters.communicationEventTypeId == 'COMMENT_NOTE' && action == 'CREATE') {
         parameters.altPermission = 'PARTYMGR_CME-NOTE'
     } else if (parameters.partyIdFrom != userLogin.partyId
             && parameters.partyIdTo != userLogin.partyId
@@ -271,6 +272,7 @@ Map partyCommunicationEventPermissionCheck() {
         result.hasPermission = true
     }
     if (!result.hasPermission) {
+        parameters.mainAction = action
         result = run service: 'basePermissionCheck', with: parameters
     }
     return result


### PR DESCRIPTION
- partyGroupPermissionCheck and partyRolePermissionCheck: call basePlusPartyIdPermissionCheck directly instead of delegating to partyStatusPermissionCheck, which was erroneously overwriting altPermission to PARTYMGR_STS and discarding the caller's intended PARTYMGR_GRP / PARTYMGR_ROLE permission check.
- partyCommunicationEventPermissionCheck: restore the missing action == 'CREATE' guard on the EMAIL_COMMUNICATION and COMMENT_NOTE branches so non-CREATE actions (such as UPDATE or DELETE) correctly fall through to the record ownership check.