### PR TITLE
Fixed: getProductRouting virtual product variant date filtering (OFBIZ-13550)

### DIFF
--- a/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/routing/RoutingServicesScript.groovy
+++ b/applications/manufacturing/src/main/groovy/org/apache/ofbiz/manufacturing/routing/RoutingServicesScript.groovy
@@ -50,7 +50,7 @@ Map getProductRouting() {
             GenericValue virtualProductAssoc = from('ProductAssoc')
                     .where(productIdTo: parameters.productId,
                             productAssocTypeId: 'PRODUCT_VARIANT')
-                    .filterByDate(filterDate)
+                    .filterByDate()
                     .queryFirst()
             if (virtualProductAssoc) {
                 lookupRouting.productId = virtualProductAssoc.productId


### PR DESCRIPTION
Backported from trunk (#1939).