### PR TITLE
Fixed: updateBudgetStatus invalid-transition error omits the requested status (OFBIZ-13558)

### DIFF
--- a/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/budget/BudgetServices.groovy
+++ b/applications/accounting/src/main/groovy/org/apache/ofbiz/accounting/budget/BudgetServices.groovy
@@ -35,7 +35,7 @@ Map updateBudgetStatus() {
                     .queryOne()
             if (!statusValidChange) {
                 return error(label('CommonUiLabels', 'CommonErrorNoStatusValidChange',
-                        [lookedUpValue: [statusId: budgetStatus.statusId]]))
+                        [lookedUpValue: [statusId: budgetStatus.statusId], parameters: parameters]))
             }
             result = run service: 'createBudgetStatus', with: parameters
         }


### PR DESCRIPTION
Follow-up to OFBIZ-13558. The CommonErrorNoStatusValidChange label references both ${lookedUpValue.statusId} and ${parameters.statusId}, but label() passes its context map straight to FlexibleStringExpander with no merging — only lookedUpValue was supplied, so the requested status always rendered blank (e.g. "status change from [BG_APPROVED] to [] is not allowed"). Adding parameters to the context map lets both placeholders resolve correctly.