### PR TITLE
Fixed: createFacilityLocation locationSeqId collision fallback regression (OFBIZ-13557)

### DIFF
--- a/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/storage/StorageServices.groovy
+++ b/applications/product/src/main/groovy/org/apache/ofbiz/product/facility/storage/StorageServices.groovy
@@ -30,15 +30,16 @@ Map createFacilityLocation() {
     "${parameters.levelId ?: ''}${parameters.positionId ?: ''}"
 
     if (locationSeqId) {
-        int i = 1
-        String nextLocationSeqId = locationSeqId
-        while (from('FacilityLocation')
-                .where([locationSeqId: nextLocationSeqId,
-                        facilityId: parameters.facilityId])
+        if (from('FacilityLocation')
+                .where(facilityId: parameters.facilityId, locationSeqId: locationSeqId)
                 .queryOne()) {
-            nextLocationSeqId = "${locationSeqId}_${i++}"
+            locationSeqId = "${locationSeqId}_2"
+            if (from('FacilityLocation')
+                    .where(facilityId: parameters.facilityId, locationSeqId: locationSeqId)
+                    .queryOne()) {
+                locationSeqId = delegator.getNextSeqId('FacilityLocation')
+            }
         }
-        locationSeqId = nextLocationSeqId
     } else {
         locationSeqId = delegator.getNextSeqId('FacilityLocation')
     }


### PR DESCRIPTION
Restore original collision handling to try a single _2 suffix before falling back to a sequenced id instead of looping indefinitely with incremental suffixes.