### PR TITLE
Fixed: MiniLang to Groovy conversion issues in ContactMechServicesScript (OFBIZ-13572)

### DIFF
--- a/applications/party/src/main/groovy/org/apache/ofbiz/party/contact/ContactMechServicesScript.groovy
+++ b/applications/party/src/main/groovy/org/apache/ofbiz/party/contact/ContactMechServicesScript.groovy
@@ -36,13 +36,14 @@ Map updateContactMech() {
             DOMAIN_NAME: 'DomainName',
             default: 'ContactMechanism'
     ]
-    String successMessage = 'Party' +
-            (successMessageMap."${parameters.contactMechTypeId}" ?: successMessageMap.default) +
-            'SuccessfullyUpdated'
-    GenericValue lookedValue = from('ContactMech').where(parameters).queryOne()
+    GenericValue lookedValue = from('ContactMech').where('contactMechId', parameters.contactMechId).queryOne()
     if (! lookedValue) {
         return error(UtilProperties.getMessage('ServiceErrorUiLabels', 'ServiceValueNotFound', locale))
     }
+    String contactMechTypeId = parameters.contactMechTypeId ?: lookedValue.contactMechTypeId
+    String successMessage = 'Party' +
+            (successMessageMap."$contactMechTypeId" ?: successMessageMap.default) +
+            'SuccessfullyUpdated'
     if (lookedValue.infoString != parameters.infoString) {
         lookedValue.setNonPKFields(parameters)
         lookedValue.contactMechId = null
@@ -99,11 +100,12 @@ Map updatePostalAddress() {
     if (errorMessage) {
         return error(UtilProperties.getMessage('PartyUiLabels', errorMessage, locale))
     }
-    GenericValue lookedValue = from('PostalAddress').where(parameters).queryOne()
+    GenericValue lookedValue = from('PostalAddress').where('contactMechId', parameters.contactMechId).queryOne()
     if (! lookedValue) {
         return error(UtilProperties.getMessage('ServiceErrorUiLabels', 'ServiceValueNotFound', locale))
     }
-    GenericValue newValue = makeValue('PostalAddress', parameters)
+    GenericValue newValue = (GenericValue) lookedValue.clone()
+    newValue.setNonPKFields(parameters)
     String contactMechId
     String oldContactMechId = lookedValue.contactMechId
     String successMessage = 'PartyPostalAddressSuccessfullyUpdated'
@@ -150,11 +152,12 @@ Map createTelecomNumber() {
  * Update Contact Mechanism with Telecom Number
  */
 Map updateTelecomNumber() {
-    GenericValue lookedValue = from('TelecomNumber').where(parameters).queryOne()
+    GenericValue lookedValue = from('TelecomNumber').where('contactMechId', parameters.contactMechId).queryOne()
     if (!lookedValue) {
         return error(UtilProperties.getMessage('ServiceErrorUiLabels', 'ServiceValueNotFound', locale))
     }
-    GenericValue newValue = makeValue('TelecomNumber', parameters)
+    GenericValue newValue = (GenericValue) lookedValue.clone()
+    newValue.setNonPKFields(parameters)
     String contactMechId
     String oldContactMechId = lookedValue.contactMechId
     String successMessage = 'PartyTelecomNumberSuccessfullyUpdated'
@@ -244,8 +247,13 @@ Map updateFtpAddressWithHistory() {
     resultMap.contactMechId = parameters.contactMechId
     Map newContactMechResult
     if (resultMap.oldContactMechId) {
-        newValue = makeValue('FtpAddress', parameters)
-        if (newValue != from('FtpAddress').where(parameters).queryOne()) {  // if there is some modifications in FtpAddress data
+        GenericValue lookedValue = from('FtpAddress').where('contactMechId', parameters.contactMechId).queryOne()
+        if (!lookedValue) {
+            return error(UtilProperties.getMessage('ServiceErrorUiLabels', 'ServiceValueNotFound', locale))
+        }
+        GenericValue newValue = (GenericValue) lookedValue.clone()
+        newValue.setNonPKFields(parameters)
+        if (newValue != lookedValue) {  // if there is some modifications in FtpAddress data
             newContactMechResult = run service: 'createFtpAddress', with: parameters
         } else { //update only contactMech
             Map updateContactMechMap = dispatcher.getDispatchContext().makeValidContext('updateContactMech', ModelService.IN_PARAM, parameters)
@@ -270,8 +278,7 @@ Map createPartyFtpAddress() {
     }
     String contactMechId = contactMech.contactMechId
 
-    Map createPartyContactMechMap = parameters
-    createPartyContactMechMap.put('contactMechId', contactMechId)
+    Map createPartyContactMechMap = [*:parameters, contactMechId: contactMechId]
     Map serviceResult = run service: 'createPartyContactMech', with: createPartyContactMechMap
     if (ServiceUtil.isError(serviceResult)) {
         return serviceResult
@@ -306,7 +313,9 @@ Map sendVerifyEmailAddressNotification() {
             .where(emailType: 'PRDS_EMAIL_VERIFY')
             .cache()
             .queryFirst()
-    GenericValue emailAddressVerification = from('EmailAddressVerification').where(parameters).queryOne()
+    GenericValue emailAddressVerification = from('EmailAddressVerification')
+            .where('emailAddress', parameters.emailAddress)
+            .queryOne()
     if (emailAddressVerification && storeEmail) {
         Map emailParams = [
             sendTo: parameters.emailAddress,


### PR DESCRIPTION
- In updateContactMech, query ContactMech explicitly by contactMechId, handle missing entity first, and fall back to lookedValue.contactMechTypeId when parameters.contactMechTypeId is omitted to construct the correct success message.
- In updatePostalAddress and updateTelecomNumber, query by contactMechId and clone lookedValue with setNonPKFields(parameters) to ensure accurate field comparison without missing timestamps/fields.
- In updateFtpAddressWithHistory, scope newValue as GenericValue, query FtpAddress by contactMechId with not-found check, and clone lookedValue with setNonPKFields(parameters) for proper comparison.
- In createPartyFtpAddress, avoid mutating parameters map directly.
- In sendVerifyEmailAddressNotification, query EmailAddressVerification explicitly by emailAddress.