### PR TITLE
Fixed: findCustomTimePeriods thruDate boundary and exclude flag (OFBIZ-13527)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/period/GPeriodServices.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/period/GPeriodServices.groovy
@@ -47,7 +47,7 @@ Map findCustomTimePeriods() {
                 .cache()
                 .queryList())
     }
-    if (parameters.excludeNoOrganizationPeriods) {
+    if (parameters.excludeNoOrganizationPeriods != 'Y') {
         EntityCondition condition = new EntityConditionBuilder().AND {
             OR {
                 EQUALS(organizationPartyId: null)
@@ -55,7 +55,7 @@ Map findCustomTimePeriods() {
             }
             LESS_THAN_EQUAL_TO(fromDate: parameters.findDate)
             OR {
-                GREATER_THAN_EQUAL_TO(thruDate: parameters.findDate)
+                GREATER_THAN(thruDate: parameters.findDate)
                 EQUALS(thruDate: null)
             }
             if (parameters.onlyIncludePeriodTypeIdList) {


### PR DESCRIPTION
- Restore strict GREATER_THAN operator for general CustomTimePeriod thruDate comparison, preventing expired periods from matching when findDate lands exactly on thruDate.
- Fix excludeNoOrganizationPeriods condition to check != 'Y', ensuring general periods are included by default when the parameter is omitted and properly excluded when set to 'Y'.