### PR TITLE
Bump ant-junit from 1.10.17 to 1.10.18 in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ dependencies {
     }
 
     junitReport 'junit:junit:4.13.2'
-    junitReport 'org.apache.ant:ant-junit:1.10.17'
+    junitReport 'org.apache.ant:ant-junit:1.10.18'
 
     // Libraries downloaded manually
     implementation fileTree(dir: file("${rootDir}/lib"), include: '**/*.jar')


### PR DESCRIPTION
The version 1.10.18 is the one already declared in dependencies.gradle.