### PR TITLE
Fixed: getFXConversion fails instead of defaulting to 1 when no rate configured (OFBIZ-13531)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/admin/AcctgAdminServices.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/admin/AcctgAdminServices.groovy
@@ -158,16 +158,14 @@ Map getFXConversion() {
     }
     List<GenericValue> rates = select().from('UomConversionDated').where(condition).orderBy('-fromDate').filterByDate().queryList()
 
-    BigDecimal conversionRate
+    BigDecimal conversionRate = BigDecimal.ONE
     int decimalScale = 2
     if (rates) {
         conversionFactor = EntityUtil.getFirst(rates).getBigDecimal('conversionFactor')
         BigDecimal originalValue = BigDecimal.ONE
         conversionRate = originalValue.divide(conversionFactor, decimalScale, RoundingMode.HALF_UP)
     } else {
-        String errorMessage = 'Could not find conversion rate'
-        logError(errorMessage)
-        return error(errorMessage)
+        logWarning('Could not find conversion rate')
     }
     result.put('conversionRate', conversionRate)
     return result


### PR DESCRIPTION
Restore the original minilang behavior in getFXConversion where an unconfigured currency pair gracefully defaults conversionRate to 1 and returns success, replacing the Groovy conversion's hard error return with a warning log.