### PR TITLE
Fixed: hasValidStateProvince returns String but declared Map (OFBIZ-13533)

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/contact/ContactMechServicesScript.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/contact/ContactMechServicesScript.groovy
@@ -59,7 +59,7 @@ Map updateContactMech() {
 /**
  * locale function to control if the state province is mandatoring
  */
-Map hasValidStateProvince(String countryGeoId, String stateProvinceGeoId) {
+String hasValidStateProvince(String countryGeoId, String stateProvinceGeoId) {
     String errorMessage
     if (!stateProvinceGeoId) {
         if (countryGeoId == 'USA') {


### PR DESCRIPTION
Correct the declared return type of internal helper hasValidStateProvince from Map to String, preventing a GroovyCastException when validating addresses missing a required state/province for USA or CAN.