### PR TITLE
Fixed: filterRateAmountList sequential filtering and fallback behavior (OFBIZ-13543)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/rate/RateServices.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/rate/RateServices.groovy
@@ -254,23 +254,14 @@ Map filterRateAmountList() {
         return success()
     }
     //Check if there is a more specific rate
-    Map filterMap = [:]
-    if (parameters.workEffortId) {
-        filterMap.workEffortId = parameters.workEffortId
-    }
-    if (parameters.partyId) {
-        filterMap.partyId = parameters.partyId
-    }
-    if (parameters.emplPositionTypeId) {
-        filterMap.emplPositionTypeId = parameters.emplPositionTypeId
-    }
-    if (parameters.rateTypeId) {
-        filterMap.rateTypeId = parameters.rateTypeId
-    }
-    List tempRatesFilteredList = EntityUtil.filterByAnd(parameters.ratesList, filterMap)
-    List ratesList = []
-    if (tempRatesFilteredList) {
-        ratesList = tempRatesFilteredList
+    List ratesList = parameters.ratesList
+    for (String field : ['workEffortId', 'partyId', 'emplPositionTypeId', 'rateTypeId']) {
+        if (parameters[field]) {
+            List tempRatesFilteredList = EntityUtil.filterByAnd(ratesList, [(field): parameters[field]])
+            if (tempRatesFilteredList) {
+                ratesList = tempRatesFilteredList
+            }
+        }
     }
     Map result = success()
     result.filteredRatesList = ratesList


### PR DESCRIPTION
### Description
In minilang, `filterRateAmountList` sequentially narrowed down the `ratesList` across `workEffortId`, `partyId`, `emplPositionTypeId`, and `rateTypeId`, updating the working list only if the filtered sublist was non-empty (as documented in the comment: *"The result is the most heavily-filtered non-empty list"*).

During the Groovy conversion, a single combined `filterMap` was constructed, causing the service to return an empty list if no single rate amount matched all specified parameters simultaneously.

This change restores sequential narrowing with fallback preservation.

### Changes
- Iteratively filter `ratesList` by `workEffortId`, `partyId`, `emplPositionTypeId`, and `rateTypeId` in sequential order.
- Retain the prior non-empty working list if any narrowing step yields an empty result.