### PR TITLE
Fixed: createMissingCategoryAndProductAltUrls default parameter handling (OFBIZ-13539)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/product/catalog/CatalogServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/product/catalog/CatalogServices.groovy
@@ -284,8 +284,8 @@ Map createMissingCategoryAndProductAltUrls() {
     int categoriesUpdated = 0
     int productsNotUpdated = 0
     int productsUpdated = 0
-    String checkProduct = parameters.product
-    String checkCategory = parameters.category
+    boolean checkCategory = parameters.category ? true : !parameters.product
+    boolean checkProduct = parameters.product ? true : !parameters.category
     List prodCatalogCategoryList = from('ProdCatalogCategory').where('prodCatalogId', parameters.prodCatalogId).queryList()
 
     // get all categories


### PR DESCRIPTION
- Default checkCategory and checkProduct to true when neither parameter is supplied, enabling the Create SEO admin action while continuing to support callers specifying only one