### PR TITLE
Fixed: recreateOrderAdjustments calls nonexistent ShoppingCartItem.getDescription (OFBIZ-13532)

### DIFF
--- a/applications/order/src/main/groovy/org/apache/ofbiz/order/order/OrderServicesScript.groovy
+++ b/applications/order/src/main/groovy/org/apache/ofbiz/order/order/OrderServicesScript.groovy
@@ -220,7 +220,7 @@ Map recreateOrderAdjustments() {
                 selectedAmount = item.getSelectedAmount()
                 unitPrice = item.getBasePrice()
                 unitListPrice = item.getListPrice()
-                itemDescription = item.getDescription()
+                itemDescription = item.getName()
                 statusId = item.getStatusId()
                 productId = item.getProductId()
                 quantity = item.getQuantity()


### PR DESCRIPTION
Restore call to item.getName() instead of item.getDescription() when creating a promotional order item, preventing issues as ShoppingCartItem has no zero-argument getDescription() method.