### PR TITLE
Fixed: PortalPageMethods portlet attribute saving and page copying regressions (OFBIZ-13568)

### DIFF
--- a/framework/common/src/main/groovy/org/apache/ofbiz/common/PortalPageMethods.groovy
+++ b/framework/common/src/main/groovy/org/apache/ofbiz/common/PortalPageMethods.groovy
@@ -25,9 +25,10 @@ import org.apache.ofbiz.entity.GenericValue
  */
 String duplicatePortalPage() {
     GenericValue portalPage = from('PortalPage').where(parameters).queryOne()
-    Map serviceResult = run service: 'createPortalPage', with: [*: portalPage.getAllFields(),
-                                                                portalPageId: null,
-                                                                originalPortalPageId: parameters.portalPageId]
+    Map createPage = [*: portalPage.getAllFields(),
+                      portalPageId: null,
+                      originalPortalPageId: portalPage.originalPortalPageId ?: parameters.portalPageId]
+    Map serviceResult = run service: 'createPortalPage', with: createPage
     run service: 'duplicatePortalPageDetails', with: [fromPortalPageId: parameters.portalPageId,
                                                       toPortalPageId: serviceResult.portalPageId]
     request.setAttribute('portalPageId', serviceResult.portalPageId)
@@ -56,9 +57,9 @@ String setPortalPortletAttributes() {
             if (porletAttr) {
                 porletAttr.remove()
             }
-            run service: 'createPortletAttribute', [*: parameters,
-                                                    attrName: it.key,
-                                                    attrValue: it.value]
+            run service: 'createPortletAttribute', with: [*: parameters,
+                                                          attrName: it.key,
+                                                          attrValue: it.value]
         }
     }
     return success()
@@ -70,18 +71,23 @@ String setPortalPortletAttributes() {
 String copyIfRequiredSystemPage() {
     GenericValue portalPage = from('PortalPage').where(parameters).cache().queryOne()
             ?: from('PortalPage').where(portalPageId: parameters.parentPortalPageId).cache().queryOne()
-    Map serviceResult = [:]
     if (portalPage && portalPage.ownerUserLoginId == '_NA_' && from('PortalPage')
             .where(originalPortalPageId: portalPage.portalPageId,
                     ownerUserLoginId: userLogin.userLoginId)
-            .queryCount() == 0 ) {
+            .queryCount() == 0) {
         // copy the portal page
-        serviceResult = run service: 'createPortalPage', with: [*: portalPage.getAllFields(),
-                                                                portalPageId: null,
-                                                                originalPortalPageId: portalPage.portalPageId,
-                                                                ownerUserLoginId: userLogin.userLoginId]
+        Map serviceResult = run service: 'createPortalPage', with: [*: portalPage.getAllFields(),
+                                                                    portalPageId: null,
+                                                                    originalPortalPageId: portalPage.portalPageId,
+                                                                    ownerUserLoginId: userLogin.userLoginId]
         run service: 'duplicatePortalPageDetails', with: [fromPortalPageId: portalPage.portalPageId,
                                                           toPortalPageId: serviceResult.portalPageId]
+        parameters.portalPageId = serviceResult.portalPageId
+    } else if (portalPage) {
+        parameters.portalPageId = portalPage.portalPageId
     }
-    return serviceResult ? serviceResult.portalPageId : portalPage?.portalPageId
+    if (binding.hasVariable('request') && request) {
+        request.setAttribute('portalPageId', parameters.portalPageId)
+    }
+    return success()
 }

--- a/framework/common/src/main/groovy/org/apache/ofbiz/common/PortalPageServices.groovy
+++ b/framework/common/src/main/groovy/org/apache/ofbiz/common/PortalPageServices.groovy
@@ -357,5 +357,6 @@ private Map checkOwnerShip() {
 private String copyIfRequiredSystemPage() {
     Script script = InvokerHelper.createScript(
             GroovyUtil.getScriptClassFromLocation('component://common/src/main/groovy/org/apache/ofbiz/common/PortalPageMethods.groovy'), binding)
-    return script.invokeMethod('copyIfRequiredSystemPage', null) as String
+    script.invokeMethod('copyIfRequiredSystemPage', null)
+    return parameters.portalPageId
 }


### PR DESCRIPTION
Fixed: PortalPageMethods portlet attribute saving and page copying regressions (OFBIZ-13568)

- setPortalPortletAttributes now includes the 'with:' keyword in its 'run service:' call, fixing a runtime MissingMethodException when saving portlet attributes.
- copyIfRequiredSystemPage sets the portalPageId request attribute and parameter and returns 'success' when invoked in a controller event context.
- duplicatePortalPage restores the original minilang guard on originalPortalPageId.