### PR TITLE
Fixed: getSystemInfoStatus open communication events condition (OFBIZ-13551)

### DIFF
--- a/applications/commonext/src/main/groovy/org/apache/ofbiz/commonext/ofbizsetup/SystemInfoServices.groovy
+++ b/applications/commonext/src/main/groovy/org/apache/ofbiz/commonext/ofbizsetup/SystemInfoServices.groovy
@@ -20,6 +20,8 @@ package org.apache.ofbiz.commonext.ofbizsetup
 
 import org.apache.ofbiz.base.util.UtilDateTime
 import org.apache.ofbiz.entity.GenericValue
+import org.apache.ofbiz.entity.condition.EntityCondition
+import org.apache.ofbiz.entity.condition.EntityOperator
 
 Map createSystemInfoNote() {
     parameters.noteParty = parameters.noteParty ?: userLogin.partyId
@@ -83,8 +85,10 @@ Map getLastSystemInfoNote() {
 Map getSystemInfoStatus() {
     List systemInfoStatus = []
     List comms = from('CommunicationEventAndRole')
-            .where(partyId: userLogin.partyId,
-                    statusId: 'COM_ROLE_COMPLETED')
+            .where(EntityCondition.makeCondition([
+                    EntityCondition.makeCondition('partyId', userLogin.partyId),
+                    EntityCondition.makeCondition('statusId', EntityOperator.NOT_EQUAL, 'COM_ROLE_COMPLETED')
+            ]))
             .orderBy('-entryDate')
             .queryList()
     if (comms) {


### PR DESCRIPTION
Query communication events where statusId is not equal to COM_ROLE_COMPLETED rather than equal to it.